### PR TITLE
fix: emit each canonical node column once in table exports (Parquet evaluated, not built)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A property named `id`, `title` or `type` no longer duplicates its column in
+  the table exports. Those three columns come from a node's canonical identity,
+  but a node can also *store* a property under one of those names — Cypher
+  `CREATE (:T {title: 'a'})` sets `title` both ways, so this hit almost every
+  Cypher-built graph. The affected surfaces were `select(...).to_df()`,
+  `collect()`, `sample()`, and `export_csv()`; the SQL-dump, d3/JSON and
+  `to_text()` exporters already dropped the colliding key and are unchanged.
+
+  The duplicate was not cosmetic. The column map backing a DataFrame is keyed
+  by name, so the second write **overwrote the canonical value** — a graph
+  built with `add_nodes(df, 'T', 'id', 'name')` plus a separate `title` column
+  silently lost the canonical title. `DataFrame.to_parquet()` rejects a
+  non-unique header outright, so the documented
+  `to_df().to_parquet(...)` recipe failed with `ValueError: Duplicate column
+  names found`; `pandas.read_csv` and DuckDB silently renamed the second column
+  to `title.1`/`title_1`, inventing a phantom column in what `export_csv`
+  documents as the portable **backup** format.
+
+  A property colliding with an emitted canonical column is now dropped and the
+  canonical value wins. A canonical column the caller opted out of is not
+  emitted and so cannot collide — `to_df(include_type=False)` still returns a
+  stored `type` property as itself.
+
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -540,15 +540,6 @@ impl KnowledgeGraph {
         })
     }
 
-    /// Thin delegate to `kglite_core::graph::handle::discover_property_keys_from_data`.
-    /// Engine logic lifted to core in 0.10.1.
-    pub(crate) fn discover_property_keys_from_data(
-        nodes: &[(&str, &kglite_core::api::NodeData)],
-        interner: &kglite_core::api::StringInterner,
-    ) -> Vec<String> {
-        kglite_core::api::discover_property_keys_from_data(nodes, interner)
-    }
-
     /// Thin delegate to `kglite_core::api::infer_selection_node_type`.
     /// Engine logic lifted to core in 0.10.1.
     pub(crate) fn infer_selection_node_type(&self) -> Option<String> {

--- a/crates/kglite-py/src/graph/pyapi/kg_fluent.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_fluent.rs
@@ -769,7 +769,29 @@ impl KnowledgeGraph {
             }
         }
 
+        // Columns emitted below straight from the node's canonical identity.
+        // A stored property of the same name must be dropped from the property
+        // set: the dict backing the DataFrame is keyed by column name, so a
+        // duplicate does not preserve both values — it overwrites the
+        // canonical one and yields a non-unique header that `to_parquet`
+        // rejects outright. A canonical column the caller opted *out* of is
+        // absent from this list, so a property under that name still survives.
+        let mut emitted_identity: Vec<&str> = vec!["title"];
+        if include_type {
+            emitted_identity.push("type");
+        }
+        if include_id {
+            emitted_identity.push("id");
+        }
+
         // Fast path: use TypeSchema for key discovery when all nodes share a type
+        let discover = |nodes: &Vec<(&str, &kglite_core::api::NodeData)>| {
+            kglite_core::api::discover_property_keys_excluding(
+                nodes,
+                &self.inner.interner,
+                &emitted_identity,
+            )
+        };
         let prop_keys: Vec<String> = if nodes_data.len() > 50 {
             let first_type = nodes_data[0].0;
             let all_same = nodes_data.iter().all(|(nt, _)| *nt == first_type);
@@ -778,19 +800,23 @@ impl KnowledgeGraph {
                     let mut keys: Vec<String> = schema
                         .iter()
                         .filter_map(|(_, ik)| {
-                            self.inner.interner.try_resolve(ik).map(|s| s.to_string())
+                            self.inner
+                                .interner
+                                .try_resolve(ik)
+                                .filter(|s| !emitted_identity.contains(s))
+                                .map(|s| s.to_string())
                         })
                         .collect();
                     keys.sort();
                     keys
                 } else {
-                    Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+                    discover(&nodes_data)
                 }
             } else {
-                Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+                discover(&nodes_data)
             }
         } else {
-            Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+            discover(&nodes_data)
         };
 
         // Build columnar dict-of-lists

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -200,6 +200,11 @@ impl ResultView {
     }
 
     /// Discover property keys by scanning all nodes (fallback path).
+    ///
+    /// Excludes keys naming a canonical identity column — `from_nodes_with_graph`
+    /// leads every row with `type`/`title`/`id` from the node header, so a
+    /// stored property of the same name would repeat the column and shadow the
+    /// canonical value.
     fn discover_property_keys(
         nodes: &[&NodeData],
         interner: &kglite_core::api::StringInterner,
@@ -208,6 +213,9 @@ impl ResultView {
         let mut keys: Vec<String> = Vec::new();
         for node in nodes {
             for key in node.property_keys(interner) {
+                if kglite_core::api::is_canonical_node_column(key) {
+                    continue;
+                }
                 if seen.insert(key) {
                     keys.push(key.to_string());
                 }
@@ -238,7 +246,13 @@ impl ResultView {
                 if let Some(schema) = graph.type_schemas.get(first_type_str) {
                     let mut keys: Vec<String> = schema
                         .iter()
-                        .filter_map(|(_, ik)| graph.interner.try_resolve(ik).map(|s| s.to_string()))
+                        .filter_map(|(_, ik)| {
+                            graph
+                                .interner
+                                .try_resolve(ik)
+                                .filter(|s| !kglite_core::api::is_canonical_node_column(s))
+                                .map(|s| s.to_string())
+                        })
                         .collect();
                     keys.sort();
                     keys

--- a/crates/kglite/src/graph/handle.rs
+++ b/crates/kglite/src/graph/handle.rs
@@ -389,6 +389,31 @@ pub fn infer_selection_node_type(
         .map(|n| n.node_type_str(&dir.interner).to_string())
 }
 
+/// Column names a row-oriented exporter emits from a node's **canonical
+/// identity** rather than from its property bag.
+///
+/// A node's `id`, `title`, and structural `type` are virtuals: every table
+/// exporter writes them as leading columns straight from the node header. A
+/// node may *also* carry a stored property under one of these names — Cypher
+/// `CREATE (:T {title: 'a'})` sets `title` both ways — and an exporter that
+/// naively appends every discovered property key then emits that column
+/// twice. See [`is_canonical_node_column`].
+pub const CANONICAL_NODE_COLUMNS: [&str; 3] = ["id", "title", "type"];
+
+/// Whether `key` names a column a row-oriented exporter already emits from
+/// the node's canonical identity.
+///
+/// Property keys that collide with a canonical column are dropped from the
+/// discovered property set: the canonical value wins. This is the rule the
+/// SQL-dump, d3/JSON, and `to_text` exporters have always applied, and the
+/// only rule that keeps a header unique. Emitting the column twice is not a
+/// lossless alternative — a name-keyed column map silently overwrites the
+/// canonical value with the property, so the duplicate *destroys* the
+/// identity it appears to preserve.
+pub fn is_canonical_node_column(key: &str) -> bool {
+    CANONICAL_NODE_COLUMNS.contains(&key)
+}
+
 /// Discover all unique property keys across a slice of typed nodes.
 /// Returns sorted, de-duplicated key names — useful for any
 /// row-oriented exporter (CSV, Parquet, DataFrame, JSON-lines) that
@@ -396,14 +421,36 @@ pub fn infer_selection_node_type(
 /// schema. The function takes only core types (`NodeData`,
 /// `StringInterner`) so every binding's table-export path can call
 /// it directly.
+///
+/// Keys naming a canonical identity column ([`CANONICAL_NODE_COLUMNS`]) are
+/// excluded, so appending the result to the exporter's leading identity
+/// columns always yields a header with unique names.
 pub fn discover_property_keys_from_data(
     nodes: &[(&str, &crate::graph::schema::NodeData)],
     interner: &crate::graph::schema::StringInterner,
+) -> Vec<String> {
+    discover_property_keys_excluding(nodes, interner, &CANONICAL_NODE_COLUMNS)
+}
+
+/// [`discover_property_keys_from_data`] with an explicit exclusion set.
+///
+/// For an exporter that emits only *some* canonical columns — the fluent
+/// `to_df(include_type=False)` drops the structural `type` column — pass the
+/// names actually emitted. A canonical name that is *not* emitted carries no
+/// collision, so a stored property under that name is real user data and must
+/// survive.
+pub fn discover_property_keys_excluding(
+    nodes: &[(&str, &crate::graph::schema::NodeData)],
+    interner: &crate::graph::schema::StringInterner,
+    excluded: &[&str],
 ) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     let mut keys = Vec::new();
     for (_, node) in nodes {
         for key in node.property_keys(interner) {
+            if excluded.contains(&key) {
+                continue;
+            }
             if seen.insert(key.to_string()) {
                 keys.push(key.to_string());
             }
@@ -673,5 +720,70 @@ mod boundary_lift_tests {
             code_entity_context(&graph, "missing", None, 1),
             CodeContextLookup::NotFound
         ));
+    }
+
+    /// A graph whose nodes store `title` (and one storing `type`) in the
+    /// property bag as well as in the canonical header — what Cypher `CREATE`
+    /// produces for any ordinary graph.
+    fn collision_graph() -> Arc<DirGraph> {
+        let mut graph = DirGraph::new();
+        let params = HashMap::new();
+        execute_mut(
+            &mut graph,
+            "CREATE (:T {id:1, title:'a', v:2}), (:T {id:2, title:'b', type:'USER', w:3})",
+            &ExecuteOptions::eager(&params),
+        )
+        .expect("fixture nodes");
+        Arc::new(graph)
+    }
+
+    fn nodes_of(graph: &DirGraph) -> Vec<(&str, &crate::graph::schema::NodeData)> {
+        graph
+            .graph
+            .node_indices()
+            .filter_map(|idx| {
+                graph
+                    .get_node(idx)
+                    .map(|n| (n.node_type_str(&graph.interner), n))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn discovered_property_keys_exclude_canonical_columns() {
+        // Every row exporter emits id/title/type from the node header, so a
+        // stored property of the same name must not become a second column.
+        let graph = collision_graph();
+        let keys = discover_property_keys_from_data(&nodes_of(&graph), &graph.interner);
+        assert_eq!(keys, vec!["v".to_string(), "w".to_string()]);
+        for canonical in CANONICAL_NODE_COLUMNS {
+            assert!(
+                !keys.contains(&canonical.to_string()),
+                "canonical column {canonical} leaked into the property key set"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unemitted_canonical_column_keeps_its_stored_property() {
+        // `to_df(include_type=False)` emits no `type` column, so there is no
+        // collision and the stored `type` property is real user data.
+        let graph = collision_graph();
+        let keys =
+            discover_property_keys_excluding(&nodes_of(&graph), &graph.interner, &["id", "title"]);
+        assert_eq!(
+            keys,
+            vec!["type".to_string(), "v".to_string(), "w".to_string()]
+        );
+    }
+
+    #[test]
+    fn is_canonical_node_column_covers_exactly_the_identity_names() {
+        assert!(is_canonical_node_column("id"));
+        assert!(is_canonical_node_column("title"));
+        assert!(is_canonical_node_column("type"));
+        assert!(!is_canonical_node_column("titles"));
+        assert!(!is_canonical_node_column("node_type"));
+        assert!(!is_canonical_node_column("Title"));
     }
 }

--- a/crates/kglite/src/graph/io/export.rs
+++ b/crates/kglite/src/graph/io/export.rs
@@ -554,6 +554,49 @@ pub struct ExportSummary {
     pub log_lines: Vec<String>,
 }
 
+/// The property columns one node type contributes to its CSV, and the
+/// blueprint type name inferred for each.
+///
+/// Returns `(sorted column names, column -> type name)`. Keys naming a
+/// canonical identity column (`id`/`title`/`type`) are excluded: those are
+/// written from the node header, and repeating one would both duplicate the
+/// CSV column and — for any name-keyed reader such as `pandas.read_csv` —
+/// shadow the identity value behind a phantom `title.1`. Each column's type is
+/// taken from its first non-null value.
+fn node_property_columns(
+    graph: &DirGraph,
+    indices: &[petgraph::graph::NodeIndex],
+) -> (Vec<String>, BTreeMap<String, String>) {
+    let mut prop_names: BTreeSet<String> = BTreeSet::new();
+    for &idx in indices {
+        if let Some(node) = graph.graph.node_weight(idx) {
+            for key in node.property_keys(&graph.interner) {
+                if crate::graph::handle::is_canonical_node_column(key) {
+                    continue;
+                }
+                prop_names.insert(key.to_string());
+            }
+        }
+    }
+    let prop_cols: Vec<String> = prop_names.into_iter().collect();
+
+    let mut prop_types: BTreeMap<String, String> = BTreeMap::new();
+    for col in &prop_cols {
+        for &idx in indices {
+            if let Some(node) = graph.graph.node_weight(idx) {
+                if let Some(val) = node.get_property(col) {
+                    if !matches!(*val, Value::Null) {
+                        prop_types.insert(col.clone(), value_type_name(&val));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    (prop_cols, prop_types)
+}
+
 /// Export the graph (or selection) to an organized CSV directory tree.
 ///
 /// Creates:
@@ -650,31 +693,7 @@ pub fn to_csv_dir(
     let mut node_type_prop_types: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for (node_type, indices) in &nodes_by_type {
-        // First pass: collect the union of all property names
-        let mut prop_names: BTreeSet<String> = BTreeSet::new();
-        for &idx in indices {
-            if let Some(node) = graph.graph.node_weight(idx) {
-                for key in node.property_keys(&graph.interner) {
-                    prop_names.insert(key.to_string());
-                }
-            }
-        }
-        let prop_cols: Vec<String> = prop_names.into_iter().collect();
-
-        // Infer property types from first non-null value of each property
-        let mut prop_types: BTreeMap<String, String> = BTreeMap::new();
-        for col in &prop_cols {
-            for &idx in indices {
-                if let Some(node) = graph.graph.node_weight(idx) {
-                    if let Some(val) = node.get_property(col) {
-                        if !matches!(*val, Value::Null) {
-                            prop_types.insert(col.clone(), value_type_name(&val));
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        let (prop_cols, prop_types) = node_property_columns(graph, indices);
 
         // Build CSV
         let mut csv = String::with_capacity(4096);

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -67,7 +67,9 @@ pub mod api {
     // (The code-tree handle helpers `resolve_code_entity` / `CODE_TYPES` /
     // `source_location` live in `api::code_entities`.)
     pub use crate::graph::handle::{
-        discover_property_keys_from_data, infer_selection_node_type, KnowledgeGraph,
+        discover_property_keys_excluding, discover_property_keys_from_data,
+        infer_selection_node_type, is_canonical_node_column, KnowledgeGraph,
+        CANONICAL_NODE_COLUMNS,
     };
     /// Core schema data types — the node record (`NodeData`), the projected
     /// `NodeInfo`, geo/temporal validity configs (`SpatialConfig` /

--- a/docs/python/guides/import-export.md
+++ b/docs/python/guides/import-export.md
@@ -161,21 +161,82 @@ so a dump can be committed and diffed.
 
 KGLite does **not** export Parquet directly, and this is a deliberate scope
 decision rather than a gap. Doing it in Rust means taking on the
-`arrow` + `parquet` dependency tree, which is large; an earlier review of
-columnar/Arrow export reached the same conclusion and dropped it. KGLite has
-been steadily *shedding* dependencies, and re-adding a heavy one for a format
-already one line away would cut against that.
+`arrow` + `parquet` dependency tree — measured at **+35 crates** on top of the
+CLI's 143 for a minimal Arrow-backed writer, and +336 lines of `Cargo.lock`.
+KGLite has been steadily *shedding* dependencies (309 → 171 across 0.14.x), and
+`arrow` in particular is a library this project already keeps at arm's length:
+kglite pins its bundled allocator to mimalloc v2 specifically to survive being
+imported alongside `pyarrow`.
 
-If you want Parquet, go through the DataFrame you already have — the
-dependency then lives in your environment, where you control it:
+Parquet is a format you can reach with tools you already have. Pick whichever
+end of the pipe you prefer.
+
+**One table, from a query.** The dependency lives in your environment, where
+you control it:
 
 ```python
 graph.cypher("MATCH (p:Person) RETURN p.id, p.title, p.age").to_df().to_parquet('people.parquet')
 ```
 
-For a whole-graph dump, {meth}`~kglite.KnowledgeGraph.export_csv` writes one
-CSV per node and connection type plus a `blueprint.json` for re-import, and
-SQLite (above) covers the "give me a real database" case.
+**The whole graph, no Python at all.** The SQLite dump above already turns
+every node type and connection type into a table, and DuckDB writes Parquet
+from those tables directly:
+
+```bash
+kglite export-sqlite mygraph.kgl dump.sql
+sqlite3 mygraph.db < dump.sql
+duckdb -c "INSTALL sqlite; LOAD sqlite; ATTACH 'mygraph.db' AS g (TYPE sqlite);
+           COPY (SELECT * FROM g.Person)   TO 'Person.parquet'   (FORMAT PARQUET);
+           COPY (SELECT * FROM g.WORKS_AT) TO 'WORKS_AT.parquet' (FORMAT PARQUET);"
+```
+
+**The whole graph, from Python.** `to_df()` covers nodes; edges come from a
+Cypher query in the same link-table shape the SQLite export uses. Drive both
+off the graph's own type lists rather than hand-writing a query per type:
+
+```python
+import pathlib
+import pandas as pd
+
+def export_parquet(graph, out_dir):
+    out = pathlib.Path(out_dir)
+    (out / 'nodes').mkdir(parents=True, exist_ok=True)
+    (out / 'edges').mkdir(exist_ok=True)
+
+    for node_type in graph.node_types:
+        graph.select(node_type).to_df().to_parquet(out / 'nodes' / f'{node_type}.parquet')
+
+    for conn in graph.connection_types():
+        ct = conn['type']
+        df = graph.cypher(f"""
+            MATCH (a)-[r:{ct}]->(b)
+            RETURN labels(a)[0] AS source_type, a.id AS source_id,
+                   labels(b)[0] AS target_type, b.id AS target_id,
+                   properties(r) AS props
+        """).to_df()
+        props = pd.json_normalize(df.pop('props')).drop(columns=['type'], errors='ignore')
+        pd.concat([df, props], axis=1).to_parquet(out / 'edges' / f'{ct}.parquet')
+```
+
+This produces `nodes/Person.parquet` with columns `type, title, id, age, city`
+and `edges/WORKS_AT.parquet` with `source_type, source_id, target_type,
+target_id, salary, since` — the same mapping the SQLite table/link-table export
+uses. Properties absent on a given node or edge become nulls, and integers,
+floats, booleans and datetimes keep their types through the round-trip.
+
+Two things to know when you write your own variant:
+
+- **`properties(r)` includes the connection type under a `type` key**; drop it
+  (as above) or it becomes a redundant column.
+- **A node's `id`, `title` and `type` come from its canonical identity**, not
+  from its property bag. If a node also stores a property under one of those
+  names, the canonical value wins and the column is not repeated — a
+  duplicated column name would make `to_parquet()` fail outright.
+
+For a whole-graph dump without a DataFrame,
+{meth}`~kglite.KnowledgeGraph.export_csv` writes one CSV per node and
+connection type plus a `blueprint.json` for re-import, and SQLite (above)
+covers the "give me a real database" case.
 
 ## Back up before upgrading
 

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -1864,12 +1864,22 @@ class KnowledgeGraph:
         Each node becomes a row with columns for title, type, id, and all
         properties. Missing properties across different node types become None.
 
+        ``id``, ``title`` and ``type`` come from the node's canonical identity.
+        A node may also *store* a property under one of those names —
+        ``CREATE (:T {title: 'a'})`` sets ``title`` both ways — in which case
+        the canonical value wins and the property is not repeated as a second
+        column. Opt a canonical column out to read the stored property
+        instead: with ``include_type=False`` there is no ``type`` column to
+        collide with, so a stored ``type`` property is returned as itself.
+
         Args:
             include_type: Include ``type`` column. Default ``True``.
             include_id: Include ``id`` column. Default ``True``.
 
         Returns:
-            DataFrame with one row per selected node.
+            DataFrame with one row per selected node. Column names are unique,
+            so the frame is directly writable with ``to_parquet()`` /
+            ``to_csv()``.
         """
         ...
 

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -196,9 +196,9 @@
     {
       "path": "crates/kglite/src/graph/io/export.rs",
       "qualified_name": "crate::to_csv_dir",
-      "lines": 307,
-      "branches": 40,
-      "nesting": 6
+      "lines": 283,
+      "branches": 32,
+      "nesting": 5
     },
     {
       "path": "crates/kglite/src/graph/io/file.rs",
@@ -516,6 +516,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +542,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",

--- a/tests/test_canonical_column_collision.py
+++ b/tests/test_canonical_column_collision.py
@@ -1,0 +1,201 @@
+"""A property named ``id``/``title``/``type`` must not duplicate its column.
+
+Every row-oriented node exporter leads each row with the node's **canonical
+identity** — ``id``, ``title``, and the structural ``type`` — taken from the
+node header rather than from its property bag. A node may *also* store a
+property under one of those names: ``CREATE (:T {title: 'a'})`` sets ``title``
+both ways, which is the ordinary way to build a graph in Cypher.
+
+An exporter that appends every discovered property key to those leading
+columns then emits the column twice. That is not a cosmetic wart:
+
+* the column map backing a DataFrame is keyed by name, so the second write
+  **overwrites the canonical value** — the duplicate destroys the identity it
+  appears to preserve (``add_nodes(df, 'T', 'id', 'name')`` plus a separate
+  ``title`` column silently lost the canonical title);
+* ``DataFrame.to_parquet()`` rejects a non-unique header outright with
+  ``ValueError: Duplicate column names found``, so the documented
+  ``to_df().to_parquet(...)`` recipe failed on any Cypher-built graph;
+* ``pandas.read_csv``/DuckDB silently rename the second column to
+  ``title.1``/``title_1``, inventing a phantom column in what
+  ``export_csv`` documents as the portable **backup** format.
+
+The rule, which the SQL-dump, d3/JSON and ``to_text`` exporters have always
+applied and which the three surfaces below now share: **a property colliding
+with an emitted canonical column is dropped; the canonical value wins.** A
+canonical column the caller opted out of (``to_df(include_type=False)``) is
+not emitted, so there is no collision and the stored property survives.
+"""
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+from kglite import KnowledgeGraph
+
+# Cypher `CREATE` stores `title` in the property bag *and* as the canonical
+# title — the collision is the normal case, not an exotic one.
+COLLIDING = "CREATE (n:T {id: 1, title: 'a', v: 2})"
+
+
+def _dupes(columns):
+    """Column names appearing more than once, in order."""
+    seen, dupes = set(), []
+    for c in columns:
+        if c in seen and c not in dupes:
+            dupes.append(c)
+        seen.add(c)
+    return dupes
+
+
+@pytest.fixture
+def graph():
+    g = KnowledgeGraph()
+    g.cypher(COLLIDING)
+    return g
+
+
+# --------------------------------------------------------------- DataFrame path
+
+
+def test_fluent_to_df_emits_title_once(graph):
+    df = graph.select("T").to_df()
+    assert _dupes(df.columns) == [], f"duplicate columns: {list(df.columns)}"
+    assert list(df.columns) == ["type", "title", "id", "v"]
+
+
+def test_fluent_to_df_keeps_canonical_values(graph):
+    """The surviving column carries real values, not a shadowed blank."""
+    row = graph.select("T").to_df().to_dict("records")[0]
+    assert row == {"type": "T", "title": "a", "id": 1, "v": 2}
+
+
+def test_collect_and_sample_emit_title_once(graph):
+    """`collect()`/`sample()` build their columns on a separate code path."""
+    for name in ("collect", "sample"):
+        cols = list(getattr(graph.select("T"), name)().columns)
+        assert _dupes(cols) == [], f"{name}() duplicate columns: {cols}"
+        assert cols == ["type", "title", "id", "v"]
+
+
+def test_schema_fast_path_emits_title_once():
+    """Above 50 same-type nodes, key discovery switches to the TypeSchema."""
+    g = KnowledgeGraph()
+    g.cypher('UNWIND range(1, 60) AS i CREATE (:B {id: i, title: "t" + toString(i), v: i})')
+    for cols in (
+        list(g.select("B").to_df().columns),
+        list(g.select("B").collect().columns),
+    ):
+        assert _dupes(cols) == [], f"duplicate columns on schema fast path: {cols}"
+        assert cols == ["type", "title", "id", "v"]
+
+
+def test_canonical_title_survives_a_differing_title_property():
+    """The regression that silently destroyed data.
+
+    `add_nodes(..., 'id', 'name')` makes `name` the canonical title, so a
+    separate `title` column is an ordinary property whose value *differs*
+    from the canonical title. The old duplicate-column output overwrote the
+    canonical value with the property; the canonical one must win.
+    """
+    pd = pytest.importorskip("pandas")
+    g = KnowledgeGraph()
+    g.add_nodes(
+        pd.DataFrame([{"id": 1, "name": "FromName", "title": "FromTitleCol", "v": 9}]),
+        "T",
+        "id",
+        "name",
+    )
+    df = g.select("T").to_df()
+    assert _dupes(df.columns) == [], f"duplicate columns: {list(df.columns)}"
+    assert df.to_dict("records")[0]["title"] == "FromName"
+
+
+def test_opted_out_canonical_column_leaves_the_property_intact():
+    """No emitted `type` column means no collision — the property is real data."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (n:T {id: 1, title: 'a', type: 'USER', v: 2})")
+
+    with_type = g.select("T").to_df()
+    assert _dupes(with_type.columns) == []
+    assert with_type.to_dict("records")[0]["type"] == "T"  # structural type wins
+
+    without_type = g.select("T").to_df(include_type=False)
+    assert _dupes(without_type.columns) == []
+    # The stored property survives, with its own value.
+    assert without_type.to_dict("records")[0]["type"] == "USER"
+
+
+# --------------------------------------------------------------------- CSV path
+
+
+def test_export_csv_header_is_unique(tmp_path, graph):
+    """`export_csv` is the documented portable backup — its header must be sane."""
+    graph.export_csv(str(tmp_path), selection_only=False)
+    header = (tmp_path / "nodes" / "T.csv").read_text(encoding="utf-8").splitlines()[0]
+    cols = header.split(",")
+    assert _dupes(cols) == [], f"duplicate CSV columns: {header}"
+    assert cols == ["id", "title", "v"]
+
+
+def test_export_csv_roundtrips_through_blueprint(tmp_path, graph):
+    """The backup path must still restore values after the de-duplication."""
+    import kglite
+
+    graph.export_csv(str(tmp_path), selection_only=False)
+    restored = kglite.from_blueprint(str(tmp_path / "blueprint.json"))
+    rows = restored.cypher("MATCH (n:T) RETURN n.id, n.title, n.v").to_list()
+    assert rows == [{"n.id": 1, "n.title": "a", "n.v": 2}]
+
+
+# ----------------------------------------------------------------- Parquet path
+#
+# The documented recipe is `to_df().to_parquet(...)`, and a non-unique header
+# is exactly what pandas refuses. We assert it end to end — but never import
+# pyarrow into the pytest runner: that arms the dual-mimalloc teardown SIGSEGV
+# the project pins mimalloc v2 to avoid (see test_pyarrow_coexistence.py).
+# Detection is import-free via find_spec; the real write happens in a
+# subprocess, run from a neutral cwd so the installed wheel wins over the
+# source tree.
+
+_PARQUET_SNIPPET = """
+import kglite
+g = kglite.KnowledgeGraph()
+g.cypher("CREATE (n:T {id: 1, title: 'a', v: 2})")
+df = g.select('T').to_df()
+assert list(df.columns) == ['type', 'title', 'id', 'v'], list(df.columns)
+
+path = 'out.parquet'
+df.to_parquet(path)
+
+import pandas as pd
+back = pd.read_parquet(path)
+assert list(back.columns) == ['type', 'title', 'id', 'v'], list(back.columns)
+assert back.to_dict('records')[0] == {'type': 'T', 'title': 'a', 'id': 1, 'v': 2}
+# Types must survive the round-trip, not just the values.
+assert str(back['id'].dtype) == 'int64', back['id'].dtype
+assert str(back['v'].dtype) == 'int64', back['v'].dtype
+print('OK')
+"""
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pyarrow") is None,
+    reason="pyarrow not installed — the documented to_parquet recipe needs it",
+)
+def test_to_df_to_parquet_recipe_roundtrips(tmp_path):
+    """`to_df().to_parquet(...)` — the documented Parquet exit — must work."""
+    result = subprocess.run(
+        [sys.executable, "-c", _PARQUET_SNIPPET],
+        cwd=str(tmp_path),  # neutral cwd: installed wheel, not the source tree
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"to_df().to_parquet() recipe failed (exit {result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
**Evaluation outcome: do not build Parquet — but verifying the argument for skipping it exposed silent data loss, which this PR fixes.** No version bump.

## The scope-out was right; its stated justification was false

The documented reason for skipping Parquet was that it's "one line away" via `…to_df().to_parquet(...)`. **Nobody had ever run it.** It raises `ValueError: Duplicate column names found` on essentially every Cypher-built graph.

Reproduced on `main`:

```python
g.cypher("CREATE (:Person {title:'Ada', age:36, city:'London'})")
g.select("Person").to_df().columns
# -> ['type', 'title', 'id', 'age', 'city', 'title']      <- title twice
```

`CREATE (:T {title: 'a'})` stores `title` both in the property bag and as canonical identity, so the exporter emitted the column twice.

**And it was worse than a duplicate — it was silent data loss.** The column map backing the DataFrame is keyed by name, so the second write *overwrote* the canonical value. A graph built via `add_nodes(df, 'T', 'id', 'name')` with a separate `title` column lost its canonical title entirely; a stored `type` property destroyed the structural type.

**The same bug is in `export_csv`** — the path documented as *backup before upgrading*. Header: `id,title,age,city,title`. pandas silently renames the second to `title.1`, DuckDB to `title_1`: a phantom column in the format documented as the portable backup.

Three surfaces affected — `to_df`, `collect()`/`sample()`, and `export_csv` — including the >50-node schema fast path.

## The fix

Aligns the two outlier exporters with the rule `to_text`, the SQL export, and the d3 export already followed: **canonical wins, the colliding property is dropped**. New `CANONICAL_NODE_COLUMNS` / `is_canonical_node_column` / `discover_property_keys_excluding` in `graph/handle.rs`, applied in the fluent `to_df`, `result_view`, and `io/export.rs`.

One near-regression avoided: `to_df(include_type=False)` emits no `type` column, so there is no collision and a stored `type` property must still be returned as itself.

**Tests:** `tests/test_canonical_column_collision.py` plus 3 Rust unit tests. Verified by reverting the fix and rebuilding — **7 of 9 fail without it**. Parquet is written in a *subprocess* so pyarrow is never imported into the pytest runner, which would arm the known dual-mimalloc teardown SIGSEGV.

The source-quality gate refused to let a 307-line function grow, so `node_property_columns` was extracted (307→283 lines, nesting 6→5) — tightening the ratchet rather than bumping it.

## Why Parquet still shouldn't be built

**Measured dependency cost**, not estimated:

| Config | Packages | Δ vs 143 baseline |
|---|---|---|
| `parquet` default features | 186 | **+43** |
| `default-features=false` + `arrow` | 178 | **+35** ← realistic minimum |
| no arrow (hand-rolled writer) | 162 | +19 |

`Cargo.lock` +336 lines; **223 MB** of debug artifacts (`libparquet.rlib` alone is 58 MB); cold compile 6.9 s wall / 22.5 s CPU per uncached runner.

+35 crates is real but not decisive alone. **What is decisive:** `arrow` is the library that has crashed this project twice, and kglite pins mimalloc **v2** — paying 3–4% on parse-heavy loads — purely to survive coexisting with pyarrow. Linking it in converts a managed external hazard into an internal one.

**Demand: zero.** No user, downstream project, or inbox message has asked. The project's own competitive analysis argues against it under a header reading *"Chasing this erodes kglite — don't"*.

**A correction for the record:** the "earlier review that dropped Arrow export", cited in the docs and in the brief for this evaluation, **no longer exists on disk**, and its last tracked content *proposed* Arrow rather than dropping it. That citation was unverifiable and has been replaced with the measured +35-crate figure.

## What replaced it in the docs

A **tested** whole-graph → Parquet recipe covering every node type and connection type, plus a verified zero-Python route: `export-sqlite` → `sqlite3` → DuckDB `ATTACH` + `COPY … (FORMAT PARQUET)`, run end to end.

## Verification

`make gate` exit 0 · clippy `--all-targets -- -D warnings` clean · `make source-quality` clean · `sphinx -W` clean · collision suite **9/9** · full suite 4800 passed, 63 skipped (8 pre-existing `_run_mcp_server` assertions absent by construction from a deliberately narrow `--no-default-features` build).

## Surfaced, not fixed

- **`when` and `end` cannot be used as property names** — `CypherSyntaxError: Expected property key`, while `start`, `order`, `count`, `all`, `any`, `filter`, `type`, `key`, `value` all work. Reserved-word leakage in the property-key parser.
- **API inconsistency**: `g.node_types` is a property but `g.connection_types()` is a method.
