### PR TITLE
docs: repositioning draft — licensing section, derived-index and primary-store guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pattern — incremental refresh and its delete caveat, carrying embeddings
   across a rebuild, freshness stamps, managed/runtime ownership layers.
   `KGLite as a primary store: scope and limits` states what holds when the
-  graph is the authoritative copy, what is opt-in, and the limits:
-  single-writer, `primary_key` restricted to `id`, no Cypher DDL, no
-  `LOAD CSV`, no migration framework, and the storage modes that keep the
+  graph is the authoritative copy, what the defaults are, and where the edges
+  are: crash-safe `open()` and the state the log cannot express, constraint
+  enforcement and the paths that bypass it, index and constraint DDL with their
+  naming and equality-vs-range asymmetries, `LOAD CSV`'s default-deny file
+  capability, forward-only migrations, and the storage modes that keep the
   whole-graph write checkpoint.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Two documentation guides covering the two ways a kglite graph gets used.
+  `Derived index over another system of record` documents the rebuild-and-swap
+  pattern — incremental refresh and its delete caveat, carrying embeddings
+  across a rebuild, freshness stamps, managed/runtime ownership layers.
+  `KGLite as a primary store: scope and limits` states what holds when the
+  graph is the authoritative copy, what is opt-in, and the limits:
+  single-writer, `primary_key` restricted to `id`, no Cypher DDL, no
+  `LOAD CSV`, no migration framework, and the storage modes that keep the
+  whole-graph write checkpoint.
+
 ### Changed
 
 - Mutating Cypher statements no longer deep-copy the graph to stay atomic. A

--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ building saves a lot of argument later.
   API, a directory, a repo) and the graph is a rebuildable projection you query.
   This is what most kglite deployments are, and it is the cheapest correct
   answer. **→ [Derived index guide](https://kglite.readthedocs.io/en/latest/python/guides/derived-index.html).**
-- **Primary store** — the graph *is* the authoritative copy. Statements are
-  atomic, crash safety is available via `open(..., durable=True)`, readers get
-  snapshot isolation, and for in-memory graphs the cost of a write scales with
-  the size of the change rather than the size of the graph — with three named
-  exceptions. One process owns the writes; the scope statement lists the rest of
-  the limits rather than softening them.
+- **Primary store** — the graph *is* the authoritative copy. `open()` is
+  crash-safe by default, statements are atomic, readers get snapshot isolation,
+  UNIQUE / NOT NULL / node-key constraints are enforced on every write path
+  including the bulk loaders, and for in-memory graphs the cost of a write scales
+  with the size of the change rather than the size of the graph. One process owns
+  the writes; the scope statement lists the limits rather than softening them.
   **→ [Primary store: scope and limits](https://kglite.readthedocs.io/en/latest/python/guides/primary-store.html).**
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ questions traverse it.
 | **MCP server for LLM agents**              | bundled in the `kglite` wheel     | [separate `mcp-server-ladybug` install](https://github.com/LadybugDB/mcp-server-ladybug) | — | — | — |
 | **`describe()` schema for LLM prompts**    | ✅                                 | —                                                   | —                  | —                  | —                      |
 | **Embeddable in Rust** (no Python in build) | pure-Rust [`kglite`](https://crates.io/crates/kglite) crate | [`lbug`](https://crates.io/crates/lbug) bindings to the C++ engine | — | ✅ | — |
-| **License**                                | MIT                               | MIT                                                 | BSD-3              | Apache-2           | GPLv3 (Community)      |
+| **License**                                | MIT                               | MIT                                                 | BSD-3              | Apache-2           | GPLv3                  |
 
 **Pick KGLite** when you want one embedded package that combines Python and
 pure-Rust Cypher APIs with a bundled MCP binary, prompt-shaped `describe()`, and
@@ -203,43 +203,18 @@ If the graph engine ships *inside* something you distribute, the licence is a
 design constraint rather than a line item.
 
 **kglite is MIT-licensed throughout — every crate in the workspace ships under
-MIT.** Neo4j's embeddable Community artifact (`org.neo4j:neo4j` on Maven
-Central) is published under **GPL-3.0-or-later**; Neo4j's own licence notice
-states that the GPL applies "to all third parties" unless you have executed a
-commercial or OEM agreement with Neo4j. Neo4j's free tiers do not close that gap
-for a shipped product: the Desktop License covers "one Named User on a single
-notebook or desktop machine solely for … internal development use", and the
-Startup License expressly prohibits "distributing any copy of the Software … to
-any third party". **If you're embedding a graph engine in a product you
-distribute, the licensing difference is real — and worth taking to your own
-counsel rather than ours.**
+MIT.** There is no separate commercial tier, no distinction between development
+and production use, and no copyleft obligation attached to shipping it: if you
+can use kglite, you can distribute it inside your own product.
 
-Two honest qualifications:
-
-- **We make no claim about what the GPL requires of an embedder.** That question
-  is unsettled, and the obligation attaches to *distribution* — not to internal
-  use within one organisation. The narrow, checkable point is that the terms
-  differ, and only one of them is MIT.
-- **The default kglite build carries no copyleft, and that is a statement about
-  the default.** The optional `fastembed` embedding backend is itself
-  Apache-2.0 and is off by default in every crate that can enable it, so neither
-  the published wheel nor the default MCP-server binary contains it. A build
-  that opts into `--features fastembed` pulls one transitive MPL-2.0 crate
-  (`option-ext`, four dependencies down); MPL-2.0 is file-level weak copyleft
-  and kglite does not modify it. The reviewed dependency-licence policy is
-  documented in
-  [dependency licences](https://kglite.readthedocs.io/en/latest/explanation/dependency-licenses.html).
-
-kglite is also not the only permissively-licensed embedded Cypher engine —
-[LadybugDB](https://ladybugdb.com/) (MIT) and
-[ArcadeDB](https://arcadedb.com/) (Apache-2.0) are both live options, and the
-comparison table above is the honest place to start. Pick kglite for the reasons
-in that table; the licence is what makes shipping it uncomplicated, not what
-makes it unique.
-
-*Neo4j® is a registered trademark of Neo4j, Inc. The quotations above are from
-Neo4j's published licensing pages and from the artifact's own Maven Central
-metadata, reproduced for factual comparison.*
+One honest qualification, because it is a statement about the *default* build:
+the optional `fastembed` embedding backend is itself Apache-2.0 and is off by
+default in every crate that can enable it, so neither the published wheel nor
+the default MCP-server binary contains it. A build that opts into
+`--features fastembed` pulls one transitive MPL-2.0 crate (`option-ext`, four
+dependencies down); MPL-2.0 is file-level weak copyleft and kglite does not
+modify it. The reviewed dependency-licence policy is documented in
+[dependency licences](https://kglite.readthedocs.io/en/latest/explanation/dependency-licenses.html).
 
 ## Primary store, or derived index?
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 KGLite is an embedded, Cypher-queryable knowledge graph for Python and Rust,
 built so the same graph can serve an application, an analyst, or an LLM agent.
 The Python wheel has no required Python runtime dependencies; the graph engine
-runs in-process without an external database service. The distribution also
-includes a CLI and MCP server, prompt-shaped `describe()` introspection, and
-structural validators that compose with Cypher.
+runs in-process without an external database service. Every crate in the
+workspace ships under MIT — if you are embedding a graph engine in something you
+distribute, see **[Licensing and embedded distribution](#licensing-and-embedded-distribution)**.
+The distribution also includes a CLI and MCP server, prompt-shaped `describe()`
+introspection, and structural validators that compose with Cypher.
 
 ## Start here
 
@@ -174,7 +176,7 @@ questions traverse it.
 | **MCP server for LLM agents**              | bundled in the `kglite` wheel     | [separate `mcp-server-ladybug` install](https://github.com/LadybugDB/mcp-server-ladybug) | — | — | — |
 | **`describe()` schema for LLM prompts**    | ✅                                 | —                                                   | —                  | —                  | —                      |
 | **Embeddable in Rust** (no Python in build) | pure-Rust [`kglite`](https://crates.io/crates/kglite) crate | [`lbug`](https://crates.io/crates/lbug) bindings to the C++ engine | — | ✅ | — |
-| **License**                                | MIT                               | MIT                                                 | BSD-3              | Apache-2           | GPLv3                  |
+| **License**                                | MIT                               | MIT                                                 | BSD-3              | Apache-2           | GPLv3 (Community)      |
 
 **Pick KGLite** when you want one embedded package that combines Python and
 pure-Rust Cypher APIs with a bundled MCP binary, prompt-shaped `describe()`, and
@@ -194,6 +196,67 @@ the in-process driver for tests.
 filter/aggregate, traversal, pathfinding, algorithms, mutations) against
 other embedded graph engines, NetworkX, rustworkx, igraph, and DuckDB on
 one shared synthetic graph. Reproduce with `python benchmarks/benchmark.py`.
+
+## Licensing and embedded distribution
+
+If the graph engine ships *inside* something you distribute, the licence is a
+design constraint rather than a line item.
+
+**kglite is MIT-licensed throughout — every crate in the workspace ships under
+MIT.** Neo4j's embeddable Community artifact (`org.neo4j:neo4j` on Maven
+Central) is published under **GPL-3.0-or-later**; Neo4j's own licence notice
+states that the GPL applies "to all third parties" unless you have executed a
+commercial or OEM agreement with Neo4j. Neo4j's free tiers do not close that gap
+for a shipped product: the Desktop License covers "one Named User on a single
+notebook or desktop machine solely for … internal development use", and the
+Startup License expressly prohibits "distributing any copy of the Software … to
+any third party". **If you're embedding a graph engine in a product you
+distribute, the licensing difference is real — and worth taking to your own
+counsel rather than ours.**
+
+Two honest qualifications:
+
+- **We make no claim about what the GPL requires of an embedder.** That question
+  is unsettled, and the obligation attaches to *distribution* — not to internal
+  use within one organisation. The narrow, checkable point is that the terms
+  differ, and only one of them is MIT.
+- **The default kglite build carries no copyleft, and that is a statement about
+  the default.** The optional `fastembed` embedding backend is itself
+  Apache-2.0 and is off by default in every crate that can enable it, so neither
+  the published wheel nor the default MCP-server binary contains it. A build
+  that opts into `--features fastembed` pulls one transitive MPL-2.0 crate
+  (`option-ext`, four dependencies down); MPL-2.0 is file-level weak copyleft
+  and kglite does not modify it. The reviewed dependency-licence policy is
+  documented in
+  [dependency licences](https://kglite.readthedocs.io/en/latest/explanation/dependency-licenses.html).
+
+kglite is also not the only permissively-licensed embedded Cypher engine —
+[LadybugDB](https://ladybugdb.com/) (MIT) and
+[ArcadeDB](https://arcadedb.com/) (Apache-2.0) are both live options, and the
+comparison table above is the honest place to start. Pick kglite for the reasons
+in that table; the licence is what makes shipping it uncomplicated, not what
+makes it unique.
+
+*Neo4j® is a registered trademark of Neo4j, Inc. The quotations above are from
+Neo4j's published licensing pages and from the artifact's own Maven Central
+metadata, reproduced for factual comparison.*
+
+## Primary store, or derived index?
+
+Two shapes, both supported, with different guarantees. Knowing which one you are
+building saves a lot of argument later.
+
+- **Derived index** — the authoritative copy lives elsewhere (a warehouse, an
+  API, a directory, a repo) and the graph is a rebuildable projection you query.
+  This is what most kglite deployments are, and it is the cheapest correct
+  answer. **→ [Derived index guide](https://kglite.readthedocs.io/en/latest/python/guides/derived-index.html).**
+- **Primary store** — the graph *is* the authoritative copy. Statements are
+  atomic, crash safety is available via `open(..., durable=True)`, readers get
+  snapshot isolation, and for in-memory graphs the cost of a write scales with
+  the size of the change rather than the size of the graph — with three named
+  exceptions. One process owns the writes; the scope statement lists the rest of
+  the limits rather than softening them.
+  **→ [Primary store: scope and limits](https://kglite.readthedocs.io/en/latest/python/guides/primary-store.html).**
 
 ## Quick Start
 
@@ -549,6 +612,8 @@ Full docs at **[kglite.readthedocs.io](https://kglite.readthedocs.io)**
 - [Data Loading](https://kglite.readthedocs.io/en/latest/python/guides/data-loading.html) — DataFrames in, DataFrames out
 - [Graph algorithms](https://kglite.readthedocs.io/en/latest/python/guides/graph-algorithms.html) — shortest path, PageRank, community detection
 - [Semantic Search](https://kglite.readthedocs.io/en/latest/python/guides/semantic-search.html) — embeddings, vector search, hybrid retrieval
+- [Derived index](https://kglite.readthedocs.io/en/latest/python/guides/derived-index.html) — rebuildable graph over a system of record you don't own
+- [Primary store](https://kglite.readthedocs.io/en/latest/python/guides/primary-store.html) — scope and limits when the graph is the authoritative copy
 - [OKF ingestion](https://kglite.readthedocs.io/en/latest/python/guides/okf.html) — `okf.build`, markdown knowledge bases & agent memory
 - [MCP server config](https://kglite.readthedocs.io/en/latest/python/guides/mcp-servers.html) — manifests, skills, extensions
 - [Spatial](https://kglite.readthedocs.io/en/latest/python/guides/spatial.html) · [Timeseries](https://kglite.readthedocs.io/en/latest/python/guides/timeseries.html) · [Blueprints](https://kglite.readthedocs.io/en/latest/python/guides/blueprints.html) · [Import/Export](https://kglite.readthedocs.io/en/latest/python/guides/import-export.html) · [Traversal & hierarchy](https://kglite.readthedocs.io/en/latest/python/guides/traversal-hierarchy.html) · [AI Agents](https://kglite.readthedocs.io/en/latest/python/guides/ai-agents.html)
@@ -594,3 +659,6 @@ Storage parity and differential Cypher oracles run on every change.
 ## License
 
 MIT — see [LICENSE](https://github.com/kkollsga/kglite/blob/main/LICENSE) for details.
+Every crate in the workspace ships under MIT;
+[Licensing and embedded distribution](#licensing-and-embedded-distribution)
+covers what that means when kglite ships inside a product you distribute.

--- a/docs/python/guides/derived-index.md
+++ b/docs/python/guides/derived-index.md
@@ -1,0 +1,214 @@
+# Derived index over another system of record
+
+The oldest and best-tested way to use KGLite is as a **derived index**: the
+authoritative copy of the data lives somewhere else — a SQL warehouse, a REST
+API, a directory of files, a git repository — and KGLite holds a rebuildable
+graph projection of it that you query.
+
+This is not a lesser use of the engine. It is the shape most KGLite deployments
+have, and the properties that make it work are deliberate: the engine runs
+in-process with no service to operate, a whole graph is one file, a rebuild is
+an ordinary load, and a graph that falls behind is a stale cache rather than
+lost data.
+
+If the graph *is* the authoritative copy, read {doc}`primary-store` instead —
+the guarantees you need are different, and so are the limits.
+
+## The shape
+
+Four steps. Only the last one is in your application's request path.
+
+1. **Extract** from the system of record.
+2. **Build** a graph with `add_nodes` / `add_connections` (or `from_records`).
+3. **Publish** it — `save()` to a `.kgl` file, or hand out a `freeze()` snapshot.
+4. **Query** it with Cypher, from your app, a notebook, or an agent.
+
+```python
+import kglite
+import pandas as pd
+
+def build(conn) -> kglite.KnowledgeGraph:
+    graph = kglite.KnowledgeGraph()
+
+    people = pd.read_sql("SELECT id, name, city FROM people", conn)
+    graph.add_nodes(
+        people, node_type="Person",
+        unique_id_field="id", node_title_field="name",
+    )
+
+    reports = pd.read_sql("SELECT src, tgt FROM reporting_line", conn)
+    graph.add_connections(
+        reports, connection_type="REPORTS_TO",
+        source_type="Person", source_id_field="src",
+        target_type="Person", target_id_field="tgt",
+    )
+    return graph
+
+graph = build(conn)
+graph.save("people.kgl")   # atomic + fsync — a reader never sees a torn file
+```
+
+From here the graph is read-only as far as your application is concerned. The
+build step is the only writer, and it runs on your schedule: nightly, on a
+webhook, or on process start.
+
+## Rebuild and swap
+
+The reason this pattern is cheap is that you never mutate a live graph to
+refresh it. You build the next one beside it and swap the reference.
+
+```python
+snapshot = graph.freeze()          # immutable, lock-free, shareable across threads
+
+# ... later, in a background thread or a separate process ...
+fresh = build(conn)
+fresh.save("people.kgl")
+```
+
+A `freeze()` snapshot is a cheap `Arc` clone and stays stable after the owner
+publishes a newer graph — readers holding one keep serving consistent results
+until they ask for the new snapshot. That makes rebuild-and-swap a matter of
+replacing one reference, with no lock held across the rebuild and no window in
+which queries see a half-built graph. The concurrency model behind this is
+described in {doc}`/concepts/concurrency`.
+
+For a long-lived process that should pick up the graph a builder wrote, `open()`
+gives you load-or-create lifecycle in one call:
+
+```python
+graph = kglite.open("people.kgl")   # loads if present, creates if not
+```
+
+## Incremental refresh instead of a full rebuild
+
+When a full extract is too expensive, re-assert only what changed.
+`add_nodes` / `add_connections` take a `conflict_handling` mode that decides how
+an incoming record meets an existing one:
+
+```python
+changed = fetch_rows_modified_since(conn, watermark)   # your extract, your watermark
+graph.add_nodes(changed, node_type="Person",
+                unique_id_field="id", node_title_field="name",
+                conflict_handling="update")
+```
+
+Two of the modes matter for this pattern, and the difference is easy to get
+wrong:
+
+- `'update'` (the default) writes **only the columns present in this call**.
+  Properties of an existing node that are absent from the incoming data are left
+  untouched. Use it when something else — an agent, a human, another job — owns
+  fields you must not clobber.
+- `'replace'` reconciles the node to the incoming record: a property absent from
+  the new data is dropped. Use it when the source really is the single source of
+  truth and you want field deletions to propagate.
+
+**Neither mode deletes nodes.** A row that disappeared upstream leaves its node
+behind. Handling upstream deletes means either a full rebuild — the simplest
+correct answer, and the reason this pattern favours rebuilds — or an explicit
+`DELETE` pass driven by the source. `examples/incremental_update.py` in the
+repository walks a merge of a second snapshot end to end.
+
+## Carrying expensive derived state across a rebuild
+
+Some of what the graph holds isn't in the system of record at all: embeddings,
+computed scores, agent annotations. Rebuilding from scratch would throw them
+away.
+
+Embeddings have first-class support for this. `copy_embeddings_from` carries
+every vector store across by node id — dimension, metric, model id, and the
+per-node text hashes — so a following `embed_texts(mode='changed')` re-embeds
+only genuinely new or edited text:
+
+```python
+fresh = build(conn)
+fresh.copy_embeddings_from(old)                            # carry the vectors
+fresh.embed_texts("Article", "summary", mode="changed")    # fill only what moved
+```
+
+See [Carrying vectors across a rebuild](semantic-search.md#carrying-vectors-across-a-rebuild)
+for the full mechanism.
+
+## Recording how fresh the graph is
+
+A derived index invites one question above all others: *how old is this?* Opt a
+node type into freshness provenance and every write stamps it automatically:
+
+```python
+graph.define_schema({"nodes": {"Person": {"auto_timestamp": True}}})
+```
+
+Writes through Cypher (`CREATE` / `SET` / `MERGE`) and through `add_nodes` then
+carry an `updated_at` timestamp, plus caller-supplied `git_sha` and
+`modified_by` when provided. It is off by default so ordinary writes stay
+deterministic. Being a property like any other, it is queryable:
+
+```cypher
+MATCH (p:Person) RETURN max(p.updated_at) AS newest
+```
+
+## When something else also writes to the graph
+
+The pattern gets interesting when the graph is both a derived index *and* a
+place another writer keeps live state — the common case being an agent that
+records status against nodes a batch job rebuilds. Declare who owns what:
+
+```python
+graph.define_schema({"nodes": {
+    "AlgorithmSpec": {"layer": "managed"},   # rebuilt from source
+    "Task":          {"layer": "runtime"},   # owned live by the agent
+}})
+```
+
+A rebuild then passes `managed_reload=True`, and writes to a `runtime` type are
+skipped as a reported no-op rather than silently overwriting the other writer's
+data:
+
+```python
+graph.add_nodes(specs, node_type="AlgorithmSpec",
+                unique_id_field="id", node_title_field="name",
+                managed_reload=True)
+```
+
+Combined with `'update'`'s partial-write guarantee, this gives you a two-writer
+contract enforced by the engine instead of by convention. The agent-facing side
+of it is in {doc}`ai-agents`.
+
+## Choosing a storage mode
+
+For a derived index the choice follows the extract size, not the query pattern:
+
+- **in-memory** (the default) — everything that fits comfortably in RAM. Fastest
+  queries; this is the product's centre of gravity.
+- **`storage="mapped"`** — mmap-backed columns when the graph stops fitting
+  comfortably on the heap.
+- **`storage="disk"`** — 100 M+ nodes, paged in on demand.
+
+{doc}`/python/core-concepts` has the decision table. Because a derived index is
+rebuildable by definition, you can change your mind later at the cost of one
+rebuild.
+
+## What this pattern does not give you
+
+- **No change data capture.** Nothing tells KGLite that the source moved; you
+  decide when to rebuild. Between rebuilds the graph is behind, by design.
+- **No upstream deletes, short of a rebuild.** See above.
+- **No distributed coordination.** If several processes might rebuild the same
+  file, one of them has to own that; see the writer-lease discussion in
+  {doc}`/concepts/concurrency`.
+
+None of these are gaps to be closed — they are what makes the pattern cheap. A
+derived index that tried to stay continuously consistent with its source would
+be a replica, and a replica is a much more expensive thing to operate.
+
+## See also
+
+- {doc}`data-loading` — the `add_nodes` / `add_connections` surface in full.
+- {doc}`blueprints` — declare the extract-to-graph mapping once, in config,
+  when you rebuild the same shape repeatedly.
+- {doc}`primary-store` — the other side of the coin: what holds when the graph
+  is the authoritative copy.
+- {doc}`durable-apps` — `open()` lifecycle and crash-safe writes for a graph
+  your app owns across runs.
+- {doc}`okf` — a worked instance of this pattern: a markdown directory stays the
+  source of truth, the graph is a rebuildable lens over it.

--- a/docs/python/guides/index.md
+++ b/docs/python/guides/index.md
@@ -27,6 +27,8 @@ Domain-specific surfaces — pull them in when your data has the shape:
 | Guide | Read this if… |
 |---|---|
 | {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, checkpoint-on-close, and crash-safe `durable=True` write-ahead-log writes. |
+| {doc}`derived-index` | …the authoritative copy of your data lives elsewhere — a warehouse, an API, a directory — and the graph is a rebuildable projection you query. Rebuild-and-swap, incremental refresh, carrying embeddings across a rebuild. |
+| {doc}`primary-store` | …the graph *is* the authoritative copy. What holds (statement atomicity, WAL crash safety, snapshot isolation), what is opt-in, and the limits stated plainly. |
 | {doc}`okf` | …your "data" is a markdown knowledge base — an OKF bundle, a Claude memory dir, a skills folder, an Obsidian vault. Frontmatter → nodes, links → typed edges. |
 | {doc}`spatial` | …your nodes have coordinates. R-tree indexing, distance-based filters, GeoJSON I/O. |
 | {doc}`timeseries` | …property values change over time. Snapshot history, valid_at / valid_during temporal filters. |

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -1,0 +1,137 @@
+# KGLite as a primary store: scope and limits
+
+Most KGLite graphs are a {doc}`derived index <derived-index>` over data owned
+somewhere else. This page is about the other case: the graph *is* the
+authoritative copy, and losing it means losing the data.
+
+That is a much stronger promise, so this page is deliberately conservative. It
+states what holds, what is opt-in, and what KGLite does not do — with enough
+detail that you can decide without running an experiment first. Where a limit
+exists, it is named rather than softened.
+
+## What holds
+
+**A mutating statement is all-or-nothing.** A Cypher statement that fails after
+its first write leaves the graph exactly as it found it — node and relationship
+identity, properties, labels, index ordering, schema metadata, and the version
+counter. Rollback replays a statement-scoped journal of inverse operations
+backwards.
+
+**The cost of a write scales with the change, not with the graph.** Because the
+journal records only what the statement touched, a single `SET` on a
+million-node graph costs about what it costs on a thousand-node graph. This is
+the property that separates a store you can write to continuously from an index
+you rebuild. It is measured, not assumed:
+`tests/benchmarks/test_bench_write_scaling.py` runs the same statements at 1 k,
+100 k, and 1 M nodes, and a reading that grows with size is a regression.
+
+Three cases keep the older whole-graph checkpoint, and there the write cost is
+still proportional to graph size:
+
+- the `mapped` and `disk` backends,
+- columnar mode, whose `SET` writes a shared column store the journal cannot
+  observe,
+- graphs carrying user-created property, range, or composite indexes, whose
+  delete path needs per-bucket position undo the journal does not record yet.
+
+**Crash safety is available, and is opt-in.** `kglite.open(path, durable=True)`
+puts the graph in write-ahead-log mode: each committed mutation appends one
+frame to a `.kgl-wal` sidecar and `fsync`s it. A frame carries a CRC32; a crash
+mid-append leaves a torn trailing frame, which replay discards rather than
+half-applying. On open, the engine loads the `.kgl` checkpoint and replays every
+frame newer than it. `save()` is separately atomic and `fsync`ed, so a reader
+never observes a torn file.
+
+**Readers see a consistent graph.** `freeze()` hands out an immutable, lock-free
+snapshot; a `session()` serializes writers, begins each from the last committed
+state, and publishes with a pointer swap only on success. Explicit transactions
+are optimistically concurrent: independent work proceeds, and a commit against a
+state that moved underneath returns a conflict rather than winning silently.
+{doc}`/concepts/concurrency` is the full model, and worth reading before you rely
+on any of it.
+
+**Failures are typed.** Errors arrive as a `KgError` hierarchy with stable
+codes, not as strings to match on — see {doc}`/python/error-handling`.
+
+## What is opt-in, and off by default
+
+| | Default | To enable |
+|---|---|---|
+| Crash safety | `open()` is `durable=False` — work reaches disk on clean close, not on a hard crash mid-session | `kglite.open(path, durable=True)` |
+| Schema | No schema; any property on any node | `define_schema(...)` |
+| Uniqueness on `id` | Permissive | declare `primary_key` on the type |
+| Freshness stamps | Off, so writes stay deterministic | `auto_timestamp: True` per type |
+
+The durability default is the one to think hardest about. If the graph is your
+authoritative copy, `durable=False` is not the setting you want, and the
+`open()` docstring says so directly. {doc}`durable-apps` covers the lifecycle
+and the per-commit `fsync` cost you are trading for.
+
+## What KGLite does not do
+
+**One process writes.** There is no shared live multi-process transaction
+handle and no replication protocol. Disk mode publishes immutable generations
+behind a cross-process writer lease, which stops two processes from publishing
+at once — that is stable-reader/single-writer publication, not concurrent
+multi-process write access. When several processes need to read and write one
+graph, the answer is to run `kglite-bolt-server` and let that one process own
+the graph while clients connect over the Bolt protocol. Note the coverage limit
+there too: the official Python driver is regression-tested, and other Bolt v5
+clients may work but are not.
+
+**Integrity constraints stop at the identity field.** `primary_key` is enforced
+on the write path, but it must be `id`; an enforced unique constraint on an
+arbitrary property is not supported. `required_fields` is checked at validation
+time rather than on every write. There is no `CHECK` constraint and no standing
+referential-integrity constraint between node types: a relationship to an
+unknown endpoint auto-vivifies a provisional stub by default. Individual loads
+can be strict — `from_records(..., on_missing_endpoint="error")` validates the
+whole input and fails atomically, and `purge_provisional()` sweeps stubs that
+were never promoted — but that is a per-load choice, not an invariant the store
+holds for you. If your correctness argument depends on the store refusing bad
+data, check it against this list first.
+
+**Schema management is not a Cypher surface.** Indexes and constraints are
+created through the Python and Rust APIs. Cypher `CREATE INDEX` is not
+supported, so a Neo4j schema script does not run unedited. `LOAD CSV` is
+likewise unsupported — bulk loading goes through `add_nodes` /
+`add_connections`, {doc}`blueprints`, or the CLI's `.import`.
+
+**There is no migration framework.** No schema-version stamp, no migration
+runner, no equivalent of Flyway or Alembic. Worse for a store that has to
+evolve: a node's primary type is immutable, so changing it means recreating the
+node — which is exactly the operation a migration performs. Plan your own
+ordered-scripts convention, and see {doc}`import-export` for the round-trip
+paths a rebuild would use.
+
+**The large-graph modes are the weaker ones.** `mapped` and `disk` exist for
+graphs that do not fit in RAM, and they reject `durable=True`. They also keep
+the whole-graph write checkpoint described above. In-memory is the product;
+the disk modes are for exploring graphs too big for it, and that is the
+trade-off you are accepting.
+
+**There is no JVM or .NET binding.** Python and Rust are first-class. Everything
+else goes through the C ABI in `crates/kglite-c` — a supported boundary with a
+generated header, but you are writing the binding. See {doc}`/rust/c-abi`.
+
+## Deciding
+
+Reach for KGLite as a primary store when a single process owns the writes, the
+data fits the storage mode you picked, you can turn `durable=True` on, and you
+are content to enforce most invariants in your application rather than in the
+store. That describes a large class of real applications: desktop and CLI tools,
+single-node services, agent state, embedded analytics.
+
+Look elsewhere when you need several processes writing concurrently without a
+server in front, declarative constraints as your integrity guarantee, or a
+migration framework you did not write. And if the data's real home is another
+system, the {doc}`derived-index` pattern is both cheaper and better tested.
+
+## See also
+
+- {doc}`durable-apps` — `open()` lifecycle, checkpoints, and `durable=True`.
+- {doc}`derived-index` — the pattern to prefer when the graph is a projection.
+- {doc}`/concepts/concurrency` — the three concurrency models, stated precisely.
+- {doc}`/python/transactions` — `begin()` / `commit()` / `rollback()`, snapshot
+  isolation, and OCC conflicts.
+- {doc}`/python/error-handling` — the typed exception hierarchy and error codes.

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -125,7 +125,7 @@ constraint that quietly lies about the rows already present.
 A composite `unique` tuple constrains only nodes carrying *every* property in it,
 and NULL is exempt throughout — a node sits outside a uniqueness constraint
 unless every property in the tuple is present and non-null, so many nodes may
-share "no email" while `email` is `UNIQUE`. This matches Neo4j.
+share "no email" while `email` is `UNIQUE`.
 
 Two gaps to know, because both are the kind that look like guarantees until they
 are not. **A large bulk load is not all-or-nothing.** `add_nodes` gates each row

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -5,9 +5,9 @@ somewhere else. This page is about the other case: the graph *is* the
 authoritative copy, and losing it means losing the data.
 
 That is a much stronger promise, so this page is deliberately conservative. It
-states what holds, what is opt-in, and what KGLite does not do — with enough
-detail that you can decide without running an experiment first. Where a limit
-exists, it is named rather than softened.
+states what holds, what the defaults are, and what KGLite does not do — with
+enough detail that you can decide without running an experiment first. Where a
+limit exists, it is named rather than softened.
 
 ## What holds
 
@@ -34,17 +34,64 @@ still proportional to graph size:
 - graphs carrying user-created property, range, or composite indexes, whose
   delete path needs per-bucket position undo the journal does not record yet.
 
-**Crash safety is available, and is opt-in.** `kglite.open(path, durable=True)`
-puts the graph in write-ahead-log mode: each committed mutation appends one
-frame to a `.kgl-wal` sidecar and `fsync`s it. A frame carries a CRC32; a crash
-mid-append leaves a torn trailing frame, which replay discards rather than
-half-applying. On open, the engine loads the `.kgl` checkpoint and replays every
-frame newer than it. `save()` is separately atomic and `fsync`ed, so a reader
+That third case is easy to walk into now that indexes are a Cypher surface:
+`CREATE INDEX`, like the `create_index` API, builds exactly those structures, so
+indexing a graph moves its writes back onto the whole-graph checkpoint.
+Uniqueness constraints are backed by a different structure whose cost interaction
+is not yet characterised. If your workload writes continuously *and* indexes or
+constrains, measure it rather than assuming flat cost.
+
+**Crash safety is the default.** `kglite.open(path)` opens in write-ahead-log
+mode wherever the storage mode supports it — the default in-memory backend and
+`storage="mapped"`. Each committed mutation appends one frame to a `<path>-wal`
+sidecar and `fsync`s it before the call returns; on open, the engine loads the
+`.kgl` checkpoint and replays every frame newer than it. A frame carries a
+CRC32, and a crash mid-append leaves a torn trailing frame that replay discards
+rather than half-applying. Every way of changing a graph is logged, not only
+Cypher — `add_nodes`, `add_connections`, label changes, and committed
+transactions included. `save()` is separately atomic and `fsync`ed, so a reader
 never observes a torn file.
+
+`storage="disk"` is the exception, and not because it was overlooked: a disk
+graph commits by publishing an immutable generation, so a logical write-ahead
+log is not its durability boundary. A disk graph opens non-durable and takes
+`save()` checkpoints instead. Asking for `durable=True` there raises
+`ValueError` explaining that; the *default* does not raise, so disk callers are
+unaffected by the default being on elsewhere.
+
+**Not everything is logged.** State the log cannot express is *checkpoint-only*
+and is persisted by `save()` rather than by the log: schema and config metadata,
+user-created indexes, embeddings, and timeseries. If those matter to you, a
+`save()` is still part of your durability story, not an optimisation.
+
+Three consequences worth internalising before you rely on this:
+
+- **It costs one `fsync` per committed mutation.** Writes now wait on physical
+  storage, so the cost is device latency rather than graph size — most visible
+  in loops of many small writes, negligible for a few large ones. Reads are
+  unaffected. `durable=False` remains fully supported and is the right choice
+  for bulk loading and for graphs you can rebuild from source. Batching writes
+  into one statement, or one `begin()` transaction, buys throughput *and* crash
+  safety.
+- **A `with` block is not a transaction.** Mutations commit as they run, so an
+  exception inside the block does not discard them — they are recovered on the
+  next `open()`. What the clean or failed exit controls is whether a *checkpoint*
+  is written. Use `begin()` when you want discard-on-error.
+- **`Session` refuses write queries on a durable graph.** Its writes land on a
+  working copy that neither the log nor `save()` can reach, so rather than
+  silently losing them it raises. Use `cypher()` or `begin()`. Because durable is
+  now the default, code that used `Session.execute()` for writes against an
+  `open()`ed graph has to change — or pass `durable=False`.
+
+Two smaller sharp edges: `save(fsync=False)` is ignored on a durable graph and
+warns, because the checkpoint truncates the log and so must itself reach disk;
+and a log written by this version is refused by older builds with a clear message
+rather than silently truncated.
 
 **Readers see a consistent graph.** `freeze()` hands out an immutable, lock-free
 snapshot; a `session()` serializes writers, begins each from the last committed
-state, and publishes with a pointer swap only on success. Explicit transactions
+state, and publishes with a pointer swap only on success — though note the
+durable-graph restriction on `Session` writes below. Explicit transactions
 are optimistically concurrent: independent work proceeds, and a commit against a
 state that moved underneath returns a conflict rather than winning silently.
 {doc}`/concepts/concurrency` is the full model, and worth reading before you rely
@@ -53,19 +100,69 @@ on any of it.
 **Failures are typed.** Errors arrive as a `KgError` hierarchy with stable
 codes, not as strings to match on — see {doc}`/python/error-handling`.
 
-## What is opt-in, and off by default
+**Integrity constraints are enforced on every write path.** Declared through
+`define_schema`, and checked on Cypher `CREATE` / `MERGE` / `SET` / `REMOVE` and
+on the bulk loaders alike — `add_nodes`, and therefore blueprints,
+`from_records`, OKF ingestion, WAL replay, and `extend_graph`:
 
-| | Default | To enable |
+```python
+graph.define_schema({"nodes": {"Person": {
+    "primary_key": "email",            # unique *and* present (NODE KEY)
+    "unique": [["first", "last"]],     # composite UNIQUE
+    "required": ["email"],             # NOT NULL, at write time
+}}})
+```
+
+Three things make this real rather than advisory. `primary_key` may name any
+property, not just `id` — a key on `id` routes through the O(1) identity index,
+any other key is backed by a unique secondary index that persists and rebuilds on
+load. `required` is enforced at write time, so a `CREATE` that omits the
+property, a `SET` that nulls it, and a `REMOVE` that drops it all raise, rather
+than surfacing later in `validate_schema()`. And declaring a constraint the
+stored data already violates is refused outright, so you cannot install a
+constraint that quietly lies about the rows already present.
+
+A composite `unique` tuple constrains only nodes carrying *every* property in it,
+and NULL is exempt throughout — a node sits outside a uniqueness constraint
+unless every property in the tuple is present and non-null, so many nodes may
+share "no email" while `email` is `UNIQUE`. This matches Neo4j.
+
+Two gaps to know, because both are the kind that look like guarantees until they
+are not. **A large bulk load is not all-or-nothing.** `add_nodes` gates each row
+before queueing it, so a violation aborts the call — but rows are flushed to the
+graph in chunks of 1000, so on an input larger than that, chunks already flushed
+stay written. Detection is unaffected; the atomicity is what is chunk-bounded.
+Treat a failed large load as needing cleanup, not as a no-op. **And two write
+paths bypass enforcement entirely:** the RDF and N-Triples loaders, and the
+embedding-carry path. A graph filled through those can hold data that violates a
+declared constraint; `verify_unique_constraints()` exists to audit exactly that
+case.
+
+Two things about the error surface are worth knowing before you write `except`
+clauses. A declaration that cannot be installed raises `ConstraintCreationError`,
+and a violation from the bulk writers raises `ConstraintViolationError`; both
+subclass `ConstraintError`, so `except ConstraintError` catches either. Note that
+`define_schema` *can* now fail this way, because installing a schema installs the
+constraints it declares — nothing is changed when it does, so you can fix the data
+and retry. A violation raised through **Cypher**, however, arrives as
+`CypherExecutionError` rather than the typed exception: the executor's internal
+error channel is a string, so the structured violation is rendered to text before
+any binding sees it. The message is stable and names the constraint, the property,
+and the offending value — match on that. Enforcement is identical either way; only
+the exception type differs.
+
+## Defaults, and how to change them
+
+| | Default | To change |
 |---|---|---|
-| Crash safety | `open()` is `durable=False` — work reaches disk on clean close, not on a hard crash mid-session | `kglite.open(path, durable=True)` |
+| Crash safety | **On** for in-memory and `mapped`; `disk` opens non-durable | `durable=False` to opt out |
 | Schema | No schema; any property on any node | `define_schema(...)` |
-| Uniqueness on `id` | Permissive | declare `primary_key` on the type |
+| UNIQUE / NOT NULL / node key | Permissive — a type declaring none keeps the old behaviour | `unique` / `required` / `primary_key` in `define_schema` |
 | Freshness stamps | Off, so writes stay deterministic | `auto_timestamp: True` per type |
 
-The durability default is the one to think hardest about. If the graph is your
-authoritative copy, `durable=False` is not the setting you want, and the
-`open()` docstring says so directly. {doc}`durable-apps` covers the lifecycle
-and the per-commit `fsync` cost you are trading for.
+All of the constraint machinery is opt-in, and older graphs load unchanged.
+{doc}`durable-apps` covers the `open()` lifecycle and the per-commit `fsync`
+cost in more detail.
 
 ## What KGLite does not do
 
@@ -75,40 +172,138 @@ behind a cross-process writer lease, which stops two processes from publishing
 at once — that is stable-reader/single-writer publication, not concurrent
 multi-process write access. When several processes need to read and write one
 graph, the answer is to run `kglite-bolt-server` and let that one process own
-the graph while clients connect over the Bolt protocol. Note the coverage limit
-there too: the official Python driver is regression-tested, and other Bolt v5
-clients may work but are not.
+the graph while clients connect over the Bolt protocol. The official Python,
+JavaScript, and Java drivers are regression-tested in CI — session and
+explicit-transaction lifecycle, managed retry, PackStream type round-trips,
+`Neo.*` error codes, and OCC conflict detection. Read that as a 22-check
+conformance suite per driver rather than a full protocol sweep, and note that
+every *other* driver — Go, .NET — remains untested: those clients may connect but
+can rely on features outside the documented wire and Cypher contracts.
 
-**Integrity constraints stop at the identity field.** `primary_key` is enforced
-on the write path, but it must be `id`; an enforced unique constraint on an
-arbitrary property is not supported. `required_fields` is checked at validation
-time rather than on every write. There is no `CHECK` constraint and no standing
-referential-integrity constraint between node types: a relationship to an
-unknown endpoint auto-vivifies a provisional stub by default. Individual loads
-can be strict — `from_records(..., on_missing_endpoint="error")` validates the
-whole input and fails atomically, and `purge_provisional()` sweeps stubs that
-were never promoted — but that is a per-load choice, not an invariant the store
-holds for you. If your correctness argument depends on the store refusing bad
-data, check it against this list first.
+**Constraints cover uniqueness and presence, not arbitrary rules.** There is no
+`CHECK` constraint, and no standing referential-integrity constraint between node
+types: a relationship to an unknown endpoint auto-vivifies a provisional stub
+rather than being rejected. Stubs are *deferred*, not exempt — the `add_nodes`
+upsert that promotes one is a normal, fully-enforced write, an unpromoted stub
+stays reportable via `validate_schema()`, and `purge_provisional()` sweeps them.
+Individual loads can also be strict up front with
+`from_records(..., on_missing_endpoint="error")`, which validates the whole input
+and fails atomically. If your correctness argument needs a rule that is not
+uniqueness or presence, it still belongs in your application.
 
-**Schema management is not a Cypher surface.** Indexes and constraints are
-created through the Python and Rust APIs. Cypher `CREATE INDEX` is not
-supported, so schema setup cannot be expressed in Cypher alone. `LOAD CSV` is
-likewise unsupported — bulk loading goes through `add_nodes` /
-`add_connections`, {doc}`blueprints`, or the CLI's `.import`.
+**Schema setup is expressible in Cypher, with two asymmetries to know.**
+`CREATE [RANGE] INDEX` / `DROP INDEX` / `SHOW INDEXES` and
+`CREATE CONSTRAINT` / `DROP CONSTRAINT` / `SHOW CONSTRAINTS` both work, so schema
+setup no longer has to happen in Python or Rust. What to watch:
 
-**There is no migration framework.** No schema-version stamp, no migration
-runner, no equivalent of Flyway or Alembic. Worse for a store that has to
-evolve: a node's primary type is immutable, so changing it means recreating the
-node — which is exactly the operation a migration performs. Plan your own
-ordered-scripts convention, and see {doc}`import-export` for the round-trip
-paths a rebuild would use.
+- **Bare `CREATE INDEX` is equality-only.** One property builds a hash equality
+  index; two or more build a composite index. `CREATE RANGE INDEX` builds *two*
+  structures — the equality index **and** a B-tree range index — and reports
+  `indexes_added` of 2. The bare form stays equality-only deliberately, since
+  building both for every statement in a ported script would double index memory.
+  Add `RANGE` when you need range scans; a multi-property `RANGE` index is
+  rejected, because the B-tree is single-property.
+- **Index names are not persisted; constraint names are.** An index name is
+  accepted for portability and then discarded — index names here are canonical
+  and derived (`Label.property`, `Label.(a,b)`). So `DROP INDEX` wants that dotted
+  canonical name, or the descriptor form `DROP INDEX FOR (n:Label) ON (n.prop)`.
+  **The trap:** dropping by a name you chose fails, and adding `IF EXISTS` to that
+  same statement turns the failure into a silent no-op that leaves your index in
+  place. `SHOW INDEXES` prints the canonical name, and its output pastes straight
+  in. Constraint names, by contrast, persist across save/load and are unique per
+  graph, so `CREATE CONSTRAINT person_email_unique …` followed by
+  `DROP CONSTRAINT person_email_unique` works as written.
+- **Uniqueness on the identity field is refused, not silently accepted.** A
+  `REQUIRE … IS UNIQUE` (or `IS NODE KEY`) that resolves to the structural `id` —
+  including the node type's own id column name — is rejected, because a unique
+  secondary index would never observe those writes and the constraint would admit
+  duplicates while reporting success. Declare identity uniqueness as
+  `primary_key` in `define_schema` instead, which probes the per-type id index on
+  every write path, or use `MERGE` as the idempotent alternative to `CREATE`.
+  `IS NOT NULL` on the id field *is* accepted, since it is present by
+  construction.
 
-**The large-graph modes are the weaker ones.** `mapped` and `disk` exist for
-graphs that do not fit in RAM, and they reject `durable=True`. They also keep
-the whole-graph write checkpoint described above. In-memory is the product;
-the disk modes are for exploring graphs too big for it, and that is the
-trade-off you are accepting.
+Forms KGLite cannot serve — `TEXT`, `POINT`, `FULLTEXT`, `VECTOR`, `LOOKUP`,
+relationship indexes, `OPTIONS { … }`, and `IS :: TYPE` constraints — fail with a
+specific unsupported-feature error naming the construct and the route that does
+work. That is the deliberate choice: a type constraint accepted and silently
+unenforced would be worse than an error, since it is exactly the kind of promise
+data-integrity assumptions get built on. Full grammar in
+{doc}`/reference/cypher-reference`.
+
+**`LOAD CSV` works, and file access is a capability you grant.** `LOAD CSV [WITH
+HEADERS] FROM <source> AS row [FIELDTERMINATOR <sep>]` runs for local files and
+`file://` URLs, and must lead the query. Fields stay strings — CSV carries no
+types, and inferring them would corrupt leading-zero identifiers — so conversion
+is explicit (`toInteger(row.id)`). `http(s)://` is refused, naming the
+network-free design: the engine ships no HTTP client.
+
+The security model deserves stating plainly, because it is default-deny:
+
+- **In-process callers** — the Python API, the Rust library, the CLI — get
+  **unrestricted** read access to any path the process can read. That is
+  deliberate, on the grounds that they already have the host process's
+  filesystem access, but it is not a sandbox and should not be read as one.
+- **A Bolt client gets nothing** unless an operator passes
+  `--allow-csv-import <DIR>` to `kglite-bolt-server` — a single directory, not a
+  repeatable flag. Imports are then confined to that directory *after* symlink
+  and `..` resolution, and a relative path resolves against the import root
+  rather than the server's working directory. Without the gate, anyone who could
+  open a Bolt connection could read `file:///etc/passwd`.
+- **The MCP server never grants the capability**, so an agent cannot use
+  `LOAD CSV` to read the filesystem. Note this holds by construction — the MCP
+  server simply never sets the field, inheriting the deny default — rather than
+  by an explicit test.
+
+Loading streams: the executor reads 1000 rows at a time, so peak memory does not
+track file size for row-local pipelines. A downstream clause that must see the
+whole result — an aggregate, `ORDER BY`, `DISTINCT`, `UNION`, `CALL` — cannot be
+batched without changing the answer, so those queries take a single capped pass
+and fail at 1,000,000 rows naming the clause that forced it, rather than
+exhausting memory. `add_nodes` / `add_connections`, {doc}`blueprints`, and the
+CLI's `.import` remain the higher-throughput routes.
+
+**Migrations are a convention plus a CLI verb, not a framework.** There is a
+user-schema version stamp — your own data-model revision, persisted with the
+graph, distinct from the engine's `.kgl` format version and never interpreted by
+the engine. Read or set it via `graph.schema_version` / `set_schema_version(n)`,
+`graph_info()['user_schema_version']`, or `kglite schema-version <graph>
+[--set N]`, and `describe()` reports it once set, so an agent opening a graph cold
+sees which generation it holds.
+
+`kglite migrate <graph> <dir>` applies ordered `<version>_<name>.cypher` files —
+ascending by parsed integer, so `010` runs after `002`, and gaps are fine — and
+advances the stamp. `--dry-run` prints the plan without applying or saving.
+Re-running is a no-op. Everything executes against an in-memory copy and the
+`.kgl` is written **once**, at the end, only if every statement succeeded: the run
+is all-or-nothing, so a failure at migration 3 of 5 saves nothing at all, not even
+1 and 2. Version `0` is reserved for the unversioned baseline. A stamp the
+migration set cannot explain, a duplicate version, and a `.cypher` file with no
+version prefix are all refused rather than guessed at.
+
+Three things it deliberately does not do. **No downgrades** — reversing a
+migration means writing the inverse as a new one, since inferring the inverse of
+arbitrary Cypher would be a guess. **No detection of an edited migration** —
+change one after it has been applied and nothing notices, so treat applied
+migrations as immutable and append. **No per-migration ledger** — the stamp is a
+high-water mark, so a migration inserted *behind* it is treated as already
+applied. Always append with a higher number.
+
+And a node's primary type is still immutable, so a type change means recreating
+the node: create the replacement, copy the properties, re-wire the edges, delete
+the original. Watch out for `SET n:NewType`, which *appears* to work — it adds a
+**secondary label**, leaves `n.type` unchanged, and still matches
+`MATCH (n:NewType)`, so a migration written that way looks successful while every
+node keeps its original type. See {doc}`import-export` for the round-trip paths a
+rebuild would use.
+
+**The large-graph modes are still the weaker ones.** `mapped` now gets the same
+per-commit crash safety as in-memory — the kill-9 suites are parametrised over
+both — but `disk` does not: its durability boundary is the generation publish, so
+it relies on `save()` checkpoints, and its crash survival is untested and
+unsupported by design. Both keep the whole-graph write checkpoint described above.
+In-memory is the product; the disk modes are for exploring graphs too big for it,
+and that is the trade-off you are accepting.
 
 **There is no JVM or .NET binding.** Python and Rust are first-class. Everything
 else goes through the C ABI in `crates/kglite-c` — a supported boundary with a
@@ -117,15 +312,16 @@ generated header, but you are writing the binding. See {doc}`/rust/c-abi`.
 ## Deciding
 
 Reach for KGLite as a primary store when a single process owns the writes, the
-data fits the storage mode you picked, you can turn `durable=True` on, and you
-are content to enforce most invariants in your application rather than in the
-store. That describes a large class of real applications: desktop and CLI tools,
-single-node services, agent state, embedded analytics.
+data fits the storage mode you picked, and uniqueness and presence cover the
+invariants you need the store itself to hold. That describes a large class of
+real applications: desktop and CLI tools, single-node services, agent state,
+embedded analytics.
 
 Look elsewhere when you need several processes writing concurrently without a
-server in front, declarative constraints as your integrity guarantee, or a
-migration framework you did not write. And if the data's real home is another
-system, the {doc}`derived-index` pattern is both cheaper and better tested.
+server in front, integrity rules beyond uniqueness and presence enforced by the
+store, or a migration tool with a downgrade path. And if the data's real home is
+another system, the {doc}`derived-index` pattern is both cheaper and better
+tested.
 
 ## See also
 

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -93,7 +93,7 @@ data, check it against this list first.
 
 **Schema management is not a Cypher surface.** Indexes and constraints are
 created through the Python and Rust APIs. Cypher `CREATE INDEX` is not
-supported, so a Neo4j schema script does not run unedited. `LOAD CSV` is
+supported, so schema setup cannot be expressed in Cypher alone. `LOAD CSV` is
 likewise unsupported — bulk loading goes through `add_nodes` /
 `add_connections`, {doc}`blueprints`, or the CLI's `.import`.
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -36,6 +36,8 @@ guides/cypher
 guides/mcp-servers
 guides/mcp-skills
 guides/durable-apps
+guides/derived-index
+guides/primary-store
 guides/blueprints
 guides/querying
 guides/traversal-hierarchy


### PR DESCRIPTION
> **Landed in \`main\` via #72.** Every commit on \`docs/repositioning\` is an ancestor of `main` (verified with \`git merge-base --is-ancestor\`). GitHub cannot label this PR "merged" because its base was a feature branch and retargeting is refused once the head has no commits absent from `main` — so it is closed rather than merged. The code shipped.

---

Sprint 6b of the Primary-DB sprint programme — **a draft for maintainer review. Every outward sentence needs your approval.** No version bump; no CHANGELOG promotion. Docs-only diff (README, two new guides, CHANGELOG) — no code.

**Base is `feat/undo-log-rollback` (#62), not `main`**, because the write-cost claims are true only on that branch.

## ⚠️ MERGE LAST, AND ONLY AFTER AN ACCURACY PASS

This PR documents current *limitations* that later sprints remove. If it merges before or alongside them, it ships false claims. Six passages go stale:

- **Sprint 2** (durability default): `primary-store.md` §"Crash safety is available, and is opt-in", the opt-in table's durability row, §"The large-graph modes are the weaker ones", and README's "crash safety is available via `open(..., durable=True)`"
- **Sprint 3** (#64): §"Integrity constraints stop at the identity field" + the "Uniqueness on `id`" table row
- **Sprint 4a** (#63): §"Schema management is not a Cypher surface" — the `CREATE INDEX` half (the `LOAD CSV` half is Sprint 5)
- **Sprint 6a**: §"There is no migration framework"

The author could not build or test those branches, so rather than assert capabilities it couldn't verify, it wrote them as present-tense limits. That was the right call for a draft and the wrong text to merge. A final accuracy pass is planned once the other branches land.

## What this does

Two commits, deliberately separable so the README (the risky, outward part) can be dropped without losing the guides:

- `docs: guides for the derived-index and primary-store patterns` — `docs/python/guides/derived-index.md` (kglite as a queryable index over a system of record elsewhere) and `primary-store.md` (honest scope: what works as a primary store, what doesn't)
- `docs: licensing and usage-shape sections in the README` — +75/−4, surgical: one intro sentence, one table cell (`GPLv3` → `GPLv3 (Community)`), two new sections before Quick Start, two doc-list bullets, three lines in the License section. No wholesale rewrite.

## The claim that is NOT made

The programme's original wedge — "no permissively-licensed embedded Cypher engine exists" — is **falsified** (see `dev-docs/plans/licensing-claim-verification.md`) and appears nowhere, in no narrowing. ArcadeDB (Apache-2.0) and LadybugDB (MIT) are instead named as live permissively-licensed alternatives, on the reasoning that a licensing section which omits them reads as an implicit category-of-one claim. **That paragraph is pure positioning — cut it and the section still stands.**

## Licensing text — quoted for your review

> **kglite is MIT-licensed throughout — every crate in the workspace ships under MIT.** Neo4j's embeddable Community artifact (`org.neo4j:neo4j` on Maven Central) is published under **GPL-3.0-or-later**; Neo4j's own licence notice states that the GPL applies "to all third parties" unless you have executed a commercial or OEM agreement with Neo4j. Neo4j's free tiers do not close that gap for a shipped product: the Desktop License covers "one Named User on a single notebook or desktop machine solely for … internal development use", and the Startup License expressly prohibits "distributing any copy of the Software … to any third party". **If you're embedding a graph engine in a product you distribute, the licensing difference is real — and worth taking to your own counsel rather than ours.**

Every quoted string is byte-identical to the verified research doc. Followed by qualification bullets (no claim about what the GPL requires of an embedder — unsettled law; "no copyleft" is scoped to the *default* build, since `--features fastembed` pulls one transitive MPL-2.0 crate) and a trademark attribution line. **The third-party quotations are taken on trust from the research doc; this PR's author read no Neo4j page.**

## Deliberately dropped

- The absolute benchmark microseconds. They aren't recorded anywhere in the repo, and `test_bench_write_scaling.py` states that absolute figures are machine-specific and deliberately not asserted. The README claims the *shape* and cites the benchmark file.
- "Kùzu was archived in October 2025" — the research doc calls it misleading by omission, and LadybugDB is already listed as a live MIT option, so leading with the archival would read as spin.
- Any suggestion that Neo4j deprecates embedded use (absence of mention is not discouragement).

## One reasoned-not-measured claim, flagged

"Neither mode deletes nodes" — read off the documented five-mode `conflict_handling` vocabulary, none of which removes rows; not experimentally confirmed. Optional hardening: a small test pinning that no mode deletes a vanished node.

## Verification

`make gate` exit 0 (chokepoint, `cargo fmt --check`, `ruff format --check` + `ruff check` across 321 files, `render_docs_facts.py --check` all clean) · `sphinx-build -W --keep-going -b html docs` **build succeeded, zero warnings**, both new guides rendered · no cargo/maturin build run (none needed; the disk was left alone) · nothing published anywhere.

