### PR TITLE
fix: complete MCP extension contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Atomic MCP domain graph context.** Embedded domain tools can use
+  `DomainGraphState::with_context` to borrow the active graph, persistence
+  target, and source root from one coherent activation snapshot.
+
 ### Fixed
 
 - **MCP manifest bundled-tool overrides now apply to the completed router.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to KGLite will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **MCP manifest bundled-tool overrides now apply to the completed router.**
+  `hidden: true` removes a tool from discovery and rejects direct calls even
+  when the route is registered by KGLite or a downstream extension; description
+  and rename overrides are validated and applied at the same late boot stage.
+
 ## [0.14.1] - 2026-07-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,6 +3097,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -3840,6 +3841,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/crates/kglite-mcp-server/Cargo.toml
+++ b/crates/kglite-mcp-server/Cargo.toml
@@ -80,6 +80,9 @@ bytes = "1"
 
 [dev-dependencies]
 tempfile = "3"
+# Exercise hidden-tool rejection through a real in-memory MCP handshake. The
+# production dependency enables only the server half; client code is test-only.
+rmcp = { version = "1.6", features = ["client"] }
 
 [features]
 # `fastembed` is an OPTIONAL feature, default OFF. Enabling it

--- a/crates/kglite-mcp-server/examples/domain_tools.rs
+++ b/crates/kglite-mcp-server/examples/domain_tools.rs
@@ -13,11 +13,18 @@ fn main() -> anyhow::Result<()> {
         registry.register_typed_tool::<SummaryArgs, _>(
             "collection_summary",
             "Summarise the active domain collection.",
-            move |args| match graph_state.schema() {
-                Some((nodes, edges)) if args.verbose => {
-                    format!("active collection: {nodes} nodes and {edges} edges")
+            move |args| match graph_state.with_context(|context| {
+                let schema = kglite::api::introspection::compute_schema(context.graph().dir());
+                let root = context.root().map_or_else(
+                    || "in-memory".to_string(),
+                    |path| path.display().to_string(),
+                );
+                (schema.node_count, schema.edge_count, root)
+            }) {
+                Some((nodes, edges, root)) if args.verbose => {
+                    format!("active collection at {root}: {nodes} nodes and {edges} edges")
                 }
-                Some((nodes, _)) => format!("active collection: {nodes} nodes"),
+                Some((nodes, _, root)) => format!("active collection at {root}: {nodes} nodes"),
                 None => "no active collection".to_string(),
             },
         )

--- a/crates/kglite-mcp-server/src/lib.rs
+++ b/crates/kglite-mcp-server/src/lib.rs
@@ -29,7 +29,7 @@
 //! - `--source-root DIR` — generic file-tree mode (no graph).
 //! - bare — framework + manifest tools only.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use anyhow::{Context, Result};
@@ -67,6 +67,36 @@ pub struct DomainGraphState {
     inner: GraphState,
 }
 
+/// One coherent, read-only view of the active graph and its path identity.
+///
+/// Values are valid only for the enclosing
+/// [`DomainGraphState::with_context`] callback. The graph, persistence target,
+/// and source root are borrowed under one active-slot read lock, so a
+/// concurrent activation cannot mix identity from one graph with another.
+#[derive(Clone, Copy)]
+pub struct DomainGraphContext<'a> {
+    graph: &'a kglite::api::KnowledgeGraph,
+    source_path: Option<&'a Path>,
+    root: Option<&'a Path>,
+}
+
+impl<'a> DomainGraphContext<'a> {
+    /// The active graph, borrowed read-only for the callback duration.
+    pub fn graph(&self) -> &'a kglite::api::KnowledgeGraph {
+        self.graph
+    }
+
+    /// Canonical persistence target used by `save_graph`, when one exists.
+    pub fn source_path(&self) -> Option<&'a Path> {
+        self.source_path
+    }
+
+    /// Canonical source identity: a source directory or loaded `.kgl` path.
+    pub fn root(&self) -> Option<&'a Path> {
+        self.root
+    }
+}
+
 impl DomainGraphState {
     /// Current `(node_count, edge_count)`, or `None` when no graph is active.
     pub fn schema(&self) -> Option<(u64, u64)> {
@@ -89,6 +119,24 @@ impl DomainGraphState {
         F: FnOnce(&kglite::api::KnowledgeGraph) -> T,
     {
         self.inner.with_kg(operation)
+    }
+
+    /// Borrow the active graph and its canonical path identity atomically.
+    ///
+    /// Keep the callback read-oriented and short: graph activation waits until
+    /// it returns. Use this instead of separate graph/path reads whenever a
+    /// domain result names the graph or source it inspected.
+    pub fn with_context<F, T>(&self, operation: F) -> Option<T>
+    where
+        F: FnOnce(DomainGraphContext<'_>) -> T,
+    {
+        self.inner.with_kg_context(|graph, source_path, root| {
+            operation(DomainGraphContext {
+                graph,
+                source_path,
+                root,
+            })
+        })
     }
 
     /// Run a parameterised read query against the active graph.
@@ -1711,6 +1759,48 @@ Use the registered domain tool.
 
         let prompts = server.prompt_router_mut().list_all();
         assert!(prompts.iter().any(|prompt| prompt.name == "domain_test"));
+    }
+
+    #[test]
+    fn graph_context_tracks_activation_as_one_coherent_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first_path = dir.path().join("first.kgl");
+        let second_path = dir.path().join("second.kgl");
+        let inner = GraphState::new(false);
+        inner
+            .create_in_mode(&first_path, StorageMode::Memory)
+            .expect("activate first graph");
+        let state = DomainGraphState {
+            inner: inner.clone(),
+        };
+
+        let first = state
+            .with_context(|context| {
+                (
+                    Arc::as_ptr(context.graph().dir()),
+                    context.source_path().map(Path::to_path_buf),
+                    context.root().map(Path::to_path_buf),
+                )
+            })
+            .expect("first context");
+        assert_eq!(first.1.as_deref(), Some(first_path.as_path()));
+        assert_eq!(first.2.as_deref(), Some(first_path.as_path()));
+
+        inner
+            .create_in_mode(&second_path, StorageMode::Memory)
+            .expect("activate second graph");
+        let second = state
+            .with_context(|context| {
+                (
+                    Arc::as_ptr(context.graph().dir()),
+                    context.source_path().map(Path::to_path_buf),
+                    context.root().map(Path::to_path_buf),
+                )
+            })
+            .expect("second context");
+        assert_ne!(first.0, second.0);
+        assert_eq!(second.1.as_deref(), Some(second_path.as_path()));
+        assert_eq!(second.2.as_deref(), Some(second_path.as_path()));
     }
 }
 

--- a/crates/kglite-mcp-server/src/lib.rs
+++ b/crates/kglite-mcp-server/src/lib.rs
@@ -36,7 +36,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use kglite::api::io::OpenDisposition;
 use mcp_methods::server::manifest::{
-    find_sibling_manifest, find_workspace_manifest, ManifestError,
+    find_sibling_manifest, find_workspace_manifest, ManifestError, ToolSpec,
 };
 use mcp_methods::server::{
     init_tracing, load_env_for_mode, maybe_watch, resolve_source_roots, serve_prompts, watch,
@@ -481,7 +481,84 @@ fn register_extension_tools(
         }
     }
     register_domain_tools(server, graph_state.clone(), domain_tools)
-        .context("downstream domain-tool registration failed")
+        .context("downstream domain-tool registration failed")?;
+    if let Some(manifest) = manifest {
+        apply_bundled_tool_overrides(server, manifest)
+            .context("manifest bundled-tool override failed")?;
+    }
+    Ok(())
+}
+
+/// Apply manifest overrides only after every route source has registered.
+///
+/// A bundled override may target a framework, KGLite, manifest, or downstream
+/// route, so applying it any earlier lets later registration silently undo a
+/// hidden flag or bypass rename/description validation.
+fn apply_bundled_tool_overrides(server: &mut McpServer, manifest: &Manifest) -> Result<()> {
+    let overrides: Vec<_> = manifest
+        .tools
+        .iter()
+        .filter_map(|tool| match tool {
+            ToolSpec::Bundled(override_) => Some(override_),
+            ToolSpec::Cypher(_) | ToolSpec::Python(_) => None,
+        })
+        .collect();
+    if overrides.is_empty() {
+        return Ok(());
+    }
+
+    let router = server.tool_router_mut();
+    for override_ in &overrides {
+        if !router.map.contains_key(override_.name.as_str()) {
+            anyhow::bail!(
+                "manifest bundled-tool override targets unknown route {:?}",
+                override_.name
+            );
+        }
+    }
+
+    let final_names = overrides
+        .iter()
+        .map(|override_| {
+            (
+                override_.name.as_str(),
+                override_.rename.as_deref().unwrap_or(&override_.name),
+            )
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut owners = std::collections::HashMap::<&str, &str>::new();
+    for name in router.map.keys().map(|name| name.as_ref()) {
+        let final_name = final_names.get(name).copied().unwrap_or(name);
+        if let Some(existing) = owners.insert(final_name, name) {
+            anyhow::bail!(
+                "manifest bundled-tool rename {final_name:?} conflicts between routes {existing:?} and {name:?}"
+            );
+        }
+    }
+
+    let mut routes = Vec::with_capacity(overrides.len());
+    for override_ in overrides {
+        let was_disabled = router.is_disabled(&override_.name);
+        let route = router
+            .map
+            .remove(override_.name.as_str())
+            .expect("override targets validated above");
+        routes.push((override_, route, was_disabled));
+    }
+
+    for (override_, mut route, was_disabled) in routes {
+        let final_name = override_.rename.as_deref().unwrap_or(&override_.name);
+        route.attr.name = final_name.to_owned().into();
+        if let Some(description) = &override_.description {
+            route.attr.description = Some(description.clone().into());
+        }
+        router.add_route(route);
+        if override_.hidden || was_disabled {
+            router.disable_route(final_name.to_owned());
+        }
+    }
+
+    Ok(())
 }
 
 /// Fail fast on bad mode-specific path arguments before any expensive setup.
@@ -1634,5 +1711,78 @@ Use the registered domain tool.
 
         let prompts = server.prompt_router_mut().list_all();
         assert!(prompts.iter().any(|prompt| prompt.name == "domain_test"));
+    }
+}
+
+#[cfg(test)]
+mod bundled_override_tests {
+    use super::*;
+    use rmcp::model::CallToolRequestParams;
+
+    fn load_manifest(yaml: &str) -> (tempfile::TempDir, Manifest) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("mcp.yaml");
+        std::fs::write(&path, yaml).expect("write manifest");
+        let manifest = mcp_methods::server::load_manifest(&path).expect("load manifest");
+        (dir, manifest)
+    }
+
+    #[tokio::test]
+    async fn hidden_route_is_unlisted_and_rejects_direct_calls() {
+        let (_dir, manifest) = load_manifest("tools:\n  - bundled: ping\n    hidden: true\n");
+        let mut server = McpServer::new(ServerOptions::default());
+
+        apply_bundled_tool_overrides(&mut server, &manifest).expect("apply override");
+
+        assert!(!server.tool_router_mut().has_route("ping"));
+        assert!(server.tool_router_mut().is_disabled("ping"));
+        let (server_transport, client_transport) = tokio::io::duplex(4096);
+        let server_handle = tokio::spawn(async move { server.serve(server_transport).await });
+        let client = ().serve(client_transport).await.expect("start MCP client");
+
+        let listed = client.peer().list_tools(None).await.expect("list tools");
+        assert!(listed.tools.iter().all(|tool| tool.name != "ping"));
+        let error = client
+            .call_tool(CallToolRequestParams::new("ping"))
+            .await
+            .expect_err("hidden route must reject direct calls");
+        assert!(error.to_string().contains("tool not found"));
+
+        client.cancel().await.expect("stop MCP client");
+        server_handle.abort();
+    }
+
+    #[test]
+    fn rename_and_description_replace_the_agent_facing_route() {
+        let (_dir, manifest) = load_manifest(
+            "tools:\n  - bundled: ping\n    rename: domain_ping\n    description: Domain health check.\n",
+        );
+        let mut server = McpServer::new(ServerOptions::default());
+
+        apply_bundled_tool_overrides(&mut server, &manifest).expect("apply override");
+
+        assert!(!server.tool_router_mut().has_route("ping"));
+        let renamed = server
+            .tool_router_mut()
+            .get("domain_ping")
+            .expect("renamed route");
+        assert_eq!(renamed.description.as_deref(), Some("Domain health check."));
+    }
+
+    #[test]
+    fn unknown_and_colliding_routes_fail_at_boot() {
+        let (_dir, unknown) =
+            load_manifest("tools:\n  - bundled: not_a_bundled_route\n    hidden: true\n");
+        let mut server = McpServer::new(ServerOptions::default());
+        let error = apply_bundled_tool_overrides(&mut server, &unknown)
+            .expect_err("unknown route must fail");
+        assert!(error.to_string().contains("unknown route"));
+
+        let (_dir, collision) =
+            load_manifest("tools:\n  - bundled: ping\n    rename: list_source\n");
+        let mut server = McpServer::new(ServerOptions::default());
+        let error = apply_bundled_tool_overrides(&mut server, &collision)
+            .expect_err("rename collision must fail");
+        assert!(error.to_string().contains("conflicts"));
     }
 }

--- a/crates/kglite-mcp-server/src/tools.rs
+++ b/crates/kglite-mcp-server/src/tools.rs
@@ -675,6 +675,21 @@ impl GraphState {
         guard.as_ref().map(|active| f(&active.kg))
     }
 
+    /// Borrow the active graph and both path identities under one read lock.
+    pub(crate) fn with_kg_context<F, T>(&self, f: F) -> Option<T>
+    where
+        F: FnOnce(&KnowledgeGraph, Option<&Path>, Option<&Path>) -> T,
+    {
+        let guard = read_lock(&self.inner);
+        guard.as_ref().map(|active| {
+            f(
+                &active.kg,
+                active.source_path.as_deref(),
+                active.root.as_deref(),
+            )
+        })
+    }
+
     /// Exclusive (write-locked) access to the active graph, for the
     /// write-enabled `cypher_query` path. The `RwLock` write-lock
     /// serializes mutations and excludes concurrent readers for the

--- a/crates/kglite/src/graph/storage/disk/property_index.rs
+++ b/crates/kglite/src/graph/storage/disk/property_index.rs
@@ -729,13 +729,13 @@ impl PropertyIndex {
 mod tests {
     use super::*;
 
+    static TMP_DIR_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
     fn tmp_dir() -> PathBuf {
         let p = std::env::temp_dir().join(format!(
-            "kglite_prop_idx_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            "kglite_prop_idx_{}_{}",
+            std::process::id(),
+            TMP_DIR_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         ));
         fs::create_dir_all(&p).unwrap();
         p

--- a/docs/python/guides/mcp-servers.md
+++ b/docs/python/guides/mcp-servers.md
@@ -494,14 +494,19 @@ fn main() -> anyhow::Result<()> {
         registry.register_typed_tool::<MyArgs, _>(
             "my_tool",
             "What the domain tool does.",
-            move |args| my_domain_logic(&graph, args),
+            move |args| graph.with_context(|context| {
+                my_domain_logic(context.graph(), context.root(), args)
+            }).unwrap_or_else(|| "no active graph".to_string()),
         )
     });
     run_with_extensions(std::env::args_os(), extensions)
 }
 ```
 
-The registry rejects names already owned by KGLite or manifest tools. It also
+The registry rejects names already owned by KGLite or manifest tools. Use
+`DomainGraphState::with_context` when the result needs both graph data and its
+identity: the borrowed graph, save target, and source root come from one
+active-slot snapshot. Keep that callback short and read-only. The registry also
 offers `register_route` for a custom rmcp `ToolRoute` while preserving the same
 collision check. See the compiling
 [`domain_tools.rs`](https://github.com/kkollsga/kglite/blob/main/crates/kglite-mcp-server/examples/domain_tools.rs)

--- a/docs/rust/building-on-kglite.md
+++ b/docs/rust/building-on-kglite.md
@@ -46,7 +46,7 @@ stability posture; kglite's CI locks against accidental drift on all of them.
 | Seam | What it is | Stability |
 |---|---|---|
 | **Engine facade** — `kglite::api::*` | The curated Rust surface: `DirGraph`, `Value`, `session::*`, `io::{save_graph, load_file}`, error types, `code_entities`. | Exact-baseline-locked in CI (cargo-public-api, pinned nightly). Additive within a minor line; deliberate breaks ship on a MINOR bump with a migration guide. See the [API reference](api-reference.md). |
-| **MCP server library** — `kglite-mcp-server` | `run`, `run_with_embedder_factory`, `run_with_code_tree_hooks`, `run_with_extensions`, `CodeTreeHooks`, `ServerExtensions`, `DomainToolRegistry`, `DomainGraphState`. The seams a producer/domain MCP server builds on. | Public-API baseline + hook/registrar-semantics unit tests. Same MINOR-break posture as the engine facade. |
+| **MCP server library** — `kglite-mcp-server` | `run`, `run_with_embedder_factory`, `run_with_code_tree_hooks`, `run_with_extensions`, `CodeTreeHooks`, `ServerExtensions`, `DomainToolRegistry`, `DomainGraphState`, `DomainGraphContext`. The seams a producer/domain MCP server builds on. | Public-API baseline + hook/registrar-semantics unit tests. Same MINOR-break posture as the engine facade. |
 | **`.kgl` file format** | The persisted graph format that P1 handoff and all persistence use. | Versioned (`v3`, `v4`, …). Readers stay backward-compatible or refuse an old format with a clear rebuild message; a format bump lands with its decoder. |
 | **Python top-level** — `kglite.*` | `kglite.load`, `kglite.from_blueprint`, `kglite.from_records`, `KnowledgeGraph` methods. The P3 entry points and the P1 handoff target. | Contract-tested + stubtest against `kglite/__init__.pyi`. |
 | **C ABI** — `include/kglite.h` | The `extern "C"` surface for non-Rust bindings. | cbindgen header-drift check in CI; see the [C ABI guide](c-abi.md). |
@@ -196,7 +196,9 @@ fn main() -> anyhow::Result<()> {
         registry.register_typed_tool::<MyArgs, _>(
             "domain_action",
             "Run the producer's domain action.",
-            move |args| my_domain::run(&graph, args),
+            move |args| graph.with_context(|context| {
+                my_domain::run(context.graph(), context.root(), args)
+            }).unwrap_or_else(|| "no active graph".to_string()),
         )
     });
     run_with_extensions(std::env::args_os(), extensions)
@@ -205,10 +207,13 @@ fn main() -> anyhow::Result<()> {
 
 The callback runs after KGLite and manifest tools are registered but before
 skills are finalised, so `tool_registered:` predicates see domain tools. The
-registry rejects collisions with existing routes and exposes the live
-`GraphState`; downstreams own their methods, while KGLite retains generic
-graph/Cypher tool ownership. `ServerExtensions::with_code_tree_hooks` composes
-both extension kinds when a binary needs them together.
+registry rejects collisions with existing routes and exposes the live graph
+state. `with_context` borrows the graph, persistence target (`source_path`),
+and source identity (`root`) under one read lock, so activation cannot produce
+a graph/path mismatch. Keep its callback short and read-only. Downstreams own
+their methods, while KGLite retains generic graph/Cypher tool ownership.
+`ServerExtensions::with_code_tree_hooks` composes both extension kinds when a
+binary needs them together.
 
 ## Testing pattern
 

--- a/tests/api-baselines/rust/kglite-mcp-server-default.txt
+++ b/tests/api-baselines/rust/kglite-mcp-server-default.txt
@@ -3,12 +3,21 @@ pub struct kglite_mcp_server::CodeTreeHooks
 pub kglite_mcp_server::CodeTreeHooks::build: alloc::boxed::Box<(dyn core::ops::function::Fn(&std::path::Path, bool) -> anyhow::Result<alloc::sync::Arc<kglite::graph::dir_graph::DirGraph>, alloc::string::String> + core::marker::Send + core::marker::Sync)>
 pub kglite_mcp_server::CodeTreeHooks::build_revs: alloc::boxed::Box<(dyn core::ops::function::Fn(&std::path::Path, &[alloc::string::String], bool) -> anyhow::Result<(alloc::sync::Arc<kglite::graph::dir_graph::DirGraph>, alloc::vec::Vec<alloc::string::String>), alloc::string::String> + core::marker::Send + core::marker::Sync)>
 pub kglite_mcp_server::CodeTreeHooks::is_code_file: alloc::boxed::Box<(dyn core::ops::function::Fn(&std::path::Path) -> bool + core::marker::Send + core::marker::Sync)>
+pub struct kglite_mcp_server::DomainGraphContext<'a>
+impl<'a> kglite_mcp_server::DomainGraphContext<'a>
+pub fn kglite_mcp_server::DomainGraphContext<'a>::graph(&self) -> &'a kglite::graph::handle::KnowledgeGraph
+pub fn kglite_mcp_server::DomainGraphContext<'a>::root(&self) -> core::option::Option<&'a std::path::Path>
+pub fn kglite_mcp_server::DomainGraphContext<'a>::source_path(&self) -> core::option::Option<&'a std::path::Path>
+impl<'a> core::clone::Clone for kglite_mcp_server::DomainGraphContext<'a>
+pub fn kglite_mcp_server::DomainGraphContext<'a>::clone(&self) -> kglite_mcp_server::DomainGraphContext<'a>
+impl<'a> core::marker::Copy for kglite_mcp_server::DomainGraphContext<'a>
 pub struct kglite_mcp_server::DomainGraphState
 impl kglite_mcp_server::DomainGraphState
 pub fn kglite_mcp_server::DomainGraphState::has_node_type(&self, node_type: &str) -> bool
 pub fn kglite_mcp_server::DomainGraphState::has_property(&self, node_type: &str, property: &str) -> bool
 pub fn kglite_mcp_server::DomainGraphState::run_cypher(&self, query: &str, params: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> alloc::string::String
 pub fn kglite_mcp_server::DomainGraphState::schema(&self) -> core::option::Option<(u64, u64)>
+pub fn kglite_mcp_server::DomainGraphState::with_context<F, T>(&self, operation: F) -> core::option::Option<T> where F: core::ops::function::FnOnce(kglite_mcp_server::DomainGraphContext<'_>) -> T
 pub fn kglite_mcp_server::DomainGraphState::with_graph<F, T>(&self, operation: F) -> core::option::Option<T> where F: core::ops::function::FnOnce(&kglite::graph::handle::KnowledgeGraph) -> T
 impl core::clone::Clone for kglite_mcp_server::DomainGraphState
 pub fn kglite_mcp_server::DomainGraphState::clone(&self) -> kglite_mcp_server::DomainGraphState


### PR DESCRIPTION
Phased MCP correctness project.

- [x] Phase 1 — enforce completed-router bundled overrides
- [x] Phase 2 — expose atomic read-only graph context
- [x] Phase 3 — complete safety and performance gates