### PR TITLE
fix: carry grouping bindings through every aggregation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ORDER BY` is no longer silently ignored after an aggregating `RETURN` when
+  the sort key is not one of the projected columns. `MATCH (t:Task) OPTIONAL
+  MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY
+  t.priority DESC` — the shape behind every "list with a count, most important
+  first" view — returned every correct row in **insertion order**, with the
+  clause dropped and no error. Combined with `SKIP`/`LIMIT` it made pagination
+  incoherent: because the underlying order was unspecified, pages could repeat
+  some rows and skip others.
+
+  Aggregation rebuilds its output rows, so a variable survives onto them only
+  if the executor carries its binding forward. The three aggregation operators
+  (streaming, materialized, and the fused `OPTIONAL MATCH` + `count()`) each
+  carried a different subset, so whether the clause worked depended on which
+  one the planner happened to pick — `count()` worked, `collect()` did not, and
+  adding an `OPTIONAL MATCH` broke a query that was correct without it. Where
+  the binding was missing the sort key evaluated to `NULL` on every row, all
+  keys tied, and the stable sort returned the input order. All three operators
+  now carry bindings for every variable the grouping keys read, so the same
+  query orders identically whichever one runs.
+
+  Ordering by a variable that is **not** determined by the grouping is now a
+  query error instead of a silent non-sort. In `RETURN t.title, count(c) ORDER
+  BY c.label`, `c` collapses into the aggregate and has no single value per
+  group; Neo4j rejects this shape and kglite now does too, with a message
+  naming the fix. The same applies to an aggregate in `ORDER BY` that is not
+  projected (`ORDER BY max(t.priority)`) or that is projected under an alias
+  (`count(*) AS n ORDER BY count(*)` — order by `n`). Ordering by a projected
+  alias, by an unaliased aggregate's expression form (`ORDER BY count(p)`), and
+  by any property of a grouping variable all keep working.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -186,6 +186,48 @@ graph.cypher("MATCH (n:Person) RETURN median(n.age), percentile_cont(n.age, 0.9)
 graph.cypher("MATCH (n:Person) RETURN variance(n.age), std(n.age)")
 ```
 
+### ORDER BY after an aggregate
+
+An aggregating `RETURN` emits one row per group, so a sort key must have a
+single value on that row. Two things do:
+
+- **Projected columns** — an alias, or an unaliased item's expression form:
+  `RETURN c.name AS company, count(p) ORDER BY count(p) DESC, company`.
+- **Anything read by a grouping key** — every non-aggregate item is a grouping
+  key, so any property of a variable it names is sortable even when it is not
+  itself projected:
+
+```python
+# t is named by the grouping key t.title, so t.priority is sortable.
+graph.cypher("""
+    MATCH (t:Task)
+    OPTIONAL MATCH (t)-[:X]->(c)
+    RETURN t.title AS title, count(c) AS n
+    ORDER BY t.priority DESC
+""")
+```
+
+The value used is the group's first row. When several distinct nodes collapse
+into one group (two `Task`s sharing a title), that representative is which one
+the group met first — project the sort key explicitly if you need it pinned.
+
+Ordering by anything else is rejected rather than silently ignored:
+
+```python
+# ERROR: c collapses into count(c), so c.label has no value per group.
+"... RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+
+# ERROR: aggregate not projected. Project it, then order by the alias.
+"... RETURN t.title AS title, count(*) AS n ORDER BY max(t.priority) DESC"
+
+# ERROR: the aggregate is projected as `n` — order by `n`.
+"... RETURN t.title AS title, count(*) AS n ORDER BY count(*) DESC"
+```
+
+A `RETURN` **without** aggregates keeps every binding on its rows, so ordering
+by a non-projected expression is unrestricted there. `WITH` narrows scope to
+what it projects, so a sort key after `WITH` must be one of its columns.
+
 ## HAVING
 
 Post-aggregation filter — use after RETURN or WITH with aggregates:

--- a/crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs
@@ -206,6 +206,7 @@ impl<'a> CypherExecutor<'a> {
         }
 
         // Compute results for each group
+        let carried_vars = grouping_variables(&clause.items);
         let mut result_rows = Vec::with_capacity(groups.len());
 
         for (group_idx, (group_key_values, row_indices)) in groups.iter().enumerate() {
@@ -239,26 +240,16 @@ impl<'a> CypherExecutor<'a> {
                 }
             }
 
-            // Preserve node/edge bindings from the first row in the group
-            // for variables that appear in the grouping keys.
-            // This ensures subsequent MATCH/OPTIONAL MATCH clauses can
-            // constrain patterns to the correct nodes.
+            // Preserve node/edge/path bindings from the first row in the group
+            // for every variable the grouping keys read — not just keys spelled
+            // as a bare variable. `RETURN t.title AS title, count(c) AS n`
+            // groups by a property access, and dropping `t` here is what made
+            // a trailing `ORDER BY t.priority` silently return insertion order.
+            // Also lets subsequent MATCH/OPTIONAL MATCH clauses constrain
+            // patterns to the correct nodes.
             let first_row = &result_set.rows[row_indices[0]];
             let mut row = ResultRow::from_projected(projected);
-            for &item_idx in &group_key_indices {
-                let expr = &clause.items[item_idx].expression;
-                if let Expression::Variable(var) = expr {
-                    if let Some(&idx) = first_row.node_bindings.get(var) {
-                        row.node_bindings.insert(var.clone(), idx);
-                    }
-                    if let Some(edge) = first_row.edge_bindings.get(var) {
-                        row.edge_bindings.insert(var.clone(), *edge);
-                    }
-                    if let Some(path) = first_row.path_bindings.get(var) {
-                        row.path_bindings.insert(var.clone(), path.clone());
-                    }
-                }
-            }
+            carry_group_bindings(&carried_vars, first_row, &mut row);
             result_rows.push(row);
         }
 

--- a/crates/kglite/src/graph/languages/cypher/executor/helpers.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/helpers.rs
@@ -7,7 +7,7 @@ use super::super::result::*;
 use crate::datatypes::values::Value;
 use crate::graph::schema::{soft_alias_fallback, DirGraph, NodeData, SoftAliasFallback};
 use crate::graph::storage::GraphRead;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // Re-export the ast aggregate helpers so downstream code can refer to them
 // via the executor namespace (backward compatibility with pre-split code).
@@ -18,6 +18,58 @@ pub use super::super::ast::is_aggregate_expression;
 // ============================================================================
 
 // is_aggregate_expression and is_window_expression are re-exported above.
+
+/// Variables a grouped aggregation still pins down on its output rows.
+///
+/// Every non-aggregate projection item is a grouping key, so any variable it
+/// reads has one representative value per group. Variables that occur *only*
+/// inside aggregate arguments do not — `count(c)` collapses many `c`s into a
+/// scalar — and are deliberately excluded.
+///
+/// The three aggregation implementations
+/// ([`super::CypherExecutor::execute_return_with_aggregation`],
+/// [`super::stream::aggregate::apply`], and
+/// [`super::CypherExecutor::execute_fused_optional_match_aggregate`]) all
+/// rebuild their output rows from scratch, so they must agree on this set or
+/// the same query orders differently depending on which one the planner picked.
+pub(crate) fn grouping_variables(items: &[ReturnItem]) -> HashSet<String> {
+    use crate::graph::languages::cypher::planner::simplification::collect_expression_refs;
+
+    let mut vars = HashSet::new();
+    for item in items {
+        if !is_aggregate_expression(&item.expression) {
+            collect_expression_refs(&item.expression, &mut vars);
+        }
+    }
+    vars
+}
+
+/// Carry a group's representative node/edge/path bindings onto an aggregation
+/// output row.
+///
+/// `source` is the group's first input row; `vars` comes from
+/// [`grouping_variables`]. Without this, `ORDER BY t.priority` after
+/// `RETURN t.title AS title, count(c) AS n` evaluates against a row that has
+/// no `t` binding: every sort key resolves to NULL, the keys all tie, and the
+/// stable sort silently hands back insertion order. Downstream
+/// MATCH/OPTIONAL MATCH clauses need the same bindings to re-anchor patterns.
+pub(crate) fn carry_group_bindings(
+    vars: &HashSet<String>,
+    source: &ResultRow,
+    target: &mut ResultRow,
+) {
+    for var in vars {
+        if let Some(&idx) = source.node_bindings.get(var) {
+            target.node_bindings.insert(var.clone(), idx);
+        }
+        if let Some(edge) = source.edge_bindings.get(var) {
+            target.edge_bindings.insert(var.clone(), *edge);
+        }
+        if let Some(path) = source.path_bindings.get(var) {
+            target.path_bindings.insert(var.clone(), path.clone());
+        }
+    }
+}
 
 /// Augment each row's `projected` with an expression-keyed copy of every
 /// aggregate return item, so HAVING predicates like `count(m) > 1` can
@@ -55,8 +107,12 @@ pub fn return_item_column_name(item: &ReturnItem) -> String {
     }
 }
 
-/// Convert an expression to its string representation (for column naming)
-pub(super) fn expression_to_string(expr: &Expression) -> String {
+/// Convert an expression to its string representation (for column naming).
+///
+/// This rendering *is* the identity the executor uses to resolve an unaliased
+/// projection, so `schema_check` compares ORDER BY keys against RETURN items
+/// with it — matching what the runtime can actually resolve.
+pub(crate) fn expression_to_string(expr: &Expression) -> String {
     match expr {
         Expression::PropertyAccess { variable, property } => format!("{}.{}", variable, property),
         Expression::Variable(name) => name.clone(),

--- a/crates/kglite/src/graph/languages/cypher/executor/match_clause/fused_match.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/match_clause/fused_match.rs
@@ -41,6 +41,7 @@ impl<'a> CypherExecutor<'a> {
             }
         }
 
+        let carried_vars = grouping_variables(&with_clause.items);
         let mut result_rows = Vec::with_capacity(existing.rows.len());
 
         for (scan_count, row) in existing.rows.iter().enumerate() {
@@ -119,21 +120,14 @@ impl<'a> CypherExecutor<'a> {
                 projected.insert(key, Value::Int64(value));
             }
 
-            // Create result row preserving bindings for group-key variables
+            // Create the result row, preserving bindings for every variable the
+            // grouping keys read (see `helpers::carry_group_bindings`). This
+            // operator is what an `OPTIONAL MATCH` + `count()` query fuses
+            // into, so narrowing the carry-over to bare-variable keys here is
+            // what made `ORDER BY t.priority` differ between the OPTIONAL and
+            // non-OPTIONAL spellings of the same query.
             let mut new_row = ResultRow::from_projected(projected);
-            for &idx in &group_key_indices {
-                if let Expression::Variable(var) = &with_clause.items[idx].expression {
-                    if let Some(&node_idx) = row.node_bindings.get(var) {
-                        new_row.node_bindings.insert(var.clone(), node_idx);
-                    }
-                    if let Some(edge) = row.edge_bindings.get(var) {
-                        new_row.edge_bindings.insert(var.clone(), *edge);
-                    }
-                    if let Some(path) = row.path_bindings.get(var) {
-                        new_row.path_bindings.insert(var.clone(), path.clone());
-                    }
-                }
-            }
+            carry_group_bindings(&carried_vars, row, &mut new_row);
 
             result_rows.push(new_row);
         }

--- a/crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs
@@ -19,7 +19,7 @@
 
 use super::super::super::ast::{is_aggregate_expression, Expression, ReturnClause};
 use super::super::super::result::{Bindings, ResultRow};
-use super::super::helpers::return_item_column_name;
+use super::super::helpers::{carry_group_bindings, grouping_variables, return_item_column_name};
 use super::super::CypherExecutor;
 use super::RowStream;
 use crate::datatypes::values::Value;
@@ -249,19 +249,19 @@ impl AggState {
 /// aggregate specs.
 struct GroupAcc {
     states: Vec<AggState>,
-    /// Captured node-binding for the first row in this group, by
-    /// variable name. Used to preserve `node_bindings` on the output
-    /// row so downstream MATCH/OPTIONAL MATCH clauses can constrain
-    /// patterns to the same nodes (matches existing materialized
+    /// Bindings-only row holding the first input row's node/edge/path
+    /// bindings for the variables the grouping keys read. Preserved on the
+    /// output row so a trailing ORDER BY and downstream MATCH/OPTIONAL MATCH
+    /// clauses can still resolve those variables (matches the materialized
     /// behavior in `execute_return_with_aggregation`).
-    first_node_bindings: Bindings<NodeIndex>,
+    carried: ResultRow,
 }
 
 impl GroupAcc {
     fn new(specs: &[AggSpec]) -> Self {
         GroupAcc {
             states: specs.iter().map(AggState::new).collect(),
-            first_node_bindings: Bindings::new(),
+            carried: ResultRow::new(),
         }
     }
 }
@@ -398,17 +398,11 @@ pub fn apply<'q>(
     let mut surrogate_groups: Vec<(Vec<GroupKeyPart>, GroupAcc)> = Vec::new();
     let mut surrogate_index: FxHashMap<Vec<GroupKeyPart>, usize> = FxHashMap::default();
 
-    // Capture variable names of group-key expressions that are pure
-    // variable references — used to copy node bindings forward on the
-    // first row of each group.
-    let group_var_names: Vec<Option<String>> = group_indices
-        .iter()
-        .map(|&i| match &return_clause.items[i].expression {
-            Expression::Variable(v) => Some(v.clone()),
-            Expression::PropertyAccess { variable, .. } => Some(variable.clone()),
-            _ => None,
-        })
-        .collect();
+    // Variables the grouping keys read — copied forward from the first row of
+    // each group so a trailing ORDER BY / downstream MATCH can still resolve
+    // them. Shared with the materialized and fused-OPTIONAL paths so all three
+    // agree on what survives aggregation.
+    let carried_vars = grouping_variables(&return_clause.items);
 
     for (row_count, row_result) in upstream.enumerate() {
         let row = row_result?;
@@ -442,13 +436,9 @@ pub fn apply<'q>(
                 let idx = surrogate_groups.len();
                 surrogate_index.insert(key_parts.clone(), idx);
                 let mut acc = GroupAcc::new(specs);
-                // Capture node bindings for variables that are
-                // group-key expressions (pure Variable or PropertyAccess).
-                for var_opt in group_var_names.iter().flatten() {
-                    if let Some(&node_idx) = row.node_bindings.get(var_opt) {
-                        acc.first_node_bindings.insert(var_opt.clone(), node_idx);
-                    }
-                }
+                // Capture this first row's bindings for every variable the
+                // grouping keys read.
+                carry_group_bindings(&carried_vars, &row, &mut acc.carried);
                 surrogate_groups.push((key_parts, acc));
                 idx
             }
@@ -536,9 +526,7 @@ pub fn apply<'q>(
         }
 
         let mut row = ResultRow::from_projected(projected);
-        for (k, v) in acc.first_node_bindings.iter() {
-            row.node_bindings.insert(k.clone(), *v);
-        }
+        carry_group_bindings(&carried_vars, &acc.carried, &mut row);
         output_rows.push(row);
     }
 
@@ -648,11 +636,11 @@ fn merge_group_accs(mut a: GroupAcc, b: GroupAcc) -> GroupAcc {
         merged_states.push(sa);
     }
     a.states = merged_states;
-    // Keep the first-seen node bindings — matches materialized behavior
+    // Keep the first-seen bindings — matches materialized behavior
     // (execute_return_with_aggregation uses the first row of the group).
     GroupAcc {
         states: a.states,
-        first_node_bindings: a.first_node_bindings,
+        carried: a.carried,
     }
 }
 

--- a/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
@@ -46,6 +46,8 @@
 //! - `crates/kglite-bolt-server/src/backend.rs::execute`
 
 use super::super::ast::*;
+use super::super::executor::helpers::expression_to_string;
+use super::simplification::collect_expression_refs;
 use crate::graph::core::pattern_matching::{Pattern, PatternElement};
 use crate::graph::mutation::validation::did_you_mean;
 use crate::graph::schema::{DirGraph, InternedKey};
@@ -152,9 +154,205 @@ fn bind_row_source(clause: &Clause, scope: &mut HashSet<String>) -> Result<(), S
     Ok(())
 }
 
+/// What a trailing `ORDER BY` may reference after an **aggregating** RETURN.
+///
+/// An aggregating RETURN emits one row per group. Only two kinds of thing have
+/// a defined value on that row: the projected columns, and the variables the
+/// grouping keys pin down (the executor carries their bindings forward — see
+/// `executor::helpers::carry_group_bindings`). Ordering by anything else is
+/// what Neo4j rejects outright: `count(c)` collapses many `c`s into a scalar,
+/// so `ORDER BY c.label` has no single value to sort on.
+///
+/// kglite splits the difference: the well-defined half sorts correctly, the
+/// ambiguous half is rejected with a message naming the fix. What it must
+/// never do — and did before this check existed — is evaluate the sort key to
+/// NULL on every row and hand back insertion order as though the clause had
+/// been honoured.
+struct AggregateOrderScope {
+    /// Projected column names plus every variable the grouping keys read.
+    allowed: HashSet<String>,
+    /// Rendered aggregate projections → their alias, if any. `ORDER BY count(p)`
+    /// resolves at runtime only when `count(p)` is projected *unaliased*, since
+    /// then the result column is literally named `count(p)`; aliasing it moves
+    /// the value to the alias and leaves the expression form unresolvable.
+    aggregates: HashMap<String, Option<String>>,
+    /// Projected aliases, listed in the error message as the way out.
+    aliases: Vec<String>,
+}
+
+impl AggregateOrderScope {
+    /// `None` when no restriction applies — either the projection does not
+    /// aggregate (a plain projection keeps every binding on its rows, so
+    /// ordering by a non-projected expression stays well defined), or it
+    /// contains `*` and we cannot enumerate what it carries.
+    fn for_projection(items: &[ReturnItem]) -> Option<Self> {
+        if !items
+            .iter()
+            .any(|item| is_aggregate_expression(&item.expression))
+        {
+            return None;
+        }
+        if items
+            .iter()
+            .any(|item| matches!(item.expression, Expression::Star))
+        {
+            return None;
+        }
+
+        let mut allowed = HashSet::new();
+        let mut aliases = Vec::new();
+        let mut aggregates = HashMap::new();
+        for item in items {
+            if let Some(alias) = &item.alias {
+                allowed.insert(alias.clone());
+                aliases.push(alias.clone());
+            } else if let Expression::Variable(name) = &item.expression {
+                allowed.insert(name.clone());
+                aliases.push(name.clone());
+            }
+            if is_aggregate_expression(&item.expression) {
+                aggregates.insert(expression_to_string(&item.expression), item.alias.clone());
+            } else {
+                collect_expression_refs(&item.expression, &mut allowed);
+            }
+        }
+        Some(AggregateOrderScope {
+            allowed,
+            aggregates,
+            aliases,
+        })
+    }
+
+    fn projected_hint(&self) -> String {
+        if self.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ", or order by a projected column ({})",
+                self.aliases.join(", ")
+            )
+        }
+    }
+
+    fn validate(&self, order: &OrderByClause) -> Result<(), SchemaError> {
+        for item in &order.items {
+            if is_aggregate_expression(&item.expression) {
+                let rendered = expression_to_string(&item.expression);
+                match self.aggregates.get(&rendered) {
+                    // Projected unaliased — the executor resolves the sort key
+                    // from the identically-named result column.
+                    Some(None) => continue,
+                    Some(Some(alias)) => {
+                        return Err(SchemaError {
+                            kind: SchemaErrorKind::UndefinedVariable,
+                            message: format!(
+                                "ORDER BY '{rendered}' cannot be resolved after an aggregating \
+                                 RETURN because that aggregate is projected as '{alias}'. \
+                                 Order by the alias instead (`ORDER BY {alias}`)."
+                            ),
+                        });
+                    }
+                    None => {
+                        return Err(SchemaError {
+                            kind: SchemaErrorKind::UndefinedVariable,
+                            message: format!(
+                                "ORDER BY cannot compute the aggregate '{rendered}' after an \
+                                 aggregating RETURN. Project it first \
+                                 (e.g. `RETURN ..., {rendered} AS sort_key ORDER BY sort_key`){}.",
+                                self.projected_hint()
+                            ),
+                        });
+                    }
+                }
+            }
+            let mut refs = HashSet::new();
+            collect_expression_refs(&item.expression, &mut refs);
+            for name in refs {
+                if !self.allowed.contains(&name) {
+                    return Err(SchemaError {
+                        kind: SchemaErrorKind::UndefinedVariable,
+                        message: format!(
+                            "ORDER BY cannot use '{name}' after an aggregating RETURN: \
+                             '{name}' is not part of the grouping keys, so it has no single \
+                             value per group. Add the sort key to the RETURN list \
+                             (e.g. `RETURN ..., {name}.<property> AS sort_key ORDER BY sort_key`){}.",
+                            self.projected_hint()
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate a RETURN's own expressions, then produce the scope its trailing
+/// clauses see: everything already in scope plus the projection's aliases.
+///
+/// RETURN is terminal for the pipeline, so unlike WITH it does not narrow the
+/// scope — HAVING and a trailing ORDER BY may still name pre-projection
+/// variables. Whether an *aggregating* RETURN leaves those variables with a
+/// usable value is a separate question, answered by [`AggregateOrderScope`].
+fn scope_after_return(
+    return_clause: &ReturnClause,
+    scope: HashSet<String>,
+) -> Result<HashSet<String>, SchemaError> {
+    for item in &return_clause.items {
+        validate_expression_scope(&item.expression, &scope)?;
+    }
+    let mut having_scope = scope;
+    having_scope.extend(
+        return_clause
+            .items
+            .iter()
+            .filter_map(|item| item.alias.clone()),
+    );
+    if let Some(having) = &return_clause.having {
+        validate_predicate_scope(having, &having_scope)?;
+    }
+    Ok(having_scope)
+}
+
+/// Validate a WITH's own expressions, then produce the scope it projects
+/// forward: only the aliases and bare variables it names, unless it carries
+/// `*` (which preserves the incoming scope wholesale).
+fn scope_after_with(
+    with_clause: &WithClause,
+    scope: HashSet<String>,
+) -> Result<HashSet<String>, SchemaError> {
+    for item in &with_clause.items {
+        validate_expression_scope(&item.expression, &scope)?;
+    }
+    let preserves_all = with_clause
+        .items
+        .iter()
+        .any(|item| matches!(item.expression, Expression::Star));
+    let mut projected = if preserves_all { scope } else { HashSet::new() };
+    for item in &with_clause.items {
+        if let Some(alias) = &item.alias {
+            projected.insert(alias.clone());
+        } else if let Expression::Variable(name) = &item.expression {
+            projected.insert(name.clone());
+        }
+    }
+    if let Some(where_clause) = &with_clause.where_clause {
+        validate_predicate_scope(&where_clause.predicate, &projected)?;
+    }
+    Ok(projected)
+}
+
 fn validate_scope(query: &CypherQuery, initial: &HashSet<String>) -> Result<(), SchemaError> {
     let mut scope = initial.clone();
+    // Set by an aggregating RETURN, consumed by the ORDER BY that follows it.
+    // Rides through a trailing SKIP/LIMIT; any other clause clears it.
+    let mut aggregate_order_scope: Option<AggregateOrderScope> = None;
     for clause in &query.clauses {
+        if !matches!(
+            clause,
+            Clause::OrderBy(_) | Clause::Skip(_) | Clause::Limit(_)
+        ) {
+            aggregate_order_scope = None;
+        }
         match clause {
             Clause::Match(m) | Clause::OptionalMatch(m) => {
                 for pattern in &m.patterns {
@@ -166,49 +364,18 @@ fn validate_scope(query: &CypherQuery, initial: &HashSet<String>) -> Result<(), 
                 validate_predicate_scope(&where_clause.predicate, &scope)?
             }
             Clause::Return(return_clause) => {
-                for item in &return_clause.items {
-                    validate_expression_scope(&item.expression, &scope)?;
-                }
-                let mut having_scope = scope.clone();
-                having_scope.extend(
-                    return_clause
-                        .items
-                        .iter()
-                        .filter_map(|item| item.alias.clone()),
-                );
-                if let Some(having) = &return_clause.having {
-                    validate_predicate_scope(having, &having_scope)?;
-                }
-                scope = having_scope;
+                scope = scope_after_return(return_clause, scope)?;
+                aggregate_order_scope = AggregateOrderScope::for_projection(&return_clause.items);
             }
             Clause::With(with_clause) => {
-                for item in &with_clause.items {
-                    validate_expression_scope(&item.expression, &scope)?;
-                }
-                let preserves_all = with_clause
-                    .items
-                    .iter()
-                    .any(|item| matches!(item.expression, Expression::Star));
-                let mut projected = if preserves_all {
-                    scope.clone()
-                } else {
-                    HashSet::new()
-                };
-                for item in &with_clause.items {
-                    if let Some(alias) = &item.alias {
-                        projected.insert(alias.clone());
-                    } else if let Expression::Variable(name) = &item.expression {
-                        projected.insert(name.clone());
-                    }
-                }
-                if let Some(where_clause) = &with_clause.where_clause {
-                    validate_predicate_scope(&where_clause.predicate, &projected)?;
-                }
-                scope = projected;
+                scope = scope_after_with(with_clause, scope)?;
             }
             Clause::OrderBy(order) => {
                 for item in &order.items {
                     validate_expression_scope(&item.expression, &scope)?;
+                }
+                if let Some(restriction) = &aggregate_order_scope {
+                    restriction.validate(order)?;
                 }
             }
             Clause::Skip(skip) => validate_expression_scope(&skip.count, &scope)?,

--- a/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
@@ -1550,7 +1550,12 @@ fn collect_predicate_refs(pred: &Predicate, out: &mut HashSet<String>) {
     }
 }
 
-fn collect_expression_refs(expr: &Expression, out: &mut HashSet<String>) {
+/// Collect every variable an expression *reads*.
+///
+/// A pure AST utility shared with the executor (`helpers::grouping_variables`)
+/// and with `schema_check`'s post-aggregation ORDER BY scope. Over-collection
+/// is safe for every caller; under-collection is not.
+pub(crate) fn collect_expression_refs(expr: &Expression, out: &mut HashSet<String>) {
     match expr {
         Expression::Variable(v) => {
             out.insert(v.clone());

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -252,8 +252,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs",
       "qualified_name": "crate::CypherExecutor<'a>::execute_return_with_aggregation",
-      "lines": 246,
-      "branches": 39,
+      "lines": 237,
+      "branches": 34,
       "nesting": 5
     },
     {
@@ -390,13 +390,6 @@
       "nesting": 3
     },
     {
-      "path": "crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs",
-      "qualified_name": "crate::apply",
-      "lines": 204,
-      "branches": 26,
-      "nesting": 4
-    },
-    {
       "path": "crates/kglite/src/graph/languages/cypher/executor/where_clause.rs",
       "qualified_name": "crate::CypherExecutor<'a>::evaluate_predicate_tristate",
       "lines": 321,
@@ -476,8 +469,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/planner/schema_check.rs",
       "qualified_name": "crate::validate_scope",
-      "lines": 201,
-      "branches": 79,
+      "lines": 179,
+      "branches": 72,
       "nesting": 6
     },
     {
@@ -516,6 +509,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +535,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -589,6 +589,40 @@ DIFFERENTIAL_QUERIES: list[tuple[str, str, str, dict | None]] = [
         "ORDER BY count(p) DESC, company LIMIT 3",
         None,
     ),
+    # ORDER BY a non-projected property of a *grouping* variable, after an
+    # aggregate. Aggregation rebuilds its output rows, so `p` survives only
+    # if the operator carries its binding forward — and the three
+    # aggregation operators (streaming, materialized, fused OPTIONAL) used
+    # to disagree about that. Where the binding was dropped the sort key
+    # evaluated to NULL on every row and the ORDER BY was silently ignored.
+    # The optimizer decides which operator runs, so opt-vs-naive is exactly
+    # the axis that exposed it. Row-order assertions live in
+    # tests/test_cypher_order_by_after_aggregate.py; these entries guard the
+    # row-set equality the corpus is responsible for.
+    (
+        "optional_match_aggregate_order_by_non_projected",
+        "social_graph",
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:WORKS_AT]->(c:Company) "
+        "RETURN p.name AS person, count(c) AS jobs ORDER BY p.age DESC",
+        None,
+    ),
+    (
+        "optional_match_aggregate_order_by_non_projected_paged",
+        "social_graph",
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) "
+        "RETURN p.name AS person, count(f) AS friends "
+        "ORDER BY p.age DESC SKIP 5 LIMIT 5",
+        None,
+    ),
+    # `collect()` is outside the streaming aggregate's reach, so this one
+    # takes the materialized path — the same defect with no OPTIONAL MATCH
+    # involved at all.
+    (
+        "collect_aggregate_order_by_non_projected",
+        "social_graph",
+        "MATCH (p:Person) RETURN p.city AS city, collect(p.name) AS names ORDER BY p.city DESC",
+        None,
+    ),
     # Aggregate on the EDGE variable (not a node variable). Pre-fix the
     # gate at fuse_match_return_aggregate only accepted count(<other-node>);
     # count(<edge_var>) silently fell out of fusion despite being

--- a/tests/test_cypher_order_by_after_aggregate.py
+++ b/tests/test_cypher_order_by_after_aggregate.py
@@ -1,0 +1,262 @@
+"""ORDER BY after an aggregating RETURN.
+
+Aggregation rebuilds its output rows from scratch, so a variable only
+survives onto them if the executor deliberately carries its binding
+forward. Three implementations produce those rows — the streaming
+aggregate, the materialized aggregate, and the fused
+`OPTIONAL MATCH` + `count()` operator — and they used to disagree about
+which variables survive. Where a variable was dropped,
+`execute_order_by` evaluated the sort key to NULL on *every* row, every
+key tied, and the stable sort handed back insertion order: the ORDER BY
+clause was silently ignored.
+
+The contract these tests pin down:
+
+* A variable read by a **grouping key** keeps a value on the aggregated
+  row, so ordering by any of its properties works — regardless of which
+  aggregation path the planner picked.
+* A variable that appears **only inside an aggregate argument** has no
+  single value per group. Ordering by it is rejected with a message
+  naming the fix, never silently ignored.
+* Ordering by a projected alias keeps working.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+
+# priority is a total order with no ties, so the expected sequence below
+# is the only correct answer — an assertion on it cannot pass by luck.
+_TASKS = [
+    ("t1", 5),
+    ("t2", 2),
+    ("t3", 7),
+    ("t4", 4),
+    ("t5", 3),
+    ("t6", 8),
+    ("t7", 9),
+]
+# Insertion order, which is what a silently-dropped ORDER BY returns.
+INSERTION_ORDER = [title for title, _ in _TASKS]
+PRIORITY_DESC = [title for title, _ in sorted(_TASKS, key=lambda t: -t[1])]
+PRIORITY_ASC = list(reversed(PRIORITY_DESC))
+
+assert PRIORITY_DESC != INSERTION_ORDER, "fixture must distinguish sorted from insertion order"
+
+
+def build_task_graph() -> kglite.KnowledgeGraph:
+    """Tasks with a comment count — the list-view shape this bug broke."""
+    g = kglite.KnowledgeGraph()
+    g.add_nodes(
+        pd.DataFrame(
+            {
+                "tid": list(range(1, len(_TASKS) + 1)),
+                "title": [title for title, _ in _TASKS],
+                "priority": [priority for _, priority in _TASKS],
+            }
+        ),
+        "Task",
+        "tid",
+        "title",
+    )
+    g.add_nodes(
+        pd.DataFrame({"cid": [1, 2, 3], "label": ["c1", "c2", "c3"]}),
+        "Comment",
+        "cid",
+        "label",
+    )
+    # t1 has two comments, t3 has one, the rest have none — so the
+    # OPTIONAL MATCH genuinely produces null-padded rows.
+    g.add_connections(
+        pd.DataFrame({"from_id": [1, 1, 3], "to_id": [1, 2, 3]}),
+        "X",
+        "Task",
+        "from_id",
+        "Comment",
+        "to_id",
+    )
+    return g
+
+
+@pytest.fixture
+def task_graph() -> kglite.KnowledgeGraph:
+    return build_task_graph()
+
+
+def titles(graph: kglite.KnowledgeGraph, query: str, **kwargs) -> list[str]:
+    return [row["title"] for row in graph.cypher(query, **kwargs).to_list()]
+
+
+# ── The reported bug ────────────────────────────────────────────────
+#
+# OPTIONAL MATCH + aggregate + ORDER BY on a non-projected expression.
+# Asserts the row *order*, not just the row set — the bug returned every
+# correct row in the wrong sequence.
+
+REPRO = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY t.priority DESC"
+
+
+def test_optional_match_aggregate_orders_by_non_projected_key(task_graph):
+    assert titles(task_graph, REPRO) == PRIORITY_DESC
+
+
+def test_repro_is_not_merely_insertion_order(task_graph):
+    """Guards the guard: a fix that ignored ORDER BY would return this."""
+    assert titles(task_graph, REPRO) != INSERTION_ORDER
+
+
+def test_optional_match_aggregate_orders_ascending(task_graph):
+    query = REPRO.replace("DESC", "ASC")
+    assert titles(task_graph, query) == PRIORITY_ASC
+
+
+def test_repro_matches_with_optimizer_disabled(task_graph):
+    """The optimizer picked a different aggregation operator for the
+    OPTIONAL shape; both must now agree, order included."""
+    assert titles(task_graph, REPRO) == titles(task_graph, REPRO, disable_optimizer=True)
+
+
+# ── Pagination ──────────────────────────────────────────────────────
+#
+# The practical damage: with the order unspecified, SKIP/LIMIT pages
+# could repeat rows and skip others.
+
+
+def test_pagination_pages_are_disjoint_and_ordered(task_graph):
+    page_size = 3
+    pages = [titles(task_graph, f"{REPRO} SKIP {skip} LIMIT {page_size}") for skip in range(0, len(_TASKS), page_size)]
+    seen = [title for page in pages for title in page]
+
+    assert seen == PRIORITY_DESC, "concatenated pages must reproduce the full ordering"
+    assert len(seen) == len(set(seen)), f"pages overlap: {pages}"
+    assert sorted(seen) == sorted(INSERTION_ORDER), "pagination dropped or duplicated rows"
+
+
+# ── Controls: shapes that already worked must keep working ──────────
+
+
+def test_order_by_projected_alias(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, t.priority AS p, count(c) AS n ORDER BY p DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_order_by_aggregate_alias(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY n DESC, title ASC"
+    )
+    assert titles(task_graph, query) == ["t1", "t3", "t2", "t4", "t5", "t6", "t7"]
+
+
+def test_plain_match_aggregate_still_correct(task_graph):
+    """The audit's working counter-example — must not regress."""
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_projection_without_aggregate_still_correct(task_graph):
+    query = "MATCH (t:Task) RETURN t.title AS title ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_group_by_bare_variable(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, t AS node, count(c) AS n ORDER BY t.priority DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_unaliased_aggregate_ordered_by_its_expression_form(task_graph):
+    """`ORDER BY count(c)` resolves against the identically-named column
+    when the aggregate is projected without an alias."""
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, count(c) ORDER BY count(c) DESC, title ASC"
+    )
+    assert titles(task_graph, query) == ["t1", "t3", "t2", "t4", "t5", "t6", "t7"]
+
+
+# ── The same defect outside OPTIONAL MATCH ──────────────────────────
+#
+# `collect()` is not computable by the streaming aggregate, so it falls
+# to the materialized path — which dropped the binding too. This shape
+# was silently unordered with no OPTIONAL MATCH and no optimizer.
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    ["collect(t.tid)", "count(*)", "max(t.tid)", "avg(t.tid)"],
+    ids=["collect", "count_star", "max", "avg"],
+)
+def test_every_aggregate_kind_honours_order_by(task_graph, aggregate):
+    query = f"MATCH (t:Task) RETURN t.title AS title, {aggregate} AS agg ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+    assert titles(task_graph, query) == titles(task_graph, query, disable_optimizer=True)
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    ["collect(c.label)", "count(c)"],
+    ids=["collect", "count"],
+)
+def test_every_aggregate_kind_honours_order_by_under_optional(task_graph, aggregate):
+    query = (
+        f"MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        f"RETURN t.title AS title, {aggregate} AS agg ORDER BY t.priority DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+    assert titles(task_graph, query) == titles(task_graph, query, disable_optimizer=True)
+
+
+# ── The ambiguous half: rejected, never silently reordered ──────────
+
+
+def test_order_by_variable_only_inside_aggregate_is_rejected(task_graph):
+    """`c` collapses into `count(c)`, so `c.label` has no single value
+    per group. Neo4j rejects this shape; so do we."""
+    query = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+
+    message = str(excinfo.value)
+    assert "'c'" in message, message
+    assert "grouping keys" in message, message
+    # The message must name a way out, not just refuse.
+    assert "sort_key" in message or "projected column" in message, message
+
+
+def test_rejection_is_identical_with_optimizer_disabled(task_graph):
+    query = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+    with pytest.raises(kglite.SchemaError):
+        task_graph.cypher(query, disable_optimizer=True).to_list()
+
+
+def test_order_by_unprojected_aggregate_is_rejected(task_graph):
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY max(t.priority) DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+    assert "max(t.priority)" in str(excinfo.value)
+
+
+def test_order_by_aliased_aggregate_expression_names_the_alias(task_graph):
+    """`count(*) AS n` moves the value to `n`; ordering by the expression
+    form can no longer resolve, so the error points at the alias."""
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY count(*) DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+    assert "ORDER BY n" in str(excinfo.value)
+
+
+def test_ordering_by_grouping_variable_expression_is_allowed(task_graph):
+    """Derived expressions over a grouping variable stay well defined."""
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, count(c) AS n ORDER BY t.priority * -1 ASC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC


### PR DESCRIPTION
> **Landed in `main` via #81.** Every commit on `fix/order-by-after-aggregate` is an ancestor of `main` (verified with `git merge-base --is-ancestor`). GitHub cannot mark it "merged" because its base was a feature branch, and retargeting is refused once the head has no commits absent from `main` — so it is closed rather than merged. The code shipped.

---

Fixes a **silent-wrong-answer bug** from the boring-app audit: `ORDER BY` after an aggregating `RETURN` returned insertion order. No version bump.

**Base is `docs/disk-crash-guarantee` (#73)** — this branch carries that commit. Review #73 first; diff against `7589362e` to see only this work.

## The bug

```python
"MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY t.priority DESC"
# before -> ['t3','t1','t4','t5','t9','t2','t6']   insertion order
# after  -> correctly ordered by priority
```

This is the shape of every list view showing a count — "tasks with their comment count, most important first" — and **with `SKIP`/`LIMIT` it made pagination incoherent**, since pages of an unspecified order can repeat and skip rows.

## Root cause

`ResultRow` holds projected values *plus* `node_bindings`/`edge_bindings`/`path_bindings`. Plain projection overwrites only `projected` and keeps the bindings — which is why `ORDER BY t.priority` works after a non-aggregating `RETURN`. **Aggregation rebuilds rows from scratch**, so bindings survive only if re-attached, and the three operators re-attached different subsets:

| operator | re-attached for | result |
|---|---|---|
| `stream/aggregate.rs` (count/sum/avg/min/max) | group keys that are `Variable` **or** `PropertyAccess` | worked |
| `execute_return_with_aggregation` (`collect`, `std`, …) | only bare `Expression::Variable` | **dropped** |
| `execute_fused_optional_match_aggregate` | only bare `Expression::Variable` | **dropped** |

`OPTIONAL MATCH` mattered only because it routes to the third operator. The *silence* came from `execute_order_by`'s `evaluate_expression(expr, row).unwrap_or(Value::Null)`: the unbound variable became `Null` on every row, all keys tied, and the stable sort returned insertion order.

## The fix — both behaviours, separated statically

- **Make it work** where the sort key is determined by the grouping: any variable read by a non-aggregate projection item. `RETURN t.title AS title, count(c) AS n` groups by `t.title`, so `t` is pinned and `ORDER BY t.priority` sorts correctly.
- **Make it an error** where it isn't: a variable appearing *only* inside an aggregate argument. In `ORDER BY c.label`, `c` collapses into `count(c)` and has no per-group value.

```
SchemaError: ORDER BY cannot use 'c' after an aggregating RETURN: 'c' is not
part of the grouping keys, so it has no single value per group.
```

The discriminator is a one-line static test — "does any grouping key read this variable?" — needing no data inspection, and computed identically by the planner (to raise the error) and the executor (to decide which bindings to carry), so the two cannot drift apart.

**Why not error everywhere, as Neo4j does:** the engine already shipped the working semantics for the `count(*)` shape, so erroring everywhere would have broken a documented, working query — and would reject `RETURN t.title, count(c) ORDER BY t.priority`, which is the query people actually write.

**Honest residual, now in `CYPHER.md`:** when two distinct nodes collapse into one group (two `Task`s sharing a title), the carried binding is the group's *first* row. That ambiguity is real and is why Neo4j refuses the shape outright; the engine's existing first-row semantics were kept rather than a third behaviour invented.

## Class sweep — wider than `OPTIONAL MATCH`

Also silently unordered before this: `RETURN t.title, collect(t.tid) ORDER BY t.priority` — **no `OPTIONAL MATCH`, no optimizer involved**, same defect on the materialized path. Plus `ORDER BY count(*)` and `ORDER BY max(t.priority)` after an aggregating `RETURN`.

Not affected: `SKIP`/`LIMIT` (they merely paginated an unspecified order); `WITH … ORDER BY <non-projected>`, which already errored cleanly. The bug is `RETURN`-only, because `Clause::Return` keeps the pre-projection scope alive for the trailing `ORDER BY` while the runtime does not.

On method: a per-shape optimizer-on/off sweep beat pass-bisection here — it showed the `collect()` shape was broken **with the optimizer disabled too**, ruling out "a pass drops it" and pointing at the operators. `EXPLAIN` then confirmed the `OPTIONAL` query lands on `FusedOptionalMatchAggregate`.

## Behaviour changes beyond the bug

Three shapes that previously "worked" now raise `SchemaError` — all three previously returned **unsorted** rows, so nothing depending on them was getting an ordering:

- `ORDER BY <var only inside an aggregate>` — names the variable and how to project it
- `ORDER BY <unprojected aggregate>` — "project it first"
- `ORDER BY count(*)` when projected as `count(*) AS n` — "order by `n`"

Unchanged: projected aliases; unaliased aggregates in expression form (`ORDER BY count(p)`, an existing corpus query); non-aggregating `RETURN`; `WITH`.

## Verification

22 new tests asserting **row order** — ASC/DESC, optimizer on and off, pagination (pages disjoint, concatenation reproduces the full ordering), plus controls. **13 of 22 fail without the fix**, the 9 controls passing; the Cypher engine at this branch's base is byte-identical to `origin/main`, so that *is* the origin/main result.

`make gate` exit 0 · clippy `--all-targets -- -D warnings` zero warnings · `make source-quality` clean · `cargo test -p kglite` **1246** · full Python suite **4781 passed, 0 failed** · `pytest -m parity` **109** · differential corpus **346** · `sphinx -W` clean.

