### PR TITLE
fix: persist new relationship types created via Cypher (critical save() data loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Critical: a relationship type introduced via Cypher `CREATE`/`MERGE` is no
+  longer silently dropped on `save()`.** Cypher edge creation registered the new
+  type only in the lightweight `connection_types` cache, not in
+  `connection_type_metadata`. The columnar `save()` consolidates edges *by
+  registered connection type*, so on a loaded/columnar graph a brand-new edge
+  type's edges were lost on save (and queries warned "unknown relationship
+  type") — while the endpoint nodes survived. Edge CREATE now upserts the full
+  connection-type metadata (matching `add_connections`), so the type and its
+  edges persist. Covers `CREATE` and `MERGE`. Reported by SimulatoRS (it broke
+  the agent-contract pattern of an agent linking runtime nodes to managed ones);
+  verified end-to-end through a full research-`managed_reload`-over-agent-board
+  round-trip.
+
 ## [0.12.1] — 2026-06-25 — write_scope edge-scoping fix + Transaction.cypher write_scope + 0.12.0 docs
 
 ### Fixed

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -1371,6 +1371,12 @@ root with no dependencies is ready as soon as it isn't done.
 
 `YIELD node, dependency_count` (how many dependencies the ready node had, all satisfied).
 
+> **Scope to the type you care about.** A node with *no* outgoing-`E` edge is a
+> root — vacuously "all dependencies satisfied" — so an unscoped `ready_set`
+> over a sparse edge type also returns every unrelated node. To get e.g. "ready
+> **tasks**", pass `node_type: 'Task'` so only that type is emitted (dependencies
+> are still followed across types).
+
 ```python
 # Which tasks can the agent pick up next?
 graph.cypher("""

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -477,16 +477,19 @@ fn execute_create(
                     // `create_node`, which enforces the scope. (Whitelisting
                     // relationship types is a possible future refinement.)
 
+                    // Endpoint types — needed for both the schema-lock check
+                    // and the connection-type metadata upsert below.
+                    let src_type = graph
+                        .get_node(actual_source)
+                        .map(|n| n.get_node_type_ref(&graph.interner).to_string())
+                        .unwrap_or_default();
+                    let tgt_type = graph
+                        .get_node(actual_target)
+                        .map(|n| n.get_node_type_ref(&graph.interner).to_string())
+                        .unwrap_or_default();
+
                     // Schema lock validation for edge
                     if graph.schema_locked {
-                        let src_type = graph
-                            .get_node(actual_source)
-                            .map(|n| n.get_node_type_ref(&graph.interner).to_string())
-                            .unwrap_or_default();
-                        let tgt_type = graph
-                            .get_node(actual_target)
-                            .map(|n| n.get_node_type_ref(&graph.interner).to_string())
-                            .unwrap_or_default();
                         crate::graph::mutation::validation::validate_edge_creation(
                             &edge_pat.connection_type,
                             &src_type,
@@ -506,7 +509,26 @@ fn execute_create(
                         }
                     }
 
+                    // Register the connection type fully — both the lightweight
+                    // cache (for `has_connection_type`) AND the metadata map.
+                    // The metadata is what `connection_types()`, the planner's
+                    // schema check, and the columnar edge-store save all read;
+                    // without it a brand-new relationship type created via
+                    // Cypher was treated as "unknown" (spurious warnings) and
+                    // — on a columnar graph — its edges were silently dropped
+                    // on `save()`, since the columnar edge store serializes by
+                    // registered connection type. (SimulatoRS, 0.12.1.)
                     graph.register_connection_type(edge_pat.connection_type.clone());
+                    let prop_types: HashMap<String, String> = edge_props
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.type_name().to_string()))
+                        .collect();
+                    graph.upsert_connection_type_metadata(
+                        &edge_pat.connection_type,
+                        &src_type,
+                        &tgt_type,
+                        prop_types,
+                    );
                     stats.relationships_created += 1;
 
                     let edge_data = EdgeData::new(

--- a/tests/test_cypher_new_edge_type_persistence.py
+++ b/tests/test_cypher_new_edge_type_persistence.py
@@ -1,0 +1,84 @@
+"""A relationship type introduced via Cypher CREATE/MERGE must register fully
+and survive save()/reload (SimulatoRS, 0.12.1 critical data-loss report).
+
+Root cause: Cypher edge CREATE added the new type to the lightweight
+`connection_types` cache but not to `connection_type_metadata`. The columnar
+`save()` consolidates edges *by registered connection type*, so a brand-new
+type's edges were silently dropped on save (and queries warned "unknown
+relationship type"). The node side already registered correctly — only the
+edge type was lost.
+"""
+
+import pandas as pd
+
+import kglite
+
+
+def _connection_type_names(kg):
+    return {c["type"] for c in kg.connection_types()}
+
+
+def test_new_edge_type_is_registered_in_metadata():
+    # The direct root-cause guard: creating an edge of a new type must make
+    # that type visible in connection_types() (i.e. connection_type_metadata),
+    # not just the internal cache.
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:A {id: 1})")
+    kg.cypher("CREATE (:B {id: 1})")
+    assert "LINKS_TO" not in _connection_type_names(kg)
+    kg.cypher("MATCH (a:A {id: 1}), (b:B {id: 1}) CREATE (a)-[:LINKS_TO]->(b)")
+    assert "LINKS_TO" in _connection_type_names(kg)
+
+
+def _multi_type_graph():
+    """A graph built the way a real loader does — multiple node types and
+    several edge types via add_connections — so its save() produces a
+    populated columnar edge store (the condition under which an unregistered
+    new edge type was dropped)."""
+    kg = kglite.KnowledgeGraph()
+    for t in ("Spec", "Algo", "Source", "Strategy"):
+        kg.add_nodes(
+            pd.DataFrame({"id": list(range(1, 6)), "title": [f"{t}{i}" for i in range(1, 6)]}),
+            node_type=t,
+            unique_id_field="id",
+            node_title_field="title",
+        )
+    for etype, s, t in [("CITES", "Algo", "Source"), ("REFINES", "Strategy", "Algo"), ("DERIVES", "Spec", "Algo")]:
+        kg.add_connections(
+            pd.DataFrame({"s": [1, 2, 3], "t": [1, 2, 3]}),
+            etype,
+            s,
+            "s",
+            t,
+            "t",
+        )
+    return kg
+
+
+def test_new_edge_type_survives_save_reload(tmp_path):
+    p = str(tmp_path / "g.kgl")
+    _multi_type_graph().save(p)
+
+    # Reload (now the edge store is columnar), then add a brand-new edge type
+    # via Cypher — the exact agent-contract operation that was dropped.
+    kg = kglite.load(p)
+    kg.cypher("CREATE (:Task {id: 1})")
+    kg.cypher("MATCH (t:Task {id: 1}), (s:Spec {id: 1}) CREATE (t)-[:IMPLEMENTS_SPEC]->(s)")
+    assert kg.cypher("MATCH (:Task)-[:IMPLEMENTS_SPEC]->() RETURN count(*) AS c").to_dicts() == [{"c": 1}]
+
+    kg.save(p)
+    reloaded = kglite.load(p)
+    # The edge (and its type) must survive the columnar save consolidation.
+    assert "IMPLEMENTS_SPEC" in _connection_type_names(reloaded)
+    assert reloaded.cypher("MATCH (:Task)-[:IMPLEMENTS_SPEC]->() RETURN count(*) AS c").to_dicts() == [{"c": 1}]
+
+
+def test_new_edge_type_via_merge_survives_save_reload(tmp_path):
+    p = str(tmp_path / "g.kgl")
+    _multi_type_graph().save(p)
+    kg = kglite.load(p)
+    kg.cypher("CREATE (:Question {id: 1})")
+    kg.cypher("MATCH (q:Question {id: 1}), (a:Algo {id: 1}) MERGE (q)-[:ABOUT]->(a)")
+    kg.save(p)
+    reloaded = kglite.load(p)
+    assert reloaded.cypher("MATCH (:Question)-[:ABOUT]->() RETURN count(*) AS c").to_dicts() == [{"c": 1}]


### PR DESCRIPTION
**Critical data-loss fix** from SimulatoRS's end-to-end retest of 0.12.1.

Cypher edge `CREATE`/`MERGE` registered a new relationship type only in the lightweight `connection_types` cache, not in `connection_type_metadata`. The columnar `save()` consolidates edges *by registered type*, so on a loaded/columnar graph a brand-new edge type's edges were **silently dropped on save()** (endpoint nodes survived; queries warned "unknown relationship type"). This broke the core agent-contract pattern (agent linking runtime `Task` → managed `AlgorithmSpec`).

**Fix:** edge creation now upserts the full connection-type metadata (matching `add_connections`). Covers CREATE + MERGE.

**Verified end-to-end** by replaying SimulatoRS's full work loop against their repro bundle: agent board (all 7 runtime edge types + cross-layer, `write_scope`) → research `managed_reload` rebuild → **all runtime nodes AND edges survive**, agent status preserved, 24/24 of their verify checks pass, save-loop idempotency holds.

Regression tests reproduce the loss (fail on prior code, pass now). Also: `ready_set` node_type-scoping doc note.

Ships as 0.12.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)