### PR TITLE
fix: write clauses fed zero rows no longer create anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A Cypher write clause fed zero rows no longer writes anything. `MATCH (p:Project
+  {key: 'NOPE'}) CREATE (t:Task ...)` used to return a row and create the node
+  even though the `MATCH` found nothing; it now returns no rows and creates
+  nothing, matching Neo4j. The same fix covers `MERGE` and `FOREACH` after an
+  empty match, and `UNWIND [] AS x CREATE ...`.
+
+  The two-variable form was the damaging one: `MATCH (t:Task {...}), (u:User
+  {...}) CREATE (t)-[:ASSIGNED_TO]->(u)` where `u` matched nothing used to
+  fabricate `u` as a real node and attach the relationship to it, leaving an
+  edge pointing at a node with no label and no properties — invisible to any
+  label scan but reachable by traversal. With no referential-integrity
+  constraints in the engine, "MATCH the parent, then CREATE the child" is the
+  only way an application can enforce a foreign key, and this silently defeated
+  it while returning a plausible-looking id.
+
+  Cause: `CREATE`, `MERGE`, and `FOREACH` each decided whether to supply
+  Cypher's implicit single start row by testing whether the incoming row set was
+  empty — which is equally true at the start of a query and after a clause that
+  matched nothing. That decision now lives in the clause pipeline, which is the
+  only place that can tell the two apart. `SET`, `DELETE`, and `REMOVE` were
+  never affected. Behaviour that deliberately does *not* change: a leading
+  `CREATE`/`MERGE`/`FOREACH` with no preceding clause still runs exactly once,
+  and `OPTIONAL MATCH` still yields one null-padded row that a following
+  `CREATE` acts on.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -269,6 +269,21 @@ fn run_clause_pipeline(
     let profiling = ctx.profiling;
     let mut result_set = seed;
 
+    // `result_set.rows.is_empty()` means two opposite things depending on where
+    // the pipeline is. Before any clause has run it means "no binding stream
+    // exists yet", and Cypher's implicit single empty row applies — a leading
+    // `CREATE` runs once. After a clause has run it means "the stream exists and
+    // holds zero rows", and every downstream clause must produce zero rows and
+    // no side effects. Only the pipeline can tell the two apart, so it owns the
+    // distinction here; individual clauses must never re-derive it from
+    // emptiness (doing so is what made `MATCH`-finds-nothing + `CREATE`
+    // fabricate a row and create an unbound node).
+    //
+    // `leading` is non-empty only for the `LOAD CSV` driver, which strips its
+    // own clause and re-enters this pipeline once per batch — those batch rows
+    // are an already-established stream.
+    let mut stream_established = !ctx.leading.is_empty();
+
     for (i, clause) in clauses.iter().enumerate() {
         if interrupt.exceeded() {
             // Deadline passed or the caller flipped the cancel flag (Ctrl-C).
@@ -276,11 +291,13 @@ fn run_clause_pipeline(
             // changes, leaving the graph unchanged.
             return Err("Query interrupted".to_string());
         }
-        // Seed first-clause WITH/UNWIND (same as read-only path)
-        if i == 0
-            && result_set.rows.is_empty()
-            && matches!(clause, Clause::With(_) | Clause::Unwind(_))
-        {
+        // Materialize Cypher's implicit start row for the clauses that consume
+        // one. Deliberately lazy rather than seeding `ResultSet::new()` up
+        // front: MATCH/OPTIONAL MATCH select their leading (scan) form over
+        // their correlated (extend-each-row) form by testing `rows.is_empty()`,
+        // so handing them a row would change how they plan. Same seed the
+        // read-only path applies in `executor/mod.rs`.
+        if !stream_established && clause_needs_implicit_row(clause) {
             result_set.rows.push(ResultRow::new());
         }
 
@@ -291,9 +308,11 @@ fn run_clause_pipeline(
             None
         };
 
-        // If a prior clause produced 0 rows, MATCH/OPTIONAL MATCH cannot
-        // extend an empty pipeline — short-circuit to 0 rows.
-        if i > 0
+        // An established-but-empty stream cannot be extended: MATCH has nothing
+        // to join against, and OPTIONAL MATCH null-pads incoming rows of which
+        // there are none. Short-circuit rather than dispatch, so neither reaches
+        // its leading form and re-scans the graph.
+        if stream_established
             && result_set.rows.is_empty()
             && matches!(clause, Clause::Match(_) | Clause::OptionalMatch(_))
         {
@@ -418,9 +437,34 @@ fn run_clause_pipeline(
                 elapsed_us: s.elapsed().as_micros() as u64,
             });
         }
+
+        // From here on, `rows.is_empty()` means "zero rows", never "not started".
+        stream_established = true;
     }
 
     Ok(result_set)
+}
+
+/// Does `clause` consume Cypher's implicit single empty start row when it opens
+/// a query?
+///
+/// These are the clauses that produce output per incoming row and therefore
+/// need one row to act on even with nothing before them: `CREATE (:T)`,
+/// `MERGE (:T)`, a standalone `FOREACH`, and a leading `WITH`/`UNWIND`. Read
+/// clauses are absent on purpose — MATCH/OPTIONAL MATCH open a query by
+/// scanning, not by extending a row.
+///
+/// Only ever consulted while the stream is unestablished, so it cannot
+/// resurrect a stream that a preceding clause emptied.
+fn clause_needs_implicit_row(clause: &Clause) -> bool {
+    matches!(
+        clause,
+        Clause::With(_)
+            | Clause::Unwind(_)
+            | Clause::Create(_)
+            | Clause::Merge(_)
+            | Clause::Foreach { .. }
+    )
 }
 
 /// Flush staged writes and project the pipeline's rows into a `CypherResult`.
@@ -483,8 +527,9 @@ fn finalize_mutation(
 /// For each incoming row, evaluate `list` in that row's context and run
 /// `body`'s update clauses once per element with `variable` bound to it.
 /// The outer row set is a side-effect input only — it is not modified
-/// and body bindings do not propagate out. A standalone FOREACH (no
-/// incoming rows) still runs once over an empty binding row.
+/// and body bindings do not propagate out. Zero incoming rows means the
+/// body never runs; a standalone FOREACH still runs once, over the implicit
+/// start row the pipeline seeds for it.
 #[allow(clippy::too_many_arguments)]
 fn execute_foreach(
     graph: &mut DirGraph,
@@ -497,16 +542,7 @@ fn execute_foreach(
     interrupt: &Interrupt,
     budget: &super::budget::ExecutionBudget,
 ) -> Result<(), String> {
-    // A FOREACH at the start of a query has no incoming rows; run it once
-    // over a single empty binding row so standalone loops work.
-    let seed = [ResultRow::new()];
-    let rows: &[ResultRow] = if outer.rows.is_empty() {
-        &seed
-    } else {
-        &outer.rows
-    };
-
-    for (row_idx, row) in rows.iter().enumerate() {
+    for (row_idx, row) in outer.rows.iter().enumerate() {
         check_interrupt_periodic(interrupt, row_idx)?;
         // Evaluate the list in this row's context (read-only borrow of the
         // graph, dropped before the per-element mutations below).
@@ -654,12 +690,12 @@ fn execute_create(
     // same mechanism `add_nodes` uses), and the disk read-side is synced once
     // at the end of this function — see the `sync_disk_column_stores` call
     // below. (SET/DELETE/REMOVE already work on disk via the staged-write path.)
-    let source_rows = if existing.rows.is_empty() {
-        // No prior MATCH: execute once with an empty row
-        vec![ResultRow::new()]
-    } else {
-        existing.rows
-    };
+    // One CREATE per incoming row, and nothing at all for zero rows. A leading
+    // CREATE gets its single empty row from the pipeline's implicit-start-row
+    // seed (`clause_needs_implicit_row`) — this function must not synthesize
+    // one, because from here an empty `existing` is indistinguishable from a
+    // preceding MATCH that found nothing.
+    let source_rows = existing.rows;
 
     let mut new_rows = Vec::with_capacity(source_rows.len());
 
@@ -1969,11 +2005,9 @@ fn execute_merge(
     // branch routes through `execute_create` (disk-capable via
     // `DirGraph::insert_node_routed`); ON CREATE/MATCH SET route through
     // `execute_set` (already disk-capable). No disk guard needed.
-    let source_rows = if existing.rows.is_empty() {
-        vec![ResultRow::new()]
-    } else {
-        existing.rows
-    };
+    // As in `execute_create`: one MERGE per incoming row, none for zero rows.
+    // The implicit start row for a leading MERGE is seeded by the pipeline.
+    let source_rows = existing.rows;
 
     let mut new_rows = Vec::with_capacity(source_rows.len());
 

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -2092,6 +2092,70 @@ MUTATION_QUERIES: list[tuple[str, str]] = [
         "many_labels_one_node",
         "MATCH (p:Person {person_id: 2}) SET p:A SET p:B SET p:C WITH p REMOVE p:B RETURN labels(p) AS ls",
     ),
+    # ── Write clauses fed an empty binding stream ────────────────────────
+    #
+    # A clause that produced zero rows must leave every downstream write with
+    # nothing to do. What these pin for the optimizer specifically: no pass may
+    # drop, hoist, or fuse a write clause out from behind the emptying clause,
+    # because doing so would restore the write to a *leading* position — where
+    # Cypher's implicit start row legitimately applies and one node really is
+    # created. Optimized and naive therefore have to agree on post-state node
+    # and edge counts, which is what the harness compares.
+    #
+    # `person_id: 999` and the `Ghost` label are chosen to match nothing in the
+    # fixture; `Ghost` also makes the pattern's node type unknown, the shape the
+    # planner emits an "unknown node label … returns no rows" warning for.
+    (
+        "create_after_empty_inline_map_match",
+        "MATCH (p:Person {person_id: 999}) CREATE (t:Task {person_id: 900}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_where_match",
+        "MATCH (p:Person) WHERE p.person_id = 999 CREATE (t:Task {person_id: 901}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_match_with",
+        "MATCH (p:Person {person_id: 999}) WITH p CREATE (t:Task {person_id: 902}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_relationship_match",
+        "MATCH (p:Person)-[:NO_SUCH_EDGE]->(q:Person) CREATE (t:Task {person_id: 903}) RETURN t.person_id AS pid",
+    ),
+    (
+        # The phantom-endpoint shape: `g` binds nothing, so creating the edge
+        # would have to invent its target node. Post-state edge count is the
+        # assertion that bites.
+        "create_edge_after_partially_unmatched_multi_pattern",
+        "MATCH (p:Person {person_id: 1}), (g:Ghost {person_id: 999}) "
+        "CREATE (p)-[:ASSIGNED_TO]->(g) RETURN count(*) AS n",
+    ),
+    (
+        "merge_after_empty_match",
+        "MATCH (p:Person {person_id: 999}) MERGE (t:Task {person_id: 904}) RETURN t.person_id AS pid",
+    ),
+    (
+        "foreach_after_empty_match",
+        "MATCH (p:Person {person_id: 999}) FOREACH (i IN [910, 911] | CREATE (:Task {person_id: i})) "
+        "WITH 1 AS done MATCH (n) RETURN count(n) AS n",
+    ),
+    (
+        "create_after_unwind_empty_list",
+        "UNWIND [] AS x CREATE (t:Task {person_id: 905}) RETURN t.person_id AS pid",
+    ),
+    (
+        # The control living in the corpus: a *leading* CREATE still gets
+        # Cypher's implicit start row. Pins that the empty-stream rule was not
+        # over-applied to writes that open a query.
+        "leading_create_still_runs_once",
+        "CREATE (t:Task {person_id: 906}) WITH 1 AS done MATCH (n) RETURN count(n) AS n",
+    ),
+    (
+        # OPTIONAL MATCH is the deliberate opposite: it null-pads rather than
+        # emptying, so the CREATE downstream of it must still run.
+        "create_after_optional_match_miss",
+        "MATCH (p:Person {person_id: 1}) OPTIONAL MATCH (g:Ghost) "
+        "CREATE (t:Task {person_id: 907}) RETURN t.person_id AS pid, g AS g",
+    ),
 ]
 
 

--- a/tests/test_cypher_empty_stream_writes.py
+++ b/tests/test_cypher_empty_stream_writes.py
@@ -1,0 +1,231 @@
+"""A write clause fed zero rows must write nothing.
+
+Cypher's pipeline conceptually starts with one implicit empty row, so a
+*leading* `CREATE`/`MERGE`/`FOREACH` runs once. Once any clause has run,
+though, an empty row set means genuinely zero rows and every downstream
+clause — read or write — must produce zero rows and no side effects.
+
+The engine used to conflate the two states: `execute_create`,
+`execute_merge`, and `execute_foreach` each re-derived "am I leading?" from
+`rows.is_empty()`, which is also what a MATCH that found nothing leaves
+behind. So `MATCH (p:Project {key:'NOPE'}) CREATE (t:Task)` fabricated a row
+and created an unbound node. `SET`/`DELETE`/`REMOVE` never had the bug
+because they simply iterate the incoming rows.
+
+Why this matters beyond row counts: with no referential-integrity
+constraints, "MATCH the parent, then CREATE the child" is the only mechanism
+an application has to enforce a foreign key. The two-variable form was worse
+than a spurious row — it fabricated the *unmatched endpoint* as a real node,
+leaving an edge pointing at a label-less, property-less node.
+
+The fix moved the implicit-start-row seed up into `run_clause_pipeline`,
+which is the only place that can tell "not started" from "zero rows".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import kglite
+
+
+def _graph_with_project():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (:Project {key: 'WEB'})").to_list()
+    return graph
+
+
+def _node_count(graph, pattern="(n)"):
+    return graph.cypher(f"MATCH {pattern} RETURN count(*) AS c").to_list()[0]["c"]
+
+
+def _edge_count(graph):
+    return graph.cypher("MATCH ()-[r]->() RETURN count(*) AS c").to_list()[0]["c"]
+
+
+# Every shape here ends in a MATCH-produced empty stream feeding a CREATE.
+# Parametrized rather than written out so a future clause form is one line.
+EMPTY_STREAM_CREATE_QUERIES = {
+    "inline_map_match": ("MATCH (p:Project {key: 'NOPE'}) CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "where_match": ("MATCH (p:Project) WHERE p.key = 'NOPE' CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "match_with_create": ("MATCH (p:Project {key: 'NOPE'}) WITH p CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "relationship_pattern_match": (
+        "MATCH (p:Project)-[:HAS]->(q:Project) CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"
+    ),
+    "with_where_filters_to_zero": (
+        "MATCH (p:Project) WITH p WHERE p.key = 'NOPE' CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"
+    ),
+    "unwind_empty_list": "UNWIND [] AS x CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id",
+}
+
+
+@pytest.mark.parametrize("query", EMPTY_STREAM_CREATE_QUERIES.values(), ids=EMPTY_STREAM_CREATE_QUERIES)
+def test_create_after_empty_stream_returns_no_rows_and_creates_nothing(query):
+    graph = _graph_with_project()
+    before = _node_count(graph)
+
+    rows = graph.cypher(query).to_list()
+
+    assert rows == [], "a CREATE fed zero rows must return zero rows"
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph) == before
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_create_after_empty_stream_does_not_run_twice_for_two_create_clauses():
+    """Two chained CREATEs after an empty MATCH create neither node.
+
+    The first CREATE must leave the stream empty rather than re-seeding it,
+    otherwise the second one inherits a fabricated row.
+    """
+    graph = _graph_with_project()
+    rows = graph.cypher(
+        "MATCH (p:Project {key: 'NOPE'}) CREATE (t:Task {title: 'a'}) CREATE (u:Task {title: 'b'}) RETURN count(*) AS c"
+    ).to_list()
+
+    assert rows == [{"c": 0}]
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_two_variable_match_does_not_fabricate_the_unmatched_endpoint():
+    """The phantom-endpoint case: neither the missing node nor the edge.
+
+    `(u:User {...})` matches nothing, so the whole MATCH is empty. Creating
+    the relationship would have to invent `u`, producing an edge that points
+    at a node carrying no label and no email — unreachable by any label scan
+    but reachable by traversal.
+    """
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (:Task {title: 'a'})").to_list()
+
+    rows = graph.cypher(
+        "MATCH (t:Task {title: 'a'}), (u:User {email: 'ghost@x.com'}) "
+        "CREATE (t)-[:ASSIGNED_TO]->(u) RETURN count(*) AS n"
+    ).to_list()
+
+    # count(*) over zero rows is one row holding 0 — the aggregate is the row,
+    # not the match. What must be zero is the writes.
+    assert rows == [{"n": 0}]
+    stats = graph.last_mutation_stats
+    assert stats["nodes_created"] == 0
+    assert stats["relationships_created"] == 0
+    assert _node_count(graph) == 1
+    assert _edge_count(graph) == 0
+    assert _node_count(graph, "(u:User)") == 0
+
+
+def test_merge_after_empty_stream_creates_nothing():
+    graph = _graph_with_project()
+    rows = graph.cypher("MATCH (p:Project {key: 'NOPE'}) MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == []
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_merge_after_empty_unwind_creates_nothing():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("UNWIND [] AS x MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == []
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_foreach_after_empty_stream_never_runs_its_body():
+    """FOREACH is a side-effect loop, so the evidence is the graph, not rows."""
+    graph = _graph_with_project()
+    graph.cypher("MATCH (p:Project {key: 'NOPE'}) FOREACH (i IN [1, 2] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_foreach_after_empty_unwind_never_runs_its_body():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("UNWIND [] AS x FOREACH (i IN [1] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+# ---------------------------------------------------------------------------
+# Controls — the behaviour the fix must NOT change.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_create_still_creates_exactly_one_node():
+    """No preceding clause means the implicit start row applies."""
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (t:Task {title: 'x'})").to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 1
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_leading_merge_still_creates():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == [{"t": "m"}]
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_standalone_foreach_still_runs_once():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("FOREACH (i IN [1, 2] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 2
+
+
+def test_foreach_over_empty_list_creates_nothing_but_still_runs():
+    """The inner loop, not the outer stream, is what's empty here."""
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("FOREACH (i IN [] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_leading_unwind_and_with_still_seed_a_row():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("UNWIND [1, 2, 3] AS x CREATE (t:Task {n: x}) RETURN count(*) AS c").to_list()
+    assert rows == [{"c": 3}]
+    assert _node_count(graph, "(t:Task)") == 3
+
+    other = kglite.KnowledgeGraph()
+    assert other.cypher("WITH 5 AS v CREATE (t:Task {n: v}) RETURN t.n AS n").to_list() == [{"n": 5}]
+
+
+def test_optional_match_still_yields_one_null_padded_row():
+    """The deliberate opposite of this fix — OPTIONAL MATCH must NOT go empty.
+
+    Guarding this here because the fix touches the same pipeline branch that
+    decides whether a clause sees a row.
+    """
+    graph = _graph_with_project()
+    rows = graph.cypher("MATCH (p:Project) OPTIONAL MATCH (u:User) RETURN p.key AS k, u AS u").to_list()
+
+    assert len(rows) == 1
+    assert rows[0]["k"] == "WEB"
+    assert rows[0]["u"] is None
+
+
+def test_optional_match_row_can_still_drive_a_create():
+    """A null-padded OPTIONAL MATCH row is a real row, so CREATE runs."""
+    graph = _graph_with_project()
+    graph.cypher(
+        "MATCH (p:Project) OPTIONAL MATCH (u:User) CREATE (t:Task {title: 'ok'}) RETURN t.title AS t"
+    ).to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 1
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_set_and_delete_after_empty_stream_stay_no_ops():
+    """These were already correct; pinned so the shared path can't regress them."""
+    graph = _graph_with_project()
+    assert graph.cypher("MATCH (p:Project {key: 'NOPE'}) SET p.x = 1 RETURN p.x AS x").to_list() == []
+    assert graph.last_mutation_stats["properties_set"] == 0
+
+    graph.cypher("MATCH (p:Project {key: 'NOPE'}) DELETE p").to_list()
+    assert graph.last_mutation_stats["nodes_deleted"] == 0
+    assert _node_count(graph, "(p:Project)") == 1


### PR DESCRIPTION
Fixes the **highest-severity bug** found by the boring-app audit: a `MATCH` that matches zero rows still executed a following `CREATE`. No version bump.

## The bug

```python
g.cypher("CREATE (:Project {key:'WEB'})")
g.cypher("MATCH (p:Project {key:'NOPE'}) CREATE (t:Task {title:'orphan'}) RETURN t.id AS id")
# before -> [{'id': 1}]  and the Task really was in the graph
# after  -> []           and nothing is created
```

Worse, the two-variable form **fabricated a phantom endpoint**: `MATCH (t:Task {...}), (u:User {email:'ghost@x.com'}) CREATE (t)-[:A]->(u)` reported `nodes_created=2, relationships_created=1` and left an edge pointing at a node unreachable by its own label. Now `0/0`, graph unchanged.

Since kglite has no referential-integrity constraints, **"MATCH the parent, CREATE the child" is the only foreign-key mechanism an application has.** This defeated it silently and returned a valid-looking id for a parent that doesn't exist.

## Root cause

`executor/write.rs` — `execute_create`, `execute_merge` and `execute_foreach` each decided whether to supply Cypher's implicit single start row with the same test:

```rust
let source_rows = if existing.rows.is_empty() {
    vec![ResultRow::new()]   // "No prior MATCH: execute once with an empty row"
} else { existing.rows };
```

**That predicate is true in two opposite situations** — at the start of a query (where a leading `CREATE` legitimately runs once) and after a clause that produced zero rows (where nothing may run). The comment shows the author believed only the first could reach it. Nothing in `ResultSet` distinguishes them; only the pipeline, which knows the clause index, can.

**Why `SET`/`DELETE`/`REMOVE` escaped:** they take `&ResultSet`, return `()`, and iterate `result_set.rows` with no seeding branch — zero rows in, zero writes. The signature difference is the visible tell.

The pipeline *already had* the right concept for reads (`if i > 0 && rows.is_empty() && matches!(Match | OptionalMatch) { continue; }`) — it was simply never applied to writes. And the planner's "returns no rows" warning is purely advisory; it never fed execution, which is why the engine could warn and then create anyway.

## The fix — deleting branches, not adding them

The seed moved **out of the three clause bodies and up into `run_clause_pipeline`**, the only place that can tell the two states apart: a `stream_established` flag, initialised from `!ctx.leading.is_empty()` (non-empty only for the LOAD CSV driver, which re-enters per batch with an established stream). The leading-`WITH`/`UNWIND` seed generalised into `clause_needs_implicit_row()` covering `With | Unwind | Create | Merge | Foreach`; the MATCH short-circuit switched from positional `i > 0` to the same flag; the three self-seeds deleted.

Seeding stays lazy deliberately — `MATCH`/`OPTIONAL MATCH` choose their scan form over their extend form by testing `rows.is_empty()`, so handing them a row would change planning.

## Class sweep — wider than reported

Also broken, also fixed: **`MERGE` after an empty MATCH**, **`UNWIND [] AS x CREATE`**, and **`FOREACH` after an empty MATCH** (which created 2 nodes) — none of which the audit had found. Plus all four MATCH spellings and chained CREATEs.

Confirmed correct and unchanged: bare `CREATE`; leading `MERGE`/`WITH`/`UNWIND`; standalone `FOREACH`; `FOREACH` over an empty list (a different mechanism); `OPTIONAL MATCH` still yields its one null-padded row and a following `CREATE` still runs; `SET`/`DELETE`. Two paths probed and cleared: writes inside `CALL {}` are parser-rejected, and an empty `LOAD CSV` already ran its suffix zero times.

Note on semantics: the phantom query returns `[{'n': 0}]`, not `[]` — an aggregate over zero rows is one row, which is correct Neo4j behaviour. What must be zero is the writes, and it is.

## An important limitation this exposed in our own safety net

`tests/test_cypher_differential.py` passed **353/353 both before and after** the fix. The harness compares optimized against naive plans, and here **both were wrong identically**, so the corpus could never have caught this class. The 10 `MUTATION_QUERIES` entries added here are therefore forward-looking: they prevent a future pass from hoisting a write back to a leading position, where the implicit row legitimately applies. Worth knowing when reasoning about what the differential corpus does and does not protect.

## Test evidence

`tests/test_cypher_empty_stream_writes.py` — 20 cases asserting returned rows, `last_mutation_stats`, **and** post-query graph state. **Fails-without-fix verified**: stashing only the Rust file and rebuilding gives **12 failed / 8 passed**, the 8 being controls that correctly stayed green; restoring gives 20/20.

`make gate` exit 0 · clippy `--all-targets -- -D warnings` exit 0 · `make source-quality` clean · `cargo test -p kglite` **1241 passed** · full Python suite **4785 passed** · `pytest -m parity` **109 passed**.

## Behaviour change to be aware of

Queries that previously received a spurious row from an empty-stream `CREATE`/`MERGE` now correctly receive none. Any application that had come to depend on the fabricated node — knowingly or not — will see zero rows instead.

## Surfaced, not fixed

A genuine pre-existing **parser** defect: a negative numeric literal is rejected inside a `MATCH` pattern's inline property map but accepted everywhere else.

```
MATCH (n:T {x: -1}) RETURN n   -> Cypher syntax error: Pattern parse error: Expected value, got Dash
CREATE (n:T {x: -1})           -> OK
MATCH (n:T) WHERE n.x = -1     -> OK
RETURN {x: -1} AS m            -> OK
```

Also fails for floats. The asymmetry with `CREATE` shows an oversight in a second map parser, not a design choice. Deliberately not bundled — it's the parser, not the write-path executor. Worked around in the corpus with a positive sentinel and a comment recording why.
