### PR TITLE
docs: state and test the disk-mode crash guarantee (WAL evaluated, not built)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented what a crash actually costs a `storage="disk"` graph, and stopped
+  steering growing apps toward it. Disk mode has no write-ahead log, which read
+  as "no crash safety"; the real guarantee is narrower and is now stated (and
+  kill-9 tested in `crates/kglite/tests/disk_crash_guarantee.rs`): a crash loses
+  exactly the mutations made since the last `save()`, and the last published
+  generation always reopens complete, never half-written. The durable-apps mode
+  table previously offered `disk` for "graphs larger than RAM" with no size
+  threshold and omitted `mapped` entirely — pointing the one audience that most
+  needs per-commit durability at the one mode that lacks it. It now names
+  `mapped` as the larger-than-RAM mode that keeps the guarantee and gates `disk`
+  on Wikidata scale. The storage-mode decision table in core-concepts gained a
+  crash-safety column, and the unqualified "`open()` is crash-safe by default"
+  claims in the README and guide index now name the disk exception. Also
+  documented that each disk `save()` retains a full superseded generation, so
+  checkpoint frequency is a disk-budget decision.
 - Index DDL is classified as a mutation, since schema is graph state: it is
   blocked on a read-only graph and in a read-only transaction, rolls back with
   a failed statement, and is rejected on a schema-locked graph when the

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ building saves a lot of argument later.
   This is what most kglite deployments are, and it is the cheapest correct
   answer. **→ [Derived index guide](https://kglite.readthedocs.io/en/latest/python/guides/derived-index.html).**
 - **Primary store** — the graph *is* the authoritative copy. `open()` is
-  crash-safe by default, statements are atomic, readers get snapshot isolation,
+  crash-safe by default for the in-memory and `mapped` backends (`disk`
+  checkpoints on `save()` instead), statements are atomic, readers get snapshot isolation,
   UNIQUE / NOT NULL / node-key constraints are enforced on every write path
   including the bulk loaders, and for in-memory graphs the cost of a write scales
   with the size of the change rather than the size of the graph. One process owns

--- a/crates/kglite/tests/disk_crash_guarantee.rs
+++ b/crates/kglite/tests/disk_crash_guarantee.rs
@@ -1,0 +1,183 @@
+//! What a `SIGKILL` costs a `storage="disk"` graph.
+//!
+//! Disk mode has no write-ahead log: `kglite.open(path, storage="disk")`
+//! opens non-durable and `durable=True` is refused. That is often read as
+//! "disk mode has no crash safety", which is wrong in a way worth pinning
+//! down with a test rather than prose.
+//!
+//! A disk graph commits by publishing an **immutable generation**: the
+//! staged snapshot is fsync'd file-by-file, renamed into `generations/`,
+//! and only then does an atomically-persisted `CURRENT` pointer select it
+//! (`storage::disk::generation::GenerationTxn::publish`). So the guarantee
+//! disk mode *does* offer is precise:
+//!
+//! > A crash loses exactly the mutations made since the last `save()`, and
+//! > nothing else. The graph reopens at the last published generation,
+//! > complete and uncorrupted — never at a partially-written one.
+//!
+//! Nothing is ever acknowledged as durable in between, so no acknowledged
+//! commit is lost; the boundary is the `save()` call itself. These tests
+//! are the evidence for that sentence, which the disk-mode documentation
+//! now states as the contract.
+//!
+//! The parent asserts the child died on signal 9 (`SIGKILL`) — uncatchable,
+//! so not even Rust `Drop` or the process's own teardown runs. A test that
+//! degraded into a graceful-shutdown test would prove nothing about a
+//! crash, which is why this file is Unix-only rather than substituting a
+//! catchable signal on Windows (the same doctrine as
+//! `tests/test_durability.py::requires_sigkill`).
+
+#![cfg(unix)]
+
+use kglite::api::cypher::{execute_mutable, parse_cypher};
+use kglite::api::io::{load_file, save_graph};
+use kglite::api::storage::{new_dir_graph_in_mode, StorageMode};
+use kglite::api::{DirGraph, GraphRead, Value};
+use std::collections::HashMap;
+use std::os::unix::process::ExitStatusExt;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const CHILD_GRAPH: &str = "KGLITE_DISK_CRASH_GRAPH";
+const CHILD_READY: &str = "KGLITE_DISK_CRASH_READY";
+
+fn run(graph: &mut Arc<DirGraph>, query: &str) {
+    let parsed = parse_cypher(query).expect("parse");
+    let dir = kglite::api::make_dir_graph_mut(graph);
+    execute_mutable(dir, &parsed, HashMap::new(), Default::default()).expect("execute");
+}
+
+/// Every node title in the graph, sorted. Disk-backed reads borrow out of
+/// the arena, so the read guard must outlive the borrows.
+fn titles(graph: &DirGraph) -> Vec<String> {
+    let _guard = graph.begin_read_pass();
+    let mut found: Vec<String> = graph
+        .graph
+        .node_indices()
+        .filter_map(|idx| graph.get_node(idx))
+        .map(|node| match &node.title {
+            Value::String(title) => title.to_string(),
+            other => other.to_string(),
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Child half of the crash tests: publish one generation, then mutate
+/// *without* saving and park until the parent kills it. Not a test on its
+/// own — it returns immediately unless the parent's env vars are set.
+#[test]
+fn disk_crash_child() {
+    let Some(root) = std::env::var_os(CHILD_GRAPH) else {
+        return;
+    };
+    let ready = std::env::var_os(CHILD_READY).expect("ready path");
+    let root = Path::new(&root);
+
+    let mut graph =
+        Arc::new(new_dir_graph_in_mode(StorageMode::Disk, Some(root)).expect("create disk graph"));
+    run(&mut graph, "CREATE (:Person {id: 1, title: 'saved'})");
+    save_graph(&mut graph, &root.to_string_lossy()).expect("publish generation");
+
+    // Committed to the process's heap overlay only — no generation is
+    // published for these, so they are exactly what the crash must lose.
+    run(&mut graph, "CREATE (:Person {id: 2, title: 'unsaved'})");
+    run(&mut graph, "CREATE (:Person {id: 3, title: 'unsaved-too'})");
+
+    std::fs::write(ready, b"ready").expect("signal readiness");
+    // The parent kills us here. Long enough that a hang is a test failure,
+    // not a race.
+    std::thread::sleep(Duration::from_secs(60));
+}
+
+/// Spawn the child, wait for it to park, and `SIGKILL` it.
+fn crash_child(root: &Path, ready: &Path) {
+    let mut child = Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "disk_crash_child", "--nocapture"])
+        .env(CHILD_GRAPH, root)
+        .env(CHILD_READY, ready)
+        .spawn()
+        .expect("spawn child");
+
+    let started = Instant::now();
+    while !ready.exists() && started.elapsed() < Duration::from_secs(30) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(ready.exists(), "child never reached its unsaved mutations");
+
+    child.kill().expect("SIGKILL child");
+    let status = child.wait().expect("reap child");
+    assert_eq!(
+        status.signal(),
+        Some(9),
+        "child must die on SIGKILL, or this is not a crash test"
+    );
+}
+
+#[test]
+fn sigkill_loses_exactly_the_mutations_since_the_last_save() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    let recovered = load_file(&root.to_string_lossy()).expect("reopen after crash");
+    assert_eq!(
+        titles(&recovered),
+        vec!["saved".to_string()],
+        "the published generation survives intact; the unsaved mutations are gone"
+    );
+}
+
+#[test]
+fn sigkill_leaves_current_selecting_a_complete_generation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    // `CURRENT` must name a real, complete generation — never a `.stage-*`
+    // directory and never a half-written one. `resolve_snapshot` rejects an
+    // incomplete target, so a successful load *is* that assertion; check the
+    // pointer's shape directly too, so a regression names the pointer rather
+    // than surfacing as a confusing load error.
+    let current = std::fs::read_to_string(root.join("CURRENT")).expect("CURRENT survives");
+    let name = current
+        .strip_suffix('\n')
+        .expect("CURRENT ends in a newline");
+    assert!(
+        name.starts_with("gen_"),
+        "CURRENT must select a published generation, got {name:?}"
+    );
+    let selected = root.join("generations").join(name);
+    assert!(
+        selected.join("metadata.json").is_file(),
+        "the selected generation must carry its completion marker"
+    );
+    assert!(
+        !name.contains(".stage-"),
+        "CURRENT must never select a staging directory"
+    );
+}
+
+#[test]
+fn a_crashed_writer_releases_its_lease_to_the_next_process() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    // The killed writer's `.kglite.lock` file is still on disk, but liveness
+    // is OS advisory-lock based, so a fresh writer takes over and can publish
+    // a new generation on top of the recovered one.
+    let mut recovered = load_file(&root.to_string_lossy()).expect("reopen after crash");
+    run(&mut recovered, "CREATE (:Person {id: 4, title: 'after'})");
+    save_graph(&mut recovered, &root.to_string_lossy()).expect("publish after recovery");
+
+    let reloaded = load_file(&root.to_string_lossy()).expect("reopen after republish");
+    assert_eq!(
+        titles(&reloaded),
+        vec!["after".to_string(), "saved".to_string()],
+        "recovery is writable: the next save publishes on top of the survivor"
+    );
+}

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -30,8 +30,9 @@ KGLite stores nodes and relationships in a Rust graph structure ([petgraph](http
   results are already materialized in Rust (Python values convert on access)
 - **Fluent API** chains build a *selection* (a set of node indices) — no data is copied until you call `collect()`, `to_df()`, etc.
 - **Persistence** uses `save()`/`load()` snapshots; `open()` is crash-safe by
-  default via a write-ahead log (`durable=False` opts out), and
-  context-managed `open()` also persists on clean exit
+  default via a write-ahead log (`durable=False` opts out; `storage="disk"`
+  is the exception — see [Choosing a storage mode](#choosing-a-storage-mode)),
+  and context-managed `open()` also persists on clean exit
 
 ## Storage Modes
 
@@ -61,15 +62,26 @@ everything that fits in RAM. Reach for `mapped` only when the graph
 stops fitting comfortably on the heap, and for `disk` only at the
 Wikidata scale where you want the OS to page data in lazily.
 
-| If your graph is… | …and you want | Use |
-|---|---|---|
-| Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) |
-| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** |
-| 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** |
+| If your graph is… | …and you want | Use | `open()` crash safety |
+|---|---|---|---|
+| Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) | Per-commit WAL, on by default |
+| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL, on by default |
+| 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** | **No WAL** — durability is your `save()` calls |
 
 When in doubt, stay in-memory; switch only once you hit a real RAM
 ceiling. Both larger-than-RAM modes keep the identical Python and
 Cypher API, so moving up is a one-line constructor change.
+
+**The two larger-than-RAM modes differ in durability, not just in layout.**
+`mapped` keeps the same per-commit crash safety as in-memory, so growing out
+of RAM costs you nothing there. `disk` commits by publishing an immutable
+generation instead of by logging a write: `kglite.open(path, storage="disk")`
+opens **non-durable** (passing `durable=True` raises rather than pretending),
+and a crash loses every mutation made since the last `save()`. That is a real
+and bounded guarantee — the published generation always survives intact — but
+it is *your* `save()` calls, not the engine, that decide how much a crash can
+cost. Pick `disk` for its scale, not because a graph outgrew RAM; `mapped`
+covers that case with the guarantee intact. See {doc}`guides/durable-apps`.
 
 ## Return Types
 

--- a/docs/python/guides/durable-apps.md
+++ b/docs/python/guides/durable-apps.md
@@ -134,13 +134,20 @@ optimising for:
 |---|---|---|
 | Every committed write to survive a hard crash | `open(path)` (the default) | One `fsync` per commit; reopen is O(graph) (loads the whole graph). |
 | Maximum write throughput on rebuildable data | `open(path, durable=False)` | No `fsync` per write; a crash loses work since the last checkpoint. |
-| Graphs larger than RAM, cheap reopen | `open(path, storage="disk")` | Paged mmap, lazy load; not a crash-safe-per-write WAL mode. |
+| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` | Same per-commit WAL guarantee; property columns spill to mmap. |
+| 100 M+ nodes (Wikidata-scale), cheap cold-open | `open(path, storage="disk")` | Paged mmap, lazy load; **no per-commit WAL** — durability is your `save()` calls. |
 
 The first two are **in-memory** — the whole graph lives in RAM, which is what
 makes traversal and multi-hop queries fast. Durability adds crash-safety on
-top of that model without changing the in-memory read path. `storage="disk"`
-(see {doc}`/python/core-concepts`) is the separate answer for *larger-than-RAM*
-graphs and cheap cold-open; it is not combined with the WAL.
+top of that model without changing the in-memory read path.
+
+**If your app is simply growing, reach for `mapped`, not `disk`.** `mapped`
+is the larger-than-RAM mode that keeps this guide's guarantee: it is durable by
+default and its crash recovery is kill-9 tested alongside in-memory. `disk` is
+a different trade — a Wikidata-scale exploration mode whose commit boundary is
+an explicit `save()`, not a logged write (see the Limitations below). Choosing
+`disk` because a graph got big means giving up per-commit crash safety you
+did not have to give up.
 
 ## Serving concurrent reads
 
@@ -194,9 +201,32 @@ model.
   logical log; reconciling a replayed frame against a published generation needs
   a generation-aware log this release does not have. `open(path,
   storage="disk")` therefore opens **non-durable**, and passing an explicit
-  `durable=True` raises `ValueError` rather than pretending. Use `save()`
-  checkpoints there. The in-memory default and `storage="mapped"` are both
-  fully durable.
+  `durable=True` raises `ValueError` rather than pretending. The in-memory
+  default and `storage="mapped"` are both fully durable — if you want crash
+  safety on a graph that outgrew RAM, `mapped` is the answer.
+
+  What disk mode *does* guarantee is worth stating exactly, because it is
+  stronger than "no crash safety" and is kill-9 tested
+  (`crates/kglite/tests/disk_crash_guarantee.rs`):
+
+  > A crash loses exactly the mutations made since the last `save()`, and
+  > nothing else. The graph reopens at the last published generation, complete
+  > and uncorrupted — never at a partially-written one.
+
+  Between `save()` calls, disk-mode mutations live only in the process's heap
+  overlay; nothing is written, so nothing can be half-written. The publish
+  itself is crash-atomic: the staged snapshot is `fsync`'d, renamed into place,
+  and only then does an atomically-replaced `CURRENT` pointer select it, so a
+  crash mid-publish leaves the previous generation selected. No acknowledged
+  commit is ever lost — the acknowledgement point is your `save()` call.
+
+  **Budget for the checkpoint's cost before you sprinkle `save()` calls.**
+  Every disk `save()` writes a complete new generation and the superseded ones
+  are retained, so *N* checkpoints leave *N* full copies of the graph on disk.
+  That is deliberate — readers hold their generation mmap'd and must not have
+  it deleted underneath them — but there is no retention policy yet, so
+  checkpoint on a schedule you have the disk budget for, and prune old
+  `generations/gen_*` directories yourself once no reader is using them.
 - **Some state is checkpoint-only.** The log describes nodes, edges, and
   labels. Schema and config metadata, user-created indexes, embeddings, and
   timeseries have no log entry, so they are persisted by `save()` rather than

--- a/docs/python/guides/index.md
+++ b/docs/python/guides/index.md
@@ -26,7 +26,7 @@ Domain-specific surfaces — pull them in when your data has the shape:
 
 | Guide | Read this if… |
 |---|---|
-| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default, checkpoint-on-close, and when to opt out with `durable=False`. |
+| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default (in-memory and `mapped`; `disk` checkpoints on `save()`), checkpoint-on-close, and when to opt out with `durable=False`. |
 | {doc}`derived-index` | …the authoritative copy of your data lives elsewhere — a warehouse, an API, a directory — and the graph is a rebuildable projection you query. Rebuild-and-swap, incremental refresh, carrying embeddings across a rebuild. |
 | {doc}`primary-store` | …the graph *is* the authoritative copy. What holds (statement atomicity, WAL crash safety, snapshot isolation), what is opt-in, and the limits stated plainly. |
 | {doc}`okf` | …your "data" is a markdown knowledge base — an OKF bundle, a Claude memory dir, a skills folder, an Obsidian vault. Frontmatter → nodes, links → typed edges. |

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -300,8 +300,13 @@ rebuild would use.
 **The large-graph modes are still the weaker ones.** `mapped` now gets the same
 per-commit crash safety as in-memory — the kill-9 suites are parametrised over
 both — but `disk` does not: its durability boundary is the generation publish, so
-it relies on `save()` checkpoints, and its crash survival is untested and
-unsupported by design. Both keep the whole-graph write checkpoint described above.
+it relies on `save()` checkpoints. That boundary is a real primitive rather than
+an absence of one, and it is kill-9 tested in its own right
+(`crates/kglite/tests/disk_crash_guarantee.rs`): a crash loses exactly the
+mutations made since the last `save()`, and the last published generation always
+reopens complete — never half-written, and never with a partially-applied commit.
+What `disk` does not give you is a *smaller* unit of durability than a whole
+`save()`. Both keep the whole-graph write checkpoint described above.
 In-memory is the product; the disk modes are for exploring graphs too big for it,
 and that is the trade-off you are accepting.
 


### PR DESCRIPTION
**Evaluation outcome: do not build a disk-mode WAL.** This PR ships the guarantee that already exists — tested — and fixes the documentation that was steering ordinary apps into the one storage mode without per-commit durability. **Zero production source changes** (verified: no `crates/*/src/` file is touched). No version bump.

## Why not a WAL

Disk mode's generation publish is a genuine, fsync'd, crash-atomic durability primitive, not an absence of one. A crash loses **only mutations never acknowledged as durable, and never corrupts or partially applies a commit**.

Between saves, disk mutations live only in the process heap overlay; nothing durable is written, so nothing can be half-written. `GenerationTxn::publish` fsyncs every staged file and directory, renames the stage in, fsyncs the parent, then atomically persists an fsync'd `CURRENT`. Existing failpoint tests already prove old-generation-selected on any pre-pointer failure. And because a stage is always a fresh directory, the in-place `Seal` path is **unreachable from `save_disk`** — no published generation is ever mutated in place.

So the gap isn't "disk is unsafe". It's "disk's durability unit is a whole `save()` rather than a single commit".

**Closing that with a log is structurally wrong for this mode, and the measurement is decisive.** A WAL's economy depends on cheap checkpoints to truncate the log. A disk checkpoint writes a complete new copy of the entire graph *and retains every superseded one*: 5 saves on a 2,000-node graph produced 5 full generations, **141,376 → 716,960 bytes, exactly linear**. So a disk WAL would either never checkpoint (unbounded log and replay) or checkpoint often (unbounded disk growth at O(graph) per commit). Both are worse than today.

Estimated ~600–900 lines across capture, replay-onto-DiskGraph, and publish/truncate ordering — with generation retention as a hard prerequisite, and replay driving the overlay/overflow/CSR path rather than the bulk path. Sprint 2 found four silent data-loss bugs in the *simpler* WAL paths; this is the highest-risk, lowest-value option available.

## The real pain point, which was documentation

`docs/python/guides/durable-apps.md` — the guide written for "the graph is long-lived state your app reopens across runs", i.e. exactly the ordinary application — had a mode-selection table whose `disk` row read *"Graphs larger than RAM, cheap reopen"* with **no size threshold**, and which **omitted `mapped` entirely**.

So the durability guide pointed the audience that most needs per-commit durability at the one mode that lacks it, without mentioning the mode that provides both. Every other surface (README, core-concepts, operators, `.pyi`) gates disk at 100M+ nodes / Wikidata scale, and no tutorial or example uses `storage="disk"`. The `open()` docstring was already precise and `durable=True` already raises a good error — the trap was in the guides.

Fixed here: added the `mapped` row, gated `disk` on Wikidata scale, stated the precise guarantee and its retention cost, added a crash-safety column to the core-concepts decision table, qualified the unqualified "crash-safe by default" claims, and replaced `primary-store.md`'s now-false *"crash survival is untested and unsupported by design"* with the tested contract.

## What's tested now

`crates/kglite/tests/disk_crash_guarantee.rs` — four Unix-gated tests so they can never degrade into graceful-shutdown tests. A child publishes a generation, mutates without saving, and parks; the parent SIGKILLs it and **asserts `status.signal() == Some(9)`**. Verified: the recovered graph holds exactly `["saved"]` (both unsaved creates gone); `CURRENT` always names a `gen_*` with its completion marker and never a `.stage-*`; a fresh process takes the writer lease and publishes on top, yielding `["after", "saved"]`.

## Two space-reclamation bugs surfaced, deliberately not fixed

They should be designed together, not patched separately:

1. **Generation retention is unbounded** — nothing prunes `generations/gen_*`; growth is one full graph copy per `save()`, forever. On the documented Wikidata-scale use case the second `save()` doubles the footprint. Safe pruning isn't trivial: readers take **no lock** by design and resolve `CURRENT` independently, so deleting generation N-1 is a race, and on Windows unlinking mmap'd files fails outright. Correct fix needs reader leases.
2. **Orphaned `.working-<pid>-<nonce>` directories are never reclaimed** — `MutationWorkspace::drop` is the only cleanup, so each SIGKILL leaks one. Usually empty, but `create_index`, `compact()`, and the bulk `defer_csr` loaders write real un-fsync'd data there. Prune-on-lock-acquire is *almost* provably safe but not quite: `detach_for_independent_copy` lets a copy retain a parent's workspace by `Arc`, and an existing test depends on that. A PID-liveness gate would make it correct.

**What would change the verdict:** if generation retention were solved and disk checkpoints became incremental (the `Seal` path exists but is production-unreachable), cheap checkpointing would make a truncatable WAL economically coherent.

## Verification

`make gate` exit 0 · `cargo clippy -p kglite --all-targets -- -D warnings` clean · `make source-quality` clean · new suite **4/4** · `cargo test -p kglite --lib storage::disk` **93/93** · `sphinx-build -W --keep-going` clean.

`pytest -m parity` deliberately not run — it gates backend-touching changes and needs a native extension build; this diff changes no production source.
