### PR TITLE
feat: native list properties (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This is ingestion-side only — `Value::List` already round-trips through
   storage, so there is no `.kgl` format change.
 
+### Fixed
+- **List (and timestamp) properties are no longer dropped through the
+  overflow property bag.** The mapped/disk overflow serializer encoded
+  `Value::List` as NULL (and the mapped reader/borrowed streaming-disk path
+  silently skipped lists), so a sparse list property could vanish on a
+  streaming-disk subset save. Lists now round-trip via a new additive
+  overflow wire tag (`8` = length-prefixed bincode); the mapped overflow
+  reader also gained the previously-missing `Timestamp` tag, restoring
+  memory↔mapped parity for timestamp overflow values. The tag is additive —
+  existing `.kgl` files never contain it, so this is read-compatible.
+
 ## [0.11.16] — 2026-06-25 — Primary-key uniqueness + the `kglite` shell on pip (kglite-cli)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Native list properties on ingestion.** A pandas column of Python
+  lists/tuples now ingests as a real list-valued property (`ColumnData::List`)
+  instead of a stringified `"['x', 'y']"`. `IN` tests membership over the
+  elements (`'y' IN n.aliases`), with no false-positive substring match, and
+  `UNWIND n.aliases` yields the individual elements. List typing is also
+  selectable explicitly via `add_nodes(..., column_types={"col": "list"})`.
+  This is ingestion-side only — `Value::List` already round-trips through
+  storage, so there is no `.kgl` format change.
+
 ## [0.11.16] — 2026-06-25 — Primary-key uniqueness + the `kglite` shell on pip (kglite-cli)
 
 ### Added

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -694,6 +694,24 @@ graph.cypher("""
 """)
 ```
 
+## List Properties
+
+Node properties can be **native lists**, not just scalars. When a pandas
+column passed to `add_nodes` holds Python lists, it is ingested as a real
+list property (auto-detected, or forced with `column_types={'col': 'list'}`)
+— stored structurally rather than stringified. List properties behave like
+list literals in every list operation:
+
+```python
+# aliases is a list property, e.g. ['Bob', 'Bobby']
+graph.cypher("MATCH (n:Person) WHERE 'Bobby' IN n.aliases RETURN n.name")  # membership
+graph.cypher("MATCH (n:Person) UNWIND n.aliases AS a RETURN n.name, a")    # explode
+graph.cypher("MATCH (n:Person) RETURN size(n.aliases) AS n_aliases")       # length
+```
+
+`IN` over a list property is true *membership* — `'Bob' IN ['Bobby']` is
+false (no substring matching).
+
 ## List Comprehensions
 
 `[x IN list WHERE predicate | expression]` syntax:

--- a/crates/kglite-py/src/datatypes/py_in.rs
+++ b/crates/kglite-py/src/datatypes/py_in.rs
@@ -2,7 +2,7 @@
 use super::type_conversions::{to_bool, to_datetime, to_f64, to_i64, to_u32};
 use super::values::{ColumnData, ColumnType, DataFrame, FilterCondition, Value};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 use pyo3::Bound;
 use std::collections::HashMap;
 
@@ -275,7 +275,34 @@ fn convert_pandas_series(series: &Bound<'_, PyAny>, col_type: ColumnType) -> PyR
             }
             Ok(ColumnData::DateTime(vec))
         }
+        ColumnType::List => {
+            // Object column of Python lists/tuples → native List property.
+            let py_list = py_list.cast::<PyList>()?;
+            let mut vec: Vec<Option<Vec<Value>>> = Vec::with_capacity(length);
+            for (i, &is_null) in null_mask.iter().enumerate() {
+                if is_null {
+                    vec.push(None);
+                } else {
+                    let item = py_list.get_item(i)?;
+                    vec.push(Some(py_cell_to_value_list(&item)?));
+                }
+            }
+            Ok(ColumnData::List(vec))
+        }
     }
+}
+
+/// Convert a single pandas cell into a `Vec<Value>`. A Python list/tuple maps
+/// element-wise via [`py_value_to_value`]; any scalar is wrapped as a
+/// single-element list so it isn't silently dropped.
+fn py_cell_to_value_list(item: &Bound<'_, PyAny>) -> PyResult<Vec<Value>> {
+    if let Ok(list) = item.cast::<PyList>() {
+        return list.iter().map(|el| py_value_to_value(&el)).collect();
+    }
+    if let Ok(tuple) = item.cast::<PyTuple>() {
+        return tuple.iter().map(|el| py_value_to_value(&el)).collect();
+    }
+    Ok(vec![py_value_to_value(item)?])
 }
 
 pub fn pandas_to_dataframe(
@@ -345,6 +372,7 @@ pub fn pandas_to_dataframe_with_options(
                         "str" | "string" | "text" => ColumnType::String,
                         "bool" | "boolean" => ColumnType::Boolean,
                         "date" | "datetime" | "timestamp" => ColumnType::DateTime,
+                        "list" | "array" => ColumnType::List,
                         _ => {
                             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                                 "Unsupported column type '{}' specified for column '{}'",
@@ -444,6 +472,11 @@ fn determine_column_type(series: &Bound<'_, PyAny>, col_name: &str) -> PyResult<
         "bool" | "boolean" => Ok(ColumnType::Boolean),
         s if s.starts_with("datetime64") => Ok(ColumnType::DateTime),
         "object" => {
+            // A column of Python lists/tuples → native List property (so
+            // `IN`/UNWIND see real elements, not a stringified list).
+            if first_non_null_is_list(series)? {
+                return Ok(ColumnType::List);
+            }
             // Object dtype may contain booleans mixed with None (common in code_tree
             // metadata like is_test, is_abstract).  Use pandas' own type inference
             // which handles skipna correctly.
@@ -465,6 +498,20 @@ fn determine_column_type(series: &Bound<'_, PyAny>, col_name: &str) -> PyResult<
             format!("Unsupported column type '{}' for column '{}'. Supported types: int, float, bool, datetime, string/object.", type_str, col_name)
         )),
     }
+}
+
+/// True when the first non-null value of an object-dtype series is a Python
+/// list or tuple — the signal for inferring a native `List` column.
+fn first_non_null_is_list(series: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let non_null = series.call_method0("dropna")?;
+    if non_null.len()? == 0 {
+        return Ok(false);
+    }
+    let first = non_null
+        .call_method0("tolist")?
+        .cast::<PyList>()?
+        .get_item(0)?;
+    Ok(first.cast::<PyList>().is_ok() || first.cast::<PyTuple>().is_ok())
 }
 
 pub fn ensure_columns(

--- a/crates/kglite/src/datatypes/values.rs
+++ b/crates/kglite/src/datatypes/values.rs
@@ -184,6 +184,11 @@ pub enum BorrowedValue<'a> {
     UniqueId(u32),
     String(&'a str),
     DateTime(NaiveDate),
+    /// A borrowed list of owned values. Unlike the scalar variants this
+    /// borrows the `Vec<Value>` slice from the source rather than copying;
+    /// it lets native list properties survive the streaming-disk save path
+    /// (which otherwise can only carry scalars).
+    List(&'a [Value]),
 }
 
 impl<'a> BorrowedValue<'a> {
@@ -198,6 +203,7 @@ impl<'a> BorrowedValue<'a> {
             BorrowedValue::UniqueId(v) => Value::UniqueId(v),
             BorrowedValue::String(s) => Value::String(s.to_string()),
             BorrowedValue::DateTime(d) => Value::DateTime(d),
+            BorrowedValue::List(items) => Value::List(items.to_vec()),
         }
     }
 }

--- a/crates/kglite/src/datatypes/values.rs
+++ b/crates/kglite/src/datatypes/values.rs
@@ -435,6 +435,9 @@ pub enum ColumnType {
     String,
     Boolean,
     DateTime,
+    /// A list-valued column — each cell is a `Value::List`. Heterogeneous
+    /// inner values (matches `Value::List(Vec<Value>)`), so no inner type tag.
+    List,
 }
 
 impl fmt::Display for ColumnType {
@@ -446,6 +449,7 @@ impl fmt::Display for ColumnType {
             ColumnType::String => "String",
             ColumnType::Boolean => "Boolean",
             ColumnType::DateTime => "DateTime",
+            ColumnType::List => "List",
         };
         write!(f, "{}", type_str)
     }
@@ -466,6 +470,9 @@ pub enum ColumnData {
     String(Vec<Option<String>>),
     Boolean(Vec<Option<bool>>),
     DateTime(Vec<Option<NaiveDate>>),
+    /// One `Value::List` payload per cell (None = null). The inner `Vec<Value>`
+    /// is the list; values are heterogeneous, mirroring `Value::List`.
+    List(Vec<Option<Vec<Value>>>),
 }
 
 #[derive(Debug)]
@@ -483,6 +490,7 @@ impl Column {
             ColumnData::String(vec) => vec.get(row_idx)?.as_ref().map(|s| Value::String(s.clone())),
             ColumnData::Boolean(vec) => vec.get(row_idx)?.map(Value::Boolean),
             ColumnData::DateTime(vec) => vec.get(row_idx)?.map(Value::DateTime),
+            ColumnData::List(vec) => vec.get(row_idx)?.as_ref().map(|v| Value::List(v.clone())),
         }
     }
 
@@ -494,6 +502,7 @@ impl Column {
             ColumnData::String(vec) => vec.len(),
             ColumnData::Boolean(vec) => vec.len(),
             ColumnData::DateTime(vec) => vec.len(),
+            ColumnData::List(vec) => vec.len(),
         }
     }
 }
@@ -512,6 +521,7 @@ impl DataFrame {
                     ColumnType::String => ColumnData::String(Vec::new()),
                     ColumnType::Boolean => ColumnData::Boolean(Vec::new()),
                     ColumnType::DateTime => ColumnData::DateTime(Vec::new()),
+                    ColumnType::List => ColumnData::List(Vec::new()),
                 };
                 column_indices.insert(name.clone(), idx);
                 Column {
@@ -586,7 +596,8 @@ impl DataFrame {
             | (ColumnType::Float64, ColumnData::Float64(_))
             | (ColumnType::String, ColumnData::String(_))
             | (ColumnType::Boolean, ColumnData::Boolean(_))
-            | (ColumnType::DateTime, ColumnData::DateTime(_)) => (),
+            | (ColumnType::DateTime, ColumnData::DateTime(_))
+            | (ColumnType::List, ColumnData::List(_)) => (),
             _ => return Err(format!("Data type mismatch for column {}", name)),
         }
 
@@ -654,15 +665,14 @@ impl DataFrame {
                     // Durations are query-time-only — never persisted as
                     // a column (Cluster 2). Serialize via the String column.
                     Value::Duration { .. } => Some(ColumnType::String),
-                    // Phase A.1 — collection / graph-entity variants
-                    // don't fit columnar; serialise via String column
-                    // (JSON-ish). A future enhancement could add
-                    // dedicated columnar shapes.
-                    Value::List(_)
-                    | Value::Map(_)
-                    | Value::Node(_)
-                    | Value::Relationship(_)
-                    | Value::Path(_) => Some(ColumnType::String),
+                    // Lists get a dedicated columnar shape so they round-trip
+                    // structurally (UNWIND/IN), not as stringified JSON.
+                    Value::List(_) => Some(ColumnType::List),
+                    // The remaining collection / graph-entity variants don't fit
+                    // columnar; serialise via the String column (JSON-ish).
+                    Value::Map(_) | Value::Node(_) | Value::Relationship(_) | Value::Path(_) => {
+                        Some(ColumnType::String)
+                    }
                     Value::Null | Value::NodeRef(_) => None,
                 };
             }
@@ -687,6 +697,7 @@ impl DataFrame {
                 ColumnType::String => ColumnData::String(Vec::with_capacity(num_rows)),
                 ColumnType::Boolean => ColumnData::Boolean(Vec::with_capacity(num_rows)),
                 ColumnType::DateTime => ColumnData::DateTime(Vec::with_capacity(num_rows)),
+                ColumnType::List => ColumnData::List(Vec::with_capacity(num_rows)),
             })
             .collect();
 
@@ -735,6 +746,14 @@ impl DataFrame {
                         Value::DateTime(v) => vec.push(Some(v)),
                         Value::Null => vec.push(None),
                         _ => vec.push(None),
+                    },
+                    ColumnData::List(vec) => match val {
+                        Value::List(v) => vec.push(Some(v)),
+                        Value::Null => vec.push(None),
+                        // A non-list value in an inferred-list column is a
+                        // heterogeneous mix; store it as a 1-element list so it
+                        // isn't silently dropped.
+                        other => vec.push(Some(vec![other])),
                     },
                 }
             }
@@ -1010,6 +1029,7 @@ fn format_col_type(col_type: &ColumnType) -> String {
         ColumnType::String => "str",
         ColumnType::Boolean => "bool",
         ColumnType::DateTime => "datetime",
+        ColumnType::List => "list",
     }
     .to_string()
 }

--- a/crates/kglite/src/graph/blueprint/csv_loader.rs
+++ b/crates/kglite/src/graph/blueprint/csv_loader.rs
@@ -6,7 +6,7 @@
 //! column without an explicit type falls back to light inference on
 //! the first non-empty cell in each column.
 
-use crate::datatypes::values::{ColumnData, ColumnType, DataFrame};
+use crate::datatypes::values::{ColumnData, ColumnType, DataFrame, Value};
 use chrono::NaiveDate;
 use std::collections::HashMap;
 use std::path::Path;
@@ -356,6 +356,51 @@ fn build_column_data(
             }
             Ok(ColumnData::UniqueId(out))
         }
+        ColumnType::List => {
+            // CSV never *infers* a list — this arm only fires when a blueprint
+            // declares `column_types = {col: "list"}`. The cell is parsed as a
+            // JSON array (`["a","b"]`); a non-array cell becomes a 1-elem list.
+            let mut out: Vec<Option<Vec<Value>>> = Vec::with_capacity(n);
+            for (r, row) in raw.rows.iter().enumerate() {
+                if raw.nulls[r][src_idx] {
+                    out.push(None);
+                    continue;
+                }
+                let s = row[src_idx].trim();
+                if s.is_empty() {
+                    out.push(None);
+                } else {
+                    out.push(Some(parse_list_cell(s)));
+                }
+            }
+            Ok(ColumnData::List(out))
+        }
+    }
+}
+
+/// Parse a CSV cell declared as a list. A JSON array maps element-wise; any
+/// other value is wrapped as a single-element list so it isn't dropped.
+fn parse_list_cell(s: &str) -> Vec<Value> {
+    match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(serde_json::Value::Array(items)) => items.iter().map(json_scalar_to_value).collect(),
+        Ok(other) => vec![json_scalar_to_value(&other)],
+        Err(_) => vec![Value::String(s.to_string())],
+    }
+}
+
+/// Minimal JSON-scalar → `Value` mapping for list elements. Nested
+/// arrays/objects are stringified — list cells are expected to hold scalars.
+fn json_scalar_to_value(j: &serde_json::Value) -> Value {
+    match j {
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Boolean(*b),
+        serde_json::Value::Number(num) => num
+            .as_i64()
+            .map(Value::Int64)
+            .or_else(|| num.as_f64().map(Value::Float64))
+            .unwrap_or(Value::Null),
+        serde_json::Value::String(s) => Value::String(s.clone()),
+        other => Value::String(other.to_string()),
     }
 }
 

--- a/crates/kglite/src/graph/mutation/subgraph_streaming_writer.rs
+++ b/crates/kglite/src/graph/mutation/subgraph_streaming_writer.rs
@@ -939,6 +939,7 @@ fn borrowed_kind(v: &BorrowedValue<'_>) -> &'static str {
         BorrowedValue::UniqueId(_) => "UniqueId",
         BorrowedValue::String(_) => "String",
         BorrowedValue::DateTime(_) => "DateTime",
+        BorrowedValue::List(_) => "List",
     }
 }
 

--- a/crates/kglite/src/graph/storage/column_store.rs
+++ b/crates/kglite/src/graph/storage/column_store.rs
@@ -963,6 +963,20 @@ impl ColumnStore {
                 let epoch = UNIX_EPOCH_DATE.and_hms_opt(0, 0, 0)?;
                 Some(Value::Timestamp(epoch + chrono::Duration::seconds(secs)))
             }
+            8 => {
+                // List: u32 length prefix + bincode(Vec<Value>).
+                if *pos + 4 > blob.len() {
+                    return None;
+                }
+                let blen = u32::from_le_bytes(blob[*pos..*pos + 4].try_into().ok()?) as usize;
+                *pos += 4;
+                if *pos + blen > blob.len() {
+                    return None;
+                }
+                let items: Vec<Value> = bincode::deserialize(&blob[*pos..*pos + blen]).ok()?;
+                *pos += blen;
+                Some(Value::List(items))
+            }
             _ => None,
         }
     }
@@ -974,8 +988,9 @@ impl ColumnStore {
             1 | 2 | 7 => *pos += 8, // Int64 / Float64 / Timestamp (i64 seconds)
             3 | 5 => *pos += 4,     // UniqueId or Date
             4 => *pos += 1,         // Bool
-            6 if *pos + 4 <= blob.len() => {
-                // String: u32 length prefix + bytes
+            6 | 8 if *pos + 4 <= blob.len() => {
+                // String (6) and List (8) share the layout: u32 length
+                // prefix + that many payload bytes.
                 let slen =
                     u32::from_le_bytes(blob[*pos..*pos + 4].try_into().unwrap_or([0; 4])) as usize;
                 *pos += 4 + slen;
@@ -1037,17 +1052,25 @@ impl ColumnStore {
                 // the overflow bag (Cluster 2). Skip as null.
                 buf.push(0);
             }
-            // Phase A.1 — collection / graph-entity variants are
-            // query-result-time values; they don't belong in the
-            // overflow property bag. Skip as null (matches the
-            // Duration/NodeRef precedent). C5 (the .kgl v4 format
-            // bump) revisits this if structural property storage
-            // becomes a requirement.
-            Value::List(_)
-            | Value::Map(_)
-            | Value::Node(_)
-            | Value::Relationship(_)
-            | Value::Path(_) => {
+            // Lists ARE real persistable property values (native list
+            // properties, 0.11.x). Tag 8: u32 length prefix + bincode of
+            // the `Vec<Value>` — additive to the wire format (old files
+            // never contain tag 8; the reader maps unknown tags to null).
+            Value::List(items) => match bincode::serialize(items) {
+                Ok(bytes) => {
+                    buf.push(8);
+                    buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+                    buf.extend_from_slice(&bytes);
+                }
+                // Serialisation should never fail for a Vec<Value>; if it
+                // somehow does, fall back to null rather than corrupting
+                // the blob.
+                Err(_) => buf.push(0),
+            },
+            // Map / graph-entity variants are query-result-time values;
+            // they don't belong in the overflow property bag. Skip as null
+            // (matches the Duration/NodeRef precedent).
+            Value::Map(_) | Value::Node(_) | Value::Relationship(_) | Value::Path(_) => {
                 buf.push(0);
             }
         }
@@ -1216,6 +1239,9 @@ impl ColumnStore {
                 Value::UniqueId(v) => crate::datatypes::values::BorrowedValue::UniqueId(*v),
                 Value::String(s) => crate::datatypes::values::BorrowedValue::String(s.as_str()),
                 Value::DateTime(d) => crate::datatypes::values::BorrowedValue::DateTime(*d),
+                // Native list properties survive the streaming path by
+                // borrowing the slice; the overflow serializer encodes it.
+                Value::List(items) => crate::datatypes::values::BorrowedValue::List(items),
                 _ => continue,
             };
             f(*key, bv)?;
@@ -1734,6 +1760,14 @@ impl ColumnStore {
                 buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
                 buf.extend_from_slice(s.as_bytes());
             }
+            BorrowedValue::List(items) => match bincode::serialize(items) {
+                Ok(bytes) => {
+                    buf.push(8);
+                    buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+                    buf.extend_from_slice(&bytes);
+                }
+                Err(_) => buf.push(0),
+            },
         }
     }
 

--- a/crates/kglite/src/graph/storage/column_store_tests.rs
+++ b/crates/kglite/src/graph/storage/column_store_tests.rs
@@ -293,3 +293,55 @@ fn test_column_store_materialize_roundtrip() {
     assert_eq!(store.get(0, name_key), Some(Value::String("Alice".into())));
     assert_eq!(store.get(1, age_key), Some(Value::Int64(25)));
 }
+
+#[test]
+fn test_overflow_value_list_roundtrip() {
+    // Native list properties must survive the overflow-bag wire format
+    // (tag 8 = u32 length prefix + bincode(Vec<Value>)). Before the
+    // 0.11.x fix this serialized as null and the list was silently lost.
+    let mut interner = StringInterner::new();
+    let key = interner.get_or_intern("aliases");
+
+    let list = Value::List(vec![
+        Value::String("x".into()),
+        Value::String("y".into()),
+        Value::Int64(7),
+    ]);
+
+    let mut buf = 1u16.to_le_bytes().to_vec(); // entry-count header
+    ColumnStore::serialize_overflow_value(&mut buf, key, &list);
+
+    let decoded = ColumnStore::decode_overflow_blob(&buf);
+    assert_eq!(decoded.len(), 1);
+    assert_eq!(decoded[0].0, key);
+    assert_eq!(decoded[0].1, list);
+}
+
+#[test]
+fn test_overflow_blob_mixed_scalars_and_list_roundtrip() {
+    // A list entry sandwiched between scalars must not desync the reader
+    // (skip_overflow_value has to advance past the tag-8 blob correctly).
+    let mut interner = StringInterner::new();
+    let k_a = interner.get_or_intern("a");
+    let k_list = interner.get_or_intern("tags");
+    let k_b = interner.get_or_intern("b");
+
+    let entries = [
+        (k_a, Value::Int64(1)),
+        (k_list, Value::List(vec![Value::String("red".into())])),
+        (k_b, Value::Boolean(true)),
+    ];
+    let mut buf = (entries.len() as u16).to_le_bytes().to_vec(); // entry-count header
+    for (k, v) in &entries {
+        ColumnStore::serialize_overflow_value(&mut buf, *k, v);
+    }
+
+    let decoded = ColumnStore::decode_overflow_blob(&buf);
+    assert_eq!(decoded.len(), 3);
+    assert_eq!(decoded[0], (k_a, Value::Int64(1)));
+    assert_eq!(
+        decoded[1],
+        (k_list, Value::List(vec![Value::String("red".into())]))
+    );
+    assert_eq!(decoded[2], (k_b, Value::Boolean(true)));
+}

--- a/crates/kglite/src/graph/storage/mapped/column_store.rs
+++ b/crates/kglite/src/graph/storage/mapped/column_store.rs
@@ -511,6 +511,30 @@ impl MmapColumnStore {
                             pos += slen;
                             f(key, BorrowedValue::String(s))?;
                         }
+                        8 => {
+                            // List: u32 length prefix + bincode(Vec<Value>).
+                            // Unlike strings this can't borrow the blob —
+                            // bincode must allocate — but the owned `Vec`
+                            // lives across the synchronous `f()` call, so a
+                            // borrowed slice into it is valid.
+                            if pos + 4 > blob.len() {
+                                break;
+                            }
+                            let blen =
+                                u32::from_le_bytes(blob[pos..pos + 4].try_into().unwrap_or([0; 4]))
+                                    as usize;
+                            pos += 4;
+                            if pos + blen > blob.len() {
+                                break;
+                            }
+                            let items: Vec<crate::datatypes::values::Value> =
+                                match bincode::deserialize(&blob[pos..pos + blen]) {
+                                    Ok(v) => v,
+                                    Err(_) => break,
+                                };
+                            pos += blen;
+                            f(key, BorrowedValue::List(&items))?;
+                        }
                         _ => break,
                     }
                 }
@@ -705,6 +729,33 @@ impl MmapColumnStore {
                 *pos += slen;
                 Some(Value::String(s))
             }
+            7 => {
+                // Timestamp: 8 bytes i64 seconds since the unix epoch.
+                // (Parity with the heap ColumnStore reader — this arm was
+                // previously missing here, silently dropping timestamps in
+                // mapped-mode overflow.)
+                if *pos + 8 > blob.len() {
+                    return None;
+                }
+                let secs = i64::from_le_bytes(blob[*pos..*pos + 8].try_into().ok()?);
+                *pos += 8;
+                let epoch = UNIX_EPOCH_DATE.and_hms_opt(0, 0, 0)?;
+                Some(Value::Timestamp(epoch + chrono::Duration::seconds(secs)))
+            }
+            8 => {
+                // List: u32 length prefix + bincode(Vec<Value>).
+                if *pos + 4 > blob.len() {
+                    return None;
+                }
+                let blen = u32::from_le_bytes(blob[*pos..*pos + 4].try_into().ok()?) as usize;
+                *pos += 4;
+                if *pos + blen > blob.len() {
+                    return None;
+                }
+                let items: Vec<Value> = bincode::deserialize(&blob[*pos..*pos + blen]).ok()?;
+                *pos += blen;
+                Some(Value::List(items))
+            }
             _ => None,
         }
     }
@@ -712,12 +763,12 @@ impl MmapColumnStore {
     /// Skip over a value in the overflow blob without decoding it.
     fn skip_overflow_value(blob: &[u8], pos: &mut usize, type_tag: u8) {
         match type_tag {
-            0 => {}             // Null: no data
-            1 | 2 => *pos += 8, // Int64 or Float64
-            3 | 5 => *pos += 4, // UniqueId or Date
-            4 => *pos += 1,     // Bool
-            6 if *pos + 4 <= blob.len() => {
-                // String: u32 length prefix + bytes
+            0 => {}                 // Null: no data
+            1 | 2 | 7 => *pos += 8, // Int64 / Float64 / Timestamp (i64 seconds)
+            3 | 5 => *pos += 4,     // UniqueId or Date
+            4 => *pos += 1,         // Bool
+            6 | 8 if *pos + 4 <= blob.len() => {
+                // String (6) and List (8): u32 length prefix + payload bytes.
                 let slen =
                     u32::from_le_bytes(blob[*pos..*pos + 4].try_into().unwrap_or([0; 4])) as usize;
                 *pos += 4 + slen;

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -986,7 +986,11 @@ class KnowledgeGraph:
             conflict_handling: ``'update'`` (default), ``'replace'``, ``'skip'``,
                 ``'preserve'``, or ``'sum'``. ``'sum'`` acts as ``'update'`` for nodes.
             skip_columns: Columns to exclude.
-            column_types: Override column dtypes ``{'col': 'string'|'integer'|'float'|'datetime'|'uniqueid'}``.
+            column_types: Override column dtypes ``{'col': 'string'|'integer'|'float'|'datetime'|'uniqueid'|'list'}``.
+                A column of Python lists/tuples is auto-detected as a native
+                ``'list'`` property (stored structurally, not stringified), so
+                ``'y' IN n.aliases`` tests membership and ``UNWIND n.aliases``
+                yields the elements; pass ``'list'`` explicitly to force it.
                 Also supports spatial types: ``'location.lat'``, ``'location.lon'``,
                 ``'geometry'``, ``'point.<name>.lat'``, ``'point.<name>.lon'``,
                 ``'shape.<name>'``.

--- a/tests/test_list_properties.py
+++ b/tests/test_list_properties.py
@@ -64,3 +64,51 @@ def test_mixed_int_list_roundtrips():
     kg.add_nodes(df, node_type="S", unique_id_field="id")
     rows = kg.cypher("MATCH (n:S) UNWIND n.scores AS s RETURN s ORDER BY s").to_dicts()
     assert [r["s"] for r in rows] == [1, 2, 3]
+
+
+# ── Cross-mode parity (Phase 2): lists survive every storage backend and
+#    the persistence round-trips (.kgl save/load + streaming-disk subset). ──
+
+_EXPECTED = [{"id": 1, "al": ["x", "y"]}, {"id": 2, "al": ["z"]}]
+_Q = "MATCH (n:Person) RETURN n.id AS id, n.aliases AS al ORDER BY id"
+
+
+def _person_df():
+    return pd.DataFrame({"id": [1, 2], "name": ["a", "b"], "aliases": [["x", "y"], ["z"]]})
+
+
+@pytest.mark.parametrize("mode", ["memory", "mapped", "disk"])
+def test_list_property_cross_mode_live(mode, tmp_path):
+    if mode == "memory":
+        kg = kglite.KnowledgeGraph()
+    elif mode == "mapped":
+        kg = kglite.KnowledgeGraph(storage="mapped")
+    else:
+        kg = kglite.KnowledgeGraph(storage="disk", path=str(tmp_path / "g"))
+    kg.add_nodes(_person_df(), node_type="Person", unique_id_field="id")
+    assert kg.cypher(_Q).to_dicts() == _EXPECTED
+
+
+@pytest.mark.parametrize("mode", ["memory", "mapped", "disk"])
+def test_list_property_save_reload(mode, tmp_path):
+    if mode == "memory":
+        kg = kglite.KnowledgeGraph()
+    elif mode == "mapped":
+        kg = kglite.KnowledgeGraph(storage="mapped")
+    else:
+        kg = kglite.KnowledgeGraph(storage="disk", path=str(tmp_path / "g"))
+    kg.add_nodes(_person_df(), node_type="Person", unique_id_field="id")
+    p = str(tmp_path / f"{mode}.kgl")
+    kg.save(p)
+    assert kglite.load(p).cypher(_Q).to_dicts() == _EXPECTED
+
+
+def test_list_property_streaming_disk_subset(tmp_path):
+    # save_subset on a disk-backed source takes the streaming-disk writer,
+    # which marshals each property through the borrowed-value overflow path.
+    # Before Phase 2 a list there serialized to NULL; now it round-trips.
+    src = kglite.KnowledgeGraph(storage="disk", path=str(tmp_path / "src"))
+    src.add_nodes(_person_df(), node_type="Person", unique_id_field="id")
+    out = str(tmp_path / "subset.kgl")
+    src.select("Person").save_subset(out)
+    assert kglite.load(out).cypher(_Q).to_dicts() == _EXPECTED

--- a/tests/test_list_properties.py
+++ b/tests/test_list_properties.py
@@ -1,0 +1,66 @@
+"""Native list properties (P3 — list ingestion as ColumnData::List).
+
+A pandas column of Python lists is ingested as a real list-valued property,
+not a stringified `"['x', 'y']"`. The load-bearing guarantee: `IN` tests
+*membership* over the elements (true `'y' IN ['x','y']`), with no
+false-positive substring match (`'xy'` is not a member), and `UNWIND`
+yields the individual elements.
+"""
+
+import pandas as pd
+import pytest
+
+import kglite
+
+
+@pytest.fixture
+def kg_with_lists():
+    kg = kglite.KnowledgeGraph()
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["a", "b", "c"],
+            "aliases": [["x", "y"], ["z"], []],
+        }
+    )
+    kg.add_nodes(df, node_type="Person", unique_id_field="id")
+    return kg
+
+
+def test_list_stored_as_native_list(kg_with_lists):
+    rows = kg_with_lists.cypher("MATCH (n:Person) RETURN n.id AS id, n.aliases AS al ORDER BY id").to_dicts()
+    assert rows[0]["al"] == ["x", "y"]
+    assert rows[1]["al"] == ["z"]
+    assert rows[2]["al"] == []
+
+
+def test_in_is_membership_not_substring(kg_with_lists):
+    hit = kg_with_lists.cypher("MATCH (n:Person) WHERE 'y' IN n.aliases RETURN n.id AS id ORDER BY id").to_dicts()
+    assert hit == [{"id": 1}]
+
+    # 'xy' is a substring of the stringified list but NOT a member — the
+    # whole point of native lists is that this returns nothing.
+    miss = kg_with_lists.cypher("MATCH (n:Person) WHERE 'xy' IN n.aliases RETURN n.id AS id").to_dicts()
+    assert miss == []
+
+
+def test_unwind_over_stored_list(kg_with_lists):
+    rows = kg_with_lists.cypher("MATCH (n:Person {id:1}) UNWIND n.aliases AS a RETURN a ORDER BY a").to_dicts()
+    assert [r["a"] for r in rows] == ["x", "y"]
+
+
+def test_explicit_list_column_type():
+    kg = kglite.KnowledgeGraph()
+    # Force list typing via column_types even though the cells look scalar-ish.
+    df = pd.DataFrame({"id": [1], "tags": [["a", "b", "c"]]})
+    kg.add_nodes(df, node_type="T", unique_id_field="id", column_types={"tags": "list"})
+    rows = kg.cypher("MATCH (n:T) RETURN n.tags AS t").to_dicts()
+    assert rows[0]["t"] == ["a", "b", "c"]
+
+
+def test_mixed_int_list_roundtrips():
+    kg = kglite.KnowledgeGraph()
+    df = pd.DataFrame({"id": [1], "scores": [[1, 2, 3]]})
+    kg.add_nodes(df, node_type="S", unique_id_field="id")
+    rows = kg.cypher("MATCH (n:S) UNWIND n.scores AS s RETURN s ORDER BY s").to_dicts()
+    assert [r["s"] for r in rows] == [1, 2, 3]


### PR DESCRIPTION
Native list properties for the agent-contract use case (P3, split out from the agent-contract plan per user request).

Plan: `dev-docs/plans/list-properties.md`

## Phases
- [x] **Phase 1** — `ColumnType::List` / `ColumnData::List(Vec<Option<Vec<Value>>>)`; CSV + pandas ingestion; golden tests (`tests/test_list_properties.py`). Ingestion-side only, no `.kgl` format bump.
- [x] **Phase 2** — round-trip lists through the overflow bag (additive tag 8 = length-prefixed bincode); fixes the silent `Value::List`→NULL drop on streaming-disk subset save; restores mapped Timestamp-overflow parity. Cross-mode + subset parity tests.
- [ ] **Phase 3** — introspection (`describe()`) + docs.
- [ ] **Phase 4** — perf gate.

## What Phase 1 gives you
A pandas column of Python lists ingests as a real list property, not a stringified `"['x','y']"`:
- `'y' IN n.aliases` → membership (true), `'xy' IN n.aliases` → empty (no substring false-positive)
- `UNWIND n.aliases AS a` yields the elements
- explicit `add_nodes(..., column_types={"col": "list"})`

🤖 Generated with [Claude Code](https://claude.com/claude-code)