### PR TITLE
fix: scope schema declaration so it stops discarding constraints silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — behaviour
 
+- **`define_schema()` now merges per node/connection type instead of replacing
+  the whole schema.** A type the call names takes the new declaration entire; a
+  type it does not name keeps the declaration it already had. Previously any
+  `define_schema` call superseded the entire schema, so the natural
+  per-module/per-type declaration pattern silently withdrew every constraint on
+  every type the call happened to omit — a graph that correctly rejected a
+  duplicate primary key one line earlier would accept it on the next, with no
+  error and no warning. Merging is per *type*, not per field, so re-declaring a
+  type is still how you narrow it.
+
+  Pass `replace=True` for the previous whole-schema semantics. Because that
+  withdraws enforcement from types the caller never mentioned, it emits a
+  `UserWarning` listing each constraint it stops enforcing. `clear_schema()`
+  removes everything.
+
+- **`clear_schema()` now withdraws the constraints the schema installed.**
+  It previously dropped the declaration but left the unique indexes a
+  `primary_key`/`unique` declaration had built still rejecting writes — with no
+  `SHOW CONSTRAINTS` row explaining them and no way to drop them. Constraints
+  declared through Cypher DDL are separate declarations and still survive;
+  `DROP CONSTRAINT` withdraws those.
+
+- **A `required` property named `id` or `title` is now enforced against an
+  explicit null.** Both are auto-supplied when a write omits them, so omitting
+  one still satisfies the requirement — but `CREATE (:T {title: null})`,
+  `SET t.title = null`, `REMOVE t.title` and a null title cell in an
+  `add_nodes` batch all produce a node that genuinely carries a null, and those
+  are now rejected. Previously they were waved through while `SHOW CONSTRAINTS`
+  reported the constraint as `NODE_PROPERTY_EXISTENCE` (or `NODE_KEY` alongside
+  a uniqueness declaration), and `validate_schema()` reported nothing.
+  `CREATE CONSTRAINT ... IS NOT NULL` on `id`/`title` likewise now refuses to
+  install against data that already violates it, as it does for any other
+  property. Requiring `type` remains a no-op — it is the node's label and
+  cannot be absent.
+
 - **`kglite.open()` is now crash-safe by default.** `durable` defaults to on, so
   every committed mutation is `fsync`'d to the `<path>-wal` sidecar before the
   call returns and is replayed on the next `open()`. Previously a graph opened
@@ -333,6 +368,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour.
 
 ### Fixed
+
+- `define_schema()` no longer withdraws a NOT NULL declared through
+  `CREATE CONSTRAINT ... IS NOT NULL`. Presence constraints live in the same
+  `required_fields` list a schema owns, so installing any schema silently
+  un-enforced them — while the uniqueness half of a DDL declaration, whose index
+  lives outside the schema, survived. A DDL constraint is now withdrawn only by
+  `DROP CONSTRAINT`, in both modes.
+
+- `SHOW CONSTRAINTS` (and `CALL db.constraints()`) now report a stable name for
+  a constraint carrying more than one registered name — the case where
+  `CREATE CONSTRAINT u … IS UNIQUE` and `CREATE CONSTRAINT nn … IS NOT NULL` on
+  the same property merge into one `NODE_KEY` row. The reported name was taken
+  from the first hash-map match, so the same graph could name the row
+  differently before and after a save/load round-trip.
 
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -1458,8 +1458,12 @@ g.define_schema({
 })
 ```
 
-> **`define_schema` replaces the whole schema** — it is not a merge. A call with
-> a subset of types drops the omitted ones, so redefine all types each call.
+> **`define_schema` merges per node/connection type.** A type the call names
+> takes the new declaration entire; a type it omits keeps its own, so declaring
+> per module never withdraws another type's constraints. Pass `replace=True` for
+> whole-schema replacement — it warns, naming each constraint it stops
+> enforcing. Constraints declared with `CREATE CONSTRAINT` are unaffected by
+> either mode; drop them with `DROP CONSTRAINT`.
 
 Every write to an opted-in type then stamps a reserved **`updated_at`** (a
 `Timestamp`) — Cypher `CREATE`/`MERGE`/`SET` and `add_nodes`/`add_connections`.

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -16,7 +16,9 @@ use kglite_core::api::io::{Cancelled, ProgressEvent, ProgressSink, ProgressValue
 use kglite_core::api::mutation::OperationReport;
 use kglite_core::api::session::CsvImportPolicy;
 use kglite_core::api::GraphRead;
-use kglite_core::api::{ConnectionSchemaDefinition, NodeSchemaDefinition, SchemaDefinition};
+use kglite_core::api::{
+    ConnectionSchemaDefinition, NodeSchemaDefinition, SchemaDefinition, SchemaInstall,
+};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use pyo3::{Bound, IntoPyObjectExt};
@@ -1049,139 +1051,40 @@ impl KnowledgeGraph {
     ///             }
     ///         }
     ///
+    ///     replace: When False (the default) the call **merges**: types named in
+    ///         `schema_dict` take the new declaration, types it does not name
+    ///         keep theirs. When True the incoming schema becomes the whole
+    ///         schema, so every unnamed type loses its constraints — a warning
+    ///         names each one that stops being enforced.
+    ///
     /// Returns:
     ///     Self with schema defined
-    fn define_schema(&mut self, schema_dict: &Bound<'_, PyDict>) -> PyResult<Self> {
+    #[pyo3(signature = (schema_dict, *, replace = false))]
+    fn define_schema(
+        &mut self,
+        py: Python<'_>,
+        schema_dict: &Bound<'_, PyDict>,
+        replace: bool,
+    ) -> PyResult<Self> {
         let mut schema = SchemaDefinition::new();
+        parse_node_schemas(schema_dict, &mut schema)?;
+        parse_connection_schemas(schema_dict, &mut schema)?;
 
-        // Parse node schemas
-        if let Some(nodes_dict) = schema_dict.get_item("nodes")? {
-            if let Ok(nodes) = nodes_dict.cast::<PyDict>() {
-                for (node_type_key, node_schema_val) in nodes.iter() {
-                    let node_type: String = node_type_key.extract()?;
-                    let node_schema_dict = node_schema_val.cast::<PyDict>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-                            "Schema for node type '{}' must be a dictionary",
-                            node_type
-                        ))
-                    })?;
-
-                    let mut node_schema = NodeSchemaDefinition::default();
-
-                    // Parse required fields
-                    if let Some(required) = node_schema_dict.get_item("required")? {
-                        node_schema.required_fields = required.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse optional fields
-                    if let Some(optional) = node_schema_dict.get_item("optional")? {
-                        node_schema.optional_fields = optional.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse field types
-                    if let Some(types) = node_schema_dict.get_item("types")? {
-                        let types_dict = types.cast::<PyDict>().map_err(|_| {
-                            PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                                "types must be a dictionary",
-                            )
-                        })?;
-                        for (field, type_val) in types_dict.iter() {
-                            node_schema
-                                .field_types
-                                .insert(field.extract::<String>()?, type_val.extract::<String>()?);
-                        }
-                    }
-
-                    parse_node_declarations(&node_type, node_schema_dict, &mut node_schema)?;
-
-                    schema.add_node_schema(node_type, node_schema);
-                }
-            }
-        }
-
-        // Parse connection schemas
-        if let Some(connections_dict) = schema_dict.get_item("connections")? {
-            if let Ok(connections) = connections_dict.cast::<PyDict>() {
-                for (conn_type_key, conn_schema_val) in connections.iter() {
-                    let conn_type: String = conn_type_key.extract()?;
-                    let conn_schema_dict = conn_schema_val.cast::<PyDict>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-                            "Schema for connection type '{}' must be a dictionary",
-                            conn_type
-                        ))
-                    })?;
-
-                    let source_type: String = conn_schema_dict
-                        .get_item("source")?
-                        .ok_or_else(|| {
-                            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                                "Connection '{}' missing required 'source' field",
-                                conn_type
-                            ))
-                        })?
-                        .extract()?;
-
-                    let target_type: String = conn_schema_dict
-                        .get_item("target")?
-                        .ok_or_else(|| {
-                            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                                "Connection '{}' missing required 'target' field",
-                                conn_type
-                            ))
-                        })?
-                        .extract()?;
-
-                    let mut conn_schema = ConnectionSchemaDefinition {
-                        source_type,
-                        target_type,
-                        cardinality: None,
-                        required_properties: Vec::new(),
-                        property_types: HashMap::new(),
-                        auto_timestamp: None,
-                    };
-
-                    // Parse optional cardinality
-                    if let Some(cardinality) = conn_schema_dict.get_item("cardinality")? {
-                        conn_schema.cardinality = Some(cardinality.extract::<String>()?);
-                    }
-
-                    // Opt-in freshness provenance for edges of this type.
-                    if let Some(ts_val) = conn_schema_dict.get_item("auto_timestamp")? {
-                        conn_schema.auto_timestamp = Some(ts_val.extract::<bool>()?);
-                    }
-
-                    // Parse required_properties
-                    if let Some(required_props) =
-                        conn_schema_dict.get_item("required_properties")?
-                    {
-                        conn_schema.required_properties =
-                            required_props.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse property_types
-                    if let Some(prop_types) = conn_schema_dict.get_item("property_types")? {
-                        let types_dict = prop_types.cast::<PyDict>().map_err(|_| {
-                            PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                                "property_types must be a dictionary",
-                            )
-                        })?;
-                        for (field, type_val) in types_dict.iter() {
-                            conn_schema
-                                .property_types
-                                .insert(field.extract::<String>()?, type_val.extract::<String>()?);
-                        }
-                    }
-
-                    schema.add_connection_schema(conn_type, conn_schema);
-                }
-            }
-        }
+        // Replacing withdraws the declarations of every type this call did not
+        // name, so say which enforcement is going away. The default merge cannot
+        // reach an unnamed type, and so has nothing to warn about.
+        let mode = if replace {
+            warn_about_constraints_dropped_by_replace(py, &self.inner, &schema)?;
+            SchemaInstall::Replace
+        } else {
+            SchemaInstall::Merge
+        };
 
         // Installing the schema installs the UNIQUE constraints it declares, so
         // it fails when existing data already violates one — nothing is changed
         // in that case, so the caller can fix the data and retry.
         get_graph_mut(&mut self.inner)
-            .set_schema(schema)
+            .set_schema(schema, mode)
             .map_err(crate::error_py::kg_to_pyerr)?;
 
         Ok(self.clone())
@@ -1938,6 +1841,164 @@ impl KnowledgeGraph {
 /// expands to all registered pass names; `disabled_passes` adds named
 /// passes on top, validated against the registry so typos surface as a
 /// `ValueError` instead of a silent no-op.
+/// Warn, naming every constraint a `replace=True` install stops enforcing.
+///
+/// Replacement is the one mode that reaches types the caller never mentioned,
+/// and losing an integrity constraint silently is how duplicates enter a graph
+/// unnoticed. Quiet when nothing enforced is being dropped, so the warning stays
+/// worth reading. Warning rather than refusing, because withdrawing a constraint
+/// is a legitimate migration step — it just must not be invisible.
+fn warn_about_constraints_dropped_by_replace(
+    py: Python<'_>,
+    graph: &kglite_core::api::DirGraph,
+    incoming: &SchemaDefinition,
+) -> PyResult<()> {
+    let dropped = graph.constraints_dropped_by_replace(incoming);
+    if dropped.is_empty() {
+        return Ok(());
+    }
+    let message = std::ffi::CString::new(format!(
+        "define_schema(replace=True) stops enforcing {} constraint(s) on types this call did not \
+         declare: {}. Drop `replace=True` to merge instead, leaving undeclared types untouched.",
+        dropped.len(),
+        dropped.join(", ")
+    ))
+    .map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "constraint descriptor contained an interior NUL",
+        )
+    })?;
+    PyErr::warn(
+        py,
+        &py.get_type::<pyo3::exceptions::PyUserWarning>(),
+        message.as_c_str(),
+        1,
+    )
+}
+
+/// Parse `define_schema`'s `nodes` mapping into `schema`.
+///
+/// Absent or non-dict `nodes` is a no-op rather than an error, matching the
+/// long-standing behaviour of the inline walk this was extracted from.
+fn parse_node_schemas(
+    schema_dict: &Bound<'_, PyDict>,
+    schema: &mut SchemaDefinition,
+) -> PyResult<()> {
+    let Some(nodes_dict) = schema_dict.get_item("nodes")? else {
+        return Ok(());
+    };
+    let Ok(nodes) = nodes_dict.cast::<PyDict>() else {
+        return Ok(());
+    };
+    for (node_type_key, node_schema_val) in nodes.iter() {
+        let node_type: String = node_type_key.extract()?;
+        let node_schema_dict = node_schema_val.cast::<PyDict>().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                "Schema for node type '{}' must be a dictionary",
+                node_type
+            ))
+        })?;
+
+        let mut node_schema = NodeSchemaDefinition::default();
+        if let Some(required) = node_schema_dict.get_item("required")? {
+            node_schema.required_fields = required.extract::<Vec<String>>()?;
+        }
+        if let Some(optional) = node_schema_dict.get_item("optional")? {
+            node_schema.optional_fields = optional.extract::<Vec<String>>()?;
+        }
+        if let Some(types) = node_schema_dict.get_item("types")? {
+            let types_dict = types.cast::<PyDict>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>("types must be a dictionary")
+            })?;
+            for (field, type_val) in types_dict.iter() {
+                node_schema
+                    .field_types
+                    .insert(field.extract::<String>()?, type_val.extract::<String>()?);
+            }
+        }
+
+        parse_node_declarations(&node_type, node_schema_dict, &mut node_schema)?;
+        schema.add_node_schema(node_type, node_schema);
+    }
+    Ok(())
+}
+
+/// Parse `define_schema`'s `connections` mapping into `schema`. The edge
+/// counterpart of [`parse_node_schemas`]; `source`/`target` are the only
+/// required keys.
+fn parse_connection_schemas(
+    schema_dict: &Bound<'_, PyDict>,
+    schema: &mut SchemaDefinition,
+) -> PyResult<()> {
+    let Some(connections_dict) = schema_dict.get_item("connections")? else {
+        return Ok(());
+    };
+    let Ok(connections) = connections_dict.cast::<PyDict>() else {
+        return Ok(());
+    };
+    for (conn_type_key, conn_schema_val) in connections.iter() {
+        let conn_type: String = conn_type_key.extract()?;
+        let conn_schema_dict = conn_schema_val.cast::<PyDict>().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                "Schema for connection type '{}' must be a dictionary",
+                conn_type
+            ))
+        })?;
+
+        let mut conn_schema = ConnectionSchemaDefinition {
+            source_type: required_endpoint(conn_schema_dict, &conn_type, "source")?,
+            target_type: required_endpoint(conn_schema_dict, &conn_type, "target")?,
+            cardinality: None,
+            required_properties: Vec::new(),
+            property_types: HashMap::new(),
+            auto_timestamp: None,
+        };
+
+        if let Some(cardinality) = conn_schema_dict.get_item("cardinality")? {
+            conn_schema.cardinality = Some(cardinality.extract::<String>()?);
+        }
+        // Opt-in freshness provenance for edges of this type.
+        if let Some(ts_val) = conn_schema_dict.get_item("auto_timestamp")? {
+            conn_schema.auto_timestamp = Some(ts_val.extract::<bool>()?);
+        }
+        if let Some(required_props) = conn_schema_dict.get_item("required_properties")? {
+            conn_schema.required_properties = required_props.extract::<Vec<String>>()?;
+        }
+        if let Some(prop_types) = conn_schema_dict.get_item("property_types")? {
+            let types_dict = prop_types.cast::<PyDict>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "property_types must be a dictionary",
+                )
+            })?;
+            for (field, type_val) in types_dict.iter() {
+                conn_schema
+                    .property_types
+                    .insert(field.extract::<String>()?, type_val.extract::<String>()?);
+            }
+        }
+
+        schema.add_connection_schema(conn_type, conn_schema);
+    }
+    Ok(())
+}
+
+/// One of a connection schema's two mandatory endpoint keys.
+fn required_endpoint(
+    conn_schema_dict: &Bound<'_, PyDict>,
+    conn_type: &str,
+    key: &str,
+) -> PyResult<String> {
+    conn_schema_dict
+        .get_item(key)?
+        .ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Connection '{}' missing required '{}' field",
+                conn_type, key
+            ))
+        })?
+        .extract()
+}
+
 /// Parse the opt-in per-node-type declarations `define_schema` accepts beyond
 /// the field list: `primary_key`, `unique`, `layer`, and `auto_timestamp`.
 ///

--- a/crates/kglite/src/graph/dir_graph/constraints.rs
+++ b/crates/kglite/src/graph/dir_graph/constraints.rs
@@ -564,13 +564,24 @@ impl DirGraph {
     /// stored ones, so a SET that nulls a required property is caught even
     /// though the property is present beforehand.
     ///
-    /// # Structural fields are exempt
+    /// # Structural fields: `type` is exempt, `id` and `title` are not
     ///
-    /// `id`, `title`, and `type` are always present by construction (they are
-    /// `NodeData` fields, not properties), so requiring them is a no-op rather
-    /// than an error — matching what the offline
-    /// `mutation::validation::validate_single_node` checker has always done, so
-    /// write-time and validation-time agree.
+    /// `type` is the node's label rather than a value a write supplies, so no
+    /// write can leave it absent and requiring it is a genuine no-op.
+    ///
+    /// `id` and `title` are **not** exempt, despite also being `NodeData`
+    /// fields. Each write path resolves them before this check — CREATE
+    /// auto-assigns an id and synthesizes a title from `name`/`title` or the
+    /// label, and the bulk path falls back to the id column — so an omitted one
+    /// reads as present and the requirement is satisfied. But both accept an
+    /// *explicit* null (`CREATE (:T {title: null})`, `SET t.title = null`,
+    /// `REMOVE t.title`, a null title cell in a batch), and the node that
+    /// results genuinely carries a null. Skipping them here made
+    /// `required: ["title"]` report itself through `SHOW CONSTRAINTS` as
+    /// `NODE_PROPERTY_EXISTENCE` — and, with uniqueness alongside it, as
+    /// `NODE_KEY` — while admitting exactly those writes: a constraint that
+    /// reported success and enforced nothing, the one outcome this module
+    /// refuses everywhere else (see `reject_structural_uniqueness`).
     ///
     /// # Provisional stubs are deferred, not exempt
     ///
@@ -613,7 +624,7 @@ impl DirGraph {
             return Ok(());
         }
         for property in required {
-            if matches!(property, "id" | "title" | "type") {
+            if property == "type" {
                 continue;
             }
             match read(property) {
@@ -674,17 +685,47 @@ impl DirGraph {
                 missing,
             ));
         }
-        self.node_schema_mut(node_type)
-            .required_fields
-            .push(property.to_string());
+        self.ddl_not_null_constraints
+            .insert((node_type.to_string(), property.to_string()));
+        self.require_property(node_type, property);
+        Ok(checked)
+    }
+
+    /// Add `property` to `node_type`'s `required_fields`, keeping the list
+    /// sorted and duplicate-free. The storage half of a presence declaration,
+    /// shared by the DDL entry point and by [`Self::reapply_ddl_not_null`].
+    fn require_property(&mut self, node_type: &str, property: &str) {
         let required = &mut self.node_schema_mut(node_type).required_fields;
+        required.push(property.to_string());
         required.sort();
         required.dedup();
-        Ok(checked)
+    }
+
+    /// Re-add every DDL-declared presence constraint to the schema now installed.
+    ///
+    /// `required_fields` lives inside the `SchemaDefinition`, so installing a
+    /// schema replaces the list a `CREATE CONSTRAINT ... IS NOT NULL` wrote into
+    /// — silently un-enforcing it. The uniqueness half has no such problem: its
+    /// index lives outside the schema and `set_schema` withdraws only what the
+    /// *outgoing schema* declared. This restores the symmetry, so a DDL
+    /// constraint is withdrawn only by `DROP CONSTRAINT`.
+    pub(crate) fn reapply_ddl_not_null(&mut self) {
+        if self.ddl_not_null_constraints.is_empty() {
+            return;
+        }
+        let declared: Vec<(String, String)> =
+            self.ddl_not_null_constraints.iter().cloned().collect();
+        for (node_type, property) in declared {
+            self.require_property(&node_type, &property);
+        }
     }
 
     /// Withdraw a NOT NULL declaration. Reports whether one was removed.
     pub(crate) fn drop_not_null_constraint(&mut self, node_type: &str, property: &str) -> bool {
+        // Forget the DDL provenance first, or the next schema install would
+        // reinstate what was just dropped.
+        self.ddl_not_null_constraints
+            .remove(&(node_type.to_string(), property.to_string()));
         let Some(node) = self
             .schema_definition
             .as_mut()
@@ -727,9 +768,11 @@ impl DirGraph {
     /// `(nodes_checked, nodes_missing_the_property)` for `node_type`.
     /// Provisional stubs are skipped — see [`Self::check_required_fields`].
     fn count_missing_property(&mut self, node_type: &str, property: &str) -> (usize, usize) {
-        // Structural fields are `NodeData` fields rather than properties, so
-        // they are present by construction and nothing can be missing.
-        if matches!(property, "id" | "title" | "type") {
+        // `type` is the node's label rather than a supplied value, so nothing
+        // can be missing. `id`/`title` are read through `read_indexed` like any
+        // other property — they are resolved on every write path but can be
+        // explicitly nulled, so existing nulls must block the declaration.
+        if property == "type" {
             let checked = self
                 .type_indices
                 .get(node_type)
@@ -799,6 +842,15 @@ impl DirGraph {
     /// The name registered for `(node_type, properties)`, if the constraint was
     /// declared with one. Property order is irrelevant, matching constraint
     /// identity. Lets `SHOW CONSTRAINTS` report the author's name.
+    ///
+    /// Several names can point at one tuple — `CREATE CONSTRAINT u … IS UNIQUE`
+    /// and `CREATE CONSTRAINT nn … IS NOT NULL` on the same property are two
+    /// declarations that `SHOW CONSTRAINTS` reports as a single `NODE_KEY` row.
+    /// Picking the first match out of a `HashMap` made *which* name that row
+    /// carried depend on hash order, so the same graph reported different names
+    /// before and after a save/load round-trip. The lowest name in sort order
+    /// wins instead: arbitrary, but stable across runs, processes and reloads,
+    /// which is what a listing an operator reads during a migration needs.
     pub(crate) fn name_for_constraint(
         &self,
         node_type: &str,
@@ -807,11 +859,12 @@ impl DirGraph {
         let wanted = normalize_properties(properties);
         self.constraint_names
             .iter()
-            .find(|(_, declared)| {
+            .filter(|(_, declared)| {
                 declared.node_type == node_type
                     && normalize_properties(&declared.properties) == wanted
             })
             .map(|(name, _)| name.as_str())
+            .min()
     }
 
     /// Drop every registered name whose constraint is no longer declared.
@@ -1079,15 +1132,50 @@ mod not_null_declaration_tests {
         assert!(graph.has_not_null_constraint("Person", "email"));
     }
 
-    /// Structural fields are `NodeData` fields, present by construction, so
-    /// requiring one is satisfied rather than rejected.
+    /// `type` is the node's label rather than a supplied value, so requiring it
+    /// is satisfied by construction — nothing a write does can leave it absent.
     #[test]
-    fn declaring_not_null_on_a_structural_field_is_satisfied() {
+    fn declaring_not_null_on_the_label_field_is_satisfied() {
         let mut graph = person_graph(&[(1, "Alice", None)]);
-        assert_eq!(graph.create_not_null_constraint("Person", "id").unwrap(), 1);
+        assert_eq!(
+            graph.create_not_null_constraint("Person", "type").unwrap(),
+            1
+        );
         graph
             .check_required_fields("Person", |_| None)
-            .expect("id is always present");
+            .expect("type is the label and always present");
+    }
+
+    /// `id`/`title` are `NodeData` fields too, but a write can null them
+    /// explicitly, so they are enforced rather than exempt. Every write path
+    /// resolves them before the check (CREATE auto-assigns an id and synthesizes
+    /// a title), which is what the reader models here: a resolved value passes,
+    /// an unresolved one is the explicit-null case and must be rejected.
+    /// Skipping them made `required: ["title"]` report itself through
+    /// `SHOW CONSTRAINTS` while admitting `CREATE (:T {title: null})`.
+    #[test]
+    fn declaring_not_null_on_id_or_title_is_enforced_against_an_explicit_null() {
+        for property in ["id", "title"] {
+            let mut graph = person_graph(&[(1, "Alice", None)]);
+            assert_eq!(
+                graph
+                    .create_not_null_constraint("Person", property)
+                    .unwrap(),
+                1
+            );
+
+            graph
+                .check_required_fields("Person", |name| {
+                    (name == property).then(|| Value::String("resolved".to_string()))
+                })
+                .expect("a write that carries the structural field passes");
+
+            let violation = graph
+                .check_required_fields("Person", |_| None)
+                .expect_err("an explicitly nulled structural field must be rejected");
+            assert_eq!(violation.kind, ConstraintKind::NotNull);
+            assert!(violation.to_string().contains(property), "{violation}");
+        }
     }
 
     #[test]

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -110,6 +110,20 @@ pub struct DirGraph {
     /// their constraints must be dropped by descriptor.
     #[serde(default)]
     pub(crate) constraint_names: HashMap<String, NamedConstraint>,
+    /// `(node_type, property)` presence constraints declared through DDL
+    /// (`CREATE CONSTRAINT ... IS NOT NULL`) rather than through a schema.
+    ///
+    /// The enforced list itself lives in `SchemaDefinition::required_fields`, so
+    /// without this provenance record an unrelated `define_schema` would replace
+    /// the schema and silently un-enforce a DDL declaration — the asymmetry that
+    /// does not exist for uniqueness, whose index lives outside the schema.
+    /// `set_schema` replays this set over the newly installed schema. A
+    /// `BTreeSet` so the persisted bytes are deterministic. Additive serde field
+    /// — older `.kgl` files load with an empty set, which only means their DDL
+    /// presence constraints are indistinguishable from schema-declared ones,
+    /// exactly as they are today.
+    #[serde(default)]
+    pub(crate) ddl_not_null_constraints: std::collections::BTreeSet<(String, String)>,
     /// Fast O(1) lookup by node ID: node_type -> TypeIdIndex
     /// Lazily built on first use for each node type, skipped during serialization.
     /// Uses compact u32 HashMap when all IDs are UniqueId (e.g., Wikidata mapped mode).
@@ -419,6 +433,7 @@ impl DirGraph {
             unique_indices: HashMap::new(),
             unique_constraint_keys: Vec::new(),
             constraint_names: HashMap::new(),
+            ddl_not_null_constraints: std::collections::BTreeSet::new(),
             id_indices: IdIndexStore::new(),
             connection_types: std::collections::HashSet::new(),
             node_type_metadata: HashMap::new(),
@@ -474,6 +489,7 @@ impl DirGraph {
             unique_indices: HashMap::new(),
             unique_constraint_keys: Vec::new(),
             constraint_names: HashMap::new(),
+            ddl_not_null_constraints: std::collections::BTreeSet::new(),
             id_indices: IdIndexStore::new(),
             connection_types: std::collections::HashSet::new(),
             node_type_metadata: HashMap::new(),

--- a/crates/kglite/src/graph/dir_graph/schema_ops.rs
+++ b/crates/kglite/src/graph/dir_graph/schema_ops.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use super::DirGraph;
 use crate::datatypes::values::Value;
 use crate::error::KgError;
-use crate::graph::schema::SchemaDefinition;
+use crate::graph::schema::{SchemaDefinition, SchemaInstall};
 
 impl DirGraph {
     /// Run one write with caller-supplied freshness provenance, restoring the
@@ -43,15 +43,35 @@ impl DirGraph {
     /// the rows already present.
     ///
     /// Constraints implied by the *outgoing* schema are withdrawn first, so
-    /// replacing a schema that declared a primary key with one that does not
-    /// stops enforcing it. A constraint declared directly (by
-    /// `DirGraph::create_unique_constraint`, e.g. from `CREATE CONSTRAINT`)
-    /// rather than through a schema is untouched by this.
+    /// re-declaring a type without the primary key it used to declare stops
+    /// enforcing it. `mode` decides how far that withdrawal reaches:
+    /// [`SchemaInstall::Merge`] scopes it to the types `schema` actually names,
+    /// [`SchemaInstall::Replace`] applies it to every type in the graph.
+    ///
+    /// Constraints declared directly through DDL (`CREATE CONSTRAINT`) rather
+    /// than through a schema survive either mode — the unique half because the
+    /// withdrawal is computed from the outgoing *schema* rather than from the
+    /// live indexes, and the presence half because
+    /// [`Self::reapply_ddl_not_null`] reinstates it. Without that second half a
+    /// schema call would wipe a DDL NOT NULL, since `required_fields` live
+    /// inside the schema being replaced.
     // `KgError` is a rich by-value error type across the whole public surface;
     // every other `Result<_, KgError>` signature in the engine carries the same
     // allow rather than boxing one variant in isolation.
     #[allow(clippy::result_large_err)]
-    pub fn set_schema(&mut self, schema: SchemaDefinition) -> Result<(), KgError> {
+    pub fn set_schema(
+        &mut self,
+        schema: SchemaDefinition,
+        mode: SchemaInstall,
+    ) -> Result<(), KgError> {
+        let schema = match mode {
+            SchemaInstall::Replace => schema,
+            SchemaInstall::Merge => self
+                .schema_definition
+                .clone()
+                .unwrap_or_default()
+                .merged_with(schema),
+        };
         let previous_schema = self.schema_definition.take();
         let withdrawn = Self::declared_unique_tuples(previous_schema.as_ref());
         for (node_type, properties) in &withdrawn {
@@ -61,6 +81,11 @@ impl DirGraph {
         // Install with the new schema already in place, so a violation reports
         // itself as NODE KEY rather than UNIQUE when the tuple is a primary key.
         self.schema_definition = Some(schema);
+        // A DDL-declared NOT NULL lives in the same `required_fields` list the
+        // schema owns, so installing a schema would otherwise withdraw it — the
+        // asymmetry that let an unrelated `define_schema` silently un-enforce a
+        // `CREATE CONSTRAINT ... IS NOT NULL`.
+        self.reapply_ddl_not_null();
         let incoming = Self::declared_unique_tuples(self.schema_definition.as_ref());
         for (index, (node_type, properties)) in incoming.iter().enumerate() {
             let refs: Vec<&str> = properties.iter().map(String::as_str).collect();
@@ -109,14 +134,66 @@ impl DirGraph {
         tuples
     }
 
+    /// The enforced constraints installing `incoming` under
+    /// [`SchemaInstall::Replace`] would stop enforcing, as human-readable
+    /// descriptors.
+    ///
+    /// Replacement is the one mode that reaches types the caller never named, so
+    /// a binding can turn this into a warning naming exactly what it is about to
+    /// un-enforce. Reports only constraints that are *live* — a declaration the
+    /// graph never installed cannot be lost — and only ones the incoming schema
+    /// does not re-declare.
+    pub fn constraints_dropped_by_replace(&self, incoming: &SchemaDefinition) -> Vec<String> {
+        let Some(current) = self.schema_definition.as_ref() else {
+            return Vec::new();
+        };
+        let mut dropped: Vec<String> = Vec::new();
+        for (node_type, node) in &current.node_schemas {
+            if incoming.node_schemas.contains_key(node_type) {
+                continue;
+            }
+            if let Some(pk) = node.primary_key.as_deref() {
+                dropped.push(format!("{node_type}.{pk} (PRIMARY KEY)"));
+            }
+            for properties in node.unique.iter().flatten() {
+                if !properties.is_empty() {
+                    dropped.push(format!("{node_type}.({}) (UNIQUE)", properties.join(", ")));
+                }
+            }
+            for property in &node.required_fields {
+                dropped.push(format!("{node_type}.{property} (NOT NULL)"));
+            }
+        }
+        dropped.sort();
+        dropped
+    }
+
     /// Get the schema definition if one is set
     pub fn get_schema(&self) -> Option<&SchemaDefinition> {
         self.schema_definition.as_ref()
     }
 
-    /// Clear the schema definition
+    /// Clear the schema definition **and** the enforcement it installed.
+    ///
+    /// Dropping the declaration alone would leave the unique indexes a
+    /// `primary_key`/`unique` declaration built still rejecting writes, with
+    /// nothing left to explain why and no `SHOW CONSTRAINTS` row reporting them
+    /// as a node key — enforcement outliving its declaration. Routing through
+    /// `set_schema` makes clearing the withdrawal of everything the schema
+    /// declared, which is what a caller asking to clear it means.
+    ///
+    /// DDL-declared constraints are untouched, as they are by any other schema
+    /// install: `CREATE CONSTRAINT` is a separate declaration with its own
+    /// `DROP CONSTRAINT`.
     pub fn clear_schema(&mut self) {
-        self.schema_definition = None;
+        // Withdrawing declarations can never fail on unchanged data — there is
+        // nothing left to violate — so the result carries no information.
+        let _ = self.set_schema(SchemaDefinition::new(), SchemaInstall::Replace);
+        if self.schema_definition.as_ref().is_some_and(|schema| {
+            schema.node_schemas.is_empty() && schema.connection_schemas.is_empty()
+        }) {
+            self.schema_definition = None;
+        }
     }
 
     /// The declared PRIMARY KEY property for `node_type`, if one is set via

--- a/crates/kglite/src/graph/introspection/topics.rs
+++ b/crates/kglite/src/graph/introspection/topics.rs
@@ -1334,7 +1334,7 @@ pub(super) fn write_fluent_topic_schema(xml: &mut String) {
     xml.push_str(
         "      <m sig=\"describe(types=['...'])\">AI-optimised XML for specific types.</m>\n",
     );
-    xml.push_str("      <m sig=\"define_schema(schema_dict)\">Enforce schema constraints on future loads.</m>\n");
+    xml.push_str("      <m sig=\"define_schema(schema_dict, replace=False)\">Enforce schema constraints. Merges per node/connection type: a type the call names takes the new declaration, a type it omits keeps its own. replace=True makes the incoming schema the whole schema, withdrawing constraints on every type it omits.</m>\n");
     xml.push_str("    </methods>\n");
     xml.push_str("    <examples>\n");
     xml.push_str("      <ex desc=\"full schema\">graph.schema()</ex>\n");

--- a/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
@@ -34,7 +34,7 @@ fn test_create_single_node() {
 
 #[test]
 fn test_create_rejects_duplicate_primary_key() {
-    use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition};
+    use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition, SchemaInstall};
 
     let mut graph = DirGraph::new();
     // Declare Person.id as an enforced primary key; Doc has none.
@@ -46,7 +46,9 @@ fn test_create_rejects_duplicate_primary_key() {
             ..Default::default()
         },
     );
-    graph.set_schema(schema).expect("schema install");
+    graph
+        .set_schema(schema, SchemaInstall::Merge)
+        .expect("schema install");
 
     fn run(g: &mut DirGraph, q: &str) -> Result<(), String> {
         let query = parser::parse_cypher(q).unwrap();

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1865,7 +1865,7 @@ mod id_index_tests {
     /// clean batch loads. Undeclared types keep the permissive default.
     #[test]
     fn add_nodes_rejects_within_batch_pk_duplicate() {
-        use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition};
+        use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition, SchemaInstall};
 
         let mut g = DirGraph::new();
         let mut schema = SchemaDefinition::new();
@@ -1876,7 +1876,8 @@ mod id_index_tests {
                 ..Default::default()
             },
         );
-        g.set_schema(schema).expect("schema install");
+        g.set_schema(schema, SchemaInstall::Merge)
+            .expect("schema install");
 
         let dup = DataFrame::from_cypher_rows(
             vec!["id".to_string()],

--- a/crates/kglite/src/graph/mutation/subgraph.rs
+++ b/crates/kglite/src/graph/mutation/subgraph.rs
@@ -1,7 +1,7 @@
 // src/graph/subgraph.rs
 //! Subgraph extraction and selection expansion operations
 
-use crate::graph::schema::{CurrentSelection, DirGraph, EdgeData};
+use crate::graph::schema::{CurrentSelection, DirGraph, EdgeData, SchemaInstall};
 use crate::graph::storage::{GraphRead, GraphWrite};
 use petgraph::graph::NodeIndex;
 use std::collections::{HashMap, HashSet};
@@ -133,7 +133,10 @@ pub fn extract_subgraph(
     // into a silently unconstrained copy.
     if let Some(schema) = source.get_schema() {
         new_graph
-            .set_schema(schema.clone())
+            // The target is a fresh graph, so merge and replace coincide; merge
+            // states the intent (install this schema) without also asserting
+            // that everything unnamed should be withdrawn.
+            .set_schema(schema.clone(), SchemaInstall::Merge)
             .map_err(|violation| format!("subgraph schema install failed: {violation}"))?;
     }
 

--- a/crates/kglite/src/graph/mutation/validation.rs
+++ b/crates/kglite/src/graph/mutation/validation.rs
@@ -77,15 +77,24 @@ fn validate_single_node(
     };
     // Check required fields
     for required_field in &schema.required_fields {
-        // Skip built-in fields that are always present
-        if required_field == "id" || required_field == "title" || required_field == "type" {
+        // `type` is the node's label rather than a supplied value, so it cannot
+        // be missing. `id`/`title` live in `NodeData` fields rather than the
+        // property map but *can* be explicitly nulled, so they are read
+        // structurally rather than skipped — matching what the write-path
+        // `DirGraph::check_required_fields` enforces, so validation-time and
+        // write-time agree about what a declaration means.
+        if required_field == "type" {
             continue;
         }
 
-        let has_field = node
-            .get_property(required_field)
-            .map(|v| !matches!(*v, Value::Null))
-            .unwrap_or(false);
+        let has_field = match required_field.as_str() {
+            "id" => !matches!(*node.id(), Value::Null),
+            "title" => !matches!(*node_title, Value::Null),
+            other => node
+                .get_property(other)
+                .map(|v| !matches!(*v, Value::Null))
+                .unwrap_or(false),
+        };
 
         if !has_field {
             errors.push(ValidationError::MissingRequiredField {

--- a/crates/kglite/src/graph/schema.rs
+++ b/crates/kglite/src/graph/schema.rs
@@ -2169,12 +2169,46 @@ pub struct SchemaDefinition {
     pub connection_schemas: HashMap<String, ConnectionSchemaDefinition>,
 }
 
+/// How an incoming [`SchemaDefinition`] combines with the one already installed.
+///
+/// The distinction exists because a declaration is also a *withdrawal*: whatever
+/// the outgoing schema declared and the incoming one does not is no longer
+/// enforced. Under [`SchemaInstall::Replace`] that reaches every type in the
+/// graph, so a call naming one type silently stops enforcing every other type's
+/// constraints — the failure mode is duplicates entering the data unnoticed.
+/// Under [`SchemaInstall::Merge`] the withdrawal is scoped to the types the call
+/// actually names, so declaring per module is safe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SchemaInstall {
+    /// Types the incoming schema names replace their previous entry; every other
+    /// type keeps the declaration it had. The default, because it is the mode
+    /// whose mistake is a rejected write rather than an admitted duplicate.
+    #[default]
+    Merge,
+    /// The incoming schema becomes the whole schema — every type it does not
+    /// name loses its declarations, and with them their enforcement.
+    Replace,
+}
+
 impl SchemaDefinition {
     pub fn new() -> Self {
         SchemaDefinition {
             node_schemas: HashMap::new(),
             connection_schemas: HashMap::new(),
         }
+    }
+
+    /// This schema with `incoming`'s entries layered over it: a named type takes
+    /// the incoming declaration wholesale, an unnamed one keeps its own.
+    ///
+    /// Per *type* rather than per *field* on purpose — a type's entry is one
+    /// declaration ("here is what a `Task` is"), so merging field-by-field would
+    /// make a re-declaration unable to withdraw anything and leave no way to
+    /// narrow a type short of replacing the whole schema.
+    pub fn merged_with(mut self, incoming: SchemaDefinition) -> Self {
+        self.node_schemas.extend(incoming.node_schemas);
+        self.connection_schemas.extend(incoming.connection_schemas);
+        self
     }
 
     /// Add a node type schema

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -77,7 +77,7 @@ pub mod api {
     pub use crate::graph::schema::{
         parse_spatial_column_types_from_pairs, parse_temporal_column_types_from_pairs,
         ConnectionSchemaDefinition, NodeData, NodeInfo, NodeSchemaDefinition, SchemaDefinition,
-        SpatialConfig, TemporalConfig, ValidationError,
+        SchemaInstall, SpatialConfig, TemporalConfig, ValidationError,
     };
     /// The fluent **selection** data model — the cursor state threaded
     /// through the fluent query chain (and through Selection-scoped

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -3504,13 +3504,31 @@ class KnowledgeGraph:
     # Schema Definition & Validation
     # ====================================================================
 
-    def define_schema(self, schema_dict: dict[str, Any]) -> KnowledgeGraph:
+    def define_schema(self, schema_dict: dict[str, Any], *, replace: bool = False) -> KnowledgeGraph:
         """Define the expected schema for the graph.
 
-        **Replaces** the entire schema — this is not a merge. Any previous
-        ``define_schema`` call is fully superseded, so a call with a *subset* of
-        types drops the types it omits. Redefine all types each call (or read
-        the current schema via :meth:`schema_definition` and merge yourself).
+        **Merges per node/connection type.** A type named in ``schema_dict``
+        takes the new declaration *entire*; a type it does not name keeps the
+        declaration it already had. So declaring per module or per type is safe
+        — it cannot affect the constraints of a type this call never mentions::
+
+            g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+            g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+            # User.email is still a NODE KEY and still enforced.
+
+        Merging is per *type*, not per field, so re-declaring a type is still
+        how you narrow it — declare ``Task`` without a ``required`` entry it
+        used to have and that requirement is withdrawn.
+
+        Pass ``replace=True`` for the whole-schema semantics: the incoming
+        schema becomes the entire schema and every type it does not name loses
+        its declarations. Because that withdraws enforcement from types the
+        caller never mentioned, it emits a ``UserWarning`` naming each
+        constraint it stops enforcing. :meth:`clear_schema` removes everything.
+
+        Constraints declared through Cypher DDL (``CREATE CONSTRAINT``) are not
+        schema declarations and are unaffected by either mode — they are
+        withdrawn only by ``DROP CONSTRAINT``.
 
         Args:
             schema_dict: Schema definition with ``nodes`` and ``connections`` keys.
@@ -3540,8 +3558,14 @@ class KnowledgeGraph:
                 ``required`` is enforced at **write time**, not only by
                 :meth:`validate_schema`: a ``CREATE`` that omits the property, a
                 ``SET`` that nulls it, and a ``REMOVE`` that drops it all raise.
-                ``id``/``title``/``type`` are structural and always present, so
-                requiring them is a no-op. Auto-vivified edge stubs are deferred
+                ``type`` is the node's label and cannot be absent, so requiring
+                it is a no-op; ``id`` and ``title`` are auto-supplied when
+                omitted (so omitting them satisfies the requirement) but *can*
+                be explicitly nulled, and that is rejected. Unlike
+                ``CREATE CONSTRAINT ... IS NOT NULL``, which verifies stored data
+                before installing, ``required`` declares intent without
+                re-checking what is already there — :meth:`validate_schema`
+                reports existing violations. Auto-vivified edge stubs are deferred
                 rather than exempt — vivification may create an incomplete
                 placeholder, but the ``add_nodes`` upsert that promotes it is a
                 normal enforced write, and an unpromoted stub stays reportable via
@@ -3598,7 +3622,15 @@ class KnowledgeGraph:
         ...
 
     def clear_schema(self) -> KnowledgeGraph:
-        """Remove the schema definition from the graph."""
+        """Remove the schema definition from the graph, and with it every
+        constraint the schema declared.
+
+        The unique indexes a ``primary_key``/``unique`` declaration installed are
+        withdrawn too — enforcement never outlives the declaration that
+        explains it. Constraints declared through Cypher DDL
+        (``CREATE CONSTRAINT``) are separate declarations and survive; drop them
+        with ``DROP CONSTRAINT``.
+        """
         ...
 
     def set_instructions(self, text: str, *, channel: str | None = None) -> KnowledgeGraph:

--- a/tests/api-baselines/lint-allowances.json
+++ b/tests/api-baselines/lint-allowances.json
@@ -237,7 +237,7 @@
       "classification": "test"
     },
     {
-      "identity": "crates/kglite/src/graph/dir_graph/schema_ops.rs::fn:set_schema:pub fn set_schema(&mut self, schema: SchemaDefinition) -> Result<(), KgError>::clippy::result_large_err",
+      "identity": "crates/kglite/src/graph/dir_graph/schema_ops.rs::fn:set_schema:pub fn set_schema( &mut self, schema: SchemaDefinition, mode: SchemaInstall, ) -> Result<(), KgError>::clippy::result_large_err",
       "classification": "api-shape"
     },
     {

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -512,7 +512,7 @@
         },
         "define_schema": {
           "kind": "method",
-          "signature": "(self, /, schema_dict)"
+          "signature": "(self, /, schema_dict, *, replace=False)"
         },
         "degree_centrality": {
           "kind": "method",

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -2026,6 +2026,15 @@ MUTATION_QUERIES: list[tuple[str, str]] = [
     ("create_constraint_not_null_ddl", "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL"),
     ("create_constraint_node_key_ddl", "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NODE KEY"),
     ("drop_constraint_ddl_missing_if_exists", "DROP CONSTRAINT person_name_u IF EXISTS"),
+    # Declaring one half of a node key on a property that already carries the
+    # other must *add* to it rather than replace it, so the post-statement graph
+    # state carries both. A pass that dropped or reordered the second statement
+    # would leave only one half enforced — which this harness sees as diverging
+    # post-state once a later write is rejected on one path and not the other.
+    # Both orders, because the merge is order-sensitive code.
+    # Multi-statement constraint shapes live in CONSTRAINT_DDL_SEQUENCES below:
+    # a schema command is a standalone statement, so a merge (declaring one half
+    # of a node key over the other) cannot be expressed as one query here.
     # ── Shapes whose rollback checkpoint is an undo journal ──────────────
     #
     # Statement atomicity is bought with an inverse-op journal rather than a
@@ -2367,6 +2376,106 @@ def test_mutation_optimized_matches_naive(name: str, query: str) -> None:
     assert rows_opt == rows_naive, f"Mutation `{name}` rows: opt={rows_opt}, naive={rows_naive}"
     assert nodes_opt == nodes_naive, f"Mutation `{name}` post-state node count: opt={nodes_opt}, naive={nodes_naive}"
     assert edges_opt == edges_naive, f"Mutation `{name}` post-state edge count: opt={edges_opt}, naive={edges_naive}"
+
+
+# ---------------------------------------------------------------------------
+# Constraint DDL sequences
+# ---------------------------------------------------------------------------
+#
+# A fourth corpus, separate for one mechanical reason: a schema command is a
+# standalone statement, so the shapes that matter here — declaring one half of a
+# node key on a property that already carries the other, then dropping one half
+# again — need *several* statements, which MUTATION_QUERIES cannot express.
+#
+# What these pin: constraint declaration is state accumulation, not replacement.
+# Comparing `SHOW CONSTRAINTS` after the sequence catches a divergence in what
+# is *reported*; the enforcement probes catch a divergence in what is actually
+# in force. Both halves are needed — the audit that produced this corpus found a
+# listing reporting NODE_KEY for a pair whose presence half was not enforced,
+# and a report whose constraint name changed across a save/load round-trip.
+CONSTRAINT_DDL_SEQUENCES: list[tuple[str, list[str], list[str]]] = [
+    (
+        "not_null_over_existing_unique",
+        [
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL",
+        ],
+        # Both halves in force: a duplicate name and a missing name are refused.
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})", "CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "unique_over_existing_not_null",
+        [
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE",
+        ],
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})", "CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "drop_the_unique_half_of_a_pair",
+        [
+            "CREATE CONSTRAINT pn_u FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT pn_nn FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "DROP CONSTRAINT pn_u",
+        ],
+        ["CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "drop_the_not_null_half_of_a_pair",
+        [
+            "CREATE CONSTRAINT pn_u FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT pn_nn FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "DROP CONSTRAINT pn_nn",
+        ],
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})"],
+    ),
+]
+
+
+def _constraint_state(g, probes: list[str]) -> tuple[list[dict], list[bool]]:
+    """What the graph reports, and what it actually enforces.
+
+    A fix to either half alone is not a fix, so the differential compares both.
+    """
+    reported = _normalize(g.cypher("SHOW CONSTRAINTS").to_list())
+    enforced = []
+    for probe in probes:
+        try:
+            g.cypher(probe)
+            enforced.append(False)
+        except Exception:
+            enforced.append(True)
+    return reported, enforced
+
+
+@pytest.mark.differential
+@pytest.mark.parametrize(
+    "name,statements,probes",
+    CONSTRAINT_DDL_SEQUENCES,
+    ids=[entry[0] for entry in CONSTRAINT_DDL_SEQUENCES],
+)
+def test_constraint_ddl_sequence_optimized_matches_naive(name: str, statements: list[str], probes: list[str]) -> None:
+    opt_reported, opt_enforced = _constraint_state(
+        _run_constraint_sequence(statements, disable_optimizer=False), probes
+    )
+    naive_reported, naive_enforced = _constraint_state(
+        _run_constraint_sequence(statements, disable_optimizer=True), probes
+    )
+
+    assert opt_reported == naive_reported, f"`{name}` SHOW CONSTRAINTS: opt={opt_reported}, naive={naive_reported}"
+    assert opt_enforced == naive_enforced, f"`{name}` enforcement: opt={opt_enforced}, naive={naive_enforced}"
+    # Every sequence above leaves at least one constraint declared and every
+    # probe violating it, so a run that silently enforced nothing is a failure
+    # rather than a vacuous pass.
+    assert opt_reported, f"`{name}` declared no constraint at all"
+    assert all(opt_enforced), f"`{name}` reported constraints it does not enforce: {opt_enforced}"
+
+
+def _run_constraint_sequence(statements: list[str], *, disable_optimizer: bool):
+    g = _build_mutation_graph()
+    for statement in statements:
+        g.cypher(statement, disable_optimizer=disable_optimizer)
+    return g
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,9 @@
 """Tests for schema definition and validation."""
 
+import warnings
+
 import pandas as pd
+import pytest
 
 from kglite import KnowledgeGraph
 
@@ -228,14 +231,43 @@ class TestManagedReloadGuard:
         except ValueError as e:
             assert "'managed' or 'runtime'" in str(e)
 
-    def test_define_schema_replaces_not_merges(self):
-        """define_schema replaces the whole schema — a subset call drops omitted
-        types (documented behaviour; locks against an accidental switch to merge)."""
+    def test_define_schema_merges_leaving_undeclared_types_alone(self):
+        """define_schema merges per node type: a subset call keeps the types it
+        does not name. Declaring per module is the natural pattern, and under the
+        old replace default it silently un-enforced every type a call omitted."""
         g = KnowledgeGraph()
         g.define_schema({"nodes": {"A": {"primary_key": "id"}, "B": {"layer": "runtime"}}})
         assert set(g.schema_definition()["nodes"]) == {"A", "B"}
         g.define_schema({"nodes": {"A": {"primary_key": "id"}}})  # subset
-        assert set(g.schema_definition()["nodes"]) == {"A"}  # B dropped
+        assert set(g.schema_definition()["nodes"]) == {"A", "B"}  # B retained
+
+    def test_define_schema_replaces_a_named_type_wholesale(self):
+        """Merging is per *type*, not per field: a type the call names takes the
+        new declaration entire, so re-declaring it is still how you narrow it."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"required": ["x", "y"], "layer": "runtime"}}})
+        g.define_schema({"nodes": {"A": {"required": ["x"]}}})
+        assert g.schema_definition()["nodes"]["A"]["required"] == ["x"]
+        assert "layer" not in g.schema_definition()["nodes"]["A"]
+
+    def test_define_schema_replace_true_drops_omitted_types_and_warns(self):
+        """replace=True restores whole-schema replacement — and names every
+        constraint it stops enforcing, so the loss is never silent."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"primary_key": "email"}, "B": {"required": ["t"]}}})
+        with pytest.warns(UserWarning, match=r"A\.email \(PRIMARY KEY\)"):
+            g.define_schema({"nodes": {"B": {"required": ["t"]}}}, replace=True)
+        assert set(g.schema_definition()["nodes"]) == {"B"}
+
+    def test_define_schema_replace_true_is_quiet_when_nothing_is_enforced(self):
+        """The warning tracks lost *enforcement*, not merely lost declarations,
+        so a replace that drops nothing enforced stays quiet."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"optional": ["x"]}}})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            g.define_schema({"nodes": {"B": {"optional": ["y"]}}}, replace=True)
+        assert set(g.schema_definition()["nodes"]) == {"B"}
 
     def test_auto_timestamp_tag_roundtrips(self, tmp_path):
         g = KnowledgeGraph()

--- a/tests/test_schema_constraint_lifecycle.py
+++ b/tests/test_schema_constraint_lifecycle.py
@@ -1,0 +1,352 @@
+"""Declaration paths must never *silently* discard enforcement.
+
+Every case here is one shape of a single failure mode: a call returns success
+while some integrity guarantee the user believes is in force has quietly stopped
+being enforced — or `SHOW CONSTRAINTS` reports one that is not. That listing is
+what an operator reads during a migration review, so it lying is the worst
+version of the bug.
+
+The audit that produced these tests found four distinct instances:
+
+1. `define_schema` replaced the whole schema, so a per-module call naming one
+   type withdrew every other type's constraints.
+2. `define_schema` wiped a NOT NULL declared through `CREATE CONSTRAINT`,
+   because `required_fields` live inside the schema being replaced — while the
+   uniqueness half survived, whose index does not.
+3. `required: ["title"]` (and `id`) reported itself as enforced while admitting
+   `CREATE (:T {title: null})`, `SET t.title = null` and `REMOVE t.title`.
+4. `clear_schema()` dropped the declaration but left the unique indexes it had
+   installed still rejecting writes — enforcement outliving its declaration.
+
+Each test asserts **both** halves: what is actually enforced, and what
+`SHOW CONSTRAINTS` reports about it. A fix to one half alone is not a fix.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+
+def constraints(g: KnowledgeGraph) -> list[tuple[str, str]]:
+    """`SHOW CONSTRAINTS` as `(name, type)` pairs — what an operator sees."""
+    return [(row["name"], row["type"]) for row in g.cypher("SHOW CONSTRAINTS").to_list()]
+
+
+def rejects(g: KnowledgeGraph, query: str) -> bool:
+    """Whether `query` is refused. The enforcement half of every assertion."""
+    try:
+        g.cypher(query)
+        return False
+    except Exception:
+        return True
+
+
+# ── 1. define_schema must not withdraw constraints on types it never named ──
+
+
+def test_a_second_define_schema_keeps_the_first_calls_constraints():
+    """The audit reproducer, verbatim.
+
+    Declaring per module is the natural pattern. Under the old replace default
+    the second call — which mentions only `Task` — withdrew `User`'s primary key,
+    and the duplicate that had just been correctly rejected was then admitted.
+    """
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}, "Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})"), "the primary key must reject a duplicate"
+
+    g.define_schema({"nodes": {"Task": {"required": ["title", "status"]}}})  # names only Task
+
+    assert ("User.email", "NODE_KEY") in constraints(g), "User's key must still be reported"
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})"), "and must still be enforced"
+    assert g.cypher("MATCH (u:User) RETURN count(u) AS c").to_list()[0]["c"] == 1
+
+
+def test_replace_true_still_withdraws_but_says_what_it_withdrew():
+    """The escape hatch stays available — it just cannot be silent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}, "Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+
+    with pytest.warns(UserWarning, match=r"User\.email \(PRIMARY KEY\)"):
+        g.define_schema({"nodes": {"Task": {"required": ["title"]}}}, replace=True)
+
+    assert ("User.email", "NODE_KEY") not in constraints(g)
+    assert not rejects(g, "CREATE (:User {email:'a@x.com'})")
+
+
+# ── 2. A DDL declaration is withdrawn only by DROP CONSTRAINT ──
+
+
+@pytest.mark.parametrize(
+    "ddl,violation",
+    [
+        ("CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.name IS NOT NULL", "CREATE (:Task {x:1})"),
+        ("CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.name IS UNIQUE", "CREATE (:Task {name:'a'})"),
+    ],
+    ids=["not_null", "unique"],
+)
+def test_define_schema_does_not_wipe_a_ddl_constraint(ddl: str, violation: str):
+    """`required_fields` live inside the SchemaDefinition, so installing a schema
+    used to withdraw a DDL-declared NOT NULL — while the uniqueness half, whose
+    index lives outside the schema, survived. The asymmetry meant an unrelated
+    `define_schema` silently un-enforced half of what `CREATE CONSTRAINT` set up.
+    """
+    g = KnowledgeGraph()
+    g.cypher(ddl)
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.define_schema({"nodes": {"Unrelated": {"required": ["z"]}}})
+
+    assert ("c", "UNIQUENESS") in constraints(g) or ("c", "NODE_PROPERTY_EXISTENCE") in constraints(g)
+    assert rejects(g, violation), "a DDL constraint is withdrawn only by DROP CONSTRAINT"
+
+
+def test_drop_constraint_still_withdraws_a_ddl_not_null():
+    """Preserving DDL provenance must not make a constraint undroppable."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("DROP CONSTRAINT nn")
+    g.define_schema({"nodes": {"Unrelated": {"required": ["z"]}}})
+
+    assert constraints(g) == [("Unrelated.z", "NODE_PROPERTY_EXISTENCE")]
+    assert not rejects(g, "CREATE (:Task {x:1})")
+
+
+# ── 3. Merging uniqueness and presence, in both orders, plus DROP ──
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        (
+            "CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE",
+            "CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL",
+        ),
+        (
+            "CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL",
+            "CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE",
+        ),
+    ],
+    ids=["unique_then_not_null", "not_null_then_unique"],
+)
+def test_declaring_the_second_half_adds_to_the_first(first: str, second: str):
+    """Declaring one half on a property that already carries the other must
+    *add* to it. Order must not matter, and the merged pair reports as NODE_KEY
+    — which is honest only because both halves are still enforced."""
+    g = KnowledgeGraph()
+    g.cypher(first)
+    g.cypher(second)
+
+    assert [kind for _, kind in constraints(g)] == ["NODE_KEY"]
+    g.cypher("CREATE (:Task {name:'a'})")
+    assert rejects(g, "CREATE (:Task {name:'a'})"), "uniqueness half"
+    assert rejects(g, "CREATE (:Task {x:1})"), "presence half"
+
+
+@pytest.mark.parametrize(
+    "dropped,expected_kind,still_rejected,now_allowed",
+    [
+        (
+            "u",
+            "NODE_PROPERTY_EXISTENCE",
+            "CREATE (:Task {name:null})",
+            "CREATE (:Task {name:'a'})",
+        ),
+        (
+            "nn",
+            "UNIQUENESS",
+            "CREATE (:Task {name:'a'})",
+            "CREATE (:Task {name:null})",
+        ),
+    ],
+    ids=["drop_unique_half", "drop_not_null_half"],
+)
+def test_dropping_one_half_leaves_the_other_enforced_and_reported(
+    dropped: str, expected_kind: str, still_rejected: str, now_allowed: str
+):
+    """Dropping half a merged pair must demote the row rather than remove it, and
+    the surviving half must still be enforced. A row that kept claiming NODE_KEY
+    would overstate enforcement at exactly the moment an operator checks."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.cypher(f"DROP CONSTRAINT {dropped}")
+
+    assert [kind for _, kind in constraints(g)] == [expected_kind]
+    assert rejects(g, still_rejected), "the surviving half must still be enforced"
+    assert not rejects(g, now_allowed), "the dropped half must stop being enforced"
+
+
+def test_a_merged_pair_survives_save_load_and_reports_the_same_name(tmp_path):
+    """Constraint state is persisted, so the round-trip must preserve both halves
+    *and* report them identically. The reported name was previously taken from
+    the first `HashMap` match, so the same graph named the row differently before
+    and after a reload."""
+    path = str(tmp_path / "merged.kgl")
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("CREATE (:Task {name:'a'})")
+    before = constraints(g)
+    g.save(path)
+
+    reloaded = kglite.load(path)
+
+    assert constraints(reloaded) == before
+    assert [kind for _, kind in before] == ["NODE_KEY"]
+    assert rejects(reloaded, "CREATE (:Task {name:'a'})"), "uniqueness half survived the reload"
+    assert rejects(reloaded, "CREATE (:Task {x:1})"), "presence half survived the reload"
+
+
+def test_a_define_schema_primary_key_survives_save_load(tmp_path):
+    path = str(tmp_path / "pk.kgl")
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    g.save(path)
+
+    reloaded = kglite.load(path)
+
+    assert constraints(reloaded) == [("User.email", "NODE_KEY")]
+    assert rejects(reloaded, "CREATE (:User {email:'a@x.com'})")
+
+
+# ── 4. A reported presence constraint must actually reject a null ──
+
+
+@pytest.mark.parametrize("prop", ["title", "id"])
+def test_a_required_structural_field_rejects_an_explicit_null(prop: str):
+    """`id`/`title` are `NodeData` fields, but a write can null them explicitly
+    and the resulting node genuinely carries a null. Skipping them made the
+    declaration report itself through `SHOW CONSTRAINTS` while enforcing
+    nothing — success reported, guarantee absent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": [prop]}}})
+
+    assert constraints(g) == [(f"Task.{prop}", "NODE_PROPERTY_EXISTENCE")]
+    assert rejects(g, f"CREATE (:Task {{{prop}:null}})"), "an explicit null must be rejected"
+    # Omitting it is still fine: every write path resolves it first (CREATE
+    # auto-assigns an id and synthesizes a title), so the requirement is met.
+    g.cypher("CREATE (:Task {x:1})")
+    assert g.cypher("MATCH (t:Task) RETURN count(t) AS c").to_list()[0]["c"] == 1
+
+
+def test_a_required_title_is_enforced_on_the_set_and_remove_paths():
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:Task {title:'ok'})")
+
+    assert rejects(g, "MATCH (t:Task) SET t.title = null")
+    assert rejects(g, "MATCH (t:Task) REMOVE t.title")
+    assert g.cypher("MATCH (t:Task) RETURN t.title AS v").to_list()[0]["v"] == "ok"
+
+
+def test_a_required_title_is_enforced_on_the_bulk_path():
+    """`add_nodes` is how blueprints and every loader reach storage, so a
+    constraint the batch engine skipped would be theatre."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+    with pytest.raises(Exception):
+        g.add_nodes(pd.DataFrame({"pid": [1], "title": [None]}), "Task", "pid", "title")
+
+
+@pytest.mark.parametrize("prop", ["title", "name"])
+def test_ddl_refuses_a_presence_constraint_the_stored_data_violates(prop: str):
+    """`CREATE CONSTRAINT` verifies against stored data before installing, so a
+    constraint that would silently exempt the rows already present is refused
+    instead. `title` must behave exactly as an ordinary property here — it was
+    waved through while the data carried a null."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (:Task {title:null, x:1})")
+
+    with pytest.raises(Exception, match="cannot declare"):
+        g.cypher(f"CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.{prop} IS NOT NULL")
+    assert constraints(g) == []
+
+
+@pytest.mark.parametrize("prop", ["title", "name"])
+def test_validate_schema_reports_a_required_field_the_data_lacks(prop: str):
+    """`define_schema` declares intent without re-verifying stored data — for
+    every property alike — and `validate_schema()` is the audit that reports what
+    the data violates. It must see a null `title` too, or the write path and the
+    validator disagree about what the same declaration means."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (:Task {title:null, x:1})")
+
+    g.define_schema({"nodes": {"Task": {"required": [prop]}}})
+
+    errors = g.validate_schema()
+    assert [e["field"] for e in errors] == [prop]
+    assert errors[0]["error_type"] == "missing_required_field"
+
+
+def test_requiring_type_stays_a_no_op():
+    """`type` is the node's label rather than a supplied value, so nothing a
+    write does can leave it absent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["type"]}}})
+    g.cypher("CREATE (:Task {x:1})")
+    g.cypher("CREATE (:Task {type:null})")
+    assert g.cypher("MATCH (t:Task) RETURN count(t) AS c").to_list()[0]["c"] == 2
+
+
+# ── 5. Clearing a schema must clear its enforcement too ──
+
+
+def test_clear_schema_withdraws_the_constraints_it_installed():
+    """Dropping the declaration but keeping the unique index left writes being
+    rejected by a constraint nothing reported and nothing could drop."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+
+    g.clear_schema()
+
+    assert constraints(g) == []
+    assert not g.has_schema()
+    assert not rejects(g, "CREATE (:User {email:'a@x.com'})")
+
+
+def test_clear_schema_leaves_ddl_constraints_alone():
+    """`CREATE CONSTRAINT` is a separate declaration with its own `DROP`, so
+    clearing the *schema* must not take it down."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.clear_schema()
+
+    assert [kind for _, kind in constraints(g)] == ["NODE_KEY"]
+    assert rejects(g, "CREATE (:Task {name:'a'})")
+    assert rejects(g, "CREATE (:Task {x:1})")
+
+
+def test_a_failed_define_schema_changes_nothing():
+    """A declaration the data violates is refused, and the refusal must leave
+    the previous constraints exactly as they were."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    g.cypher("CREATE (:Task {name:'dup'})")
+    g.cypher("CREATE (:Task {name:'dup'})")
+
+    with pytest.raises(Exception):
+        g.define_schema({"nodes": {"Task": {"primary_key": "name"}}})
+
+    assert constraints(g) == [("User.email", "NODE_KEY")]
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a merge must never warn
+        g.define_schema({"nodes": {"Other": {"required": ["z"]}}})


### PR DESCRIPTION
Fixes silent constraint destruction found by the boring-app audit — and corrects one of the two reported bugs, which did not reproduce as framed. No version bump.

## Bug A: `define_schema` silently voided constraints on types it didn't mention

```python
g.define_schema({"nodes": {"User": {"primary_key":"email"}, "Task": {"required":["title"]}}})
g.cypher("CREATE (:User {email:'a@x.com'})")          # 2nd correctly rejected
g.define_schema({"nodes": {"Task": {"required":["title","status"]}}})   # only Task
g.cypher("CREATE (:User {email:'a@x.com'})")          # before: SUCCEEDED silently
```

Declaring schema per module or per type is the natural thing to do, and it voided every constraint on every unmentioned type. Documented in exactly one place, buried in a subsection about `auto_timestamp`.

**Root cause:** `set_schema` computed its withdrawal set from the *outgoing* schema — which under wholesale replacement is every type in the graph. Now scoped to the types the incoming schema names.

**Semantics chosen: merge per node/connection type by default; `replace=True` opts back in and warns, naming every constraint it stops enforcing.**

Evidence from the callers: only **two** production `set_schema` call sites exist in the workspace — `mutation/subgraph.rs` (a brand-new graph, where merge and replace coincide) and `define_schema` itself. The blueprint path, `.kgl` load, RDF loaders, CLI, MCP server and C ABI install no schema at all. Exactly one test pinned replace semantics, and its own docstring said it existed to "lock against an accidental switch to merge" — a lock on the behaviour, not a dependency.

The deciding argument is fail-safety: merge's worst case is a constraint you meant to drop still rejecting a write — loud and immediately fixable. Replace's worst case is duplicates entering the data unnoticed. Merging is per *type*, not per field, so re-declaring a type is still how you narrow it.

## Bug B: does not reproduce as reported — and the real bug was next door

The reported case was `IS UNIQUE` destroying an existing NOT NULL and misreporting as `NODE_KEY`. With an ordinary property it behaves correctly: uniqueness *adds*, `SHOW CONSTRAINTS` reports `NODE_KEY` honestly, the inverse order works, and dropping either half demotes the row correctly.

The reproducer used `title`, a **structural** field. `CREATE (:Task {x:1})` succeeded because KGLite auto-synthesizes a title (`'Task_0'`), so the requirement was genuinely satisfied — nothing was destroyed and `NODE_KEY` was honest.

**But the instinct was right.** `check_required_fields` unconditionally skipped `id`/`title`/`type`, so `required: ["title"]` *reported* as enforced while `CREATE (:Task {title:null})`, `SET t.title = null`, `REMOVE t.title`, and a null title cell in `add_nodes` all produced a node genuinely carrying a null — and `validate_schema()` reported nothing. Now `type` stays exempt (it is the label, unsettable) while `id`/`title` are enforced: every write path resolves them *before* the check, so omitting one still passes, but an explicit null is rejected. The offline validator reads them structurally so it agrees.

## Class sweep — three more silent-void bugs

- **`define_schema` wiped a DDL-declared NOT NULL.** `required_fields` live inside the schema being replaced, while the uniqueness half of the same `CREATE CONSTRAINT` survived (its index lives outside it) — so an unrelated `define_schema` silently un-enforced half of what DDL set up. Fixed by recording DDL provenance and replaying it: DDL constraints are now withdrawn only by `DROP CONSTRAINT`.
- **`clear_schema()` left enforcement behind** — it dropped the declaration but kept the unique indexes rejecting writes, with no `SHOW CONSTRAINTS` row to explain them.
- **`SHOW CONSTRAINTS` reported a nondeterministic name** when several names point at one tuple: the name came from the first `HashMap` match, so the same graph named the row `u` before save and `nn` after load.

Checked and clean: the blueprint path installs no schema; `CREATE CONSTRAINT` ↔ `define_schema` in both orders; `.kgl` save/load round-trips a merged pair with both halves enforced and identically reported.

Two pre-existing behaviours confirmed deliberate and left alone: `CREATE CONSTRAINT` materializing a node-schema entry turns on the unknown-property typo-guard for that type; and `define_schema`'s `required` declares intent without re-verifying stored data (for all properties alike — `validate_schema()` is the audit), whereas DDL verifies before installing.

## Verification

`tests/test_schema_constraint_lifecycle.py` — 23 cases, **12 failing on unmodified `origin/main`** (verified by reverting, rebuilding, re-running). The 11 that already passed are the "Bug B doesn't reproduce" cases, now locked in as regression guards. Plus four multi-statement `CONSTRAINT_DDL_SEQUENCES` in the differential corpus comparing *both* what is reported and what is enforced — a schema command is standalone, so these couldn't be expressed in `MUTATION_QUERIES`.

`make gate` exit 0 · clippy `-p kglite -p kglite-py --all-targets` clean · `make source-quality` clean · `cargo test -p kglite` **1242** · full Python suite **4786 passed / 0 failed** · `pytest -m parity` **109** · `sphinx -W` succeeded.

Five-place checklist: pyapi ✅ · `__init__.pyi` ✅ · `describe()` ✅ · MCP `tools.rs` **N/A** (`define_schema` is not an MCP tool) · CHANGELOG ✅. Also refreshed `python-api.json` and the lint-allowance baseline.

## One item for release/CI

`tests/api-baselines/rust/*.txt` will drift — `set_schema` gained a `SchemaInstall` parameter and `SchemaInstall` is newly exported from `kglite::api`. The manifest pins `cargo-public-api 0.49.0` but 0.52.0 is installed globally, and replacing a shared tool other agents are using was the wrong trade; CLAUDE.md designates the five-profile pass a release-time operation with CI as the authority.

## User-visible changes

The merge default; the `replace=True` warning; `clear_schema()` withdrawing enforcement; and explicit nulls on a required `id`/`title` now being rejected.
