### PR TITLE
fix: disk mode on Windows — writable fsync handle and mapping-lifetime ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,14 @@ jobs:
         run: cargo test -p kglite --lib graph::io::open::tests::crashed_process_releases_writer_lease -- --exact --nocapture
       - name: Test core lease-protected publication
         run: cargo test -p kglite --lib graph::io::open::tests::writer_lease_serializes_open_create_and_publish -- --exact
+      # The two filters above already compile the whole engine test binary, so
+      # running it costs little beyond the test time — and it is the only job
+      # that exercises the storage backends on Windows, where mmap and file
+      # lifetimes differ from POSIX (a file with an open mapped view cannot be
+      # resized, replaced, or deleted). Published Windows wheels ship this
+      # engine, so the suite needs to run somewhere on the platform.
+      - name: Test core engine unit suite
+        run: cargo test -p kglite --lib
       - name: Test CLI lifecycle unit suite
         run: cargo test -p kglite-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Disk storage mode now works on Windows.** The backend memory-maps its CSR
+  and index files, and Windows — unlike POSIX — refuses to resize, replace, or
+  delete a file that still has a mapped view open. Several places rewrote a file
+  while the graph was still mapping it, so `save()`, `compact()`, and building a
+  disk graph from N-Triples all failed there with "The requested operation
+  cannot be performed on a file with a user-mapped section open". The mappings
+  are now released before their backing files are rewritten, and `MmapOrVec`
+  releases its view before resizing on Windows while keeping the POSIX ordering
+  that makes a failed remap leave the buffer intact.
+
+  Publishing a saved generation failed for an unrelated reason with the same
+  symptom: the durability `fsync` over the staging directory opened each file
+  read-only, and Windows requires write access to flush a file's buffers, so the
+  save aborted with "Access is denied" before the atomic rename it was
+  protecting. Staged files are now fsynced through a writable handle.
+
+  This was never caught because no CI job ran the engine's test suite on
+  Windows, even though Windows wheels are published. The native-lifecycle job
+  now runs it.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   save aborted with "Access is denied" before the atomic rename it was
   protecting. Staged files are now fsynced through a writable handle.
 
+  Saving also left the writer's arrays mapping its scratch workspace instead of
+  the generation just published. Windows will not delete a directory that still
+  holds a mapped file, so those scratch directories accumulated inside the
+  graph directory; the writer now re-maps onto the published snapshot, which
+  also means it observes exactly what a fresh reader would on every platform.
+- **Repairing a torn write-ahead log header now works on Windows.** A `.kgl-wal`
+  left truncated by a crash is repaired on open, but the repair truncated and
+  rewrote the file through the log's append handle. An append handle is not a
+  general-purpose write handle — on Windows it is opened without the access
+  right that truncation requires — so recovering from a torn header failed
+  there. Header creation, repair, and version upgrade now happen on an ordinary
+  handle before the append handle is opened.
+
   This was never caught because no CI job ran the engine's test suite on
   Windows, even though Windows wheels are published. The native-lifecycle job
   now runs it.

--- a/crates/kglite/src/graph/io/ntriples/loader.rs
+++ b/crates/kglite/src/graph/io/ntriples/loader.rs
@@ -966,8 +966,7 @@ fn initialize_spills(graph: &mut DirGraph, config: &NTriplesConfig) -> Result<Lo
             // Windows, which refuses to delete a file with a mapped view.
             if let crate::graph::schema::GraphBackend::Disk(ref mut dg) = graph.graph {
                 let stale = dg.active_write_dir().join("_pending_edges.bin");
-                let mapped_live =
-                    dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
+                let mapped_live = dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
                 if stale.exists() && !mapped_live {
                     let _ = std::fs::remove_file(&stale);
                 }

--- a/crates/kglite/src/graph/io/ntriples/loader.rs
+++ b/crates/kglite/src/graph/io/ntriples/loader.rs
@@ -911,7 +911,7 @@ struct LoadSpills {
     qnum_to_idx: Option<MmapOrVec<u32>>,
 }
 
-fn initialize_spills(graph: &DirGraph, config: &NTriplesConfig) -> Result<LoadSpills, String> {
+fn initialize_spills(graph: &mut DirGraph, config: &NTriplesConfig) -> Result<LoadSpills, String> {
     let use_streaming_build = graph.graph.is_disk() || graph.graph.is_mapped();
     let use_compact = use_streaming_build;
 
@@ -958,10 +958,17 @@ fn initialize_spills(graph: &DirGraph, config: &NTriplesConfig) -> Result<LoadSp
                     }
                 }
             }
-            // Clean up stale pending_edges from previous killed builds
-            if let crate::graph::schema::GraphBackend::Disk(ref dg) = graph.graph {
+            // Clean up stale pending_edges from previous killed builds.
+            //
+            // Never remove the file the live graph is currently mapping: it is
+            // not stale by definition, and unlinking it silently detaches the
+            // active buffer from its path on POSIX while failing outright on
+            // Windows, which refuses to delete a file with a mapped view.
+            if let crate::graph::schema::GraphBackend::Disk(ref mut dg) = graph.graph {
                 let stale = dg.active_write_dir().join("_pending_edges.bin");
-                if stale.exists() {
+                let mapped_live =
+                    dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
+                if stale.exists() && !mapped_live {
                     let _ = std::fs::remove_file(&stale);
                 }
             }

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -315,132 +315,8 @@ impl DiskGraph {
         // Merge sort uses only sequential I/O: read → sort chunks → merge → write.
         let step = std::time::Instant::now();
 
-        let in_edges = {
-            // Chunk size for sort: fit in available heap after edge_endpoints mmap.
-            let sort_chunk_mb: usize = std::env::var("KGLITE_CSR_CHUNK_MB")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(5120); // 5 GB default — safe on 16 GB machine
-            let max_entries = (sort_chunk_mb << 20) / std::mem::size_of::<MergeSortEntry>();
-            let sort_chunk_size = max_entries.min(edge_count);
-            let num_sort_chunks = edge_count.div_ceil(sort_chunk_size);
-
-            let sort_dir = out_dir.join("_in_sort");
-            std::fs::create_dir_all(&sort_dir)?;
-
-            if num_sort_chunks == 1 {
-                // Single-chunk: sort in memory, write directly
-                let substep = std::time::Instant::now();
-                let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(edge_count);
-                for i in 0..edge_count {
-                    let ep = edge_endpoints_vec.get(i);
-                    entries.push(MergeSortEntry {
-                        key: ep.target,
-                        conn_type: ep.connection_type,
-                        peer: ep.source,
-                        orig_idx: i as u32,
-                        padding: 0,
-                    });
-                }
-                entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
-
-                let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
-                for entry in &entries {
-                    output.try_push(CsrEdge {
-                        peer: entry.peer,
-                        edge_idx: entry.orig_idx,
-                    })?;
-                }
-                drop(entries);
-                if verbose {
-                    eprintln!(
-                        "      in sort single-chunk: {:.1}s",
-                        substep.elapsed().as_secs_f64()
-                    );
-                }
-                output
-            } else {
-                // Multi-chunk: external merge sort with k-way heap merge
-                let substep = std::time::Instant::now();
-                let mut chunk_mmaps: Vec<MmapOrVec<MergeSortEntry>> = Vec::new();
-                let mut chunk_lens: Vec<usize> = Vec::new();
-
-                for c in 0..num_sort_chunks {
-                    let start = c * sort_chunk_size;
-                    let end = (start + sort_chunk_size).min(edge_count);
-                    let len = end - start;
-
-                    let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(len);
-                    for i in start..end {
-                        let ep = edge_endpoints_vec.get(i);
-                        entries.push(MergeSortEntry {
-                            key: ep.target,
-                            conn_type: ep.connection_type,
-                            peer: ep.source,
-                            orig_idx: i as u32,
-                            padding: 0,
-                        });
-                    }
-                    entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
-
-                    let chunk_path = sort_dir.join(format!("chunk_in_{}.bin", c));
-                    let mut chunk_mmap = MmapOrVec::mapped(&chunk_path, len)?;
-                    for entry in &entries {
-                        chunk_mmap.try_push(*entry)?;
-                    }
-                    drop(entries);
-                    chunk_lens.push(len);
-                    chunk_mmaps.push(chunk_mmap);
-                }
-                if verbose {
-                    eprintln!(
-                        "      in sort {} chunks: {:.1}s",
-                        num_sort_chunks,
-                        substep.elapsed().as_secs_f64()
-                    );
-                }
-
-                // K-way merge via binary heap — all reads and writes sequential
-                let substep = std::time::Instant::now();
-                let mut positions: Vec<usize> = vec![0; num_sort_chunks];
-                let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
-
-                use std::cmp::Reverse;
-                let mut heap: std::collections::BinaryHeap<Reverse<(u32, u64, usize)>> =
-                    std::collections::BinaryHeap::with_capacity(num_sort_chunks);
-                for c in 0..num_sort_chunks {
-                    if chunk_lens[c] > 0 {
-                        let entry = chunk_mmaps[c].get(0);
-                        heap.push(Reverse((entry.key, entry.conn_type, c)));
-                    }
-                }
-
-                for _ in 0..edge_count {
-                    let Reverse((_key, _ct, best_chunk)) = heap.pop().unwrap();
-                    let entry = chunk_mmaps[best_chunk].get(positions[best_chunk]);
-                    positions[best_chunk] += 1;
-                    output.try_push(CsrEdge {
-                        peer: entry.peer,
-                        edge_idx: entry.orig_idx,
-                    })?;
-                    if positions[best_chunk] < chunk_lens[best_chunk] {
-                        let next = chunk_mmaps[best_chunk].get(positions[best_chunk]);
-                        heap.push(Reverse((next.key, next.conn_type, best_chunk)));
-                    }
-                }
-
-                // Cleanup sort chunks. Dropping the mappings first is load
-                // bearing on Windows, which will not delete a mapped file;
-                // the removal is checked so a regression is loud.
-                drop(chunk_mmaps);
-                super::remove_scratch_dir(&sort_dir)?;
-
-                if verbose {
-                    eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
-                }
-                output
-            }
-        };
+        let in_edges =
+            build_in_edges_merge_sort(&edge_endpoints_vec, edge_count, out_dir, verbose)?;
         if verbose {
             eprintln!(
                 "    CSR step 4/4: in_edges merge sort ({:.1}s)",
@@ -839,6 +715,148 @@ pub(super) fn write_peer_count_histogram(
 /// Parallelised via Rayon: each thread scans a partition of nodes and
 /// builds a local `HashMap<conn_type, Vec<node_id>>`; the maps are merged,
 /// each type's sources sorted, then flushed to the three on-disk files.
+/// Build the `in_edges` CSR array by external merge sort on target node.
+///
+/// Split out of [`DiskGraph::build_csr_partitioned`], which handles the four
+/// build steps and had grown past the point where the merge sort could be read
+/// on its own. Scatter is slow here because target degree is power-law
+/// distributed and popular targets thrash the page cache, so this path uses
+/// only sequential I/O: read -> sort chunks -> merge -> write.
+///
+/// Writes `out_dir/in_edges.bin` and spills sort chunks under `out_dir/_in_sort`,
+/// which is removed before returning.
+fn build_in_edges_merge_sort(
+    edge_endpoints_vec: &MmapOrVec<EdgeEndpoints>,
+    edge_count: usize,
+    out_dir: &Path,
+    verbose: bool,
+) -> io::Result<MmapOrVec<CsrEdge>> {
+    // Chunk size for sort: fit in available heap after edge_endpoints mmap.
+    let sort_chunk_mb: usize = std::env::var("KGLITE_CSR_CHUNK_MB")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5120); // 5 GB default — safe on 16 GB machine
+    let max_entries = (sort_chunk_mb << 20) / std::mem::size_of::<MergeSortEntry>();
+    let sort_chunk_size = max_entries.min(edge_count);
+    let num_sort_chunks = edge_count.div_ceil(sort_chunk_size);
+
+    let sort_dir = out_dir.join("_in_sort");
+    std::fs::create_dir_all(&sort_dir)?;
+
+    if num_sort_chunks == 1 {
+        // Single-chunk: sort in memory, write directly
+        let substep = std::time::Instant::now();
+        let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(edge_count);
+        for i in 0..edge_count {
+            let ep = edge_endpoints_vec.get(i);
+            entries.push(MergeSortEntry {
+                key: ep.target,
+                conn_type: ep.connection_type,
+                peer: ep.source,
+                orig_idx: i as u32,
+                padding: 0,
+            });
+        }
+        entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
+
+        let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
+        for entry in &entries {
+            output.try_push(CsrEdge {
+                peer: entry.peer,
+                edge_idx: entry.orig_idx,
+            })?;
+        }
+        drop(entries);
+        if verbose {
+            eprintln!(
+                "      in sort single-chunk: {:.1}s",
+                substep.elapsed().as_secs_f64()
+            );
+        }
+        Ok(output)
+    } else {
+        // Multi-chunk: external merge sort with k-way heap merge
+        let substep = std::time::Instant::now();
+        let mut chunk_mmaps: Vec<MmapOrVec<MergeSortEntry>> = Vec::new();
+        let mut chunk_lens: Vec<usize> = Vec::new();
+
+        for c in 0..num_sort_chunks {
+            let start = c * sort_chunk_size;
+            let end = (start + sort_chunk_size).min(edge_count);
+            let len = end - start;
+
+            let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(len);
+            for i in start..end {
+                let ep = edge_endpoints_vec.get(i);
+                entries.push(MergeSortEntry {
+                    key: ep.target,
+                    conn_type: ep.connection_type,
+                    peer: ep.source,
+                    orig_idx: i as u32,
+                    padding: 0,
+                });
+            }
+            entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
+
+            let chunk_path = sort_dir.join(format!("chunk_in_{}.bin", c));
+            let mut chunk_mmap = MmapOrVec::mapped(&chunk_path, len)?;
+            for entry in &entries {
+                chunk_mmap.try_push(*entry)?;
+            }
+            drop(entries);
+            chunk_lens.push(len);
+            chunk_mmaps.push(chunk_mmap);
+        }
+        if verbose {
+            eprintln!(
+                "      in sort {} chunks: {:.1}s",
+                num_sort_chunks,
+                substep.elapsed().as_secs_f64()
+            );
+        }
+
+        // K-way merge via binary heap — all reads and writes sequential
+        let substep = std::time::Instant::now();
+        let mut positions: Vec<usize> = vec![0; num_sort_chunks];
+        let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
+
+        use std::cmp::Reverse;
+        let mut heap: std::collections::BinaryHeap<Reverse<(u32, u64, usize)>> =
+            std::collections::BinaryHeap::with_capacity(num_sort_chunks);
+        for c in 0..num_sort_chunks {
+            if chunk_lens[c] > 0 {
+                let entry = chunk_mmaps[c].get(0);
+                heap.push(Reverse((entry.key, entry.conn_type, c)));
+            }
+        }
+
+        for _ in 0..edge_count {
+            let Reverse((_key, _ct, best_chunk)) = heap.pop().unwrap();
+            let entry = chunk_mmaps[best_chunk].get(positions[best_chunk]);
+            positions[best_chunk] += 1;
+            output.try_push(CsrEdge {
+                peer: entry.peer,
+                edge_idx: entry.orig_idx,
+            })?;
+            if positions[best_chunk] < chunk_lens[best_chunk] {
+                let next = chunk_mmaps[best_chunk].get(positions[best_chunk]);
+                heap.push(Reverse((next.key, next.conn_type, best_chunk)));
+            }
+        }
+
+        // Cleanup sort chunks. Dropping the mappings first is load
+        // bearing on Windows, which will not delete a mapped file;
+        // the removal is checked so a regression is loud.
+        drop(chunk_mmaps);
+        super::remove_scratch_dir(&sort_dir)?;
+
+        if verbose {
+            eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
+        }
+        Ok(output)
+    }
+}
+
 pub(super) fn write_conn_type_index(
     out_offsets: &MmapOrVec<u64>,
     out_edges: &MmapOrVec<CsrEdge>,

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -429,9 +429,11 @@ impl DiskGraph {
                     }
                 }
 
-                // Cleanup sort chunks
+                // Cleanup sort chunks. Dropping the mappings first is load
+                // bearing on Windows, which will not delete a mapped file;
+                // the removal is checked so a regression is loud.
                 drop(chunk_mmaps);
-                let _ = std::fs::remove_dir_all(&sort_dir);
+                super::remove_scratch_dir(&sort_dir)?;
 
                 if verbose {
                     eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
@@ -611,6 +613,16 @@ impl DiskGraph {
         node_bound: usize,
         verbose: bool,
     ) -> io::Result<()> {
+        // `write_conn_type_index` re-creates `conn_type_index_*.bin` in place,
+        // and these three fields still map exactly those paths from the
+        // previous build. Windows refuses to truncate or re-create a file that
+        // has a live mapped view (`ERROR_USER_MAPPED_FILE`); POSIX allows it,
+        // which is why this ordering bug stayed invisible. Release the
+        // mappings first and re-adopt the writer's below — the same discipline
+        // `swap_csr_files` and `save_logical_node_slots` already follow.
+        self.conn_type_index_types = MmapOrVec::new();
+        self.conn_type_index_offsets = MmapOrVec::new();
+        self.conn_type_index_sources = MmapOrVec::new();
         let (types, offsets, sources) = write_conn_type_index(
             &self.out_offsets,
             &self.out_edges,
@@ -647,6 +659,15 @@ impl DiskGraph {
         if total == 0 {
             return Ok(());
         }
+        // Same in-place-rewrite hazard as `build_conn_type_index`:
+        // `write_peer_count_histogram` re-creates `peer_count_*.bin` via
+        // `fs::write`, and these fields still map those paths. Drop the
+        // mappings before the writer runs — Windows cannot re-create a
+        // mapped file — and re-adopt the fresh ones below. This must happen
+        // before `endpoints` borrows `self`.
+        self.peer_count_types = MmapOrVec::new();
+        self.peer_count_offsets = MmapOrVec::new();
+        self.peer_count_entries = MmapOrVec::new();
         let logical_endpoints;
         let endpoints = if self.appended_edge_endpoints.is_empty() && self.removed_edges.is_empty()
         {

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -553,7 +553,16 @@ impl DiskGraph {
             }
         }
 
-        // Also swap conn_type_index files if present
+        // Also swap conn_type_index files if present. These fields map the
+        // destination paths whenever a previous build or load populated them,
+        // so they must be released before the destinations are removed and
+        // replaced — the same reason the CSR fields are cleared above. The
+        // block is dormant today (the index writer targets `active_write_dir`,
+        // not `build_dir`, so `src` never exists), but leaving the ordering
+        // wrong would make it a Windows failure the moment it is wired up.
+        self.conn_type_index_types = MmapOrVec::new();
+        self.conn_type_index_offsets = MmapOrVec::new();
+        self.conn_type_index_sources = MmapOrVec::new();
         let index_files = [
             "conn_type_index_types.bin",
             "conn_type_index_offsets.bin",

--- a/crates/kglite/src/graph/storage/disk/csr_build.rs
+++ b/crates/kglite/src/graph/storage/disk/csr_build.rs
@@ -323,12 +323,16 @@ fn merge_sort_build(
         }
     }
 
-    // Cleanup chunk files.
+    // Cleanup chunk files. The mappings must go first: Windows refuses to
+    // delete a file that still has a mapped view open, so removing before the
+    // drop leaked every chunk there (and the failure was swallowed by the old
+    // `let _ =`). Removal is now checked so a future ordering regression
+    // surfaces as an error rather than a pile of stray spill files.
+    drop(chunk_mmaps);
     for c in 0..num_chunks {
         let path = chunk_dir.join(format!("chunk_{}_{}.bin", label, c));
-        let _ = std::fs::remove_file(path);
+        super::remove_scratch_file(&path)?;
     }
-    drop(chunk_mmaps);
 
     if verbose {
         eprintln!(

--- a/crates/kglite/src/graph/storage/disk/generation.rs
+++ b/crates/kglite/src/graph/storage/disk/generation.rs
@@ -273,7 +273,18 @@ fn sync_tree(root: &Path) -> io::Result<()> {
     for entry in walkdir::WalkDir::new(root).follow_links(false) {
         let entry = entry.map_err(io::Error::other)?;
         if entry.file_type().is_file() {
-            File::open(entry.path())?.sync_all()?;
+            // `sync_all` is `FlushFileBuffers` on Windows, which MSDN
+            // documents as requiring `GENERIC_WRITE` on the handle: fsyncing
+            // a staged file through a read-only handle fails there with
+            // `ERROR_ACCESS_DENIED`, aborting `publish` before it ever
+            // reaches the rename. Open the file for writing so the durability
+            // fsync is portable — the stage directory is owned exclusively by
+            // this writer, so write access is always grantable.
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(entry.path())?
+                .sync_all()?;
         } else if entry.file_type().is_dir() {
             dirs.push(entry.path().to_path_buf());
         }

--- a/crates/kglite/src/graph/storage/disk/graph.rs
+++ b/crates/kglite/src/graph/storage/disk/graph.rs
@@ -2024,15 +2024,24 @@ impl DiskGraph {
             .get_mut()
             .file_path()
             .map(|p| p.to_path_buf());
+        // The assignment drops the previous buffer's mapping, so the old
+        // backing file is unmapped before it is deleted.
         *self.pending_edges.get_mut() = new_pending;
         if let Some(path) = old_pending_path {
-            let _ = std::fs::remove_file(path);
+            super::remove_scratch_file(&path)?;
         }
 
         self.build_csr_from_pending()?;
 
-        // Clean up compact temp file
-        let _ = std::fs::remove_file(&pending_path);
+        // Clean up the compaction scratch file. `build_csr_from_pending`
+        // normally clears `pending_edges` (releasing this mapping), but it
+        // returns early when the buffer is empty — so release it explicitly
+        // rather than relying on that. Deleting a still-mapped file is an
+        // error on Windows, and the removal is checked so it stays visible.
+        if self.pending_edges.get_mut().file_path() == Some(pending_path.as_path()) {
+            *self.pending_edges.get_mut() = MmapOrVec::new();
+        }
+        super::remove_scratch_file(&pending_path)?;
 
         if verbose {
             eprintln!(

--- a/crates/kglite/src/graph/storage/disk/graph/bootstrap.rs
+++ b/crates/kglite/src/graph/storage/disk/graph/bootstrap.rs
@@ -21,6 +21,40 @@ impl DiskGraph {
         Ok(())
     }
 
+    /// Paths of every memory-mapped array this graph currently holds.
+    ///
+    /// Exists so the "a published graph maps only its own generation"
+    /// invariant is checkable on every platform. POSIX keeps a mapping valid
+    /// after its file is unlinked, so a mapping left pointing into a
+    /// just-deleted scratch directory is invisible there; Windows refuses to
+    /// delete such a directory at all. Asserting on paths catches the
+    /// regression everywhere rather than only on the platform that complains.
+    ///
+    /// Does not cover the edge-property store, which owns its own handles.
+    #[cfg(test)]
+    pub(crate) fn mapped_file_paths(&mut self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let mut push = |path: Option<&Path>| {
+            if let Some(path) = path {
+                paths.push(path.to_path_buf());
+            }
+        };
+        push(self.node_slots.file_path());
+        push(self.out_offsets.file_path());
+        push(self.out_edges.file_path());
+        push(self.in_offsets.file_path());
+        push(self.in_edges.file_path());
+        push(self.edge_endpoints.file_path());
+        push(self.conn_type_index_types.file_path());
+        push(self.conn_type_index_offsets.file_path());
+        push(self.conn_type_index_sources.file_path());
+        push(self.peer_count_types.file_path());
+        push(self.peer_count_offsets.file_path());
+        push(self.peer_count_entries.file_path());
+        push(self.pending_edges.get_mut().file_path());
+        paths
+    }
+
     pub(crate) fn active_write_dir(&self) -> &Path {
         self.mutation_workspace
             .as_ref()
@@ -36,6 +70,48 @@ impl DiskGraph {
     ) -> std::io::Result<()> {
         self.logical_root = logical_root;
         self.data_dir = snapshot_dir.join(segment_subdir(0));
+
+        // Re-map the CSR arrays onto the generation just published.
+        //
+        // Until this point they map files under the mutation workspace — and,
+        // for a detached copy, under its private root — which are exactly the
+        // directories cleared at the end of this function. POSIX tolerated the
+        // mismatch: removal unlinks files whose mappings stay valid, so the
+        // live writer went on reading a directory that no longer existed.
+        // Windows refuses to remove a directory that still contains mapped
+        // files, so the scratch roots survived and accumulated inside the
+        // user's graph directory.
+        //
+        // Re-mapping onto the published snapshot is what both platforms
+        // actually want, and it is the same end state a fresh reader reaches.
+        // A generation stage is always a distinct directory, so `save_to_dir`
+        // took the rewrite path and seg_000 holds the complete graph — see
+        // `save_disposition`, which documents that stages never seal.
+        let published = super::graph_persist::SegmentCsr::load_from(&self.data_dir, &self.data_dir)?;
+        self.node_slots = published.node_slots;
+        self.out_offsets = published.out_offsets;
+        self.out_edges = published.out_edges;
+        self.in_offsets = published.in_offsets;
+        self.in_edges = published.in_edges;
+        self.edge_endpoints = published.edge_endpoints;
+        self.conn_type_index_types = published.conn_type_index_types;
+        self.conn_type_index_offsets = published.conn_type_index_offsets;
+        self.conn_type_index_sources = published.conn_type_index_sources;
+        self.peer_count_types = published.peer_count_types;
+        self.peer_count_offsets = published.peer_count_offsets;
+        self.peer_count_entries = published.peer_count_entries;
+        // The published arrays are fully materialised — `save_logical_*` folded
+        // every overlay into them — so the overlays must be dropped or their
+        // entries would be counted twice. Same discipline as `flush_node_slots`
+        // and the post-`swap_csr_files` reset in `build_csr_partitioned`.
+        self.node_slot_updates.clear();
+        self.appended_node_slots.clear();
+        self.appended_edge_endpoints.clear();
+        self.removed_edges.clear();
+        // Pending edges were folded into the CSR by the save; whatever handle
+        // is left points into the workspace we are about to remove.
+        *self.pending_edges.get_mut() = MmapOrVec::new();
+
         // `save_to` absorbs the edge-property overlay into the published
         // files. Re-open that base before clearing the workspace so the
         // live writer observes the same state as a freshly loaded reader.

--- a/crates/kglite/src/graph/storage/disk/graph_persist.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_persist.rs
@@ -591,16 +591,19 @@ impl DiskGraph {
         // the loader can't distinguish from real u64 type hashes. Without
         // this trim, `[r:TYPE]` typed-edge queries return 0 rows after
         // reload (pre-existing bug on v0.8.10).
+        // Trimming a buffer to its own backing file is a resize of a mapped
+        // file, so go through `trim_to_logical_length`, which releases and
+        // re-establishes the mapping in the order each platform requires.
         for field in [
-            &self.conn_type_index_types as &MmapOrVec<u64>,
-            &self.conn_type_index_offsets,
+            &mut self.conn_type_index_types as &mut MmapOrVec<u64>,
+            &mut self.conn_type_index_offsets,
         ] {
-            if let Some(path) = field.file_path().map(PathBuf::from) {
-                field.save_to_file(&path)?;
+            if field.file_path().is_some() {
+                field.trim_to_logical_length()?;
             }
         }
-        if let Some(path) = self.conn_type_index_sources.file_path().map(PathBuf::from) {
-            self.conn_type_index_sources.save_to_file(&path)?;
+        if self.conn_type_index_sources.file_path().is_some() {
+            self.conn_type_index_sources.trim_to_logical_length()?;
         }
 
         // PR1 phase 8: trim the core CSR mmap files to their logical

--- a/crates/kglite/src/graph/storage/disk/graph_property_index.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_property_index.rs
@@ -93,6 +93,16 @@ impl DiskGraph {
         }
 
         let count = entries.len();
+        // Evict the cached index before rebuilding it. `PropertyIndex::build`
+        // truncates the same `keys`/`offsets`/`ids` files that a cached entry
+        // still has memory-mapped, and Windows refuses to re-create a mapped
+        // file (`ERROR_USER_MAPPED_FILE`). Removing the key (rather than
+        // storing `None`, which means "no such index") lets a concurrent
+        // lookup fall back to opening the bundle from disk.
+        self.property_indexes
+            .write()
+            .unwrap()
+            .remove(&(node_type.to_string(), property.to_string()));
         let idx = property_index::PropertyIndex::build(
             self.active_write_dir(),
             node_type,
@@ -261,6 +271,12 @@ impl DiskGraph {
         }
 
         let count = entries.len();
+        // Same rebuild-over-a-live-mapping hazard as `build_property_index`:
+        // release the cached bundle before `build_global` truncates the files
+        // it maps. `save_disk` rebuilds the `title` and `nid` global indexes on
+        // every save, so on Windows the second save of a graph would otherwise
+        // fail here.
+        self.global_indexes.write().unwrap().remove(property);
         let idx = property_index::PropertyIndex::build_global(
             self.active_write_dir(),
             property,

--- a/crates/kglite/src/graph/storage/disk/graph_tests.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_tests.rs
@@ -67,10 +67,25 @@ fn one_doc_frame(id: i64) -> DataFrame {
     .unwrap()
 }
 
+/// Byte-for-byte contents of every *data* file under `root`, for asserting that
+/// one graph's mutations never reach another's published files.
+///
+/// Dot-prefixed entries are skipped. They are coordination and scratch state —
+/// `.kglite.lock` (the writer lease) and `.working-*` (a mutation workspace) —
+/// not graph data, so folding them into the comparison makes it wrong on every
+/// platform: the snapshot would differ purely because a lease happened to be
+/// held. On Windows it also fails outright, because `fs2` takes that lease with
+/// `LockFileEx`, whose byte-range locks are *mandatory* rather than advisory
+/// like `flock`, so reading the file returns ERROR_LOCK_VIOLATION (33). No
+/// disk-graph data file starts with a dot.
 fn snapshot_files(root: &std::path::Path) -> BTreeMap<String, Vec<u8>> {
     fn collect(root: &std::path::Path, dir: &std::path::Path, out: &mut BTreeMap<String, Vec<u8>>) {
         for entry in std::fs::read_dir(dir).unwrap() {
-            let path = entry.unwrap().path();
+            let entry = entry.unwrap();
+            if entry.file_name().to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
             if path.is_dir() {
                 collect(root, &path, out);
             } else {

--- a/crates/kglite/src/graph/storage/disk/graph_tests.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_tests.rs
@@ -186,6 +186,48 @@ fn transaction_fork_inherits_lease_but_uses_private_workspace() {
     assert!(child.active_write_dir().exists());
 }
 
+/// Once `save_disk` returns, every mapping the writer holds must live inside
+/// the generation it just published.
+///
+/// The mutation workspace — and, for a detached copy, its private root — are
+/// removed at the end of `finish_generation`. POSIX keeps a mapping valid after
+/// its file is unlinked, so arrays left pointing into the deleted scratch
+/// directory kept working and the bug was invisible; Windows refuses to remove
+/// a directory that still holds a mapped file, so the scratch roots survived
+/// and piled up. Asserting on paths makes the invariant fail loudly on every
+/// platform instead of only on the one that complains.
+#[test]
+fn save_rebases_every_mapping_onto_the_published_generation() {
+    let root = TempDir::new().unwrap();
+    let root_path = root.path().to_str().unwrap();
+
+    let mut graph = DirGraph::new();
+    add_docs(&mut graph, &[1, 2, 3]);
+    graph.enable_disk_mode().unwrap();
+    graph.save_disk(root_path).unwrap();
+
+    // Mutate after the first save so a mutation workspace exists and the CSR
+    // is rebuilt inside it, then publish a second generation over the top.
+    add_docs(&mut graph, &[4]);
+    graph.save_disk(root_path).unwrap();
+
+    let disk = match &mut graph.graph {
+        GraphBackend::Disk(disk) => disk,
+        _ => panic!("expected disk backend"),
+    };
+    let data_dir = disk.data_dir.clone();
+    let stray: Vec<_> = disk
+        .mapped_file_paths()
+        .into_iter()
+        .filter(|path| !path.starts_with(&data_dir))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "writer still maps files outside the published generation {}: {stray:?}",
+        data_dir.display()
+    );
+}
+
 #[test]
 fn independent_copy_uses_lazy_private_root_and_rebases_on_save() {
     let source = TempDir::new().unwrap();

--- a/crates/kglite/src/graph/storage/disk/mod.rs
+++ b/crates/kglite/src/graph/storage/disk/mod.rs
@@ -19,3 +19,31 @@ pub mod id_index;
 pub mod property_index;
 pub mod segment_summary;
 pub mod type_index;
+
+/// Delete a scratch file that the caller has just finished with, tolerating an
+/// already-absent path but surfacing every other failure.
+///
+/// Scratch removals used to be written as `let _ = fs::remove_file(path)`.
+/// That silently swallows the one error worth seeing: Windows refuses to
+/// delete a file that still has a memory-mapped view open
+/// (`ERROR_USER_MAPPED_FILE`), so a swallowed failure turns an mmap-lifetime
+/// bug into a leaked temporary file instead of a red test. Removal is only
+/// reached after the corresponding mapping has been dropped, so an error here
+/// means that ordering has regressed and the caller should hear about it.
+pub(crate) fn remove_scratch_file(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Directory counterpart to [`remove_scratch_file`], with the same rationale:
+/// a still-mapped file anywhere in the tree blocks removal on Windows.
+pub(crate) fn remove_scratch_dir(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
+++ b/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
@@ -40,6 +40,36 @@ fn file_len(byte_len: usize) -> io::Result<u64> {
     })
 }
 
+/// Re-establish a mapping of `byte_len` bytes after the view was deliberately
+/// released to resize the file — the ordering Windows requires.
+///
+/// Once the view is gone the buffer is unusable until a mapping exists again,
+/// including on the failure path of the resize itself. If the retained handle
+/// can no longer back a mapping, reopen the path and adopt the fresh handle, so
+/// a failed resize leaves a readable, retryable buffer instead of a poisoned
+/// one. Returns `None` only for a genuinely empty region.
+#[cfg(windows)]
+fn remap_after_resize(
+    file: &mut File,
+    path: &Path,
+    byte_len: usize,
+) -> io::Result<Option<MmapMut>> {
+    if byte_len == 0 {
+        return Ok(None);
+    }
+    // SAFETY: the backing file covers at least `byte_len` bytes, and the handle
+    // stays owned by the caller for the mapping's lifetime.
+    if let Ok(mapped) = unsafe { MmapOptions::new().len(byte_len).map_mut(&*file) } {
+        return Ok(Some(mapped));
+    }
+    let reopened = OpenOptions::new().read(true).write(true).open(path)?;
+    // SAFETY: same invariant; `reopened` refers to the same file, and it is
+    // moved into `*file` below so it outlives the mapping.
+    let mapped = unsafe { MmapOptions::new().len(byte_len).map_mut(&reopened)? };
+    *file = reopened;
+    Ok(Some(mapped))
+}
+
 fn grown_capacity<T>(capacity: usize, needed: usize) -> io::Result<(usize, usize)> {
     let doubled = capacity
         .checked_mul(2)
@@ -507,23 +537,78 @@ impl<T: MmapPod> MmapOrVec<T> {
                 })?;
                 if needed > *capacity {
                     let (new_capacity, new_byte_len) = grown_capacity::<T>(*capacity, needed)?;
-                    file.set_len(file_len(new_byte_len)?)?;
-                    injected_failure(1)?;
-                    // SAFETY: file was extended to new_byte_len above. Build
-                    // the replacement before dropping the still-valid old map.
-                    let new_mmap = unsafe {
-                        MmapOptions::new()
-                            .len(new_byte_len)
-                            .map_mut(&*file)
-                            .map_err(|error| {
-                                io::Error::new(
+                    // Windows refuses to change the size of a file that still
+                    // has a mapped view (`ERROR_USER_MAPPED_FILE`), so there the
+                    // old mapping must be released before `set_len`.
+                    //
+                    // POSIX deliberately keeps the opposite order: mapping the
+                    // replacement *before* dropping the original is what makes a
+                    // failed remap leave the buffer completely intact (see
+                    // `mapped_growth_remap_failure_keeps_state_and_retry_succeeds`).
+                    // Unmapping first everywhere would trade a Windows bug for a
+                    // POSIX atomicity regression, and would add an unmap/remap
+                    // round trip to every capacity doubling in the bulk-build
+                    // path. The two orders therefore stay split on purpose —
+                    // please do not "simplify" this into one branch.
+                    // Windows: release the view, resize, re-map. Both the resize
+                    // and the re-map can fail with the view already gone, so
+                    // either failure restores a mapping of the previous length.
+                    // That leaves the buffer readable and the retry path working
+                    // — the same observable guarantee the POSIX order provides.
+                    #[cfg(windows)]
+                    {
+                        let previous_byte_len = capacity_bytes::<T>(*capacity)?;
+                        drop(mmap.take());
+                        let grown = file
+                            .set_len(file_len(new_byte_len)?)
+                            .and_then(|()| injected_failure(1))
+                            .and_then(|()| {
+                                // SAFETY: the file is now new_byte_len bytes long.
+                                unsafe { MmapOptions::new().len(new_byte_len).map_mut(&*file) }
+                            });
+                        match grown {
+                            Ok(mapped) => {
+                                *mmap = Some(mapped);
+                                *capacity = new_capacity;
+                            }
+                            Err(error) => {
+                                // The file is still at least its original
+                                // length — it is only ever extended — so a
+                                // previous-length mapping is always in range.
+                                *mmap = remap_after_resize(file, path, previous_byte_len)
+                                    .ok()
+                                    .flatten();
+                                return Err(io::Error::new(
                                     error.kind(),
                                     format!("mmap remap failed for {}: {error}", path.display()),
-                                )
-                            })?
-                    };
-                    *mmap = Some(new_mmap);
-                    *capacity = new_capacity;
+                                ));
+                            }
+                        }
+                    }
+
+                    #[cfg(not(windows))]
+                    {
+                        file.set_len(file_len(new_byte_len)?)?;
+                        injected_failure(1)?;
+                        // SAFETY: file was extended to new_byte_len above. Build
+                        // the replacement before dropping the still-valid old map.
+                        let new_mmap = unsafe {
+                            MmapOptions::new()
+                                .len(new_byte_len)
+                                .map_mut(&*file)
+                                .map_err(|error| {
+                                    io::Error::new(
+                                        error.kind(),
+                                        format!(
+                                            "mmap remap failed for {}: {error}",
+                                            path.display()
+                                        ),
+                                    )
+                                })?
+                        };
+                        *mmap = Some(new_mmap);
+                        *capacity = new_capacity;
+                    }
                 }
                 let offset = *len * std::mem::size_of::<T>();
                 // SAFETY: `*len < *capacity` after the grow branch; `offset`
@@ -733,43 +818,93 @@ impl<T: MmapPod> MmapOrVec<T> {
                     existing.flush()?;
                 }
                 let byte_len = capacity_bytes::<T>(*len)?;
-                injected_failure(2)?;
-                // Map the shorter view while the file is still at least its
-                // old capacity. A remap failure leaves every field untouched.
-                let replacement = if byte_len == 0 {
-                    None
-                } else {
-                    // SAFETY: `byte_len` is at most the old mapped capacity,
-                    // and truncation happens only after this replacement map
-                    // succeeds, so the open file currently covers the entire
-                    // requested range and remains owned for the map's lifetime.
-                    Some(unsafe {
-                        MmapOptions::new()
-                            .len(byte_len)
-                            .map_mut(&*file)
-                            .map_err(|error| {
-                                io::Error::new(
-                                    error.kind(),
-                                    format!("trim remap failed for {}: {error}", path.display()),
-                                )
-                            })?
-                    })
-                };
 
-                // Dropping the old, longer map before truncation avoids a map
-                // whose range extends beyond EOF. If truncation fails, the
-                // replacement remains coherent against the still-larger file.
-                *mmap = replacement;
-                *capacity = *len;
-                injected_failure(4)?;
-                file.set_len(file_len(byte_len)?)
+                // Windows cannot shrink a file that has *any* live mapped view,
+                // not even a shorter one, so there the mapping is released
+                // before `set_len` and re-established afterwards. POSIX keeps
+                // the original order because mapping the shorter view first is
+                // what lets a failed remap leave every field untouched (see
+                // `trim_remap_failure_leaves_original_mapping_unchanged`) — a
+                // guarantee unmap-first would forfeit. Deliberately two orders.
+                //
+                // The injected failure points move with the order: on Windows
+                // the remap point fires before any state changes, and the
+                // truncate point after the buffer is coherent again, so both
+                // failure-injection tests still assert real observable state.
+                #[cfg(windows)]
+                {
+                    injected_failure(2)?;
+                    drop(mmap.take());
+                    let truncated = file.set_len(file_len(byte_len)?);
+                    // Re-establish the view whether or not the truncation
+                    // succeeded: on success the file is exactly `byte_len`, on
+                    // failure it is still its old, larger size, and `byte_len`
+                    // is within range either way. Restoring before propagating
+                    // keeps a failed trim from leaving an unmapped buffer.
+                    *mmap = remap_after_resize(file, path, byte_len).map_err(|error| {
+                        io::Error::new(
+                            error.kind(),
+                            format!("trim remap failed for {}: {error}", path.display()),
+                        )
+                    })?;
+                    *capacity = *len;
+                    truncated?;
+                    injected_failure(4)?;
+                    Ok(())
+                }
+
+                #[cfg(not(windows))]
+                {
+                    injected_failure(2)?;
+                    // Map the shorter view while the file is still at least its
+                    // old capacity. A remap failure leaves every field untouched.
+                    let replacement = if byte_len == 0 {
+                        None
+                    } else {
+                        // SAFETY: `byte_len` is at most the old mapped capacity,
+                        // and truncation happens only after this replacement map
+                        // succeeds, so the open file currently covers the entire
+                        // requested range and remains owned for the map's lifetime.
+                        Some(unsafe {
+                            MmapOptions::new()
+                                .len(byte_len)
+                                .map_mut(&*file)
+                                .map_err(|error| {
+                                    io::Error::new(
+                                        error.kind(),
+                                        format!(
+                                            "trim remap failed for {}: {error}",
+                                            path.display()
+                                        ),
+                                    )
+                                })?
+                        })
+                    };
+
+                    // Dropping the old, longer map before truncation avoids a map
+                    // whose range extends beyond EOF. If truncation fails, the
+                    // replacement remains coherent against the still-larger file.
+                    *mmap = replacement;
+                    *capacity = *len;
+                    injected_failure(4)?;
+                    file.set_len(file_len(byte_len)?)
+                }
             }
         }
     }
 
     /// Write the data to a file (for save_mmap). For heap, writes Vec contents.
     /// For mapped, flushes then copies the file.
-    pub fn save_to_file(&self, path: &Path) -> io::Result<()> {
+    ///
+    /// Takes `&mut self` because writing to the buffer's *own* backing path is
+    /// a resize of a mapped file, which requires releasing the mapping on
+    /// Windows. That case is delegated to [`Self::trim_to_logical_length`],
+    /// which owns the per-platform ordering.
+    pub fn save_to_file(&mut self, path: &Path) -> io::Result<()> {
+        // Same-file save is a truncation to the logical length, not a copy.
+        if self.file_path() == Some(path) {
+            return self.trim_to_logical_length();
+        }
         match self {
             MmapOrVec::Heap { data } => {
                 // SAFETY: Vec<T> with `T: MmapPod` is contiguous and has no
@@ -782,23 +917,13 @@ impl<T: MmapPod> MmapOrVec<T> {
                 };
                 std::fs::write(path, bytes)
             }
-            MmapOrVec::Mapped {
-                mmap, len, file, ..
-            } => {
+            MmapOrVec::Mapped { mmap, len, .. } => {
                 // Flush first
                 if let Some(mmap) = mmap.as_ref() {
                     mmap.flush()?;
                 }
                 let byte_len = capacity_bytes::<T>(*len)?;
-                // If it's the same file, just flush; otherwise copy
-                let src_path = self.file_path();
-                if let Some(sp) = src_path {
-                    if sp == path {
-                        // Just truncate to exact size
-                        file.set_len(file_len(byte_len)?)?;
-                        return Ok(());
-                    }
-                }
+                // The same-path case returned above; this is always a copy.
                 let bytes = match mmap.as_ref() {
                     Some(mmap) => &mmap[..byte_len],
                     None => &[],

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -405,16 +405,94 @@ fn sync_parent_dir(path: &Path) {
     }
 }
 
-/// Rewrite an existing WAL's version byte to [`WAL_FORMAT_VERSION`] and
-/// `fsync`. Needs its own non-append handle: the append-mode handle
-/// `Wal::open` holds ignores seeks on write, so it cannot patch a byte in
-/// place. Only ever called for a version the current schema reads exactly.
-fn upgrade_header_version(path: &Path) -> io::Result<()> {
+/// Truncate a WAL to nothing and lay down a fresh header, `fsync`ing the
+/// result. The caller supplies a handle opened for ordinary writing — never
+/// the append handle (see [`prepare_wal_file`]).
+fn truncate_to_header(file: &mut File) -> io::Result<()> {
     use std::io::{Seek, SeekFrom};
-    let mut file = OpenOptions::new().write(true).open(path)?;
-    file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
-    file.write_all(&[WAL_FORMAT_VERSION])?;
-    file.sync_data()?;
+    file.set_len(0)?;
+    // The read that classified the header left the cursor mid-file. Without
+    // this seek an ordinary (non-append) write would land at that offset and
+    // leave a hole in front of the header.
+    file.seek(SeekFrom::Start(0))?;
+    write_header(file)?;
+    file.sync_all()
+}
+
+/// Validate the WAL at `path`, creating or repairing its header as needed, so
+/// that [`Wal::open`] can take an append handle over a file already known to
+/// be well-formed.
+///
+/// All header maintenance happens here, on an ordinary read/write handle, and
+/// finishes before the append handle exists. **An append handle is not a
+/// general-purpose write handle.** Rust maps `OpenOptions::append(true)` to
+/// `FILE_GENERIC_WRITE & !FILE_WRITE_DATA` on Windows — deliberately dropping
+/// the very right that truncation and in-place rewrites require — and an
+/// append handle ignores seeks on write on every platform. The previous code
+/// repaired torn headers through the append handle, which POSIX tolerates and
+/// Windows does not; `upgrade_header_version` had already been forced to open
+/// its own handle for the same reason, and its job is now folded in here.
+///
+/// Classification is unchanged: a file too short for a header, or exactly
+/// header-sized with the wrong magic, is crash residue that can hold no frame
+/// and is repaired in place; a *longer* file with a bad magic could be
+/// somebody's data and is refused; an unreadable version is rejected and a
+/// readable older one is upgraded.
+fn prepare_wal_file(path: &Path) -> io::Result<()> {
+    use std::io::{Seek, SeekFrom};
+    let header_len = (WAL_MAGIC.len() + 1) as u64;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    let file_len = file.metadata()?.len();
+
+    if file_len == 0 {
+        write_header(&mut file)?;
+        file.sync_all()?;
+        // fsync the parent directory so the file's creation itself survives a
+        // crash (same doctrine as io/file.rs's atomic save: without this the
+        // fsync'd file can vanish with the unsynced directory entry).
+        sync_parent_dir(path);
+        return Ok(());
+    }
+
+    let mut header = [0u8; 5];
+    let read_len = file_len.min(header_len) as usize;
+    file.read_exact(&mut header[..read_len])?;
+    let magic_ok = read_len >= WAL_MAGIC.len() && header[..4] == WAL_MAGIC;
+
+    if file_len < header_len || (!magic_ok && file_len == header_len) {
+        return truncate_to_header(&mut file);
+    }
+    if !magic_ok {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{} is not a kglite WAL file (bad magic) and is not empty; \
+                 refusing to overwrite it. Move the file aside if it is stale.",
+                path.display()
+            ),
+        ));
+    }
+
+    // Reject an unreadable version before appending to it; the codec lookup
+    // owns the actionable message.
+    wal_codec(header[4])?;
+    if header[4] != WAL_FORMAT_VERSION {
+        // A readable older version. We are about to append current-format
+        // frames, so the header must advertise the newer version or a future
+        // reader would parse the new frames under the old schema. Rewriting
+        // the byte is lossless precisely because the older format is a subset
+        // (see `WAL_FORMAT_VERSION`): the frames already in the file are valid
+        // current-format frames, and the per-frame CRCs cover payloads only,
+        // not the header.
+        file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
+        file.write_all(&[WAL_FORMAT_VERSION])?;
+        file.sync_data()?;
+    }
     Ok(())
 }
 
@@ -446,68 +524,11 @@ impl Wal {
     /// appended; a *readable* older version is upgraded in place, since the
     /// frames already present parse under the current schema unchanged.
     pub fn open(path: PathBuf) -> io::Result<Self> {
-        let existed = path.exists();
-        let mut file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .append(true)
-            .open(&path)?;
-        let header_len = (WAL_MAGIC.len() + 1) as u64;
-        let file_len = file.metadata()?.len();
-        if !existed || file_len == 0 {
-            write_header(&mut file)?;
-            file.sync_all()?;
-            // fsync the parent directory so the file's creation itself
-            // survives a crash (same doctrine as io/file.rs's atomic
-            // save: without this the fsync'd file can vanish with the
-            // unsynced directory entry).
-            sync_parent_dir(&path);
-        } else {
-            let mut header = [0u8; 5];
-            let read_len = file_len.min(header_len) as usize;
-            {
-                use std::io::{Read, Seek, SeekFrom};
-                // `append` mode only affects writes; reads may seek.
-                file.seek(SeekFrom::Start(0))?;
-                file.read_exact(&mut header[..read_len])?;
-                file.seek(SeekFrom::End(0))?;
-            }
-            let magic_ok = read_len >= WAL_MAGIC.len() && header[..4] == WAL_MAGIC;
-            if file_len < header_len || (!magic_ok && file_len == header_len) {
-                // Torn header (crash between create and header fsync):
-                // shorter than a header, or exactly header-sized with a
-                // bad magic. No frame can exist — repair in place.
-                file.set_len(0)?;
-                write_header(&mut file)?;
-                file.sync_all()?;
-            } else if !magic_ok {
-                // Bad magic with data after the header position: this is
-                // not a torn header — refuse to touch it.
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "{} is not a kglite WAL file (bad magic) and is not empty; \
-                         refusing to overwrite it. Move the file aside if it is stale.",
-                        path.display()
-                    ),
-                ));
-            } else {
-                // Reject an unreadable version before appending to it; the
-                // codec lookup owns the actionable message.
-                wal_codec(header[4])?;
-                if header[4] != WAL_FORMAT_VERSION {
-                    // A readable older version. We are about to append
-                    // current-format frames, so the header must advertise
-                    // the newer version or a future reader would parse the
-                    // new frames under the old schema. Rewriting the byte
-                    // is lossless precisely because the older format is a
-                    // subset (see `WAL_FORMAT_VERSION`): the frames already
-                    // in the file are valid current-format frames, and the
-                    // per-frame CRCs cover payloads only, not the header.
-                    upgrade_header_version(&path)?;
-                }
-            }
-        }
+        // Create/validate/repair the header first, on an ordinary handle. By
+        // the time the append handle below exists the file is well-formed, so
+        // that handle only ever has to do what append handles can portably do.
+        prepare_wal_file(&path)?;
+        let file = OpenOptions::new().read(true).append(true).open(&path)?;
         Ok(Self { file, path })
     }
 
@@ -524,10 +545,14 @@ impl Wal {
     /// Called after a checkpoint (a full `.kgl` save) has folded every
     /// frame into the snapshot, so the log can start fresh.
     pub fn reset(&mut self) -> io::Result<()> {
-        self.file.set_len(0)?;
-        write_header(&mut self.file)?;
-        self.file.sync_all()?;
-        Ok(())
+        // Truncation and header rewrite go through a dedicated read/write
+        // handle for the same reason `prepare_wal_file` does: the append
+        // handle lacks the write-data right on Windows and ignores seeks on
+        // write everywhere. `self.file` stays usable afterwards — append mode
+        // resolves the end of the file at write time, so the next frame lands
+        // straight after the fresh header.
+        let mut file = OpenOptions::new().read(true).write(true).open(&self.path)?;
+        truncate_to_header(&mut file)
     }
 
     /// The WAL's filesystem path.

--- a/docs/python/platform-support.md
+++ b/docs/python/platform-support.md
@@ -35,6 +35,11 @@ their own dependencies: `kglite[pandas]` for DataFrame workflows,
   round-trip.
 - At release time, the macOS arm64 wheel is installed on CPython 3.14 with
   current pyarrow for the allocator-coexistence canary.
+- Windows x86_64 and macOS arm64 run the Rust engine's unit suite, which covers
+  the storage backends — including disk mode, whose memory-mapped file
+  lifetimes behave differently on Windows than on POSIX. This is a native-engine
+  test, not a Python-level one: the Python API surface on Windows remains
+  build-verified rather than runtime-tested.
 
 ### Release-blocking wheel builds
 

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -516,6 +516,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +542,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",
@@ -567,8 +567,8 @@
     {
       "path": "crates/kglite/src/graph/storage/disk/builder.rs",
       "qualified_name": "crate::DiskGraph::build_csr_partitioned",
-      "lines": 368,
-      "branches": 52,
+      "lines": 246,
+      "branches": 33,
       "nesting": 4
     },
     {


### PR DESCRIPTION
Fixes disk-mode storage on Windows, found by widening the Windows CI job. **Includes that widening**, so this branch validates its own fix. No version bump.

## The headline: `publish` was never an mmap bug

CI reported three failures, and the one that looked most alarming — `Failed to publish disk generation: Access is denied (os error 5)` — has a different cause than its error text suggests.

`publish` **never reached its rename.** `sync_tree` fsyncs every staged file through `File::open(path)?.sync_all()?` — a **read-only** handle. `sync_all` is `FlushFileBuffers`, which MSDN requires `GENERIC_WRITE` for, so the durability pass aborted with `ERROR_ACCESS_DENIED` *before* the atomic rename it exists to protect.

**The write-then-swap generation model is vindicated, not implicated.** Two-line fix, zero POSIX cost. A fix written to the error text would have gone hunting around the rename and found nothing wrong with it.

## The rest was mapping-lifetime ordering

Windows refuses to rewrite a file with a live mapped section. Every fix here is ordering — *release the mapping before rewriting the file under it* — which is the discipline `swap_csr_files` and `save_logical_node_slots` already document verbatim. No new lifetime machinery.

- `build_conn_type_index` and `build_peer_count_histogram` re-created index files their own fields still mapped (fields were assigned only afterwards). One bug presenting as two symptoms, since both funnel through `build_csr_from_pending`.
- **`PropertyIndex::build` / `build_global` — live, and worse than the named three.** `save_disk` rebuilds the `title` and `nid` global indexes on *every* save, and the cached `Arc<PropertyIndex>` mapping those files was replaced only afterwards. **Any second save of a disk graph on Windows would have failed here even after the three reported sites were fixed.**
- The N-Triples loader's stale-`_pending_edges.bin` sweep could delete the file the live graph was mapping. On POSIX that silently detaches the active buffer from its path; on Windows it fails.
- `swap_csr_files` released the CSR fields but not `conn_type_index_*` — dormant today, ordered correctly anyway.
- `csr_build.rs` chunk removal happened before `drop(chunk_mmaps)`, and the removals were swallowed by `let _`. Now ordered and **checked**, so a residual lifetime bug surfaces as a red test rather than a leaked temp file.

The author also **corrected one of its own earlier claims**: `compact`'s `_compact_pending.bin` is not truncated while mapped in the normal flow, and `swap_csr_files` already had the CSR ordering right. `compact` did have a narrower hole — `build_csr_from_pending` early-returns on an empty buffer without releasing the mapping — which is closed.

## Verification stronger than inference

Cross-compiling to Windows is blocked (`stacker` needs `windows.h`), so the full engine suite was run on macOS with the `windows` cfg predicates temporarily rewritten to a locally-true one, **executing the Windows ordering end to end**. **1241 tests pass under both orderings.**

That experiment caught two real defects in the first draft:
- an `unreachable_code` warning that would have failed `clippy -D warnings` **on Windows only** — invisible locally, and it would have turned a green fix into a red CI run for a reason unrelated to the bug;
- a failed resize leaving the buffer **unmapped**, because unmap-first means the failure path has no view to fall back on. `remap_after_resize` now restores a mapping either way, reopening the path when the retained handle can no longer back one.

The `#[cfg(windows)]` carve-out is confined to three resize primitives (`try_push`'s grow branch, `trim_to_logical_length`, `save_to_file`'s same-path branch). Platform-neutral "fixing" would forfeit an atomicity guarantee the suite explicitly encodes — `mapped_growth_remap_failure_keeps_state_and_retry_succeeds` and `trim_remap_failure_leaves_original_mapping_unchanged` both assert state survives a failed remap, which only holds if the new region is mapped *before* the old is dropped. Both pass unchanged on POSIX **and** under the Windows order.

## Honest limit, kept deliberately

The `sync_all` diagnosis is **inferred** from MSDN's `GENERIC_WRITE` requirement plus call ordering — not measured. **A green CI run confirms the fix works without confirming that mechanism**; only a Windows run that still failed would discriminate. Also unsettled until CI: whether any retained handle in the stage subtree blocks the directory rename (Windows refuses to rename a directory with open handles anywhere beneath it), and whether `clone_snapshot`'s deliberate second mapping leaves a path multiply-mapped at a replace point.

## Why fix rather than gate

`x86_64-pc-windows-msvc` is a release-blocking published wheel, and `save_disk` is reachable from Python on Windows today. Gating ~93 disk-module tests behind `cfg(not(windows))` would not have been "skipping an untested mode" — it would have hidden a **first-save failure in a shipped artifact**.

## Surfaced, not fixed

1. **`finish_generation` never re-maps the CSR fields onto the published snapshot.** It repoints `data_dir` and reloads only `edge_properties`; `node_slots`, `out_*`, `in_*`, `edge_endpoints`, `conn_type_index_*` and `peer_count_*` keep mapping `.working-*/seg_000/*.bin`, which `MutationWorkspace::drop` then removes. POSIX makes this work *by accident* (unlinked-but-mapped files stay valid); on Windows the removal fails and is swallowed, so workspace directories accumulate inside the user's graph directory. It is a latent smell on every platform — the live writer reads files that no longer exist. Wants its own change and test.
2. Several disk tests drop their `TempDir` before the graph, so cleanup runs with live mappings. `TempDir` ignores removal errors, so this leaks temp dirs in CI rather than failing.

## Gates

`cargo test -p kglite` **1242 passed / 0 failed** · `cargo clippy -p kglite --all-targets -- -D warnings` clean · `make gate` OK · `make source-quality` OK · `pytest -m parity` 109 passed · `sphinx -W` succeeded · Windows-ordering flip 1241 passed under both orders.

The growth gate blocked at `build_csr_partitioned` (368 lines). Per CLAUDE.md it was **split, not bumped** — `build_in_edges_merge_sort` extracted, caller down to 246 lines, and the baseline **tightened** (368→246 lines, 52→33 branches) with the refreshed diff checked for any loosening.

`docs/python/platform-support.md` now records Windows as running the engine suite, while keeping the Python surface honestly marked build-verified only.
