### PR TITLE
fix: bound AST nesting so a deep query cannot abort the Bolt or MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fixed a denial of service in the Bolt and MCP servers: a single deeply
+  nested query from any client could overflow a server worker thread's stack,
+  and because a Rust stack overflow aborts rather than unwinds, the whole
+  server process died — disconnecting every other connected session. The
+  query is now rejected with a `Neo.ClientError.Statement.SyntaxError`
+  ("Expression nesting exceeds 512 levels; simplify the query") and the server
+  keeps serving.
+
+  The parser's 512-level nesting budget previously counted only *recursively*
+  parsed nesting (parentheses, lists, `NOT`, unary minus). The
+  left-associative operator chains — `OR` / `XOR` / `AND`, `+` / `-` / `||`,
+  `*` / `/` / `%`, subscripting, and `n:A:B` label chains — are parsed
+  iteratively, so the parser stayed shallow while the tree it returned grew
+  one level per term. The planner's expression walkers, the executor's
+  predicate evaluator, and the AST's drop glue all recurse per level, so an
+  unbounded chain walked off the end of the stack. Those chains now charge the
+  same budget, making it a bound on AST depth rather than on parser call depth.
+
+### Changed
+
+- The Bolt and MCP servers now give their tokio worker threads an 8 MiB stack
+  (`kglite::api::session::QUERY_THREAD_STACK_SIZE`) instead of tokio's 2 MiB
+  default, matching the headroom the CLI and Python wheel already get on the
+  main thread. Bindings that dispatch queries onto their own threads should
+  size them with this constant.
+
+### Fixed
+
+- `n:A:B` label chains, subscript chains, and long arithmetic/boolean operator
+  chains past the nesting budget now report the documented
+  "nesting exceeds 512 levels" syntax error instead of aborting the process
+  (all frontends, including in-process Python).
+
 ## [0.14.5] - 2026-07-22
 
 ### Changed

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -144,8 +144,24 @@ fn init_tracing() {
         .init();
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+/// Build the runtime by hand rather than via `#[tokio::main]` so the worker
+/// threads get `QUERY_THREAD_STACK_SIZE` instead of tokio's 2 MiB default.
+/// Connection tasks run the Cypher pipeline inline on a worker (see
+/// `KgliteBackend::execute` in `backend.rs`), and that pipeline recurses per
+/// level of expression nesting — on a 2 MiB worker a deeply nested query overflows
+/// the stack, which in Rust aborts the whole process and so disconnects every
+/// other client. The parser's nesting cap bounds the recursion; this gives
+/// that bound room to land.
+fn main() -> Result<()> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(kglite::api::session::QUERY_THREAD_STACK_SIZE)
+        .build()
+        .context("failed to build tokio runtime")?
+        .block_on(serve())
+}
+
+async fn serve() -> Result<()> {
     init_tracing();
 
     let cli = Cli::parse();

--- a/crates/kglite-mcp-server/src/lib.rs
+++ b/crates/kglite-mcp-server/src/lib.rs
@@ -483,8 +483,15 @@ where
     if cli.selftest {
         return selftest::run_selftest(&cli, &argv);
     }
+    // Tool handlers are synchronous closures that run the Cypher pipeline
+    // inline on a worker thread (see `tools.rs`), and that pipeline recurses
+    // per level of expression nesting. Tokio's default 2 MiB worker stack is
+    // too small for the deepest query the parser accepts, and a Rust stack
+    // overflow aborts the process rather than failing the one request — so
+    // give workers the same headroom the CLI's main thread has.
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .thread_stack_size(kglite::api::session::QUERY_THREAD_STACK_SIZE)
         .build()
         .context("failed to build tokio runtime")?;
     runtime.block_on(run_async(cli, factory, extensions))

--- a/crates/kglite/src/graph/languages/cypher/parser/expression.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/expression.rs
@@ -11,42 +11,51 @@ impl CypherParser {
     }
 
     fn parse_boolean_or_expression(&mut self) -> Result<Expression, String> {
-        let mut left = self.parse_boolean_xor_expression()?;
-        while self.check(&CypherToken::Or) {
-            self.advance();
-            let right = self.parse_boolean_xor_expression()?;
-            left = Expression::PredicateExpr(Box::new(Predicate::Or(
-                Box::new(Self::expression_as_predicate(left)),
-                Box::new(Self::expression_as_predicate(right)),
-            )));
-        }
-        Ok(left)
+        self.chain(|p| {
+            let mut left = p.parse_boolean_xor_expression()?;
+            while p.check(&CypherToken::Or) {
+                p.advance();
+                p.deepen()?;
+                let right = p.parse_boolean_xor_expression()?;
+                left = Expression::PredicateExpr(Box::new(Predicate::Or(
+                    Box::new(Self::expression_as_predicate(left)),
+                    Box::new(Self::expression_as_predicate(right)),
+                )));
+            }
+            Ok(left)
+        })
     }
 
     fn parse_boolean_xor_expression(&mut self) -> Result<Expression, String> {
-        let mut left = self.parse_boolean_and_expression()?;
-        while self.check(&CypherToken::Xor) {
-            self.advance();
-            let right = self.parse_boolean_and_expression()?;
-            left = Expression::PredicateExpr(Box::new(Predicate::Xor(
-                Box::new(Self::expression_as_predicate(left)),
-                Box::new(Self::expression_as_predicate(right)),
-            )));
-        }
-        Ok(left)
+        self.chain(|p| {
+            let mut left = p.parse_boolean_and_expression()?;
+            while p.check(&CypherToken::Xor) {
+                p.advance();
+                p.deepen()?;
+                let right = p.parse_boolean_and_expression()?;
+                left = Expression::PredicateExpr(Box::new(Predicate::Xor(
+                    Box::new(Self::expression_as_predicate(left)),
+                    Box::new(Self::expression_as_predicate(right)),
+                )));
+            }
+            Ok(left)
+        })
     }
 
     fn parse_boolean_and_expression(&mut self) -> Result<Expression, String> {
-        let mut left = self.parse_boolean_not_expression()?;
-        while self.check(&CypherToken::And) {
-            self.advance();
-            let right = self.parse_boolean_not_expression()?;
-            left = Expression::PredicateExpr(Box::new(Predicate::And(
-                Box::new(Self::expression_as_predicate(left)),
-                Box::new(Self::expression_as_predicate(right)),
-            )));
-        }
-        Ok(left)
+        self.chain(|p| {
+            let mut left = p.parse_boolean_not_expression()?;
+            while p.check(&CypherToken::And) {
+                p.advance();
+                p.deepen()?;
+                let right = p.parse_boolean_not_expression()?;
+                left = Expression::PredicateExpr(Box::new(Predicate::And(
+                    Box::new(Self::expression_as_predicate(left)),
+                    Box::new(Self::expression_as_predicate(right)),
+                )));
+            }
+            Ok(left)
+        })
     }
 
     fn parse_boolean_not_expression(&mut self) -> Result<Expression, String> {
@@ -71,6 +80,26 @@ impl CypherParser {
                 right: Expression::Literal(Value::Boolean(false)),
             },
         }
+    }
+
+    /// Continue a `n:A:B:C` label chain, `first` being the already-parsed
+    /// `n:A` check. Each extra label nests one more `Predicate::And`, so each
+    /// is charged against the nesting budget like any other operator chain.
+    fn parse_label_chain(&mut self, var: String, first: Predicate) -> Result<Predicate, String> {
+        let mut pred = first;
+        while self.check(&CypherToken::Colon) {
+            self.advance();
+            self.deepen()?;
+            let next_label = self.expect_name("label name after ':'")?;
+            pred = Predicate::And(
+                Box::new(pred),
+                Box::new(Predicate::LabelCheck {
+                    variable: var.clone(),
+                    label: next_label,
+                }),
+            );
+        }
+        Ok(pred)
     }
 
     fn parse_comparison_expression(&mut self) -> Result<Expression, String> {
@@ -99,21 +128,11 @@ impl CypherParser {
                 let var = var.clone();
                 self.advance(); // consume :
                 let first_label = self.expect_name("label name after ':'")?;
-                let mut pred = Predicate::LabelCheck {
+                let first = Predicate::LabelCheck {
                     variable: var.clone(),
                     label: first_label,
                 };
-                while self.check(&CypherToken::Colon) {
-                    self.advance();
-                    let next_label = self.expect_name("label name after ':'")?;
-                    pred = Predicate::And(
-                        Box::new(pred),
-                        Box::new(Predicate::LabelCheck {
-                            variable: var.clone(),
-                            label: next_label,
-                        }),
-                    );
-                }
+                let pred = self.chain(|p| p.parse_label_chain(var, first))?;
                 return Ok(Expression::PredicateExpr(Box::new(pred)));
             }
         }
@@ -208,12 +227,17 @@ impl CypherParser {
     }
 
     pub(super) fn parse_additive_expression(&mut self) -> Result<Expression, String> {
+        self.chain(Self::parse_additive_chain)
+    }
+
+    fn parse_additive_chain(&mut self) -> Result<Expression, String> {
         let mut left = self.parse_multiplicative_expression()?;
 
         loop {
             match self.peek() {
                 Some(CypherToken::Plus) => {
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_multiplicative_expression()?;
                     left = Expression::Add(Box::new(left), Box::new(right));
                 }
@@ -236,11 +260,13 @@ impl CypherParser {
                         break;
                     }
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_multiplicative_expression()?;
                     left = Expression::Subtract(Box::new(left), Box::new(right));
                 }
                 Some(CypherToken::DoublePipe) => {
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_multiplicative_expression()?;
                     left = Expression::Concat(Box::new(left), Box::new(right));
                 }
@@ -252,22 +278,29 @@ impl CypherParser {
     }
 
     pub(super) fn parse_multiplicative_expression(&mut self) -> Result<Expression, String> {
+        self.chain(Self::parse_multiplicative_chain)
+    }
+
+    fn parse_multiplicative_chain(&mut self) -> Result<Expression, String> {
         let mut left = self.parse_unary_expression()?;
 
         loop {
             match self.peek() {
                 Some(CypherToken::Star) => {
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_unary_expression()?;
                     left = Expression::Multiply(Box::new(left), Box::new(right));
                 }
                 Some(CypherToken::Slash) => {
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_unary_expression()?;
                     left = Expression::Divide(Box::new(left), Box::new(right));
                 }
                 Some(CypherToken::Percent) => {
                     self.advance();
+                    self.deepen()?;
                     let right = self.parse_unary_expression()?;
                     left = Expression::Modulo(Box::new(left), Box::new(right));
                 }
@@ -292,9 +325,14 @@ impl CypherParser {
     }
 
     /// Parse postfix operators: expr[index] or expr[start..end]
-    pub(super) fn parse_postfix(&mut self, mut expr: Expression) -> Result<Expression, String> {
+    pub(super) fn parse_postfix(&mut self, expr: Expression) -> Result<Expression, String> {
+        self.chain(|p| p.parse_postfix_chain(expr))
+    }
+
+    fn parse_postfix_chain(&mut self, mut expr: Expression) -> Result<Expression, String> {
         while self.check(&CypherToken::LBracket) {
             self.advance(); // consume [
+            self.deepen()?;
 
             if self.check(&CypherToken::DotDot) {
                 // [..end] — slice with no start. Also accept [..] (both

--- a/crates/kglite/src/graph/languages/cypher/parser/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/mod.rs
@@ -30,10 +30,12 @@ pub mod predicate;
 pub struct CypherParser {
     tokens: Vec<CypherToken>,
     pos: usize,
-    /// Current recursion depth of the expression/predicate parser. Guarded by
-    /// [`Self::descend`] so pathologically nested input (thousands of nested
-    /// parens/lists/`NOT`s) returns a parse error instead of overflowing the
-    /// stack and aborting the process.
+    /// Nesting depth of the expression/predicate AST currently under
+    /// construction. Charged by [`Self::descend`] for *recursive* nesting
+    /// (parens/lists/`NOT`) and by [`Self::deepen`] for the *iteratively*
+    /// built left-associative operator chains, so pathologically nested
+    /// input returns a parse error instead of overflowing the stack and
+    /// aborting the process.
     depth: usize,
     /// Verbatim source lexeme per keyword-token index (see
     /// [`super::tokenizer::TokenizedCypher::keyword_lexemes`]). Keyword
@@ -45,7 +47,7 @@ pub struct CypherParser {
     keyword_lexemes: std::collections::HashMap<usize, String>,
 }
 
-/// Maximum expression-nesting depth accepted by the parser.
+/// Maximum expression/predicate AST nesting depth accepted by the parser.
 ///
 /// The recursive-descent expression parser, the planner's expression walkers,
 /// and the executor's `evaluate_expression` all recurse once per nesting
@@ -54,8 +56,18 @@ pub struct CypherParser {
 /// Debug-profile frames are several times larger than release frames — deep
 /// nesting within this budget can exhaust a default thread stack before the
 /// guard fires — so [`CypherParser::descend`] also grows the stack on demand
-/// via `stacker`; the budget is the semantic contract, not the overflow
-/// protection.
+/// via `stacker`.
+///
+/// The budget bounds **AST depth, not parser call depth**, and those differ:
+/// the left-associative operator chains (`OR`/`XOR`/`AND`, `+`/`-`/`||`,
+/// `*`/`/`/`%`, subscripting, `n:A:B` label chains) are parsed *iteratively*,
+/// so the parser itself stays shallow while each iteration adds one level to
+/// the tree it returns. Those levels are charged via [`CypherParser::deepen`]
+/// inside a [`CypherParser::chain`] scope; recursive nesting is charged by
+/// [`CypherParser::descend`]. Charging both is what makes the budget an
+/// actual bound on what the downstream walkers recurse through — the
+/// walkers themselves have no guard, and they run on server worker threads
+/// whose stacks are far smaller than the main thread's.
 const MAX_EXPRESSION_DEPTH: usize = 512;
 
 /// Remaining-stack threshold below which [`CypherParser::descend`] allocates
@@ -97,6 +109,21 @@ impl CypherParser {
         &mut self,
         f: impl FnOnce(&mut Self) -> Result<T, String>,
     ) -> Result<T, String> {
+        self.deepen()?;
+        let result = stacker::maybe_grow(STACK_RED_ZONE, STACK_GROW_SIZE, || f(self));
+        self.depth -= 1;
+        result
+    }
+
+    /// Charge one level of AST nesting against [`MAX_EXPRESSION_DEPTH`],
+    /// failing with a clean parse error once the budget is exhausted.
+    ///
+    /// Call this — inside a [`Self::chain`] scope — once per iteration of an
+    /// iteratively-parsed operator chain, because each iteration wraps the
+    /// accumulated operand in one more AST node. Unlike [`Self::descend`]
+    /// the charge is *not* released when the current call returns; `chain`
+    /// releases the whole run at once.
+    pub(super) fn deepen(&mut self) -> Result<(), String> {
         if self.depth >= MAX_EXPRESSION_DEPTH {
             return Err(format!(
                 "Expression nesting exceeds {} levels; simplify the query",
@@ -104,8 +131,25 @@ impl CypherParser {
             ));
         }
         self.depth += 1;
-        let result = stacker::maybe_grow(STACK_RED_ZONE, STACK_GROW_SIZE, || f(self));
-        self.depth -= 1;
+        Ok(())
+    }
+
+    /// Run `f` as an iteratively-built operator chain, releasing every level
+    /// it charged via [`Self::deepen`] once the chain is complete.
+    ///
+    /// Releasing on exit is what makes the budget track AST *depth* rather
+    /// than total node count: two sibling chains each 400 levels deep form a
+    /// tree only 401 levels deep, so the second must not inherit the first's
+    /// charges. A chain nested inside another chain's operand is still parsed
+    /// while the outer chain holds its charges, so genuine nesting keeps
+    /// accumulating — the bound stays conservative in the safe direction.
+    pub(super) fn chain<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let entry_depth = self.depth;
+        let result = f(self);
+        self.depth = entry_depth;
         result
     }
 

--- a/crates/kglite/src/graph/session/mod.rs
+++ b/crates/kglite/src/graph/session/mod.rs
@@ -58,6 +58,24 @@ use crate::graph::schema::GraphBackend;
 // did `pub use kglite_core::graph::*` glob which brought it in.
 use crate::graph::storage::GraphRead;
 
+/// Stack size a thread must have to run [`execute_read`] / [`execute_mut`]
+/// safely — servers that dispatch queries onto their own threads should
+/// configure their pool with this value.
+///
+/// The pipeline recurses once per level of expression/predicate nesting, in
+/// the parser, in ~25 planner walkers, in the executor's predicate evaluator,
+/// and again in the drop glue of the boxed AST. The parser caps nesting so
+/// that recursion is bounded (a "simplify the query" parse error past the
+/// budget), but the *bound* still has to fit in the thread's stack, and a
+/// runtime default worker stack (tokio: 2 MiB) is not comfortably larger than
+/// the deepest permitted tree in a debug build. A thread with less than this
+/// cannot merely fail a query — a Rust stack overflow aborts the **process**,
+/// so one client's deep query would take down every other session sharing it.
+///
+/// 8 MiB matches the main-thread default that the CLI and the Python wheel
+/// already get for free, so every frontend has the same headroom.
+pub const QUERY_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
 /// Resolve any `Value::NodeRef` entries in Cypher result rows to the
 /// referenced node's `title` value. Called by bindings just before
 /// emitting rows to their consumer (`PyDict`/`PyList` for the wheel,

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -440,7 +440,7 @@ pub mod api {
     pub mod session {
         pub use crate::graph::session::{
             execute_mut, execute_read, resolve_noderefs, CommitOutcome, ExecuteOptions,
-            ExecuteOutcome, Session, Transaction,
+            ExecuteOutcome, Session, Transaction, QUERY_THREAD_STACK_SIZE,
         };
     }
 }

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -1322,6 +1322,7 @@ pub fn kglite::api::session::Transaction::has_writes(&self) -> bool
 pub fn kglite::api::session::Transaction::is_read_only(&self) -> bool
 pub fn kglite::api::session::Transaction::take_working(self) -> (core::option::Option<kglite::api::DirGraph>, u64)
 pub fn kglite::api::session::Transaction::working_mut(&mut self) -> core::result::Result<&mut kglite::api::DirGraph, kglite::error::KgError>
+pub const kglite::api::session::QUERY_THREAD_STACK_SIZE: usize
 pub fn kglite::api::session::execute_mut(graph: &mut kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::execute_read(graph: &kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::resolve_noderefs(graph: &kglite::api::storage::GraphBackend, rows: &mut [alloc::vec::Vec<kglite::datatypes::values::Value>])

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -1307,6 +1307,7 @@ pub fn kglite::api::session::Transaction::has_writes(&self) -> bool
 pub fn kglite::api::session::Transaction::is_read_only(&self) -> bool
 pub fn kglite::api::session::Transaction::take_working(self) -> (core::option::Option<kglite::api::DirGraph>, u64)
 pub fn kglite::api::session::Transaction::working_mut(&mut self) -> core::result::Result<&mut kglite::api::DirGraph, kglite::error::KgError>
+pub const kglite::api::session::QUERY_THREAD_STACK_SIZE: usize
 pub fn kglite::api::session::execute_mut(graph: &mut kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::execute_read(graph: &kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::resolve_noderefs(graph: &kglite::api::storage::GraphBackend, rows: &mut [alloc::vec::Vec<kglite::datatypes::values::Value>])

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -1307,6 +1307,7 @@ pub fn kglite::api::session::Transaction::has_writes(&self) -> bool
 pub fn kglite::api::session::Transaction::is_read_only(&self) -> bool
 pub fn kglite::api::session::Transaction::take_working(self) -> (core::option::Option<kglite::api::DirGraph>, u64)
 pub fn kglite::api::session::Transaction::working_mut(&mut self) -> core::result::Result<&mut kglite::api::DirGraph, kglite::error::KgError>
+pub const kglite::api::session::QUERY_THREAD_STACK_SIZE: usize
 pub fn kglite::api::session::execute_mut(graph: &mut kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::execute_read(graph: &kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::resolve_noderefs(graph: &kglite::api::storage::GraphBackend, rows: &mut [alloc::vec::Vec<kglite::datatypes::values::Value>])

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -1307,6 +1307,7 @@ pub fn kglite::api::session::Transaction::has_writes(&self) -> bool
 pub fn kglite::api::session::Transaction::is_read_only(&self) -> bool
 pub fn kglite::api::session::Transaction::take_working(self) -> (core::option::Option<kglite::api::DirGraph>, u64)
 pub fn kglite::api::session::Transaction::working_mut(&mut self) -> core::result::Result<&mut kglite::api::DirGraph, kglite::error::KgError>
+pub const kglite::api::session::QUERY_THREAD_STACK_SIZE: usize
 pub fn kglite::api::session::execute_mut(graph: &mut kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::execute_read(graph: &kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::resolve_noderefs(graph: &kglite::api::storage::GraphBackend, rows: &mut [alloc::vec::Vec<kglite::datatypes::values::Value>])

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -1322,6 +1322,7 @@ pub fn kglite::api::session::Transaction::has_writes(&self) -> bool
 pub fn kglite::api::session::Transaction::is_read_only(&self) -> bool
 pub fn kglite::api::session::Transaction::take_working(self) -> (core::option::Option<kglite::api::DirGraph>, u64)
 pub fn kglite::api::session::Transaction::working_mut(&mut self) -> core::result::Result<&mut kglite::api::DirGraph, kglite::error::KgError>
+pub const kglite::api::session::QUERY_THREAD_STACK_SIZE: usize
 pub fn kglite::api::session::execute_mut(graph: &mut kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::execute_read(graph: &kglite::api::DirGraph, query: &str, opts: &kglite::api::session::ExecuteOptions<'_>) -> core::result::Result<kglite::api::session::ExecuteOutcome, kglite::error::KgError>
 pub fn kglite::api::session::resolve_noderefs(graph: &kglite::api::storage::GraphBackend, rows: &mut [alloc::vec::Vec<kglite::datatypes::values::Value>])

--- a/tests/test_bolt_server_correctness.py
+++ b/tests/test_bolt_server_correctness.py
@@ -293,16 +293,111 @@ def test_edge_whitespace_only_query(bolt_server):
 def test_edge_long_query_10kb(bolt_server):
     """10 KB query — long but valid WHERE clause built from many small
     OR predicates. Pins that the parser doesn't have an unreasonable
-    short-query bias and that boltr framing handles the size."""
-    # ~10 KB of predicates: WHERE n.title = 'X0' OR n.title = 'X1' OR ...
-    predicates = " OR ".join([f"n.title = 'X{i}'" for i in range(1500)])
+    short-query bias and that boltr framing handles the size.
+
+    Deliberately sized *under* the parser's nesting budget (see
+    `test_deep_query_errors_without_killing_server`): query length and
+    query nesting depth are independent, and this test is about length.
+    """
+    # >10 KB of predicates, 500 levels deep:
+    # WHERE n.title = 'X00000' OR n.title = 'X00001' OR ...
+    predicates = " OR ".join([f"n.title = 'X{i:05d}'" for i in range(500)])
     query = f"MATCH (n:Person) WHERE {predicates} RETURN count(n) AS c"
     assert len(query) >= 10_000, f"query is only {len(query)} bytes, want >= 10000"
     with neo4j.GraphDatabase.driver(bolt_server, auth=("neo4j", "password")) as driver:
         with driver.session() as session:
             result = session.run(query)
-            # None of the X0..X1499 match Alice/Bob/Carol/Dave, so 0 rows.
+            # None of the X00000..X00499 match Alice/Bob/Carol/Dave, so 0 rows.
             assert result.single()["c"] == 0
+
+
+# Query shapes that nest one AST level per operator. Each is parsed by an
+# *iterative* loop, so the parser itself stays shallow while the tree it
+# returns grows one level per term — the shape that used to walk the
+# planner/executor recursion off the end of a 2 MiB tokio worker stack and
+# abort the whole process, taking every other session with it.
+_DEEP_QUERY_SHAPES = {
+    "or_chain": lambda n: (
+        "MATCH (n:Person) WHERE " + " OR ".join(f"n.title = 'X{i}'" for i in range(n)) + " RETURN count(n) AS c"
+    ),
+    "and_chain": lambda n: (
+        "MATCH (n:Person) WHERE " + " AND ".join(f"n.title <> 'X{i}'" for i in range(n)) + " RETURN count(n) AS c"
+    ),
+    "additive_chain": lambda n: "RETURN " + " + ".join(["1"] * n) + " AS s",
+    "multiplicative_chain": lambda n: "RETURN " + " * ".join(["1"] * n) + " AS s",
+    "concat_chain": lambda n: "RETURN " + " || ".join(["'a'"] * n) + " AS s",
+    "subscript_chain": lambda n: "RETURN [1]" + "[0]" * n + " AS s",
+    # Recursively-parsed shapes — already guarded before this fix; kept so
+    # both families stay covered by one test.
+    "paren_nest": lambda n: "RETURN " + "(" * n + "1" + ")" * n + " AS s",
+    "not_chain": lambda n: "MATCH (n:Person) WHERE " + "NOT " * n + "n.title = 'A' RETURN count(n) AS c",
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_DEEP_QUERY_SHAPES))
+def test_deep_query_errors_without_killing_server(tmp_path, shape):
+    """A pathologically deep query must fail *that one query* — not abort
+    the server process.
+
+    A Rust stack overflow is an abort, not an unwind, so a query that
+    recursed past the worker thread's stack used to kill the process and
+    disconnect every other client. The parser now caps AST nesting, so the
+    client gets a SyntaxError and the server keeps serving.
+
+    Asserts, per shape: (1) a proper Bolt `Neo.ClientError.*` error rather
+    than a dropped connection; (2) the *same* process is still running
+    afterwards — never restarted, PID unchanged; (3) a fresh session still
+    executes queries; (4) stderr shows no stack-overflow abort.
+    """
+    from tests.conftest import (
+        _build_bolt_fixture_graph,
+        _spawn_bolt_server,
+        _teardown_bolt_server,
+    )
+
+    query = _DEEP_QUERY_SHAPES[shape](2000)
+
+    fixture = tmp_path / "fixture.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    pid_before = proc.pid
+    try:
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                with pytest.raises(neo4j.exceptions.ClientError) as exc_info:
+                    session.run(query).consume()
+        # A *client* error, not ServiceUnavailable — which is what a dead
+        # process looks like from the driver's side.
+        assert exc_info.value.code.startswith("Neo.ClientError."), exc_info.value.code
+
+        # The process must still be the one we started.
+        assert proc.poll() is None, f"server exited with {proc.returncode} — a deep query must not kill the process"
+        assert proc.pid == pid_before, "server was restarted, not survived"
+
+        # A brand-new session on the same process still works.
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                assert session.run("RETURN 1 AS x").single()["x"] == 1
+    finally:
+        _teardown_bolt_server(proc)
+        stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+        assert "overflowed its stack" not in stderr, stderr[-2000:]
+
+
+@pytest.mark.parametrize("shape", sorted(_DEEP_QUERY_SHAPES))
+def test_moderately_deep_query_still_succeeds(bolt_server, shape):
+    """Control for `test_deep_query_errors_without_killing_server`: the
+    guard must reject only pathological nesting, not ordinary queries.
+
+    Without this control, a guard that rejected *everything* would pass
+    the abort test.
+    """
+    query = _DEEP_QUERY_SHAPES[shape](100)
+    with neo4j.GraphDatabase.driver(bolt_server, auth=("neo4j", "password")) as driver:
+        with driver.session() as session:
+            # Succeeds and returns exactly one row; the value differs per
+            # shape, so assert only that the query ran.
+            assert session.run(query).single() is not None
 
 
 def test_edge_unicode_in_param_value(bolt_server):

--- a/tests/test_cypher_parser_hardening.py
+++ b/tests/test_cypher_parser_hardening.py
@@ -117,6 +117,82 @@ def test_not_chain_past_budget_is_a_clean_syntax_error():
         g.cypher("RETURN " + "NOT " * 600 + "false AS x")
 
 
+# The left-associative operator chains are parsed *iteratively*, so the
+# parser's own call depth stays flat while the tree it returns grows one level
+# per term. The budget has to charge those levels too: the planner walkers, the
+# executor's predicate evaluator, and the AST's drop glue all recurse per
+# level, and on a server worker thread (tokio default: 2 MiB) that recursion
+# used to overflow — aborting the whole process, not just failing the query.
+# `n` is the number of nesting levels the shape produces.
+_CHAIN_SHAPES = {
+    "or": lambda n: "RETURN " + " OR ".join(["false"] * (n + 1)) + " AS x",
+    "xor": lambda n: "RETURN " + " XOR ".join(["false"] * (n + 1)) + " AS x",
+    "and": lambda n: "RETURN " + " AND ".join(["true"] * (n + 1)) + " AS x",
+    "add": lambda n: "RETURN " + " + ".join(["1"] * (n + 1)) + " AS x",
+    "subtract": lambda n: "RETURN 0" + " - 0" * n + " AS x",
+    "multiply": lambda n: "RETURN " + " * ".join(["1"] * (n + 1)) + " AS x",
+    "divide": lambda n: "RETURN 1" + " / 1" * n + " AS x",
+    "modulo": lambda n: "RETURN 3" + " % 5" * n + " AS x",
+    "concat": lambda n: "RETURN " + " || ".join(["'a'"] * (n + 1)) + " AS x",
+    "subscript": lambda n: "RETURN [1]" + "[0]" * n + " AS x",
+    "label_chain": lambda n: "MATCH (h:Hop) WHERE h" + ":Hop" * n + " RETURN count(h) AS x",
+}
+
+_CHAIN_EXPECTED_WITHIN_BUDGET = {
+    "or": False,
+    "xor": False,
+    "and": True,
+    "add": 400,
+    "subtract": 0,
+    "multiply": 1,
+    "divide": 1,
+    "modulo": 3,
+    "concat": "a" * 400,
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_CHAIN_EXPECTED_WITHIN_BUDGET))
+def test_operator_chain_within_budget_parses_and_executes(shape):
+    # 399 levels — comfortably inside the budget, so charging chain levels
+    # must not reject ordinary (if long) queries.
+    g = KnowledgeGraph()
+    got = g.cypher(_CHAIN_SHAPES[shape](399)).scalar()
+    assert got == _CHAIN_EXPECTED_WITHIN_BUDGET[shape]
+
+
+def test_label_chain_within_budget_parses_and_executes(chain):
+    assert chain.cypher(_CHAIN_SHAPES["label_chain"](399)).scalar() == 13
+
+
+@pytest.mark.parametrize("shape", sorted(_CHAIN_SHAPES))
+def test_operator_chain_past_budget_is_a_clean_syntax_error(shape, chain):
+    # Every iteratively-parsed chain must hit the same budget as the
+    # recursively-parsed shapes rather than running off the stack.
+    with pytest.raises(kglite.CypherSyntaxError, match=f"nesting exceeds {BUDGET} levels"):
+        chain.cypher(_CHAIN_SHAPES[shape](BUDGET + 100))
+
+
+@pytest.mark.parametrize("shape", sorted(_CHAIN_SHAPES))
+def test_pathological_operator_chain_cannot_kill_the_process(shape):
+    # Subprocess for the same reason as the nesting crash-shape test below:
+    # on regression this aborts the interpreter, which would otherwise take
+    # the whole test run with it. 20k levels is far past any stack.
+    code = (
+        "import kglite\n"
+        "g = kglite.KnowledgeGraph()\n"
+        "g.cypher('CREATE (:Hop {id: 0})')\n"
+        f"q = {_CHAIN_SHAPES[shape](20_000)!r}\n"
+        "try:\n"
+        "    g.cypher(q)\n"
+        "    print('UNEXPECTED-SUCCESS')\n"
+        "except kglite.CypherSyntaxError:\n"
+        "    print('CLEAN-ERROR')\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, f"process died (rc={proc.returncode}): {proc.stderr[-300:]}"
+    assert proc.stdout.strip() == "CLEAN-ERROR", proc.stdout
+
+
 @pytest.mark.parametrize("opener,closer", [("(", ")"), ("[", "]")], ids=["parens", "lists"])
 def test_pathological_nesting_cannot_kill_the_process(opener, closer):
     # Run in a subprocess: before the recursion budget existed this shape


### PR DESCRIPTION
**Security/availability fix for a pre-existing bug. Based on `main`, independent of the sprint chain.** No version bump.

## The bug

A single deep Cypher query **aborted the entire server process**, killing every connected client. A Rust stack overflow is an abort, not an unwind:

```
thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

Reproduced before any change (debug profile): `ServiceUnavailable`, `rc=-6` (SIGABRT). **The true cliff is 900 terms survive / 950 aborts** — narrower than the originally-reported 900-fine/1500-abort.

**It was not one shape, and not one server.** Scanning for the bug *class* rather than the reported symptom found **six aborting shapes across seven parser sites**: `OR`, `AND`, `+`/`-`/`||`, `*`/`/`/`%`, subscript chains (`[1][0][0]…`), and `n:A:B` label chains. And **the MCP server shared the exposure** — its tool handlers call `execute_read` inline on a worker with no `spawn_blocking`; driving a real stdio handshake against the unfixed binary reproduced the same `rc=-6` abort.

## Root cause: the guard existed but counted the wrong thing

`MAX_EXPRESSION_DEPTH = 512` and a `stacker`-backed `descend` were already there, and the doc comment claimed it "bounds stack use across the whole pipeline". It didn't. **It counts parser call depth, not AST depth.** Left-associative chains are parsed in `while` loops, so the parser stays ~2 levels deep while the returned tree grows one level per term — `descend` was never reached.

Clean A/B evidence: the two shapes that *did* route through the guard (`paren_nest`, `not_chain`) returned a proper error and survived, on the unfixed build.

## Fix: charge chain iterations against the existing budget

`deepen`, scoped by `chain` so sibling chains don't inherit charges (AST height is the `max` of siblings, not their sum). **No new limit, no new mechanism, no second knob** — the existing budget now measures what it always claimed to.

**Raising the stack was measured and rejected as a standalone fix.** With 8 MiB workers and the budget removed, the abort merely **moved from ~950 to between 3000 and 4000 terms**. Bigger stacks move the cliff; they don't remove it. 8 MiB workers are kept as a *complement* because ~25 unguarded planner walkers recurse per level with varying frame cost (one pair nests `reorder_predicate` × `estimate_predicate_cost`, roughly doubling frames), so 512 levels on a 2 MiB stack sits uncomfortably close to the measured cliff. 8 MiB matches what the CLI and wheel already get on the main thread.

## The acceptance test asserts survival, not a bigger ceiling

`test_deep_query_errors_without_killing_server` (8 shapes × 2000 levels) asserts a `Neo.ClientError.*` code — **not** `ServiceUnavailable`, which is what a dead process looks like — plus `proc.poll() is None` **and an unchanged PID** (survived rather than restarted), a fresh session running `RETURN 1`, and no `overflowed its stack` in stderr. Control: `test_moderately_deep_query_still_succeeds` at 100 levels, so "reject everything" cannot pass.

**Verified by neutering:** reverting `crates/` to `main` and rebuilding makes it **fail 6 ways** with `fatal runtime error: stack overflow` (the 2 already-guarded shapes still pass); neutering just the budget fails all 22 new parser-level tests. Neither assertion is vacuous.

`test_edge_long_query_10kb` still tests query *length* (>10 KB) but now at 500 levels — length and depth are independent, and conflating them is exactly what would re-arm the trap at a new threshold.

Why the CLI was never affected: no tokio at all, `execute_read` runs on the process main thread (8 MiB). `kglite-py` runs in-process on the caller's thread. `stacker` had exactly one call site repo-wide.

## Verification

`make gate` **exit 0** · `cargo clippy --all-targets -- -D warnings` **exit 0** · `make source-quality` **OK** (no baseline edits, no ceiling raised) · `cargo test -p kglite-bolt-server` **12 passed** · `cargo test -p kglite-mcp-server` **42 passed** · `cargo test -p kglite` **1093 passed** · `pytest -m "bolt and not benchmark"` **373 passed, 11 skipped** (all skips pre-existing) · broad Python suite **4453 passed, 0 failed** · MCP `--selftest` passes.

## ⚠️ Needs a decision: a user-visible limit tightened on every frontend

Previously a 1500-term `OR` chain **worked** via the CLI and in-process Python (8 MiB main thread) while **killing** the servers. Now anything past **512 nesting levels is rejected everywhere**:

```
Expression syntax error … Expression nesting exceeds 512 levels; simplify the query
```
(wire code `Neo.ClientError.Statement.SyntaxError`)

Most plausible way to hit it: machine-generated queries — an ORM or codegen expanding a large `IN` list into `x = a OR x = b OR …`, or a long `+` concatenation. Pragmatic workaround: `WHERE n.title IN [...]`, which is one AST level regardless of list size.

512 was kept because it is the already-documented budget and one uniform limit across CLI/Bolt/MCP/Python is more defensible than per-frontend cliffs. **If larger generated chains should be accepted, the budget could go to ~2000** given the 8 MiB workers (measured headroom: the budget-free cliff is ~3500) — that trades margin for a case no test currently demands. It is one constant: `MAX_EXPRESSION_DEPTH`, mirrored by `BUDGET` in `tests/test_cypher_parser_hardening.py`.

**Also:** `QUERY_THREAD_STACK_SIZE` is a **new public item** in `kglite::api::session`, so the Rust API baseline will show a delta. Intentional addition, not drift — being refreshed separately.
