### PR TITLE
fix: name the IN [...] rewrite in the nesting error, and widen Windows CI (stack guard evaluated, not extended)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,16 @@ jobs:
         run: cargo test -p kglite --lib graph::io::open::tests::crashed_process_releases_writer_lease -- --exact --nocapture
       - name: Test core lease-protected publication
         run: cargo test -p kglite --lib graph::io::open::tests::writer_lease_serializes_open_create_and_publish -- --exact
+      # The two steps above already compile the whole kglite lib test binary,
+      # so running the rest of it is close to free — and these are the only
+      # runners where the engine is exercised on Windows at all (no Windows
+      # job runs pytest, yet Windows wheels ship). It is also the only place
+      # the stack-depth bound gets checked against non-Linux frame sizes:
+      # stack_probe::budget_ceiling_query_fits_the_query_thread_stack walks
+      # the deepest AST the parser accepts, and a platform whose frames are
+      # much larger would overflow here instead of in a user's process.
+      - name: Test core lib suite
+        run: cargo test -p kglite --lib
       - name: Test CLI lifecycle unit suite
         run: cargo test -p kglite-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The expression-nesting limit now names the fix instead of only the problem.
+  The overwhelmingly common way to reach 512 levels is generated code — a
+  filter or facet builder emitting one `OR` term per selected value — and each
+  term costs a nesting level, so an app that worked with 400 selections breaks
+  at 600 with nothing to go on but "simplify the query". The error now points
+  at the rewrite that actually works: `x = a OR x = b OR ...` becomes
+  `x IN [a, b, ...]`, which costs one nesting level however many values the
+  list holds (and is faster, since it can be pushed into the MATCH and use an
+  index). `CYPHER.md` documents the ceiling and the habit alongside the WHERE
+  clause. Note the planner already folds single-property `OR` chains into `IN`
+  automatically, but only once the query has parsed, so it cannot rescue a
+  chain that is already over the limit.
+
 - Index DDL is classified as a mutation, since schema is graph state: it is
   blocked on a read-only graph and in a read-only transaction, rolls back with
   a failed statement, and is rejected on a schema-locked graph when the

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -126,6 +126,33 @@ graph.cypher("MATCH (n:Person) WHERE n.name =~ '(?i)^ali.*' RETURN n.name")
 graph.cypher("MATCH (n:Person) WHERE n.email =~ '.*@example\\.com$' RETURN n.name")
 ```
 
+### Generated filters: prefer `IN [...]` over long `OR` chains
+
+Expression nesting is capped at **512 levels**, and every `OR` term adds one
+level — so a filter builder that emits one term per selected value
+(`n.sku = 'a' OR n.sku = 'b' OR ...`) stops parsing at ~512 selections:
+
+```
+Expression nesting exceeds 512 levels; simplify the query. ...
+```
+
+A list membership test is one level no matter how long the list is, so the
+same filter expressed with `IN` has no practical ceiling — and it is faster,
+because it can be pushed into the MATCH and use an index:
+
+```python
+# Fragile above ~512 values, and slower below it
+graph.cypher("MATCH (n:Product) WHERE " + " OR ".join(f"n.sku = '{s}'" for s in skus) + " RETURN n")
+
+# Prefer this — one AST level for any number of values, and parameterised
+graph.cypher("MATCH (n:Product) WHERE n.sku IN $skus RETURN n", params={"skus": skus})
+```
+
+The planner already rewrites `OR` chains of equalities on a *single* property
+into `IN` for you, but only after the query parses — so it cannot rescue a
+chain that is already too long, and it does not fire for chains spanning
+different properties. Generating `IN` directly is the robust habit.
+
 ## Relationship Properties
 
 Relationships can have properties. Access them with `r.property` syntax:

--- a/crates/kglite/src/graph/languages/cypher/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/mod.rs
@@ -19,6 +19,8 @@ pub mod parser;
 pub mod plan_cache;
 pub mod planner;
 pub mod result;
+#[cfg(test)]
+mod stack_probe;
 pub mod tokenizer;
 pub mod value_codec;
 mod window;

--- a/crates/kglite/src/graph/languages/cypher/parser/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/mod.rs
@@ -137,8 +137,18 @@ impl CypherParser {
     /// releases the whole run at once.
     pub(super) fn deepen(&mut self) -> Result<(), String> {
         if self.depth >= MAX_EXPRESSION_DEPTH {
+            // Name the rewrite. The overwhelmingly common way to reach this
+            // limit is generated code — a filter/facet builder emitting one
+            // `OR` term per selected value — and each term costs a nesting
+            // level while the equivalent `IN [...]` costs one level no matter
+            // how many values it holds. "Simplify the query" alone leaves the
+            // author guessing at a limit they did not know existed.
             return Err(format!(
-                "Expression nesting exceeds {} levels; simplify the query",
+                "Expression nesting exceeds {} levels; simplify the query. \
+                 Long chains of OR'd equality tests are the usual cause and \
+                 nest one level per term — rewrite `x = a OR x = b OR ...` as \
+                 `x IN [a, b, ...]`, which nests one level however many \
+                 values the list holds.",
                 MAX_EXPRESSION_DEPTH
             ));
         }

--- a/crates/kglite/src/graph/languages/cypher/parser/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/mod.rs
@@ -61,12 +61,32 @@ pub struct CypherParser {
 /// It does not, however, bound their *stack use* equally. Only
 /// [`CypherParser::descend`] grows the stack on demand (via `stacker`); the
 /// planner, executor and `Drop` walkers recurse on whatever stack their
-/// thread already has. Debug-profile frames are several times larger than
-/// release frames, so the guarantee those stages actually carry is "at most
-/// 512 levels", not "cannot overflow" — a thread with a small stack (Windows
-/// defaults to 1 MB) has not been measured against a 512-level AST. Extending
-/// the `stacker` guard past the parser is deliberately deferred until that
-/// measurement exists.
+/// thread already has. That has now been measured
+/// (`super::stack_probe`, macOS/aarch64, worst shape: an `OR`/`AND`/`NOT`
+/// tree walked by the executor):
+///
+/// | stage | debug | release |
+/// |---|---|---|
+/// | executor `evaluate_predicate`/`evaluate_expression` | 7,248 B/level | 1,056 B/level |
+/// | planner walkers (WHERE chains) | 2,160 B/level | 480 B/level |
+/// | recursive `Drop` | 112 B/level | 64 B/level |
+///
+/// At this budget the deepest accepted query therefore peaks at ~3.7 MiB in
+/// debug and ~0.54 MiB in release, against the 8 MiB every frontend runs on
+/// ([`crate::graph::session::QUERY_THREAD_STACK_SIZE`], and the main-thread
+/// default for the CLI and the Python wheel). So the stages downstream of the
+/// parser do not need their own `stacker` guard — the budget alone keeps them
+/// inside the stack they are given, and
+/// `stack_probe::budget_ceiling_query_fits_the_query_thread_stack` holds that
+/// true on every platform CI runs.
+///
+/// The corollary is that this budget is load-bearing, not decorative: raising
+/// it scales the peak linearly, and the release peak would pass 1 MiB — the
+/// smallest in-process stack in play — somewhere around 1,000 levels. Raising
+/// the budget means adding a guard first, and a guard on the per-row
+/// `evaluate_expression` measured **+14%** on the in-memory expression path.
+/// Growing the stack once at executor entry measured free, and is the shape
+/// to reach for if the budget ever has to move.
 ///
 /// The budget bounds **AST depth, not parser call depth**, and those differ:
 /// the left-associative operator chains (`OR`/`XOR`/`AND`, `+`/`-`/`||`,
@@ -79,7 +99,7 @@ pub struct CypherParser {
 /// walkers themselves have neither a depth guard nor stack growth, and they
 /// run on server worker threads whose stacks are far smaller than the main
 /// thread's.
-const MAX_EXPRESSION_DEPTH: usize = 512;
+pub(super) const MAX_EXPRESSION_DEPTH: usize = 512;
 
 /// Remaining-stack threshold below which [`CypherParser::descend`] allocates
 /// a fresh segment, and the size of that segment. The red zone must cover the

--- a/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
@@ -8,16 +8,7 @@ use crate::datatypes::values::Value;
 use crate::graph::core::pattern_matching::PatternElement;
 use crate::graph::languages::cypher::ast::*;
 
-/// Push simple equality predicates from WHERE into MATCH pattern properties.
-/// This enables the pattern executor to filter during matching rather than after.
-///
-/// Fold OR chains of equalities on the same variable.property into IN predicates.
-///
-/// Example: `WHERE n.name = 'A' OR n.name = 'B' OR n.name = 'C'`
-/// Becomes: `WHERE n.name IN ['A', 'B', 'C']`
-///
-/// This enables predicate pushdown into MATCH patterns and index acceleration.
-/// Must run BEFORE `push_where_into_match`.
+/// Fuse `OPTIONAL MATCH` followed by an aggregate into a single pass.
 pub(crate) fn fuse_optional_match_aggregate(query: &mut CypherQuery) {
     let mut i = 0;
     while i + 1 < query.clauses.len() {

--- a/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
@@ -7,6 +7,26 @@ use crate::graph::core::pattern_matching::{Pattern, PatternElement, PropertyMatc
 use crate::graph::schema::DirGraph;
 use std::collections::{HashMap, HashSet};
 
+/// Fold OR chains of equalities on the same `variable.property` into a
+/// single IN predicate.
+///
+/// Example: `WHERE n.name = 'A' OR n.name = 'B' OR n.name = 'C'`
+/// becomes:  `WHERE n.name IN ['A', 'B', 'C']`
+///
+/// This enables predicate pushdown into MATCH patterns and index
+/// acceleration, which is why a second `push_where_into_match` pass is
+/// registered immediately after this one — the first runs before it and
+/// cannot see the IN predicates this creates.
+///
+/// It only folds equalities on one and the same property, with a literal or
+/// parameter on the other side. A chain across *different* properties is left
+/// alone and reaches the executor as a genuine one-level-per-term predicate
+/// tree, which is the shape that costs the most stack (see
+/// `super::super::stack_probe`).
+///
+/// Note this is a *planner* pass, so it cannot rescue a chain long enough to
+/// exhaust the parser's nesting budget: the parse fails first. The budget
+/// error names the `IN [...]` rewrite for exactly that reason.
 pub(super) fn fold_or_to_in(query: &mut CypherQuery) {
     for clause in &mut query.clauses {
         if let Clause::Where(ref mut w) = clause {

--- a/crates/kglite/src/graph/languages/cypher/stack_probe.rs
+++ b/crates/kglite/src/graph/languages/cypher/stack_probe.rs
@@ -1,0 +1,441 @@
+//! How much stack does one level of AST nesting actually cost, and does the
+//! deepest query the parser accepts still fit the stack it runs on?
+//!
+//! `MAX_EXPRESSION_DEPTH` bounds AST *depth*, and only the parser grows its
+//! stack on demand (`stacker`). The planner's expression walkers, the
+//! executor's `evaluate_expression` and the AST's recursive `Drop` run on
+//! whatever stack the caller owns, so "at most 512 levels" only becomes
+//! "cannot overflow" once someone measures the bytes per level. This module
+//! is that measurement, plus the regression test that keeps the answer true.
+//!
+//! Two things live here:
+//!
+//! 1. [`budget_ceiling_query_fits_the_query_thread_stack`] — an always-on
+//!    test. It runs the deepest accepted query end-to-end on a thread sized
+//!    exactly [`QUERY_THREAD_STACK_SIZE`], which is what the Bolt and MCP
+//!    servers give their query threads and what the CLI and Python wheel get
+//!    from the main thread. No `unsafe`, no platform assumptions: it either
+//!    completes or the process aborts, and an abort is the finding.
+//! 2. [`stack_probe`] — an exploratory harness, inert unless
+//!    `KGL_STACK_PROBE` is set, that reports the exact bytes a chosen stage
+//!    consumes at a chosen depth. Re-run it when frame costs might have moved.
+//!
+//! # Method used by the exploratory harness
+//!
+//! Paint the unused stack below the current stack pointer with a known byte
+//! pattern, run the stage, then scan upward from the bottom for the first
+//! word that no longer matches — that address is the deepest point the stage
+//! reached. This yields the real figure in one run without ever overflowing
+//! anything, so there is no crash-and-binary-search loop.
+//!
+//! Painting walks *downward one page at a time*: Windows commits stack pages
+//! through a guard page that must be touched in descending order, and a
+//! straight ascending `memset` from the bottom of the window would fault
+//! there. The numbers on record were taken on macOS/aarch64.
+//!
+//! ```text
+//! KGL_STACK_PROBE=1 KGL_PROBE_STAGE=exec KGL_PROBE_SHAPE=or \
+//! KGL_PROBE_DEPTH=408 <lib-test-binary> \
+//!     --exact graph::languages::cypher::stack_probe::stack_probe --nocapture
+//! ```
+//!
+//! Stages: `parse`, `plan`, `exec`, `drop`, `full`, plus `calibrate` (a
+//! recursion of known frame size, to prove the method) and `bench` (a
+//! release-profile timing of the per-row expression path, for costing any
+//! proposed guard). `KGL_PROBE_STACK_KIB` sizes the measured thread.
+
+use super::ast::CypherQuery;
+use super::executor::CypherExecutor;
+use super::parser::{parse_cypher, MAX_EXPRESSION_DEPTH};
+use super::planner::optimize;
+use crate::datatypes::Value;
+use crate::graph::algorithms::Interrupt;
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::session::QUERY_THREAD_STACK_SIZE;
+use std::collections::HashMap;
+
+/// Stack for the preparation threads, which are never measured.
+const PREP_STACK: usize = 512 * 1024 * 1024;
+const PAINT: u8 = 0xA5;
+const PAINT_WORD: u64 = u64::from_ne_bytes([PAINT; 8]);
+const PAGE: usize = 4096;
+
+fn probe_stack() -> usize {
+    std::env::var("KGL_PROBE_STACK_KIB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|kib| kib * 1024)
+        .unwrap_or(512 * 1024 * 1024)
+}
+
+fn paint_len() -> usize {
+    (probe_stack() / 4 * 3).min(64 * 1024 * 1024) / PAGE * PAGE
+}
+
+/// Query text for `shape` producing `depth` levels of AST nesting.
+fn query(shape: &str, depth: usize) -> String {
+    match shape {
+        // Recursively parsed shapes.
+        "parens" => format!("RETURN {}1{} AS x", "(".repeat(depth), ")".repeat(depth)),
+        "lists" => format!("RETURN {}1{} AS x", "[".repeat(depth), "]".repeat(depth)),
+        "not" => format!("RETURN {}false AS x", "NOT ".repeat(depth)),
+        "neg" => format!("RETURN {}5 AS x", "-".repeat(depth)),
+        // Iteratively parsed left-associative chains (one AST level each).
+        "or" => format!("RETURN {} AS x", vec!["false"; depth + 1].join(" OR ")),
+        "and" => format!("RETURN {} AS x", vec!["true"; depth + 1].join(" AND ")),
+        "add" => format!("RETURN {} AS x", vec!["1"; depth + 1].join(" + ")),
+        "concat" => format!("RETURN {} AS x", vec!["'a'"; depth + 1].join(" || ")),
+        "subscript" => format!("RETURN [1]{} AS x", "[0]".repeat(depth)),
+        // Distinct values on purpose: identical disjuncts get collapsed, which
+        // would hide the recursion this exists to measure. This is also the
+        // literal shape a filter/facet builder emits for a multi-select — and
+        // the planner's `fold_or_to_in` pass rewrites it to `IN [...]`, so the
+        // executor never sees the chain.
+        "where_or" => format!(
+            "MATCH (n:T) WHERE {} RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| format!("n.id = {i}"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ),
+        // ORs across *different* properties: `fold_or_to_in` only folds
+        // same-property equalities, so this shape survives into the executor
+        // as a genuine one-level-per-term predicate tree.
+        "where_or_mixed" => format!(
+            "MATCH (n:T) WHERE {} RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| format!("n.p{i} = {i}"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ),
+        // The rewrite a user should reach for instead: one AST level no
+        // matter how many values the list holds.
+        "where_in" => format!(
+            "MATCH (n:T) WHERE n.id IN [{}] RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        other => panic!("unknown shape {other}"),
+    }
+}
+
+/// Every nesting shape under test. The always-on stack test walks this list,
+/// so a new nesting construct gets stack coverage by being added in one place.
+const ALL_SHAPES: &[&str] = &[
+    "or",
+    "and",
+    "not",
+    "neg",
+    "lists",
+    "add",
+    "concat",
+    "subscript",
+    "parens",
+    "where_or",
+    "where_or_mixed",
+    "where_in",
+];
+
+/// A one-node `:T` graph, so `MATCH (n:T) WHERE …` actually produces a row
+/// and the executor really walks the predicate tree. On an empty graph the
+/// WHERE shapes measure zero — no rows, no evaluation.
+fn seeded_graph() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let create = parse_cypher("CREATE (:T {id: 1})").expect("seed parses");
+    super::executor::write::execute_mutable(
+        &mut graph,
+        &create,
+        HashMap::new(),
+        Interrupt::default(),
+    )
+    .expect("seed executes");
+    graph
+}
+
+/// Run the whole pipeline — parse, plan, execute, and drop the AST.
+fn run_full_pipeline(graph: &DirGraph, text: &str) {
+    let params: HashMap<String, Value> = HashMap::new();
+    let mut q = parse_cypher(text).expect("query must parse within the budget");
+    optimize(&mut q, graph, &params);
+    let exec = CypherExecutor::with_params(graph, &params, None);
+    exec.execute(&q).expect("query must execute");
+}
+
+/// The load-bearing invariant: the deepest AST the parser accepts still fits
+/// the stack the engine actually runs queries on.
+///
+/// [`QUERY_THREAD_STACK_SIZE`] is what the Bolt and MCP servers hand their
+/// query threads, and it matches the main-thread default the CLI and the
+/// Python wheel get. Only the parser grows its stack on demand; the planner
+/// walkers, `evaluate_expression` and the recursive `Drop` do not, so this is
+/// the only thing standing between a budget-ceiling query and a process
+/// abort. A stack overflow here aborts the test binary rather than failing
+/// cleanly — that is the intended signal, and it is why the bound is checked
+/// on every platform CI runs rather than reasoned about.
+///
+/// Measured headroom when this was written (macOS/aarch64, worst shape `or`,
+/// executor path): 3.7 MiB of 8 MiB in debug, 0.54 MiB in release.
+#[test]
+fn budget_ceiling_query_fits_the_query_thread_stack() {
+    let depth = MAX_EXPRESSION_DEPTH - 1;
+    std::thread::Builder::new()
+        .stack_size(QUERY_THREAD_STACK_SIZE)
+        .spawn(move || {
+            let graph = seeded_graph();
+            for shape in ALL_SHAPES {
+                run_full_pipeline(&graph, &query(shape, depth));
+            }
+        })
+        .expect("spawn query-sized thread")
+        .join()
+        .expect("budget-ceiling query overflowed the query-thread stack");
+}
+
+/// A query past the budget is refused by the parser, so no downstream walker
+/// ever sees it — and the refusal names the rewrite that actually works.
+#[test]
+fn past_budget_is_refused_with_the_in_rewrite_named() {
+    let err = parse_cypher(&query("or", MAX_EXPRESSION_DEPTH + 50))
+        .expect_err("past-budget query must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("nesting exceeds"),
+        "unexpected error text: {msg}"
+    );
+    assert!(
+        msg.contains("IN ["),
+        "the budget error must name the IN [...] rewrite, got: {msg}"
+    );
+}
+
+// ── Exploratory harness ─────────────────────────────────────────────────────
+
+/// Parse (and optionally plan) on a separate generously-sized thread, so the
+/// measured thread only pays for the stage under test.
+fn prepared_off_thread(text: String, plan: bool) -> CypherQuery {
+    std::thread::Builder::new()
+        .stack_size(PREP_STACK)
+        .spawn(move || {
+            let mut q = parse_cypher(&text).expect("probe query must parse");
+            if plan {
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                optimize(&mut q, &graph, &params);
+            }
+            q
+        })
+        .expect("spawn")
+        .join()
+        .expect("prep thread")
+}
+
+/// Paint the free stack below the current frame, run `body`, then report how
+/// far down it reached.
+///
+/// # Safety
+/// Every write lies strictly below the current frame and strictly inside the
+/// thread's own reserved stack, and pages are touched in descending order so
+/// the Windows guard-page protocol is respected. Rust installs its
+/// stack-overflow handler on a `sigaltstack`, so no signal handler runs in
+/// the painted window.
+fn measure(body: impl FnOnce()) -> usize {
+    let anchor = 0u64;
+    // `&anchor` is an address *inside* the current frame, not the true stack
+    // pointer: the compiler may place other live locals of this same frame
+    // (notably `body`) below it, and painting over them corrupts live data.
+    // Skip a margin that clears the whole frame. It is a constant offset in
+    // every reading, so it cancels in the depth-to-depth deltas that matter.
+    const MARGIN: usize = 4 * 1024;
+    let reference = ((&anchor as *const u64 as usize) & !7) - MARGIN;
+    let len = paint_len();
+    let bottom = reference - len;
+
+    let mut page = reference - PAGE;
+    while page >= bottom {
+        // Descending, one page at a time: that is what Windows requires to
+        // commit stack pages through the guard page.
+        //
+        // SAFETY: `page` walks `[bottom, reference)`, which lies below this
+        // frame and inside this thread's own reserved stack. Nothing live is
+        // there — the callee frames that will use it do not exist yet, and
+        // `MARGIN` keeps the write clear of this frame's own locals.
+        unsafe { std::ptr::write_bytes(page as *mut u8, PAINT, PAGE) };
+        page -= PAGE;
+    }
+
+    body();
+
+    let mut deepest = reference;
+    for i in 0..len / 8 {
+        let addr = bottom + i * 8;
+        // SAFETY: `addr` is an 8-byte-aligned address inside the window just
+        // painted, so it is mapped, committed and readable. The read is
+        // volatile so the scan is not optimised against the `write_bytes`
+        // above, whose effect the compiler cannot otherwise see.
+        if unsafe { std::ptr::read_volatile(addr as *const u64) } != PAINT_WORD {
+            deepest = addr;
+            break;
+        }
+    }
+    assert!(
+        deepest > bottom,
+        "stage reached the bottom of the paint window; raise KGL_PROBE_STACK_KIB"
+    );
+    reference - deepest
+}
+
+/// Self-check of the measurement method: a recursion whose frame cost is
+/// knowable independently, so a wrong number here invalidates the rest.
+#[inline(never)]
+fn calibration_recurse(depth: usize, sink: &mut u64) {
+    let mut pad = [0u64; 16]; // 128 bytes, must not be optimised away
+    pad[depth % 16] = depth as u64;
+    if depth > 0 {
+        calibration_recurse(depth - 1, sink);
+    }
+    *sink = sink.wrapping_add(std::hint::black_box(pad)[depth % 16]);
+}
+
+fn on_probe_thread<R: Send + 'static>(body: impl FnOnce() -> R + Send + 'static) -> R {
+    std::thread::Builder::new()
+        .stack_size(probe_stack())
+        .spawn(body)
+        .expect("spawn probe thread")
+        .join()
+        .expect("probe thread panicked")
+}
+
+/// Release-profile timing of the per-row expression path — the cost centre
+/// any `stacker::maybe_grow` inside `evaluate_expression` would tax. Reports
+/// the minimum over rounds (CLAUDE.md: trust min over median for
+/// sub-millisecond work).
+fn run_bench() {
+    let rounds: usize = std::env::var("KGL_PROBE_ROUNDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+    let nodes: usize = std::env::var("KGL_PROBE_NODES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20_000);
+    let mut graph = DirGraph::new();
+    for i in 0..nodes {
+        let create =
+            parse_cypher(&format!("CREATE (:T {{id: {i}, v: {}}})", i * 3)).expect("seed parses");
+        super::executor::write::execute_mutable(
+            &mut graph,
+            &create,
+            HashMap::new(),
+            Interrupt::default(),
+        )
+        .expect("seed executes");
+    }
+    let params: HashMap<String, Value> = HashMap::new();
+    // Arithmetic-heavy projection: several `evaluate_expression` calls per
+    // row, which is precisely the hot path under discussion.
+    let mut q = parse_cypher("MATCH (n:T) RETURN sum(n.id * 2 + n.v * 3 - n.id + 1) AS s")
+        .expect("bench query parses");
+    optimize(&mut q, &graph, &params);
+    let mut best = std::time::Duration::from_secs(3600);
+    for _ in 0..rounds {
+        let exec = CypherExecutor::with_params(&graph, &params, None);
+        let t0 = std::time::Instant::now();
+        let r = exec.execute(&q).expect("bench executes");
+        let dt = t0.elapsed();
+        std::hint::black_box(&r);
+        best = best.min(dt);
+    }
+    println!(
+        "PROBE-BENCH nodes={nodes} rounds={rounds} min_us={}",
+        best.as_micros()
+    );
+}
+
+#[test]
+fn stack_probe() {
+    if std::env::var_os("KGL_STACK_PROBE").is_none() {
+        return;
+    }
+    let env = |k: &str| std::env::var(k).unwrap_or_else(|_| panic!("{k} must be set"));
+    let stage = env("KGL_PROBE_STAGE");
+
+    match stage.as_str() {
+        "calibrate" => {
+            for depth in [1usize, 101, 1101] {
+                let used = on_probe_thread(move || {
+                    measure(|| {
+                        let mut sink = 0u64;
+                        calibration_recurse(depth, &mut sink);
+                        std::hint::black_box(sink);
+                    })
+                });
+                println!("PROBE-RESULT stage=calibrate shape=none depth={depth} bytes={used}");
+            }
+            println!("PROBE-OK");
+            return;
+        }
+        "bench" => {
+            run_bench();
+            println!("PROBE-OK");
+            return;
+        }
+        _ => {}
+    }
+
+    let shape = env("KGL_PROBE_SHAPE");
+    let depth: usize = env("KGL_PROBE_DEPTH").parse().expect("depth");
+    let text = query(&shape, depth);
+
+    let used = match stage.as_str() {
+        // Parser only; the AST is leaked so the recursive Drop never runs
+        // here. On the huge default probe stack `stacker` never fires, so
+        // this reports what the parser *would* need unguarded.
+        "parse" => on_probe_thread(move || {
+            measure(|| {
+                let q = parse_cypher(&text).expect("parse");
+                std::mem::forget(q);
+            })
+        }),
+        "drop" => {
+            let q = prepared_off_thread(text, false);
+            on_probe_thread(move || measure(move || drop(q)))
+        }
+        "plan" => {
+            let q = prepared_off_thread(text, false);
+            on_probe_thread(move || {
+                let mut q = q;
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                let used = measure(|| optimize(&mut q, &graph, &params));
+                std::mem::forget(q);
+                used
+            })
+        }
+        "exec" => {
+            let q = prepared_off_thread(text, true);
+            on_probe_thread(move || {
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                let used = measure(|| {
+                    let exec = CypherExecutor::with_params(&graph, &params, None);
+                    let result = exec.execute(&q).expect("execute");
+                    std::mem::forget(result);
+                });
+                std::mem::forget(q);
+                used
+            })
+        }
+        // Set KGL_PROBE_STACK_KIB to a realistic thread stack to see the
+        // parser's `stacker` guard actually engage.
+        "full" => on_probe_thread(move || {
+            let graph = seeded_graph();
+            measure(|| run_full_pipeline(&graph, &text))
+        }),
+        other => panic!("unknown stage {other}"),
+    };
+
+    println!("PROBE-RESULT stage={stage} shape={shape} depth={depth} bytes={used}");
+    println!("PROBE-OK");
+}


### PR DESCRIPTION
**Evaluation outcome: do not extend the `stacker` guard.** The hazard doesn't exist at the enforced budget, and the guard would cost **+14%** on the in-memory expression path. The real defect the measurements exposed was a *usability* one, and that's what this PR fixes. No version bump.

## Measured stack per nesting level

Method: paint the unused stack below the frame, run one stage, find the deepest byte disturbed — calibrated against a recursion of known frame size, where it reports exactly 512 B/frame, perfectly linear. macOS/aarch64. Parser excluded (it is `stacker`-guarded and offloads).

| stage | debug | release |
|---|---|---|
| executor (`OR`/`AND`/`NOT` trees) | **7,248 B/level** | **1,056 B/level** |
| planner walkers | 2,160 | 480 |
| recursive `Drop` | 112 | 64 |

End-to-end at the true ceiling (511 levels, full pipeline, real 8 MiB stack): **3.56 MiB debug, 534 KiB release** — 2.2× headroom in debug, and **1.9× even against a 1 MiB Windows stack** in release.

## Reachability splits cleanly

- **Abort: not reachable.** Shipped wheels are release builds. At the pinned must-succeed 400 levels a release build uses 422 KiB; at the ceiling, 534 KiB. Every stack in play survives.
- **Rejection: real, and mundane.** A filter builder emitting `n.sku = 'a' OR n.sku = 'b' OR …` charges one level *per term*, so a shopping filter breaks somewhere past 512 selections — ordinary generated application code.

**512 turns out to be well-chosen, not arbitrary.** Raising it scales the peak linearly and would push a release build past 1 MiB near ~1,000 levels. So raising the budget *requires adding a guard first* — the opposite of the intuition that we had headroom to spend.

## The engine already knew the answer and didn't say it

The planner has a `fold_or_to_in` pass that rewrites exactly this shape — but it runs *after* parsing, so it can never rescue a chain that's already too long, and it doesn't fire across different properties. Meanwhile `IN [...]` costs **one level regardless of list length**, because the parser charges per nesting level, not per element.

The old error said only *"…simplify the query"*. It now says:

> Expression nesting exceeds 512 levels; simplify the query. Long chains of OR'd equality tests are the usual cause and nest one level per term — rewrite `x = a OR x = b OR ...` as `x IN [a, b, ...]`, which nests one level however many values the list holds.

Plus a `CYPHER.md` section on generated filters, and a fix for two doc-comment defects found in passing: the `push_where_into_match` / `fold_or_to_in` docs were stranded on `fuse_optional_match_aggregate` and asserted an ordering the pass list contradicts.

## The overhead that disqualified the guard

- `stacker::maybe_grow` inside `evaluate_expression`: **1768 → 2019 µs, +14.2%** (min of 100 rounds, release, quiet machine; three runs agreed to 0.06%).
- Growing once at **executor entry**: 1736 vs 1780 µs baseline — **free**, within noise. Recorded in the docstring as the shape to reach for *if* the budget ever has to move.

## The substantive deliverable: Windows CI widening

`native-lifecycle-locks` already compiled the whole `kglite` lib test binary on Windows but ran only two `--exact` filters. It now also runs `cargo test -p kglite --lib` — close to free, and these are the only runners where the engine is exercised on Windows at all. **No Windows job runs pytest, yet Windows wheels ship.**

That matters because these measurements are macOS/aarch64. Windows x86_64/MSVC frames could plausibly be larger (more spills, 32-byte shadow space per call), and the release margin is 1.9× against a 1 MiB stack — so a 2× frame-size delta would be marginal. The new `budget_ceiling_query_fits_the_query_thread_stack` test walks all 12 nesting shapes at the deepest accepted depth on a thread sized exactly `QUERY_THREAD_STACK_SIZE`, with no `unsafe` and no platform assumptions. A platform with much larger frames now overflows **in CI instead of in a user's process**.

**This widening is unvalidated and may surface pre-existing Windows failures on its first run. That is the point of it** — those failures would be real and currently invisible.

## Verification

`make gate` exit 0 · `cargo clippy -p kglite --all-targets -- -D warnings` clean · `make source-quality` clean · **1,244** Rust lib tests · **416** Cypher Python tests · installed extension confirmed debug. The measurement harness is inert unless `KGL_STACK_PROBE` is set.
