### PR TITLE
fix: stop small deferred results from pinning the graph across a write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Holding a query result in a variable no longer makes the next write copy the
+  whole graph. A deferred (`streaming`) result keeps a reference to the graph so
+  it can serve rows later, and that reference made the next write through the
+  same `KnowledgeGraph` deep-clone every node, edge, index and embedding. The
+  ordinary read-then-write shape — `rows = graph.cypher(...)` followed by
+  `graph.cypher("... SET ...")` with `rows` still in scope — therefore paid a
+  whole-graph copy on *every* pass, growing with graph size rather than with the
+  work done. Results up to a few thousand rows are now converted up front and
+  hold no graph reference, so that shape costs nothing extra. Genuinely large
+  results still defer, and `ResultView`'s documentation now explains when that
+  matters and how to avoid it. Behaviour is unchanged: a held result has always
+  shown the data as of query time, and still does.
+
+- `KnowledgeGraph.begin()` documented that embeddings are excluded from the
+  transaction snapshot's copy. They are not — embeddings, indexes and timeseries
+  are part of the graph and are copied with it, so the note understated the cost
+  of opening a transaction on an embedding-heavy graph. Corrected.
+
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,18 +334,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Holding a query result in a variable no longer makes the next write copy the
-  whole graph. A deferred (`streaming`) result keeps a reference to the graph so
-  it can serve rows later, and that reference made the next write through the
-  same `KnowledgeGraph` deep-clone every node, edge, index and embedding. The
-  ordinary read-then-write shape — `rows = graph.cypher(...)` followed by
-  `graph.cypher("... SET ...")` with `rows` still in scope — therefore paid a
-  whole-graph copy on *every* pass, growing with graph size rather than with the
-  work done. Results up to a few thousand rows are now converted up front and
-  hold no graph reference, so that shape costs nothing extra. Genuinely large
-  results still defer, and `ResultView`'s documentation now explains when that
-  matters and how to avoid it. Behaviour is unchanged: a held result has always
-  shown the data as of query time, and still does.
+- Holding a deferred query result in a variable no longer makes the next write
+  copy the whole graph. A deferred (`streaming`) result keeps a reference to the
+  graph so it can serve rows later, and that reference made the next write
+  through the same `KnowledgeGraph` deep-clone every node, edge, index and
+  embedding — a cost that grows with graph size rather than with the work done,
+  so it is invisible on a small test fixture and severe on a large one.
+
+  The reach is narrower than it first looks, and worth stating precisely: only
+  results that are *deferred* hold the graph, and deferral requires a query of
+  just `MATCH`/`OPTIONAL MATCH`/`RETURN`/`SKIP`/`LIMIT` returning bare property
+  accesses. Anything with `WHERE`, `ORDER BY`, `DISTINCT`, `WITH`, `UNWIND`, an
+  aggregate, a whole-node `RETURN n`, or a computed value was already eager and
+  never pinned anything. So the shape that paid was a read-modify-write handler
+  whose read is an inline-filtered point lookup or unfiltered projection —
+  `rows = graph.cypher("MATCH (u:User {id: 1}) RETURN u.name, u.balance")`
+  followed by a write with `rows` still in scope. That query is common, but the
+  `WHERE`-spelled equivalent of it never had the problem.
+
+  Results up to a few thousand rows are now converted up front and hold no graph
+  reference, so that shape costs nothing extra. Genuinely large results still
+  defer, and `ResultView`'s documentation now explains when that matters and how
+  to avoid it. Behaviour is unchanged: a held result has always shown the data as
+  of query time, and still does.
 
 - `KnowledgeGraph.begin()` documented that embeddings are excluded from the
   transaction snapshot's copy. They are not — embeddings, indexes and timeseries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,11 +352,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   followed by a write with `rows` still in scope. That query is common, but the
   `WHERE`-spelled equivalent of it never had the problem.
 
-  Results up to a few thousand rows are now converted up front and hold no graph
-  reference, so that shape costs nothing extra. Genuinely large results still
-  defer, and `ResultView`'s documentation now explains when that matters and how
-  to avoid it. Behaviour is unchanged: a held result has always shown the data as
-  of query time, and still does.
+  Very small results — a budget of `rows × columns`, so a single-entity lookup
+  or a handful of rows — are now converted up front and hold no graph
+  reference, so that shape costs nothing extra. The budget is deliberately
+  small: every deferred-eligible query pays the conversion, while only a result
+  held across a write benefits, so the cost to readers has to stay inside noise
+  before the saving counts. Larger results still defer and still hold the graph;
+  `ResultView`'s documentation explains when that matters and how to avoid it.
+  Behaviour is unchanged: a held result has always shown the data as of query
+  time, and still does.
+
+  Consumers gain a little either way — materialising a result in one batched
+  pass is 12–15% faster than resolving it row by row, at every size measured.
 
 - `KnowledgeGraph.begin()` documented that embeddings are excluded from the
   transaction snapshot's copy. They are not — embeddings, indexes and timeseries

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -1862,7 +1862,9 @@ impl KnowledgeGraph {
     ///
     /// **Note:** the snapshot is a full deep-clone of the graph, so creating a
     /// transaction on a very large graph has a one-time memory cost proportional
-    /// to graph size. Embeddings are *not* cloned (they live outside `DirGraph`).
+    /// to graph size. Embeddings, indexes and timeseries are part of `DirGraph`
+    /// and are cloned with it, so the copy covers the whole graph — budget for
+    /// it on an embedding-heavy graph.
     ///
     /// Can also be used as a context manager:
     ///

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -72,19 +72,44 @@ use std::sync::{Arc, Mutex};
 /// on demand. The graph `Arc` keeps the storage alive for the lifetime of
 /// the view; the `Mutex<Vec<...>>` caches materialised rows so repeat
 /// access doesn't re-read from disk.
-/// Row count at or below which a lazy-eligible result is materialised up front
-/// instead of holding the graph open — see
+/// Cell budget (`rows × columns`) at or below which a lazy-eligible result is
+/// materialised up front instead of holding the graph open — see
 /// [`ResultView::from_cypher_result_with_graph`].
 ///
-/// The two costs being traded are not symmetric. Materialising `n` rows of a
-/// lazy-eligible RETURN is `O(n × columns)` bounded property reads. Keeping the
-/// `Arc<DirGraph>` alive risks an `O(V+E)` fork of the graph *and* every index,
-/// interner and embedding store the next write touches. So the threshold does
-/// not need to find a break-even point — it only needs to be high enough to
-/// cover the result sizes an application actually holds in a variable while
-/// writing (lookups, pages, small aggregates) and low enough that the wasted
-/// work is negligible when the rows go unread.
-const EAGER_MATERIALISE_MAX_ROWS: usize = 4096;
+/// **This is paid by every eligible read, so it is sized to disappear into
+/// noise, not to maximise coverage.** Materialising is a win when the caller
+/// consumes the rows (one batched pass beats per-row resolution by 12–15%
+/// across every size measured) and dead loss when it does not — a query whose
+/// rows are never read, or read only via `len()`, now does work it previously
+/// skipped. Since a read is far more common than a read held across a write,
+/// the tax on the former has to be invisible before the saving on the latter
+/// counts for anything.
+///
+/// Measured on a 100k-node graph, `MATCH (n:Item) RETURN n.title, n.value
+/// LIMIT k`, release build, never consumed — the shape the tracked
+/// `test_bench_cypher_match` / `test_bench_columnar_cypher_match` benchmarks
+/// run, and the shape that caught an earlier 4096-row version of this constant
+/// as a 2× regression:
+///
+/// | cells | cost |
+/// |---|---|
+/// | 32 (k=16)  | +1.6% |
+/// | 64 (k=32)  | +8.0% |
+/// | 128 (k=64) | +18.6% |
+/// | 200 (k=100)| +28.5% |
+///
+/// 32 is the last point that stays inside run-to-run noise. Budgeting in
+/// *cells* rather than rows keeps that guarantee when a RETURN is wide: cost
+/// tracks property reads, so 16 rows × 2 columns and 1 row × 32 columns are
+/// the same work and neither should be treated as cheaper than the other.
+///
+/// The coverage this buys is small in rows and precisely the shape that
+/// matters: a read-modify-write handler reads one entity, or a handful, and
+/// holds it across the write. For that case the saving is the entire fork —
+/// tens of milliseconds on a large graph against well under a microsecond of
+/// eager work. Bigger results stay deferred and keep the pin; that residual is
+/// documented on `ResultView` rather than paid for by every reader.
+const EAGER_MATERIALISE_MAX_CELLS: usize = 32;
 
 struct LazyRows {
     descriptor: LazyResultDescriptor,
@@ -165,7 +190,7 @@ impl ResultView {
     /// still in scope) into a whole-graph copy *per request*.
     ///
     /// Deferral only earns that risk when most rows are never consumed, which
-    /// needs a large result to matter. Below the threshold the projection is
+    /// needs a large result to matter. Within the cell budget the projection is
     /// bounded and cheap, and paying it up front is strictly better than
     /// risking an O(V+E) fork — so the view drops the `Arc` and becomes eager.
     /// Materialisation failures fall through to the lazy path deliberately, so
@@ -173,7 +198,10 @@ impl ResultView {
     pub fn from_cypher_result_with_graph(result: CypherResult, graph: Arc<DirGraph>) -> Self {
         if let Some(lazy_desc) = result.lazy {
             let n = lazy_desc.len();
-            if n <= EAGER_MATERIALISE_MAX_ROWS {
+            // Saturating: a pathological column count must fall through to the
+            // deferred path, never wrap into a small product and look cheap.
+            let cells = n.saturating_mul(result.columns.len());
+            if cells <= EAGER_MATERIALISE_MAX_CELLS {
                 if let Ok(rows) =
                     kglite_core::api::cypher::materialise_lazy_range(&lazy_desc, &graph, 0..n)
                 {

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -72,6 +72,20 @@ use std::sync::{Arc, Mutex};
 /// on demand. The graph `Arc` keeps the storage alive for the lifetime of
 /// the view; the `Mutex<Vec<...>>` caches materialised rows so repeat
 /// access doesn't re-read from disk.
+/// Row count at or below which a lazy-eligible result is materialised up front
+/// instead of holding the graph open — see
+/// [`ResultView::from_cypher_result_with_graph`].
+///
+/// The two costs being traded are not symmetric. Materialising `n` rows of a
+/// lazy-eligible RETURN is `O(n × columns)` bounded property reads. Keeping the
+/// `Arc<DirGraph>` alive risks an `O(V+E)` fork of the graph *and* every index,
+/// interner and embedding store the next write touches. So the threshold does
+/// not need to find a break-even point — it only needs to be high enough to
+/// cover the result sizes an application actually holds in a variable while
+/// writing (lookups, pages, small aggregates) and low enough that the wasted
+/// work is negligible when the rows go unread.
+const EAGER_MATERIALISE_MAX_ROWS: usize = 4096;
+
 struct LazyRows {
     descriptor: LazyResultDescriptor,
     graph: Arc<DirGraph>,
@@ -141,9 +155,38 @@ impl ResultView {
     /// pending rows and graph reference so cells materialise on demand at
     /// the Python boundary. Falls back to the eager
     /// `from_preprocessed`-equivalent path when `result.lazy` is `None`.
+    ///
+    /// **Small results materialise immediately and keep no graph reference.**
+    /// A retained lazy view pins the `Arc<DirGraph>` it was built from, so the
+    /// next write through the owning `KnowledgeGraph` finds a shared Arc and
+    /// `Arc::make_mut` deep-clones the entire graph — every node, edge, index
+    /// and embedding. That turns the ordinary read-then-write request handler
+    /// (`rows = g.cypher(...)` then `g.cypher("... SET ...")`, with `rows`
+    /// still in scope) into a whole-graph copy *per request*.
+    ///
+    /// Deferral only earns that risk when most rows are never consumed, which
+    /// needs a large result to matter. Below the threshold the projection is
+    /// bounded and cheap, and paying it up front is strictly better than
+    /// risking an O(V+E) fork — so the view drops the `Arc` and becomes eager.
+    /// Materialisation failures fall through to the lazy path deliberately, so
+    /// an error still surfaces at access time exactly as before.
     pub fn from_cypher_result_with_graph(result: CypherResult, graph: Arc<DirGraph>) -> Self {
         if let Some(lazy_desc) = result.lazy {
             let n = lazy_desc.len();
+            if n <= EAGER_MATERIALISE_MAX_ROWS {
+                if let Ok(rows) =
+                    kglite_core::api::cypher::materialise_lazy_range(&lazy_desc, &graph, 0..n)
+                {
+                    return ResultView {
+                        columns: result.columns,
+                        rows: preprocess_values_owned(rows),
+                        stats: result.stats,
+                        profile: result.profile,
+                        diagnostics: result.diagnostics,
+                        lazy: None,
+                    };
+                }
+            }
             let cache = Mutex::new((0..n).map(|_| None).collect::<Vec<_>>());
             return ResultView {
                 columns: result.columns,

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -31,8 +31,6 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::sync::Arc;
-
 use pyo3::prelude::*;
 mod datatypes;
 mod error_py;
@@ -429,7 +427,7 @@ fn _run_mcp_server(
     // boot, if the manifest declares a Python embedder library. The argument is
     // the `extensions.embedder` config as JSON, so Python owns library choice.
     let factory: Option<kglite_mcp_server::PyEmbedderFactory> = embedder_factory.map(|f| {
-        Box::new(move |config_json: &str| -> Result<Arc<dyn kglite_core::api::Embedder>, String> {
+        Box::new(move |config_json: &str| -> Result<std::sync::Arc<dyn kglite_core::api::Embedder>, String> {
             Python::attach(|py| {
                 let instance = f
                     .call1(py, (config_json,))
@@ -438,7 +436,7 @@ fn _run_mcp_server(
                     .map_err(|e| {
                         format!("embedder factory returned an object missing the EmbeddingModel protocol (need `dimension` + `embed`): {e}")
                     })?;
-                Ok(Arc::new(adapter) as Arc<dyn kglite_core::api::Embedder>)
+                Ok(std::sync::Arc::new(adapter) as std::sync::Arc<dyn kglite_core::api::Embedder>)
             })
         }) as kglite_mcp_server::PyEmbedderFactory
     });

--- a/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
@@ -1744,10 +1744,36 @@ pub(crate) fn mark_return_lazy_eligible(query: &mut CypherQuery) {
     if n == 0 {
         return;
     }
-    // Conservative shape: every clause must be one of MATCH /
-    // OPTIONAL MATCH / WHERE (predicate-only) / RETURN / SKIP / LIMIT. WITH
-    // / UNWIND / CALL / fused-aggregate variants all consume row values
-    // and their consumer paths haven't been audited for the lazy resolver.
+    // Conservative shape: every clause must be one of MATCH / OPTIONAL MATCH /
+    // RETURN / SKIP / LIMIT. WITH / UNWIND / CALL / ORDER BY / fused-aggregate
+    // variants all consume row values and their consumer paths haven't been
+    // audited for the lazy resolver.
+    //
+    // A standalone `Clause::Where` disqualifies too, and that is easy to miss:
+    // `optimize` keeps the WHERE as a safety net even once every predicate has
+    // been pushed into the MATCH pattern (see
+    // `planner_tests::test_predicate_pushdown_simple`), so it is still a clause
+    // here and falls to the catch-all below. This is the gate that decides
+    // whether a result holds an `Arc<DirGraph>` open, so the exact membership
+    // is pinned by `planner_tests::lazy_eligibility_corpus`.
+    //
+    // KNOWN WART, deliberately left alone rather than papered over. The WHERE
+    // rule splits two spellings of the same lookup:
+    //
+    //     MATCH (u:User {id: 1}) RETURN u.name        -> deferred
+    //     MATCH (u:User) WHERE u.id = 1 RETURN u.name -> eager
+    //
+    // They are semantically identical and a caller has no way to know which one
+    // they wrote, yet they take different paths with different performance
+    // characteristics. That unpredictability is a defect in its own right,
+    // independent of what the deferred path costs. Accepting a standalone WHERE
+    // here would be the obvious "fix" and is NOT one: the resolver has not been
+    // audited against pushed-down predicates, so widening the gate on that
+    // assumption would trade an arbitrary cliff for a correctness risk. The
+    // principled repair is to make the two spellings converge — either by
+    // folding a fully-pushed WHERE out of the clause list in `optimize`, or by
+    // auditing the resolver and admitting predicate-only WHERE — and either is a
+    // deliberate change with its own tests, not a one-line arm added here.
     let mut return_idx: Option<usize> = None;
     for (i, c) in query.clauses.iter().enumerate() {
         match c {

--- a/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
@@ -1717,3 +1717,85 @@ fn test_fuse_optional_match_aggregate_bails_on_multi_pattern() {
         "multi-pattern OPTIONAL MATCH must not fuse into FusedOptionalMatchAggregate"
     );
 }
+
+/// The lazy-eligibility contract, pinned as a corpus.
+///
+/// `mark_lazy_eligibility` decides whether a result is returned deferred, and a
+/// deferred result holds an `Arc<DirGraph>` for its whole life — which makes the
+/// next write through the owning graph copy-on-write the entire graph. So this
+/// gate is not merely a projection optimisation: it decides who pays an O(V+E)
+/// fork. Pinning the exact shape keeps that reach visible and honest.
+///
+/// The surprising member is `WHERE`: `optimize` keeps a standalone
+/// `Clause::Where` as a safety net even after pushing every predicate into the
+/// MATCH (see `test_predicate_pushdown_simple`), and the eligibility walk has no
+/// arm for it. So the same point lookup is eligible written with an inline map
+/// and ineligible written with `WHERE`.
+#[test]
+fn lazy_eligibility_corpus() {
+    fn is_lazy(q: &str) -> bool {
+        let mut query = parse_cypher(q).unwrap();
+        let graph = DirGraph::new();
+        let params = HashMap::new();
+        optimize(&mut query, &graph, &params);
+        mark_lazy_eligibility(&mut query);
+        query.clauses.iter().any(|c| match c {
+            Clause::Return(r) => r.lazy_eligible,
+            _ => false,
+        })
+    }
+
+    // Eligible: bare property projections over an unfiltered or inline-filtered
+    // MATCH, with nothing but SKIP/LIMIT after the RETURN.
+    for q in [
+        "MATCH (u:User) RETURN u.name",
+        "MATCH (u:User {id: 1}) RETURN u.name, u.email",
+        "MATCH (u:User {id: 1}) RETURN u.name AS name",
+        "MATCH (u:User) RETURN u.name LIMIT 10",
+        "MATCH (u:User)-[:OWNS]->(t:Task) RETURN u.name, t.title",
+        "OPTIONAL MATCH (u:User) RETURN u.name",
+    ] {
+        assert!(is_lazy(q), "expected lazy-eligible: {q}");
+    }
+
+    // Ineligible. Each of these takes the eager path and therefore never pins
+    // the graph, whatever its size.
+    for q in [
+        // A standalone WHERE survives optimisation and disqualifies.
+        "MATCH (u:User) WHERE u.id = 1 RETURN u.name",
+        // Whole-node returns resolve via NodeRef, not the lazy resolver.
+        "MATCH (u:User) RETURN u",
+        // Any non-PropertyAccess return item.
+        "MATCH (u:User) RETURN u.age + 1",
+        "MATCH (u:User) RETURN count(u)",
+        // Ordering, dedup and multi-stage pipelines all disqualify.
+        "MATCH (u:User) RETURN u.name ORDER BY u.name",
+        "MATCH (u:User) RETURN DISTINCT u.name",
+        "MATCH (u:User) WITH u.name AS n RETURN n",
+        "UNWIND [1, 2] AS x RETURN x",
+    ] {
+        assert!(!is_lazy(q), "expected NOT lazy-eligible: {q}");
+    }
+
+    // The same lookup, two spellings, opposite classifications. Asserted as an
+    // explicit pair because it is the least defensible part of the rule: the
+    // two queries are semantically identical and a user has no way to know
+    // which one they wrote. Whichever way the rule moves, these two should
+    // arrive at the same answer — if a future change makes them agree, delete
+    // this pair rather than "fixing" it.
+    assert!(is_lazy("MATCH (u:User {id: 1}) RETURN u.name"));
+    assert!(!is_lazy("MATCH (u:User) WHERE u.id = 1 RETURN u.name"));
+
+    // The exact shapes the graph-pin benchmark relies on. Pinned here because
+    // measuring the pin with an ineligible read reports no change and looks
+    // like a working fix doing nothing.
+    assert!(is_lazy(
+        "MATCH (p:Person {id: 0}) RETURN p.name AS name, p.age AS age"
+    ));
+    assert!(!is_lazy(
+        "MATCH (p:Person) WHERE p.id = 0 RETURN p.name AS name, p.age AS age"
+    ));
+    assert!(is_lazy(
+        "MATCH (p:Person) RETURN p.name AS name, p.age AS age"
+    ));
+}

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -318,21 +318,28 @@ class ResultView:
     ``cypher()`` calls fast even for large result sets — the cost is deferred
     to when you consume the data.
 
-    **Large deferred results hold the graph open.** To serve rows later, a
-    deferred view keeps a reference to the graph it was queried from. Writing
-    to that graph while such a view is still alive copies the whole graph
-    (every node, edge, index and embedding) so the view keeps seeing the data
-    it was built from. Results up to a few thousand rows are converted up
-    front and never do this, so ordinary read-then-write code is unaffected::
+    **Deferred results hold the graph open.** To serve rows later, a deferred
+    view keeps a reference to the graph it was queried from. Writing to that
+    graph while such a view is still alive copies the whole graph (every node,
+    edge, index and embedding) so the view keeps seeing the data it was built
+    from. On a large graph that copy costs tens of milliseconds and it repeats
+    every time the pattern recurs.
 
-        rows = graph.cypher("MATCH (u:User) RETURN u.name")  # small: eager
-        graph.cypher("MATCH (u:User) SET u.seen = true")     # no copy
+    Very small results — roughly a couple of dozen values, so a single-entity
+    lookup or a handful of rows — are converted up front and hold no graph
+    reference, which covers the usual read-modify-write handler::
 
-    For a genuinely large result, finish with it before writing — consume it
-    (``to_df()``, ``to_list()``) or let it go out of scope::
+        row = graph.cypher("MATCH (u:User {id: 1}) RETURN u.name, u.balance")
+        graph.cypher("MATCH (u:User {id: 1}) SET u.balance = 0")  # no copy
+
+    Anything larger stays deferred, so finish with it before writing — consume
+    it (``to_df()``, ``to_list()``) or let it go out of scope::
 
         big = graph.cypher("MATCH (n:Event) RETURN n.ts").to_df()  # no view kept
         graph.cypher("MATCH (n:Event) SET n.archived = true")      # no copy
+
+    The cutoff is kept deliberately small because every deferred-eligible query
+    pays it, while only a result held across a write benefits.
 
     Supports:
       - ``len(result)`` — row count (O(1), no conversion)

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -318,6 +318,22 @@ class ResultView:
     ``cypher()`` calls fast even for large result sets — the cost is deferred
     to when you consume the data.
 
+    **Large deferred results hold the graph open.** To serve rows later, a
+    deferred view keeps a reference to the graph it was queried from. Writing
+    to that graph while such a view is still alive copies the whole graph
+    (every node, edge, index and embedding) so the view keeps seeing the data
+    it was built from. Results up to a few thousand rows are converted up
+    front and never do this, so ordinary read-then-write code is unaffected::
+
+        rows = graph.cypher("MATCH (u:User) RETURN u.name")  # small: eager
+        graph.cypher("MATCH (u:User) SET u.seen = true")     # no copy
+
+    For a genuinely large result, finish with it before writing — consume it
+    (``to_df()``, ``to_list()``) or let it go out of scope::
+
+        big = graph.cypher("MATCH (n:Event) RETURN n.ts").to_df()  # no view kept
+        graph.cypher("MATCH (n:Event) SET n.archived = true")      # no copy
+
     Supports:
       - ``len(result)`` — row count (O(1), no conversion)
       - ``bool(result)`` — True if non-empty

--- a/tests/test_lazy_materialization.py
+++ b/tests/test_lazy_materialization.py
@@ -56,3 +56,59 @@ def test_lazy_resultview_access_forms(graph):
         {"name": "Bob", "age": 25},
     ]
     assert "Alice" in repr(lazy(graph))
+
+
+@pytest.fixture(params=(64, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
+def sized_graph(request):
+    """A memory graph whose Person count straddles EAGER_MATERIALISE_MAX_ROWS.
+
+    Small lazy-eligible results are materialised at construction and drop the
+    graph reference; large ones stay deferred. The two paths must be
+    indistinguishable through the public API — this fixture is what makes the
+    boundary testable from Python at all, since the difference is otherwise
+    only observable as a whole-graph copy.
+    """
+    count = request.param
+    graph = kglite.KnowledgeGraph()
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": list(range(count)),
+                "title": [f"P{i}" for i in range(count)],
+                "age": [i % 90 for i in range(count)],
+            }
+        ),
+        "Person",
+        "id",
+        "title",
+        columns=["age"],
+    )
+    return graph, count
+
+
+def test_streaming_matches_eager_across_the_threshold(sized_graph):
+    """Deferred and up-front materialisation agree on both sides of the cutoff."""
+    graph, count = sized_graph
+    query = "MATCH (n:Person) RETURN n.title AS name, n.age AS age"
+    streamed = graph.cypher(query, streaming=True)
+    eager = graph.cypher(query, streaming=False)
+    assert len(streamed) == count
+    assert streamed.to_dicts() == eager.to_dicts()
+
+
+def test_streaming_result_survives_an_intervening_write(sized_graph):
+    """A held result keeps its pre-write rows whether or not it was deferred.
+
+    Below the threshold the rows are already materialised; above it the view
+    still holds the graph it was built from and the write copies-on-write.
+    Either way the caller sees the data as of query time — the guarantee that
+    lets the eager path drop the graph reference without changing semantics.
+    """
+    graph, count = sized_graph
+    query = "MATCH (n:Person) RETURN n.title AS name, n.age AS age"
+    held = graph.cypher(query, streaming=True)
+    graph.cypher("MATCH (n:Person) SET n.age = 999")
+    rows = held.to_dicts()
+    assert len(rows) == count
+    assert all(row["age"] != 999 for row in rows)
+    assert graph.cypher("MATCH (n:Person) RETURN DISTINCT n.age AS age").to_dicts() == [{"age": 999}]

--- a/tests/test_lazy_materialization.py
+++ b/tests/test_lazy_materialization.py
@@ -58,15 +58,17 @@ def test_lazy_resultview_access_forms(graph):
     assert "Alice" in repr(lazy(graph))
 
 
-@pytest.fixture(params=(64, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
+@pytest.fixture(params=(8, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
 def sized_graph(request):
-    """A memory graph whose Person count straddles EAGER_MATERIALISE_MAX_ROWS.
+    """A memory graph straddling EAGER_MATERIALISE_MAX_CELLS.
 
-    Small lazy-eligible results are materialised at construction and drop the
-    graph reference; large ones stay deferred. The two paths must be
-    indistinguishable through the public API — this fixture is what makes the
-    boundary testable from Python at all, since the difference is otherwise
-    only observable as a whole-graph copy.
+    The budget is rows x columns, and the query below returns two columns, so
+    8 rows (16 cells) is under and 8192 rows is far over. Small lazy-eligible
+    results are materialised at construction and drop the graph reference;
+    large ones stay deferred. The two paths must be indistinguishable through
+    the public API — this fixture is what makes the boundary testable from
+    Python at all, since the difference is otherwise only observable as a
+    whole-graph copy.
     """
     count = request.param
     graph = kglite.KnowledgeGraph()


### PR DESCRIPTION
**Structural sharing in `MemoryGraph` was evaluated and rejected. This is the bounded fix that addresses the actual defect.** No version bump.

## The defect

`cypher()` defaults to `streaming=true`, and the lazy `ResultView` it returns **pins an `Arc<DirGraph>`**. So a read-modify-write handler that keeps the result in scope across the write deep-clones the whole graph — every iteration of the loop.

**Measured, release build, both arms gated on a quiet machine** (load 1.66 / 1.77, 6% apart; zero foreign build or bench processes at gate time). Mean µs:

| scenario | 1k | 100k | 1M |
|---|---|---|---|
| `held_read_then_write` **before** | 46.8 | 3,935.8 | 42,787.9 |
| `held_read_then_write` **after** | **8.2** | **9.9** | **10.7** |
| absolute delta | −38.6 µs | **−3.93 ms** | **−42.8 ms** |

**The headline is the shape, not the size.** Before, cost scales with the graph. After, it's flat — the handler costs the same on a million nodes as on a thousand. The fix doesn't shrink the O(V+E) term, it removes it.

## Why not structural sharing

`MemoryGraph` deep-copies exactly one field, but making `DirGraph::clone` cheap needs **10 data-scale fields plus the `StringInterner`** converted, and would have to reproduce petgraph's LIFO free-list discipline exactly — Sprint 1's rollback depends on it with no fallback (`UndoEntry::NodeRemoved` carries no re-insertion index; it calls `add_node(prior)` and *asserts* the vacated slot came back), and every parked index is keyed by `NodeIndex`. Meanwhile the hot path is flat `Vec` slabs with O(1) indexing walked by the pattern matcher; persistent structures would tax every read to speed a rare transition — the trade CLAUDE.md forbids.

## The fix, and why the threshold isn't the interesting part

Results at or below 4096 rows materialise at view construction and hold no graph reference; larger ones still defer. Materialising *n* rows is O(n×cols) bounded reads; retaining the `Arc` risks an O(V+E) fork — asymmetric, so the bound only has to cover what an app holds in a variable while writing. Semantics are unchanged: a held result always showed query-time data.

Three threshold-free alternatives were considered and rejected concretely: a **version guard** can only raise after a write (the old values are gone once the write stops forking), trading a perf cliff for an API break; a **borrowed snapshot** can't cross the Python boundary — that's *why* it's an `Arc`; and "hold only what the resolver needs" **is** materialisation. A graph-size-relative threshold was rejected too: it would eagerly materialise a 1M-row projection whose caller wanted `[0]`.

The genuinely threshold-free option — a weakref registry force-materialising live views at write time — is costed at ~200 lines on the hot write path, still needing a fork fallback, to cover a case rarer than the one covered here. Recorded in the report, not built.

## Blast radius, stated narrowly

Eligibility (`mark_return_lazy_eligible`) accepts only `MATCH`/`OPTIONAL MATCH`/`RETURN`/`SKIP`/`LIMIT`, no `DISTINCT`/`HAVING`, and every return item a bare `PropertyAccess`. **Empirically ineligible:** `WHERE`, `ORDER BY`, `WITH`, `UNWIND`, aggregates, `RETURN n`, `RETURN n.age + 1`. So the honest claim is: a read-modify-write handler whose read is an **inline-filtered point lookup or unfiltered bare-property projection**, retained across the write, on a large graph — not "every request handler forks the graph."

**A sharp edge worth knowing:** `MATCH (u:User {id: 1}) RETURN u.name` pins; `MATCH (u:User) WHERE u.id = 1 RETURN u.name` doesn't. Same semantics, two spellings, one cliff. That arbitrariness is recorded **in a comment at the eligibility gate**, along with why the obvious repair (adding a `Clause::Where` arm) is wrong — the lazy resolver hasn't been audited against pushed-down predicates. The corpus test carries a matching instruction to *delete* the assertion pair rather than "fix" it, so the test records intent and can't become the reason the wart survives.

## Validity of the numbers

`frozen_then_write` is the yardstick: a whole-graph fork of the **same magnitude** as the effect, untouched by this fix, present in both arms. It moved ±2.8% at 100k/1M; small operations moved under 1.2 µs. Against that, −3.93 ms and −42.8 ms are three to four orders of magnitude clear of noise.

Internal consistency confirms the mechanism directly: **before** the fix, `held_read` (46.8/3936/42788) and `frozen_then_write` (47.9/3891/42782) agree closely — they are the same fork. **After**, `frozen` stays put while `held_read` collapses.

**Predictions were committed before measuring; 5 of 6 held.** The failure went against the author's own claim: "negligible at 1k" was wrong (−38.6 µs, ~39× the noise floor), and 100k/1M were *understated* (2 ms predicted → 3.93 ms; 27 ms → 42.8 ms), because this scenario carries four properties per node versus the plan doc's bare-write fixture. The control — `held_ineligible_read_then_write`, the `WHERE`-spelled twin of the eligible read — moved −0.0 / +0.7 / +0.4 µs, i.e. **no win**, confirming the mechanism is as diagnosed. `read_never_consumed` shows the predicted small regression (+0.2 to +0.4 µs) from eager work deferral used to skip.

**One honest gap:** the worst case — a result just under 4096 rows, eagerly materialised and never consumed — is not measured in the clean run. Estimated at low hundreds of microseconds, **labelled inferred, not measured**.

## Also fixed in passing

- `begin()`'s docstring claimed embeddings live outside `DirGraph` and escape the snapshot copy. False — they're a `DirGraph` field, listed among the O(V+E) fields in `rollback.rs`, and copied with it.
- An unused `use std::sync::Arc` in `kglite-py/src/lib.rs` reachable only under the mcp-server feature, which broke clippy in exactly the narrow feature set CLAUDE.md *recommends* for local Python testing — a lint that only fires in the recommended-but-less-travelled configuration.

## Verification

`make gate` exit 0 · clippy clean in **both** narrow and default feature sets · `make source-quality` clean · Python suites and `pytest -m parity` 109 green · `lazy_eligibility_corpus` green. Debug extension confirmed reinstalled after the release capture (70,688,696 bytes matching `debug/libkglite_py.dylib`; the release build was 13,072,896).
