### PR TITLE
Integrate the boring-app audit fixes and the three build-or-not evaluations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,16 @@ jobs:
         run: cargo test -p kglite --lib graph::io::open::tests::crashed_process_releases_writer_lease -- --exact --nocapture
       - name: Test core lease-protected publication
         run: cargo test -p kglite --lib graph::io::open::tests::writer_lease_serializes_open_create_and_publish -- --exact
+      # The two steps above already compile the whole kglite lib test binary,
+      # so running the rest of it is close to free — and these are the only
+      # runners where the engine is exercised on Windows at all (no Windows
+      # job runs pytest, yet Windows wheels ship). It is also the only place
+      # the stack-depth bound gets checked against non-Linux frame sizes:
+      # stack_probe::budget_ceiling_query_fits_the_query_thread_stack walks
+      # the deepest AST the parser accepts, and a platform whose frames are
+      # much larger would overflow here instead of in a user's process.
+      - name: Test core lib suite
+        run: cargo test -p kglite --lib
       - name: Test CLI lifecycle unit suite
         run: cargo test -p kglite-cli
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,14 @@ jobs:
         run: cargo test -p kglite --lib graph::io::open::tests::crashed_process_releases_writer_lease -- --exact --nocapture
       - name: Test core lease-protected publication
         run: cargo test -p kglite --lib graph::io::open::tests::writer_lease_serializes_open_create_and_publish -- --exact
+      # The two filters above already compile the whole engine test binary, so
+      # running it costs little beyond the test time — and it is the only job
+      # that exercises the storage backends on Windows, where mmap and file
+      # lifetimes differ from POSIX (a file with an open mapped view cannot be
+      # resized, replaced, or deleted). Published Windows wheels ship this
+      # engine, so the suite needs to run somewhere on the platform.
+      - name: Test core engine unit suite
+        run: cargo test -p kglite --lib
       - name: Test CLI lifecycle unit suite
         run: cargo test -p kglite-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A property named `id`, `title` or `type` no longer duplicates its column in
+  the table exports. Those three columns come from a node's canonical identity,
+  but a node can also *store* a property under one of those names — Cypher
+  `CREATE (:T {title: 'a'})` sets `title` both ways, so this hit almost every
+  Cypher-built graph. The affected surfaces were `select(...).to_df()`,
+  `collect()`, `sample()`, and `export_csv()`; the SQL-dump, d3/JSON and
+  `to_text()` exporters already dropped the colliding key and are unchanged.
+
+  The duplicate was not cosmetic. The column map backing a DataFrame is keyed
+  by name, so the second write **overwrote the canonical value** — a graph
+  built with `add_nodes(df, 'T', 'id', 'name')` plus a separate `title` column
+  silently lost the canonical title. `DataFrame.to_parquet()` rejects a
+  non-unique header outright, so the documented
+  `to_df().to_parquet(...)` recipe failed with `ValueError: Duplicate column
+  names found`; `pandas.read_csv` and DuckDB silently renamed the second column
+  to `title.1`/`title_1`, inventing a phantom column in what `export_csv`
+  documents as the portable **backup** format.
+
+  A property colliding with an emitted canonical column is now dropped and the
+  canonical value wins. A canonical column the caller opted out of is not
+  emitted and so cannot collide — `to_df(include_type=False)` still returns a
+  stored `type` property as itself.
+
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — behaviour
 
+- **`define_schema()` now merges per node/connection type instead of replacing
+  the whole schema.** A type the call names takes the new declaration entire; a
+  type it does not name keeps the declaration it already had. Previously any
+  `define_schema` call superseded the entire schema, so the natural
+  per-module/per-type declaration pattern silently withdrew every constraint on
+  every type the call happened to omit — a graph that correctly rejected a
+  duplicate primary key one line earlier would accept it on the next, with no
+  error and no warning. Merging is per *type*, not per field, so re-declaring a
+  type is still how you narrow it.
+
+  Pass `replace=True` for the previous whole-schema semantics. Because that
+  withdraws enforcement from types the caller never mentioned, it emits a
+  `UserWarning` listing each constraint it stops enforcing. `clear_schema()`
+  removes everything.
+
+- **`clear_schema()` now withdraws the constraints the schema installed.**
+  It previously dropped the declaration but left the unique indexes a
+  `primary_key`/`unique` declaration had built still rejecting writes — with no
+  `SHOW CONSTRAINTS` row explaining them and no way to drop them. Constraints
+  declared through Cypher DDL are separate declarations and still survive;
+  `DROP CONSTRAINT` withdraws those.
+
+- **A `required` property named `id` or `title` is now enforced against an
+  explicit null.** Both are auto-supplied when a write omits them, so omitting
+  one still satisfies the requirement — but `CREATE (:T {title: null})`,
+  `SET t.title = null`, `REMOVE t.title` and a null title cell in an
+  `add_nodes` batch all produce a node that genuinely carries a null, and those
+  are now rejected. Previously they were waved through while `SHOW CONSTRAINTS`
+  reported the constraint as `NODE_PROPERTY_EXISTENCE` (or `NODE_KEY` alongside
+  a uniqueness declaration), and `validate_schema()` reported nothing.
+  `CREATE CONSTRAINT ... IS NOT NULL` on `id`/`title` likewise now refuses to
+  install against data that already violates it, as it does for any other
+  property. Requiring `type` remains a no-op — it is the node's label and
+  cannot be absent.
+
 - **`kglite.open()` is now crash-safe by default.** `durable` defaults to on, so
   every committed mutation is `fsync`'d to the `<path>-wal` sidecar before the
   call returns and is replayed on the next `open()`. Previously a graph opened
@@ -333,6 +368,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour.
 
 ### Fixed
+
+- `define_schema()` no longer withdraws a NOT NULL declared through
+  `CREATE CONSTRAINT ... IS NOT NULL`. Presence constraints live in the same
+  `required_fields` list a schema owns, so installing any schema silently
+  un-enforced them — while the uniqueness half of a DDL declaration, whose index
+  lives outside the schema, survived. A DDL constraint is now withdrawn only by
+  `DROP CONSTRAINT`, in both modes.
+
+- `SHOW CONSTRAINTS` (and `CALL db.constraints()`) now report a stable name for
+  a constraint carrying more than one registered name — the case where
+  `CREATE CONSTRAINT u … IS UNIQUE` and `CREATE CONSTRAINT nn … IS NOT NULL` on
+  the same property merge into one `NODE_KEY` row. The reported name was taken
+  from the first hash-map match, so the same graph could name the row
+  differently before and after a save/load round-trip.
 
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The expression-nesting limit now names the fix instead of only the problem.
+  The overwhelmingly common way to reach 512 levels is generated code — a
+  filter or facet builder emitting one `OR` term per selected value — and each
+  term costs a nesting level, so an app that worked with 400 selections breaks
+  at 600 with nothing to go on but "simplify the query". The error now points
+  at the rewrite that actually works: `x = a OR x = b OR ...` becomes
+  `x IN [a, b, ...]`, which costs one nesting level however many values the
+  list holds (and is faster, since it can be pushed into the MATCH and use an
+  index). `CYPHER.md` documents the ceiling and the habit alongside the WHERE
+  clause. Note the planner already folds single-property `OR` chains into `IN`
+  automatically, but only once the query has parsed, so it cannot rescue a
+  chain that is already over the limit.
+
 - Index DDL is classified as a mutation, since schema is graph state: it is
   blocked on a read-only graph and in a read-only transaction, rolls back with
   a failed statement, and is rejected on a schema-locked graph when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Disk storage mode now works on Windows.** The backend memory-maps its CSR
+  and index files, and Windows — unlike POSIX — refuses to resize, replace, or
+  delete a file that still has a mapped view open. Several places rewrote a file
+  while the graph was still mapping it, so `save()`, `compact()`, and building a
+  disk graph from N-Triples all failed there with "The requested operation
+  cannot be performed on a file with a user-mapped section open". The mappings
+  are now released before their backing files are rewritten, and `MmapOrVec`
+  releases its view before resizing on Windows while keeping the POSIX ordering
+  that makes a failed remap leave the buffer intact.
+
+  Publishing a saved generation failed for an unrelated reason with the same
+  symptom: the durability `fsync` over the staging directory opened each file
+  read-only, and Windows requires write access to flush a file's buffers, so the
+  save aborted with "Access is denied" before the atomic rename it was
+  protecting. Staged files are now fsynced through a writable handle.
+
+  This was never caught because no CI job ran the engine's test suite on
+  Windows, even though Windows wheels are published. The native-lifecycle job
+  now runs it.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Holding a query result in a variable no longer makes the next write copy the
+  whole graph. A deferred (`streaming`) result keeps a reference to the graph so
+  it can serve rows later, and that reference made the next write through the
+  same `KnowledgeGraph` deep-clone every node, edge, index and embedding. The
+  ordinary read-then-write shape — `rows = graph.cypher(...)` followed by
+  `graph.cypher("... SET ...")` with `rows` still in scope — therefore paid a
+  whole-graph copy on *every* pass, growing with graph size rather than with the
+  work done. Results up to a few thousand rows are now converted up front and
+  hold no graph reference, so that shape costs nothing extra. Genuinely large
+  results still defer, and `ResultView`'s documentation now explains when that
+  matters and how to avoid it. Behaviour is unchanged: a held result has always
+  shown the data as of query time, and still does.
+
+- `KnowledgeGraph.begin()` documented that embeddings are excluded from the
+  transaction snapshot's copy. They are not — embeddings, indexes and timeseries
+  are part of the graph and are copied with it, so the note understated the cost
+  of opening a transaction on an embedding-heavy graph. Corrected.
+
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A Cypher write clause fed zero rows no longer writes anything. `MATCH (p:Project
+  {key: 'NOPE'}) CREATE (t:Task ...)` used to return a row and create the node
+  even though the `MATCH` found nothing; it now returns no rows and creates
+  nothing, matching Neo4j. The same fix covers `MERGE` and `FOREACH` after an
+  empty match, and `UNWIND [] AS x CREATE ...`.
+
+  The two-variable form was the damaging one: `MATCH (t:Task {...}), (u:User
+  {...}) CREATE (t)-[:ASSIGNED_TO]->(u)` where `u` matched nothing used to
+  fabricate `u` as a real node and attach the relationship to it, leaving an
+  edge pointing at a node with no label and no properties — invisible to any
+  label scan but reachable by traversal. With no referential-integrity
+  constraints in the engine, "MATCH the parent, then CREATE the child" is the
+  only way an application can enforce a foreign key, and this silently defeated
+  it while returning a plausible-looking id.
+
+  Cause: `CREATE`, `MERGE`, and `FOREACH` each decided whether to supply
+  Cypher's implicit single start row by testing whether the incoming row set was
+  empty — which is equally true at the start of a query and after a clause that
+  matched nothing. That decision now lives in the clause pipeline, which is the
+  only place that can tell the two apart. `SET`, `DELETE`, and `REMOVE` were
+  never affected. Behaviour that deliberately does *not* change: a leading
+  `CREATE`/`MERGE`/`FOREACH` with no preceding clause still runs exactly once,
+  and `OPTIONAL MATCH` still yields one null-padded row that a following
+  `CREATE` acts on.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,18 +334,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Holding a query result in a variable no longer makes the next write copy the
-  whole graph. A deferred (`streaming`) result keeps a reference to the graph so
-  it can serve rows later, and that reference made the next write through the
-  same `KnowledgeGraph` deep-clone every node, edge, index and embedding. The
-  ordinary read-then-write shape — `rows = graph.cypher(...)` followed by
-  `graph.cypher("... SET ...")` with `rows` still in scope — therefore paid a
-  whole-graph copy on *every* pass, growing with graph size rather than with the
-  work done. Results up to a few thousand rows are now converted up front and
-  hold no graph reference, so that shape costs nothing extra. Genuinely large
-  results still defer, and `ResultView`'s documentation now explains when that
-  matters and how to avoid it. Behaviour is unchanged: a held result has always
-  shown the data as of query time, and still does.
+- Holding a deferred query result in a variable no longer makes the next write
+  copy the whole graph. A deferred (`streaming`) result keeps a reference to the
+  graph so it can serve rows later, and that reference made the next write
+  through the same `KnowledgeGraph` deep-clone every node, edge, index and
+  embedding — a cost that grows with graph size rather than with the work done,
+  so it is invisible on a small test fixture and severe on a large one.
+
+  The reach is narrower than it first looks, and worth stating precisely: only
+  results that are *deferred* hold the graph, and deferral requires a query of
+  just `MATCH`/`OPTIONAL MATCH`/`RETURN`/`SKIP`/`LIMIT` returning bare property
+  accesses. Anything with `WHERE`, `ORDER BY`, `DISTINCT`, `WITH`, `UNWIND`, an
+  aggregate, a whole-node `RETURN n`, or a computed value was already eager and
+  never pinned anything. So the shape that paid was a read-modify-write handler
+  whose read is an inline-filtered point lookup or unfiltered projection —
+  `rows = graph.cypher("MATCH (u:User {id: 1}) RETURN u.name, u.balance")`
+  followed by a write with `rows` still in scope. That query is common, but the
+  `WHERE`-spelled equivalent of it never had the problem.
+
+  Results up to a few thousand rows are now converted up front and hold no graph
+  reference, so that shape costs nothing extra. Genuinely large results still
+  defer, and `ResultView`'s documentation now explains when that matters and how
+  to avoid it. Behaviour is unchanged: a held result has always shown the data as
+  of query time, and still does.
 
 - `KnowledgeGraph.begin()` documented that embeddings are excluded from the
   transaction snapshot's copy. They are not — embeddings, indexes and timeseries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   save aborted with "Access is denied" before the atomic rename it was
   protecting. Staged files are now fsynced through a writable handle.
 
+  Saving also left the writer's arrays mapping its scratch workspace instead of
+  the generation just published. Windows will not delete a directory that still
+  holds a mapped file, so those scratch directories accumulated inside the
+  graph directory; the writer now re-maps onto the published snapshot, which
+  also means it observes exactly what a fresh reader would on every platform.
+- **Repairing a torn write-ahead log header now works on Windows.** A `.kgl-wal`
+  left truncated by a crash is repaired on open, but the repair truncated and
+  rewrote the file through the log's append handle. An append handle is not a
+  general-purpose write handle — on Windows it is opened without the access
+  right that truncation requires — so recovering from a torn header failed
+  there. Header creation, repair, and version upgrade now happen on an ordinary
+  handle before the append handle is opened.
+
   This was never caught because no CI job ran the engine's test suite on
   Windows, even though Windows wheels are published. The native-lifecycle job
   now runs it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented what a crash actually costs a `storage="disk"` graph, and stopped
+  steering growing apps toward it. Disk mode has no write-ahead log, which read
+  as "no crash safety"; the real guarantee is narrower and is now stated (and
+  kill-9 tested in `crates/kglite/tests/disk_crash_guarantee.rs`): a crash loses
+  exactly the mutations made since the last `save()`, and the last published
+  generation always reopens complete, never half-written. The durable-apps mode
+  table previously offered `disk` for "graphs larger than RAM" with no size
+  threshold and omitted `mapped` entirely — pointing the one audience that most
+  needs per-commit durability at the one mode that lacks it. It now names
+  `mapped` as the larger-than-RAM mode that keeps the guarantee and gates `disk`
+  on Wikidata scale. The storage-mode decision table in core-concepts gained a
+  crash-safety column, and the unqualified "`open()` is crash-safe by default"
+  claims in the README and guide index now name the disk exception. Also
+  documented that each disk `save()` retains a full superseded generation, so
+  checkpoint frequency is a disk-budget decision.
 - Index DDL is classified as a mutation, since schema is graph state: it is
   blocked on a read-only graph and in a read-only transaction, rolls back with
   a failed statement, and is rejected on a schema-locked graph when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ORDER BY` is no longer silently ignored after an aggregating `RETURN` when
+  the sort key is not one of the projected columns. `MATCH (t:Task) OPTIONAL
+  MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY
+  t.priority DESC` — the shape behind every "list with a count, most important
+  first" view — returned every correct row in **insertion order**, with the
+  clause dropped and no error. Combined with `SKIP`/`LIMIT` it made pagination
+  incoherent: because the underlying order was unspecified, pages could repeat
+  some rows and skip others.
+
+  Aggregation rebuilds its output rows, so a variable survives onto them only
+  if the executor carries its binding forward. The three aggregation operators
+  (streaming, materialized, and the fused `OPTIONAL MATCH` + `count()`) each
+  carried a different subset, so whether the clause worked depended on which
+  one the planner happened to pick — `count()` worked, `collect()` did not, and
+  adding an `OPTIONAL MATCH` broke a query that was correct without it. Where
+  the binding was missing the sort key evaluated to `NULL` on every row, all
+  keys tied, and the stable sort returned the input order. All three operators
+  now carry bindings for every variable the grouping keys read, so the same
+  query orders identically whichever one runs.
+
+  Ordering by a variable that is **not** determined by the grouping is now a
+  query error instead of a silent non-sort. In `RETURN t.title, count(c) ORDER
+  BY c.label`, `c` collapses into the aggregate and has no single value per
+  group; Neo4j rejects this shape and kglite now does too, with a message
+  naming the fix. The same applies to an aggregate in `ORDER BY` that is not
+  projected (`ORDER BY max(t.priority)`) or that is projected under an alias
+  (`count(*) AS n ORDER BY count(*)` — order by `n`). Ordering by a projected
+  alias, by an unaliased aggregate's expression form (`ORDER BY count(p)`), and
+  by any property of a grouping variable all keep working.
 - `claude_config` now reads and writes Claude MCP config files as UTF-8. On a
   non-UTF-8 Windows codepage the read mis-decoded the file and the atomic write
   committed the damage over every unrelated MCP server entry; non-ASCII text in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,11 +352,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   followed by a write with `rows` still in scope. That query is common, but the
   `WHERE`-spelled equivalent of it never had the problem.
 
-  Results up to a few thousand rows are now converted up front and hold no graph
-  reference, so that shape costs nothing extra. Genuinely large results still
-  defer, and `ResultView`'s documentation now explains when that matters and how
-  to avoid it. Behaviour is unchanged: a held result has always shown the data as
-  of query time, and still does.
+  Very small results — a budget of `rows × columns`, so a single-entity lookup
+  or a handful of rows — are now converted up front and hold no graph
+  reference, so that shape costs nothing extra. The budget is deliberately
+  small: every deferred-eligible query pays the conversion, while only a result
+  held across a write benefits, so the cost to readers has to stay inside noise
+  before the saving counts. Larger results still defer and still hold the graph;
+  `ResultView`'s documentation explains when that matters and how to avoid it.
+  Behaviour is unchanged: a held result has always shown the data as of query
+  time, and still does.
+
+  Consumers gain a little either way — materialising a result in one batched
+  pass is 12–15% faster than resolving it row by row, at every size measured.
 
 - `KnowledgeGraph.begin()` documented that embeddings are excluded from the
   transaction snapshot's copy. They are not — embeddings, indexes and timeseries

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -1458,8 +1458,12 @@ g.define_schema({
 })
 ```
 
-> **`define_schema` replaces the whole schema** — it is not a merge. A call with
-> a subset of types drops the omitted ones, so redefine all types each call.
+> **`define_schema` merges per node/connection type.** A type the call names
+> takes the new declaration entire; a type it omits keeps its own, so declaring
+> per module never withdraws another type's constraints. Pass `replace=True` for
+> whole-schema replacement — it warns, naming each constraint it stops
+> enforcing. Constraints declared with `CREATE CONSTRAINT` are unaffected by
+> either mode; drop them with `DROP CONSTRAINT`.
 
 Every write to an opted-in type then stamps a reserved **`updated_at`** (a
 `Timestamp`) — Cypher `CREATE`/`MERGE`/`SET` and `add_nodes`/`add_connections`.

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -126,6 +126,33 @@ graph.cypher("MATCH (n:Person) WHERE n.name =~ '(?i)^ali.*' RETURN n.name")
 graph.cypher("MATCH (n:Person) WHERE n.email =~ '.*@example\\.com$' RETURN n.name")
 ```
 
+### Generated filters: prefer `IN [...]` over long `OR` chains
+
+Expression nesting is capped at **512 levels**, and every `OR` term adds one
+level — so a filter builder that emits one term per selected value
+(`n.sku = 'a' OR n.sku = 'b' OR ...`) stops parsing at ~512 selections:
+
+```
+Expression nesting exceeds 512 levels; simplify the query. ...
+```
+
+A list membership test is one level no matter how long the list is, so the
+same filter expressed with `IN` has no practical ceiling — and it is faster,
+because it can be pushed into the MATCH and use an index:
+
+```python
+# Fragile above ~512 values, and slower below it
+graph.cypher("MATCH (n:Product) WHERE " + " OR ".join(f"n.sku = '{s}'" for s in skus) + " RETURN n")
+
+# Prefer this — one AST level for any number of values, and parameterised
+graph.cypher("MATCH (n:Product) WHERE n.sku IN $skus RETURN n", params={"skus": skus})
+```
+
+The planner already rewrites `OR` chains of equalities on a *single* property
+into `IN` for you, but only after the query parses — so it cannot rescue a
+chain that is already too long, and it does not fire for chains spanning
+different properties. Generating `IN` directly is the robust habit.
+
 ## Relationship Properties
 
 Relationships can have properties. Access them with `r.property` syntax:

--- a/CYPHER.md
+++ b/CYPHER.md
@@ -186,6 +186,48 @@ graph.cypher("MATCH (n:Person) RETURN median(n.age), percentile_cont(n.age, 0.9)
 graph.cypher("MATCH (n:Person) RETURN variance(n.age), std(n.age)")
 ```
 
+### ORDER BY after an aggregate
+
+An aggregating `RETURN` emits one row per group, so a sort key must have a
+single value on that row. Two things do:
+
+- **Projected columns** — an alias, or an unaliased item's expression form:
+  `RETURN c.name AS company, count(p) ORDER BY count(p) DESC, company`.
+- **Anything read by a grouping key** — every non-aggregate item is a grouping
+  key, so any property of a variable it names is sortable even when it is not
+  itself projected:
+
+```python
+# t is named by the grouping key t.title, so t.priority is sortable.
+graph.cypher("""
+    MATCH (t:Task)
+    OPTIONAL MATCH (t)-[:X]->(c)
+    RETURN t.title AS title, count(c) AS n
+    ORDER BY t.priority DESC
+""")
+```
+
+The value used is the group's first row. When several distinct nodes collapse
+into one group (two `Task`s sharing a title), that representative is which one
+the group met first — project the sort key explicitly if you need it pinned.
+
+Ordering by anything else is rejected rather than silently ignored:
+
+```python
+# ERROR: c collapses into count(c), so c.label has no value per group.
+"... RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+
+# ERROR: aggregate not projected. Project it, then order by the alias.
+"... RETURN t.title AS title, count(*) AS n ORDER BY max(t.priority) DESC"
+
+# ERROR: the aggregate is projected as `n` — order by `n`.
+"... RETURN t.title AS title, count(*) AS n ORDER BY count(*) DESC"
+```
+
+A `RETURN` **without** aggregates keeps every binding on its rows, so ordering
+by a non-projected expression is unrestricted there. `WITH` narrows scope to
+what it projects, so a sort key after `WITH` must be one of its columns.
+
 ## HAVING
 
 Post-aggregation filter — use after RETURN or WITH with aggregates:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ building saves a lot of argument later.
   This is what most kglite deployments are, and it is the cheapest correct
   answer. **→ [Derived index guide](https://kglite.readthedocs.io/en/latest/python/guides/derived-index.html).**
 - **Primary store** — the graph *is* the authoritative copy. `open()` is
-  crash-safe by default, statements are atomic, readers get snapshot isolation,
+  crash-safe by default for the in-memory and `mapped` backends (`disk`
+  checkpoints on `save()` instead), statements are atomic, readers get snapshot isolation,
   UNIQUE / NOT NULL / node-key constraints are enforced on every write path
   including the bulk loaders, and for in-memory graphs the cost of a write scales
   with the size of the change rather than the size of the graph. One process owns

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -540,15 +540,6 @@ impl KnowledgeGraph {
         })
     }
 
-    /// Thin delegate to `kglite_core::graph::handle::discover_property_keys_from_data`.
-    /// Engine logic lifted to core in 0.10.1.
-    pub(crate) fn discover_property_keys_from_data(
-        nodes: &[(&str, &kglite_core::api::NodeData)],
-        interner: &kglite_core::api::StringInterner,
-    ) -> Vec<String> {
-        kglite_core::api::discover_property_keys_from_data(nodes, interner)
-    }
-
     /// Thin delegate to `kglite_core::api::infer_selection_node_type`.
     /// Engine logic lifted to core in 0.10.1.
     pub(crate) fn infer_selection_node_type(&self) -> Option<String> {

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -1862,7 +1862,9 @@ impl KnowledgeGraph {
     ///
     /// **Note:** the snapshot is a full deep-clone of the graph, so creating a
     /// transaction on a very large graph has a one-time memory cost proportional
-    /// to graph size. Embeddings are *not* cloned (they live outside `DirGraph`).
+    /// to graph size. Embeddings, indexes and timeseries are part of `DirGraph`
+    /// and are cloned with it, so the copy covers the whole graph — budget for
+    /// it on an embedding-heavy graph.
     ///
     /// Can also be used as a context manager:
     ///

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -16,7 +16,9 @@ use kglite_core::api::io::{Cancelled, ProgressEvent, ProgressSink, ProgressValue
 use kglite_core::api::mutation::OperationReport;
 use kglite_core::api::session::CsvImportPolicy;
 use kglite_core::api::GraphRead;
-use kglite_core::api::{ConnectionSchemaDefinition, NodeSchemaDefinition, SchemaDefinition};
+use kglite_core::api::{
+    ConnectionSchemaDefinition, NodeSchemaDefinition, SchemaDefinition, SchemaInstall,
+};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use pyo3::{Bound, IntoPyObjectExt};
@@ -1049,139 +1051,40 @@ impl KnowledgeGraph {
     ///             }
     ///         }
     ///
+    ///     replace: When False (the default) the call **merges**: types named in
+    ///         `schema_dict` take the new declaration, types it does not name
+    ///         keep theirs. When True the incoming schema becomes the whole
+    ///         schema, so every unnamed type loses its constraints — a warning
+    ///         names each one that stops being enforced.
+    ///
     /// Returns:
     ///     Self with schema defined
-    fn define_schema(&mut self, schema_dict: &Bound<'_, PyDict>) -> PyResult<Self> {
+    #[pyo3(signature = (schema_dict, *, replace = false))]
+    fn define_schema(
+        &mut self,
+        py: Python<'_>,
+        schema_dict: &Bound<'_, PyDict>,
+        replace: bool,
+    ) -> PyResult<Self> {
         let mut schema = SchemaDefinition::new();
+        parse_node_schemas(schema_dict, &mut schema)?;
+        parse_connection_schemas(schema_dict, &mut schema)?;
 
-        // Parse node schemas
-        if let Some(nodes_dict) = schema_dict.get_item("nodes")? {
-            if let Ok(nodes) = nodes_dict.cast::<PyDict>() {
-                for (node_type_key, node_schema_val) in nodes.iter() {
-                    let node_type: String = node_type_key.extract()?;
-                    let node_schema_dict = node_schema_val.cast::<PyDict>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-                            "Schema for node type '{}' must be a dictionary",
-                            node_type
-                        ))
-                    })?;
-
-                    let mut node_schema = NodeSchemaDefinition::default();
-
-                    // Parse required fields
-                    if let Some(required) = node_schema_dict.get_item("required")? {
-                        node_schema.required_fields = required.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse optional fields
-                    if let Some(optional) = node_schema_dict.get_item("optional")? {
-                        node_schema.optional_fields = optional.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse field types
-                    if let Some(types) = node_schema_dict.get_item("types")? {
-                        let types_dict = types.cast::<PyDict>().map_err(|_| {
-                            PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                                "types must be a dictionary",
-                            )
-                        })?;
-                        for (field, type_val) in types_dict.iter() {
-                            node_schema
-                                .field_types
-                                .insert(field.extract::<String>()?, type_val.extract::<String>()?);
-                        }
-                    }
-
-                    parse_node_declarations(&node_type, node_schema_dict, &mut node_schema)?;
-
-                    schema.add_node_schema(node_type, node_schema);
-                }
-            }
-        }
-
-        // Parse connection schemas
-        if let Some(connections_dict) = schema_dict.get_item("connections")? {
-            if let Ok(connections) = connections_dict.cast::<PyDict>() {
-                for (conn_type_key, conn_schema_val) in connections.iter() {
-                    let conn_type: String = conn_type_key.extract()?;
-                    let conn_schema_dict = conn_schema_val.cast::<PyDict>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-                            "Schema for connection type '{}' must be a dictionary",
-                            conn_type
-                        ))
-                    })?;
-
-                    let source_type: String = conn_schema_dict
-                        .get_item("source")?
-                        .ok_or_else(|| {
-                            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                                "Connection '{}' missing required 'source' field",
-                                conn_type
-                            ))
-                        })?
-                        .extract()?;
-
-                    let target_type: String = conn_schema_dict
-                        .get_item("target")?
-                        .ok_or_else(|| {
-                            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                                "Connection '{}' missing required 'target' field",
-                                conn_type
-                            ))
-                        })?
-                        .extract()?;
-
-                    let mut conn_schema = ConnectionSchemaDefinition {
-                        source_type,
-                        target_type,
-                        cardinality: None,
-                        required_properties: Vec::new(),
-                        property_types: HashMap::new(),
-                        auto_timestamp: None,
-                    };
-
-                    // Parse optional cardinality
-                    if let Some(cardinality) = conn_schema_dict.get_item("cardinality")? {
-                        conn_schema.cardinality = Some(cardinality.extract::<String>()?);
-                    }
-
-                    // Opt-in freshness provenance for edges of this type.
-                    if let Some(ts_val) = conn_schema_dict.get_item("auto_timestamp")? {
-                        conn_schema.auto_timestamp = Some(ts_val.extract::<bool>()?);
-                    }
-
-                    // Parse required_properties
-                    if let Some(required_props) =
-                        conn_schema_dict.get_item("required_properties")?
-                    {
-                        conn_schema.required_properties =
-                            required_props.extract::<Vec<String>>()?;
-                    }
-
-                    // Parse property_types
-                    if let Some(prop_types) = conn_schema_dict.get_item("property_types")? {
-                        let types_dict = prop_types.cast::<PyDict>().map_err(|_| {
-                            PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                                "property_types must be a dictionary",
-                            )
-                        })?;
-                        for (field, type_val) in types_dict.iter() {
-                            conn_schema
-                                .property_types
-                                .insert(field.extract::<String>()?, type_val.extract::<String>()?);
-                        }
-                    }
-
-                    schema.add_connection_schema(conn_type, conn_schema);
-                }
-            }
-        }
+        // Replacing withdraws the declarations of every type this call did not
+        // name, so say which enforcement is going away. The default merge cannot
+        // reach an unnamed type, and so has nothing to warn about.
+        let mode = if replace {
+            warn_about_constraints_dropped_by_replace(py, &self.inner, &schema)?;
+            SchemaInstall::Replace
+        } else {
+            SchemaInstall::Merge
+        };
 
         // Installing the schema installs the UNIQUE constraints it declares, so
         // it fails when existing data already violates one — nothing is changed
         // in that case, so the caller can fix the data and retry.
         get_graph_mut(&mut self.inner)
-            .set_schema(schema)
+            .set_schema(schema, mode)
             .map_err(crate::error_py::kg_to_pyerr)?;
 
         Ok(self.clone())
@@ -1938,6 +1841,164 @@ impl KnowledgeGraph {
 /// expands to all registered pass names; `disabled_passes` adds named
 /// passes on top, validated against the registry so typos surface as a
 /// `ValueError` instead of a silent no-op.
+/// Warn, naming every constraint a `replace=True` install stops enforcing.
+///
+/// Replacement is the one mode that reaches types the caller never mentioned,
+/// and losing an integrity constraint silently is how duplicates enter a graph
+/// unnoticed. Quiet when nothing enforced is being dropped, so the warning stays
+/// worth reading. Warning rather than refusing, because withdrawing a constraint
+/// is a legitimate migration step — it just must not be invisible.
+fn warn_about_constraints_dropped_by_replace(
+    py: Python<'_>,
+    graph: &kglite_core::api::DirGraph,
+    incoming: &SchemaDefinition,
+) -> PyResult<()> {
+    let dropped = graph.constraints_dropped_by_replace(incoming);
+    if dropped.is_empty() {
+        return Ok(());
+    }
+    let message = std::ffi::CString::new(format!(
+        "define_schema(replace=True) stops enforcing {} constraint(s) on types this call did not \
+         declare: {}. Drop `replace=True` to merge instead, leaving undeclared types untouched.",
+        dropped.len(),
+        dropped.join(", ")
+    ))
+    .map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "constraint descriptor contained an interior NUL",
+        )
+    })?;
+    PyErr::warn(
+        py,
+        &py.get_type::<pyo3::exceptions::PyUserWarning>(),
+        message.as_c_str(),
+        1,
+    )
+}
+
+/// Parse `define_schema`'s `nodes` mapping into `schema`.
+///
+/// Absent or non-dict `nodes` is a no-op rather than an error, matching the
+/// long-standing behaviour of the inline walk this was extracted from.
+fn parse_node_schemas(
+    schema_dict: &Bound<'_, PyDict>,
+    schema: &mut SchemaDefinition,
+) -> PyResult<()> {
+    let Some(nodes_dict) = schema_dict.get_item("nodes")? else {
+        return Ok(());
+    };
+    let Ok(nodes) = nodes_dict.cast::<PyDict>() else {
+        return Ok(());
+    };
+    for (node_type_key, node_schema_val) in nodes.iter() {
+        let node_type: String = node_type_key.extract()?;
+        let node_schema_dict = node_schema_val.cast::<PyDict>().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                "Schema for node type '{}' must be a dictionary",
+                node_type
+            ))
+        })?;
+
+        let mut node_schema = NodeSchemaDefinition::default();
+        if let Some(required) = node_schema_dict.get_item("required")? {
+            node_schema.required_fields = required.extract::<Vec<String>>()?;
+        }
+        if let Some(optional) = node_schema_dict.get_item("optional")? {
+            node_schema.optional_fields = optional.extract::<Vec<String>>()?;
+        }
+        if let Some(types) = node_schema_dict.get_item("types")? {
+            let types_dict = types.cast::<PyDict>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>("types must be a dictionary")
+            })?;
+            for (field, type_val) in types_dict.iter() {
+                node_schema
+                    .field_types
+                    .insert(field.extract::<String>()?, type_val.extract::<String>()?);
+            }
+        }
+
+        parse_node_declarations(&node_type, node_schema_dict, &mut node_schema)?;
+        schema.add_node_schema(node_type, node_schema);
+    }
+    Ok(())
+}
+
+/// Parse `define_schema`'s `connections` mapping into `schema`. The edge
+/// counterpart of [`parse_node_schemas`]; `source`/`target` are the only
+/// required keys.
+fn parse_connection_schemas(
+    schema_dict: &Bound<'_, PyDict>,
+    schema: &mut SchemaDefinition,
+) -> PyResult<()> {
+    let Some(connections_dict) = schema_dict.get_item("connections")? else {
+        return Ok(());
+    };
+    let Ok(connections) = connections_dict.cast::<PyDict>() else {
+        return Ok(());
+    };
+    for (conn_type_key, conn_schema_val) in connections.iter() {
+        let conn_type: String = conn_type_key.extract()?;
+        let conn_schema_dict = conn_schema_val.cast::<PyDict>().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                "Schema for connection type '{}' must be a dictionary",
+                conn_type
+            ))
+        })?;
+
+        let mut conn_schema = ConnectionSchemaDefinition {
+            source_type: required_endpoint(conn_schema_dict, &conn_type, "source")?,
+            target_type: required_endpoint(conn_schema_dict, &conn_type, "target")?,
+            cardinality: None,
+            required_properties: Vec::new(),
+            property_types: HashMap::new(),
+            auto_timestamp: None,
+        };
+
+        if let Some(cardinality) = conn_schema_dict.get_item("cardinality")? {
+            conn_schema.cardinality = Some(cardinality.extract::<String>()?);
+        }
+        // Opt-in freshness provenance for edges of this type.
+        if let Some(ts_val) = conn_schema_dict.get_item("auto_timestamp")? {
+            conn_schema.auto_timestamp = Some(ts_val.extract::<bool>()?);
+        }
+        if let Some(required_props) = conn_schema_dict.get_item("required_properties")? {
+            conn_schema.required_properties = required_props.extract::<Vec<String>>()?;
+        }
+        if let Some(prop_types) = conn_schema_dict.get_item("property_types")? {
+            let types_dict = prop_types.cast::<PyDict>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "property_types must be a dictionary",
+                )
+            })?;
+            for (field, type_val) in types_dict.iter() {
+                conn_schema
+                    .property_types
+                    .insert(field.extract::<String>()?, type_val.extract::<String>()?);
+            }
+        }
+
+        schema.add_connection_schema(conn_type, conn_schema);
+    }
+    Ok(())
+}
+
+/// One of a connection schema's two mandatory endpoint keys.
+fn required_endpoint(
+    conn_schema_dict: &Bound<'_, PyDict>,
+    conn_type: &str,
+    key: &str,
+) -> PyResult<String> {
+    conn_schema_dict
+        .get_item(key)?
+        .ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Connection '{}' missing required '{}' field",
+                conn_type, key
+            ))
+        })?
+        .extract()
+}
+
 /// Parse the opt-in per-node-type declarations `define_schema` accepts beyond
 /// the field list: `primary_key`, `unique`, `layer`, and `auto_timestamp`.
 ///

--- a/crates/kglite-py/src/graph/pyapi/kg_fluent.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_fluent.rs
@@ -769,7 +769,29 @@ impl KnowledgeGraph {
             }
         }
 
+        // Columns emitted below straight from the node's canonical identity.
+        // A stored property of the same name must be dropped from the property
+        // set: the dict backing the DataFrame is keyed by column name, so a
+        // duplicate does not preserve both values — it overwrites the
+        // canonical one and yields a non-unique header that `to_parquet`
+        // rejects outright. A canonical column the caller opted *out* of is
+        // absent from this list, so a property under that name still survives.
+        let mut emitted_identity: Vec<&str> = vec!["title"];
+        if include_type {
+            emitted_identity.push("type");
+        }
+        if include_id {
+            emitted_identity.push("id");
+        }
+
         // Fast path: use TypeSchema for key discovery when all nodes share a type
+        let discover = |nodes: &Vec<(&str, &kglite_core::api::NodeData)>| {
+            kglite_core::api::discover_property_keys_excluding(
+                nodes,
+                &self.inner.interner,
+                &emitted_identity,
+            )
+        };
         let prop_keys: Vec<String> = if nodes_data.len() > 50 {
             let first_type = nodes_data[0].0;
             let all_same = nodes_data.iter().all(|(nt, _)| *nt == first_type);
@@ -778,19 +800,23 @@ impl KnowledgeGraph {
                     let mut keys: Vec<String> = schema
                         .iter()
                         .filter_map(|(_, ik)| {
-                            self.inner.interner.try_resolve(ik).map(|s| s.to_string())
+                            self.inner
+                                .interner
+                                .try_resolve(ik)
+                                .filter(|s| !emitted_identity.contains(s))
+                                .map(|s| s.to_string())
                         })
                         .collect();
                     keys.sort();
                     keys
                 } else {
-                    Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+                    discover(&nodes_data)
                 }
             } else {
-                Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+                discover(&nodes_data)
             }
         } else {
-            Self::discover_property_keys_from_data(&nodes_data, &self.inner.interner)
+            discover(&nodes_data)
         };
 
         // Build columnar dict-of-lists

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -72,19 +72,44 @@ use std::sync::{Arc, Mutex};
 /// on demand. The graph `Arc` keeps the storage alive for the lifetime of
 /// the view; the `Mutex<Vec<...>>` caches materialised rows so repeat
 /// access doesn't re-read from disk.
-/// Row count at or below which a lazy-eligible result is materialised up front
-/// instead of holding the graph open — see
+/// Cell budget (`rows × columns`) at or below which a lazy-eligible result is
+/// materialised up front instead of holding the graph open — see
 /// [`ResultView::from_cypher_result_with_graph`].
 ///
-/// The two costs being traded are not symmetric. Materialising `n` rows of a
-/// lazy-eligible RETURN is `O(n × columns)` bounded property reads. Keeping the
-/// `Arc<DirGraph>` alive risks an `O(V+E)` fork of the graph *and* every index,
-/// interner and embedding store the next write touches. So the threshold does
-/// not need to find a break-even point — it only needs to be high enough to
-/// cover the result sizes an application actually holds in a variable while
-/// writing (lookups, pages, small aggregates) and low enough that the wasted
-/// work is negligible when the rows go unread.
-const EAGER_MATERIALISE_MAX_ROWS: usize = 4096;
+/// **This is paid by every eligible read, so it is sized to disappear into
+/// noise, not to maximise coverage.** Materialising is a win when the caller
+/// consumes the rows (one batched pass beats per-row resolution by 12–15%
+/// across every size measured) and dead loss when it does not — a query whose
+/// rows are never read, or read only via `len()`, now does work it previously
+/// skipped. Since a read is far more common than a read held across a write,
+/// the tax on the former has to be invisible before the saving on the latter
+/// counts for anything.
+///
+/// Measured on a 100k-node graph, `MATCH (n:Item) RETURN n.title, n.value
+/// LIMIT k`, release build, never consumed — the shape the tracked
+/// `test_bench_cypher_match` / `test_bench_columnar_cypher_match` benchmarks
+/// run, and the shape that caught an earlier 4096-row version of this constant
+/// as a 2× regression:
+///
+/// | cells | cost |
+/// |---|---|
+/// | 32 (k=16)  | +1.6% |
+/// | 64 (k=32)  | +8.0% |
+/// | 128 (k=64) | +18.6% |
+/// | 200 (k=100)| +28.5% |
+///
+/// 32 is the last point that stays inside run-to-run noise. Budgeting in
+/// *cells* rather than rows keeps that guarantee when a RETURN is wide: cost
+/// tracks property reads, so 16 rows × 2 columns and 1 row × 32 columns are
+/// the same work and neither should be treated as cheaper than the other.
+///
+/// The coverage this buys is small in rows and precisely the shape that
+/// matters: a read-modify-write handler reads one entity, or a handful, and
+/// holds it across the write. For that case the saving is the entire fork —
+/// tens of milliseconds on a large graph against well under a microsecond of
+/// eager work. Bigger results stay deferred and keep the pin; that residual is
+/// documented on `ResultView` rather than paid for by every reader.
+const EAGER_MATERIALISE_MAX_CELLS: usize = 32;
 
 struct LazyRows {
     descriptor: LazyResultDescriptor,
@@ -165,7 +190,7 @@ impl ResultView {
     /// still in scope) into a whole-graph copy *per request*.
     ///
     /// Deferral only earns that risk when most rows are never consumed, which
-    /// needs a large result to matter. Below the threshold the projection is
+    /// needs a large result to matter. Within the cell budget the projection is
     /// bounded and cheap, and paying it up front is strictly better than
     /// risking an O(V+E) fork — so the view drops the `Arc` and becomes eager.
     /// Materialisation failures fall through to the lazy path deliberately, so
@@ -173,7 +198,10 @@ impl ResultView {
     pub fn from_cypher_result_with_graph(result: CypherResult, graph: Arc<DirGraph>) -> Self {
         if let Some(lazy_desc) = result.lazy {
             let n = lazy_desc.len();
-            if n <= EAGER_MATERIALISE_MAX_ROWS {
+            // Saturating: a pathological column count must fall through to the
+            // deferred path, never wrap into a small product and look cheap.
+            let cells = n.saturating_mul(result.columns.len());
+            if cells <= EAGER_MATERIALISE_MAX_CELLS {
                 if let Ok(rows) =
                     kglite_core::api::cypher::materialise_lazy_range(&lazy_desc, &graph, 0..n)
                 {

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -72,6 +72,20 @@ use std::sync::{Arc, Mutex};
 /// on demand. The graph `Arc` keeps the storage alive for the lifetime of
 /// the view; the `Mutex<Vec<...>>` caches materialised rows so repeat
 /// access doesn't re-read from disk.
+/// Row count at or below which a lazy-eligible result is materialised up front
+/// instead of holding the graph open — see
+/// [`ResultView::from_cypher_result_with_graph`].
+///
+/// The two costs being traded are not symmetric. Materialising `n` rows of a
+/// lazy-eligible RETURN is `O(n × columns)` bounded property reads. Keeping the
+/// `Arc<DirGraph>` alive risks an `O(V+E)` fork of the graph *and* every index,
+/// interner and embedding store the next write touches. So the threshold does
+/// not need to find a break-even point — it only needs to be high enough to
+/// cover the result sizes an application actually holds in a variable while
+/// writing (lookups, pages, small aggregates) and low enough that the wasted
+/// work is negligible when the rows go unread.
+const EAGER_MATERIALISE_MAX_ROWS: usize = 4096;
+
 struct LazyRows {
     descriptor: LazyResultDescriptor,
     graph: Arc<DirGraph>,
@@ -141,9 +155,38 @@ impl ResultView {
     /// pending rows and graph reference so cells materialise on demand at
     /// the Python boundary. Falls back to the eager
     /// `from_preprocessed`-equivalent path when `result.lazy` is `None`.
+    ///
+    /// **Small results materialise immediately and keep no graph reference.**
+    /// A retained lazy view pins the `Arc<DirGraph>` it was built from, so the
+    /// next write through the owning `KnowledgeGraph` finds a shared Arc and
+    /// `Arc::make_mut` deep-clones the entire graph — every node, edge, index
+    /// and embedding. That turns the ordinary read-then-write request handler
+    /// (`rows = g.cypher(...)` then `g.cypher("... SET ...")`, with `rows`
+    /// still in scope) into a whole-graph copy *per request*.
+    ///
+    /// Deferral only earns that risk when most rows are never consumed, which
+    /// needs a large result to matter. Below the threshold the projection is
+    /// bounded and cheap, and paying it up front is strictly better than
+    /// risking an O(V+E) fork — so the view drops the `Arc` and becomes eager.
+    /// Materialisation failures fall through to the lazy path deliberately, so
+    /// an error still surfaces at access time exactly as before.
     pub fn from_cypher_result_with_graph(result: CypherResult, graph: Arc<DirGraph>) -> Self {
         if let Some(lazy_desc) = result.lazy {
             let n = lazy_desc.len();
+            if n <= EAGER_MATERIALISE_MAX_ROWS {
+                if let Ok(rows) =
+                    kglite_core::api::cypher::materialise_lazy_range(&lazy_desc, &graph, 0..n)
+                {
+                    return ResultView {
+                        columns: result.columns,
+                        rows: preprocess_values_owned(rows),
+                        stats: result.stats,
+                        profile: result.profile,
+                        diagnostics: result.diagnostics,
+                        lazy: None,
+                    };
+                }
+            }
             let cache = Mutex::new((0..n).map(|_| None).collect::<Vec<_>>());
             return ResultView {
                 columns: result.columns,

--- a/crates/kglite-py/src/graph/pyapi/result_view.rs
+++ b/crates/kglite-py/src/graph/pyapi/result_view.rs
@@ -200,6 +200,11 @@ impl ResultView {
     }
 
     /// Discover property keys by scanning all nodes (fallback path).
+    ///
+    /// Excludes keys naming a canonical identity column — `from_nodes_with_graph`
+    /// leads every row with `type`/`title`/`id` from the node header, so a
+    /// stored property of the same name would repeat the column and shadow the
+    /// canonical value.
     fn discover_property_keys(
         nodes: &[&NodeData],
         interner: &kglite_core::api::StringInterner,
@@ -208,6 +213,9 @@ impl ResultView {
         let mut keys: Vec<String> = Vec::new();
         for node in nodes {
             for key in node.property_keys(interner) {
+                if kglite_core::api::is_canonical_node_column(key) {
+                    continue;
+                }
                 if seen.insert(key) {
                     keys.push(key.to_string());
                 }
@@ -238,7 +246,13 @@ impl ResultView {
                 if let Some(schema) = graph.type_schemas.get(first_type_str) {
                     let mut keys: Vec<String> = schema
                         .iter()
-                        .filter_map(|(_, ik)| graph.interner.try_resolve(ik).map(|s| s.to_string()))
+                        .filter_map(|(_, ik)| {
+                            graph
+                                .interner
+                                .try_resolve(ik)
+                                .filter(|s| !kglite_core::api::is_canonical_node_column(s))
+                                .map(|s| s.to_string())
+                        })
                         .collect();
                     keys.sort();
                     keys

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -31,8 +31,6 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::sync::Arc;
-
 use pyo3::prelude::*;
 mod datatypes;
 mod error_py;
@@ -429,7 +427,7 @@ fn _run_mcp_server(
     // boot, if the manifest declares a Python embedder library. The argument is
     // the `extensions.embedder` config as JSON, so Python owns library choice.
     let factory: Option<kglite_mcp_server::PyEmbedderFactory> = embedder_factory.map(|f| {
-        Box::new(move |config_json: &str| -> Result<Arc<dyn kglite_core::api::Embedder>, String> {
+        Box::new(move |config_json: &str| -> Result<std::sync::Arc<dyn kglite_core::api::Embedder>, String> {
             Python::attach(|py| {
                 let instance = f
                     .call1(py, (config_json,))
@@ -438,7 +436,7 @@ fn _run_mcp_server(
                     .map_err(|e| {
                         format!("embedder factory returned an object missing the EmbeddingModel protocol (need `dimension` + `embed`): {e}")
                     })?;
-                Ok(Arc::new(adapter) as Arc<dyn kglite_core::api::Embedder>)
+                Ok(std::sync::Arc::new(adapter) as std::sync::Arc<dyn kglite_core::api::Embedder>)
             })
         }) as kglite_mcp_server::PyEmbedderFactory
     });

--- a/crates/kglite/src/graph/dir_graph/constraints.rs
+++ b/crates/kglite/src/graph/dir_graph/constraints.rs
@@ -564,13 +564,24 @@ impl DirGraph {
     /// stored ones, so a SET that nulls a required property is caught even
     /// though the property is present beforehand.
     ///
-    /// # Structural fields are exempt
+    /// # Structural fields: `type` is exempt, `id` and `title` are not
     ///
-    /// `id`, `title`, and `type` are always present by construction (they are
-    /// `NodeData` fields, not properties), so requiring them is a no-op rather
-    /// than an error — matching what the offline
-    /// `mutation::validation::validate_single_node` checker has always done, so
-    /// write-time and validation-time agree.
+    /// `type` is the node's label rather than a value a write supplies, so no
+    /// write can leave it absent and requiring it is a genuine no-op.
+    ///
+    /// `id` and `title` are **not** exempt, despite also being `NodeData`
+    /// fields. Each write path resolves them before this check — CREATE
+    /// auto-assigns an id and synthesizes a title from `name`/`title` or the
+    /// label, and the bulk path falls back to the id column — so an omitted one
+    /// reads as present and the requirement is satisfied. But both accept an
+    /// *explicit* null (`CREATE (:T {title: null})`, `SET t.title = null`,
+    /// `REMOVE t.title`, a null title cell in a batch), and the node that
+    /// results genuinely carries a null. Skipping them here made
+    /// `required: ["title"]` report itself through `SHOW CONSTRAINTS` as
+    /// `NODE_PROPERTY_EXISTENCE` — and, with uniqueness alongside it, as
+    /// `NODE_KEY` — while admitting exactly those writes: a constraint that
+    /// reported success and enforced nothing, the one outcome this module
+    /// refuses everywhere else (see `reject_structural_uniqueness`).
     ///
     /// # Provisional stubs are deferred, not exempt
     ///
@@ -613,7 +624,7 @@ impl DirGraph {
             return Ok(());
         }
         for property in required {
-            if matches!(property, "id" | "title" | "type") {
+            if property == "type" {
                 continue;
             }
             match read(property) {
@@ -674,17 +685,47 @@ impl DirGraph {
                 missing,
             ));
         }
-        self.node_schema_mut(node_type)
-            .required_fields
-            .push(property.to_string());
+        self.ddl_not_null_constraints
+            .insert((node_type.to_string(), property.to_string()));
+        self.require_property(node_type, property);
+        Ok(checked)
+    }
+
+    /// Add `property` to `node_type`'s `required_fields`, keeping the list
+    /// sorted and duplicate-free. The storage half of a presence declaration,
+    /// shared by the DDL entry point and by [`Self::reapply_ddl_not_null`].
+    fn require_property(&mut self, node_type: &str, property: &str) {
         let required = &mut self.node_schema_mut(node_type).required_fields;
+        required.push(property.to_string());
         required.sort();
         required.dedup();
-        Ok(checked)
+    }
+
+    /// Re-add every DDL-declared presence constraint to the schema now installed.
+    ///
+    /// `required_fields` lives inside the `SchemaDefinition`, so installing a
+    /// schema replaces the list a `CREATE CONSTRAINT ... IS NOT NULL` wrote into
+    /// — silently un-enforcing it. The uniqueness half has no such problem: its
+    /// index lives outside the schema and `set_schema` withdraws only what the
+    /// *outgoing schema* declared. This restores the symmetry, so a DDL
+    /// constraint is withdrawn only by `DROP CONSTRAINT`.
+    pub(crate) fn reapply_ddl_not_null(&mut self) {
+        if self.ddl_not_null_constraints.is_empty() {
+            return;
+        }
+        let declared: Vec<(String, String)> =
+            self.ddl_not_null_constraints.iter().cloned().collect();
+        for (node_type, property) in declared {
+            self.require_property(&node_type, &property);
+        }
     }
 
     /// Withdraw a NOT NULL declaration. Reports whether one was removed.
     pub(crate) fn drop_not_null_constraint(&mut self, node_type: &str, property: &str) -> bool {
+        // Forget the DDL provenance first, or the next schema install would
+        // reinstate what was just dropped.
+        self.ddl_not_null_constraints
+            .remove(&(node_type.to_string(), property.to_string()));
         let Some(node) = self
             .schema_definition
             .as_mut()
@@ -727,9 +768,11 @@ impl DirGraph {
     /// `(nodes_checked, nodes_missing_the_property)` for `node_type`.
     /// Provisional stubs are skipped — see [`Self::check_required_fields`].
     fn count_missing_property(&mut self, node_type: &str, property: &str) -> (usize, usize) {
-        // Structural fields are `NodeData` fields rather than properties, so
-        // they are present by construction and nothing can be missing.
-        if matches!(property, "id" | "title" | "type") {
+        // `type` is the node's label rather than a supplied value, so nothing
+        // can be missing. `id`/`title` are read through `read_indexed` like any
+        // other property — they are resolved on every write path but can be
+        // explicitly nulled, so existing nulls must block the declaration.
+        if property == "type" {
             let checked = self
                 .type_indices
                 .get(node_type)
@@ -799,6 +842,15 @@ impl DirGraph {
     /// The name registered for `(node_type, properties)`, if the constraint was
     /// declared with one. Property order is irrelevant, matching constraint
     /// identity. Lets `SHOW CONSTRAINTS` report the author's name.
+    ///
+    /// Several names can point at one tuple — `CREATE CONSTRAINT u … IS UNIQUE`
+    /// and `CREATE CONSTRAINT nn … IS NOT NULL` on the same property are two
+    /// declarations that `SHOW CONSTRAINTS` reports as a single `NODE_KEY` row.
+    /// Picking the first match out of a `HashMap` made *which* name that row
+    /// carried depend on hash order, so the same graph reported different names
+    /// before and after a save/load round-trip. The lowest name in sort order
+    /// wins instead: arbitrary, but stable across runs, processes and reloads,
+    /// which is what a listing an operator reads during a migration needs.
     pub(crate) fn name_for_constraint(
         &self,
         node_type: &str,
@@ -807,11 +859,12 @@ impl DirGraph {
         let wanted = normalize_properties(properties);
         self.constraint_names
             .iter()
-            .find(|(_, declared)| {
+            .filter(|(_, declared)| {
                 declared.node_type == node_type
                     && normalize_properties(&declared.properties) == wanted
             })
             .map(|(name, _)| name.as_str())
+            .min()
     }
 
     /// Drop every registered name whose constraint is no longer declared.
@@ -1079,15 +1132,50 @@ mod not_null_declaration_tests {
         assert!(graph.has_not_null_constraint("Person", "email"));
     }
 
-    /// Structural fields are `NodeData` fields, present by construction, so
-    /// requiring one is satisfied rather than rejected.
+    /// `type` is the node's label rather than a supplied value, so requiring it
+    /// is satisfied by construction — nothing a write does can leave it absent.
     #[test]
-    fn declaring_not_null_on_a_structural_field_is_satisfied() {
+    fn declaring_not_null_on_the_label_field_is_satisfied() {
         let mut graph = person_graph(&[(1, "Alice", None)]);
-        assert_eq!(graph.create_not_null_constraint("Person", "id").unwrap(), 1);
+        assert_eq!(
+            graph.create_not_null_constraint("Person", "type").unwrap(),
+            1
+        );
         graph
             .check_required_fields("Person", |_| None)
-            .expect("id is always present");
+            .expect("type is the label and always present");
+    }
+
+    /// `id`/`title` are `NodeData` fields too, but a write can null them
+    /// explicitly, so they are enforced rather than exempt. Every write path
+    /// resolves them before the check (CREATE auto-assigns an id and synthesizes
+    /// a title), which is what the reader models here: a resolved value passes,
+    /// an unresolved one is the explicit-null case and must be rejected.
+    /// Skipping them made `required: ["title"]` report itself through
+    /// `SHOW CONSTRAINTS` while admitting `CREATE (:T {title: null})`.
+    #[test]
+    fn declaring_not_null_on_id_or_title_is_enforced_against_an_explicit_null() {
+        for property in ["id", "title"] {
+            let mut graph = person_graph(&[(1, "Alice", None)]);
+            assert_eq!(
+                graph
+                    .create_not_null_constraint("Person", property)
+                    .unwrap(),
+                1
+            );
+
+            graph
+                .check_required_fields("Person", |name| {
+                    (name == property).then(|| Value::String("resolved".to_string()))
+                })
+                .expect("a write that carries the structural field passes");
+
+            let violation = graph
+                .check_required_fields("Person", |_| None)
+                .expect_err("an explicitly nulled structural field must be rejected");
+            assert_eq!(violation.kind, ConstraintKind::NotNull);
+            assert!(violation.to_string().contains(property), "{violation}");
+        }
     }
 
     #[test]

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -110,6 +110,20 @@ pub struct DirGraph {
     /// their constraints must be dropped by descriptor.
     #[serde(default)]
     pub(crate) constraint_names: HashMap<String, NamedConstraint>,
+    /// `(node_type, property)` presence constraints declared through DDL
+    /// (`CREATE CONSTRAINT ... IS NOT NULL`) rather than through a schema.
+    ///
+    /// The enforced list itself lives in `SchemaDefinition::required_fields`, so
+    /// without this provenance record an unrelated `define_schema` would replace
+    /// the schema and silently un-enforce a DDL declaration — the asymmetry that
+    /// does not exist for uniqueness, whose index lives outside the schema.
+    /// `set_schema` replays this set over the newly installed schema. A
+    /// `BTreeSet` so the persisted bytes are deterministic. Additive serde field
+    /// — older `.kgl` files load with an empty set, which only means their DDL
+    /// presence constraints are indistinguishable from schema-declared ones,
+    /// exactly as they are today.
+    #[serde(default)]
+    pub(crate) ddl_not_null_constraints: std::collections::BTreeSet<(String, String)>,
     /// Fast O(1) lookup by node ID: node_type -> TypeIdIndex
     /// Lazily built on first use for each node type, skipped during serialization.
     /// Uses compact u32 HashMap when all IDs are UniqueId (e.g., Wikidata mapped mode).
@@ -419,6 +433,7 @@ impl DirGraph {
             unique_indices: HashMap::new(),
             unique_constraint_keys: Vec::new(),
             constraint_names: HashMap::new(),
+            ddl_not_null_constraints: std::collections::BTreeSet::new(),
             id_indices: IdIndexStore::new(),
             connection_types: std::collections::HashSet::new(),
             node_type_metadata: HashMap::new(),
@@ -474,6 +489,7 @@ impl DirGraph {
             unique_indices: HashMap::new(),
             unique_constraint_keys: Vec::new(),
             constraint_names: HashMap::new(),
+            ddl_not_null_constraints: std::collections::BTreeSet::new(),
             id_indices: IdIndexStore::new(),
             connection_types: std::collections::HashSet::new(),
             node_type_metadata: HashMap::new(),

--- a/crates/kglite/src/graph/dir_graph/schema_ops.rs
+++ b/crates/kglite/src/graph/dir_graph/schema_ops.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use super::DirGraph;
 use crate::datatypes::values::Value;
 use crate::error::KgError;
-use crate::graph::schema::SchemaDefinition;
+use crate::graph::schema::{SchemaDefinition, SchemaInstall};
 
 impl DirGraph {
     /// Run one write with caller-supplied freshness provenance, restoring the
@@ -43,15 +43,35 @@ impl DirGraph {
     /// the rows already present.
     ///
     /// Constraints implied by the *outgoing* schema are withdrawn first, so
-    /// replacing a schema that declared a primary key with one that does not
-    /// stops enforcing it. A constraint declared directly (by
-    /// `DirGraph::create_unique_constraint`, e.g. from `CREATE CONSTRAINT`)
-    /// rather than through a schema is untouched by this.
+    /// re-declaring a type without the primary key it used to declare stops
+    /// enforcing it. `mode` decides how far that withdrawal reaches:
+    /// [`SchemaInstall::Merge`] scopes it to the types `schema` actually names,
+    /// [`SchemaInstall::Replace`] applies it to every type in the graph.
+    ///
+    /// Constraints declared directly through DDL (`CREATE CONSTRAINT`) rather
+    /// than through a schema survive either mode — the unique half because the
+    /// withdrawal is computed from the outgoing *schema* rather than from the
+    /// live indexes, and the presence half because
+    /// [`Self::reapply_ddl_not_null`] reinstates it. Without that second half a
+    /// schema call would wipe a DDL NOT NULL, since `required_fields` live
+    /// inside the schema being replaced.
     // `KgError` is a rich by-value error type across the whole public surface;
     // every other `Result<_, KgError>` signature in the engine carries the same
     // allow rather than boxing one variant in isolation.
     #[allow(clippy::result_large_err)]
-    pub fn set_schema(&mut self, schema: SchemaDefinition) -> Result<(), KgError> {
+    pub fn set_schema(
+        &mut self,
+        schema: SchemaDefinition,
+        mode: SchemaInstall,
+    ) -> Result<(), KgError> {
+        let schema = match mode {
+            SchemaInstall::Replace => schema,
+            SchemaInstall::Merge => self
+                .schema_definition
+                .clone()
+                .unwrap_or_default()
+                .merged_with(schema),
+        };
         let previous_schema = self.schema_definition.take();
         let withdrawn = Self::declared_unique_tuples(previous_schema.as_ref());
         for (node_type, properties) in &withdrawn {
@@ -61,6 +81,11 @@ impl DirGraph {
         // Install with the new schema already in place, so a violation reports
         // itself as NODE KEY rather than UNIQUE when the tuple is a primary key.
         self.schema_definition = Some(schema);
+        // A DDL-declared NOT NULL lives in the same `required_fields` list the
+        // schema owns, so installing a schema would otherwise withdraw it — the
+        // asymmetry that let an unrelated `define_schema` silently un-enforce a
+        // `CREATE CONSTRAINT ... IS NOT NULL`.
+        self.reapply_ddl_not_null();
         let incoming = Self::declared_unique_tuples(self.schema_definition.as_ref());
         for (index, (node_type, properties)) in incoming.iter().enumerate() {
             let refs: Vec<&str> = properties.iter().map(String::as_str).collect();
@@ -109,14 +134,66 @@ impl DirGraph {
         tuples
     }
 
+    /// The enforced constraints installing `incoming` under
+    /// [`SchemaInstall::Replace`] would stop enforcing, as human-readable
+    /// descriptors.
+    ///
+    /// Replacement is the one mode that reaches types the caller never named, so
+    /// a binding can turn this into a warning naming exactly what it is about to
+    /// un-enforce. Reports only constraints that are *live* — a declaration the
+    /// graph never installed cannot be lost — and only ones the incoming schema
+    /// does not re-declare.
+    pub fn constraints_dropped_by_replace(&self, incoming: &SchemaDefinition) -> Vec<String> {
+        let Some(current) = self.schema_definition.as_ref() else {
+            return Vec::new();
+        };
+        let mut dropped: Vec<String> = Vec::new();
+        for (node_type, node) in &current.node_schemas {
+            if incoming.node_schemas.contains_key(node_type) {
+                continue;
+            }
+            if let Some(pk) = node.primary_key.as_deref() {
+                dropped.push(format!("{node_type}.{pk} (PRIMARY KEY)"));
+            }
+            for properties in node.unique.iter().flatten() {
+                if !properties.is_empty() {
+                    dropped.push(format!("{node_type}.({}) (UNIQUE)", properties.join(", ")));
+                }
+            }
+            for property in &node.required_fields {
+                dropped.push(format!("{node_type}.{property} (NOT NULL)"));
+            }
+        }
+        dropped.sort();
+        dropped
+    }
+
     /// Get the schema definition if one is set
     pub fn get_schema(&self) -> Option<&SchemaDefinition> {
         self.schema_definition.as_ref()
     }
 
-    /// Clear the schema definition
+    /// Clear the schema definition **and** the enforcement it installed.
+    ///
+    /// Dropping the declaration alone would leave the unique indexes a
+    /// `primary_key`/`unique` declaration built still rejecting writes, with
+    /// nothing left to explain why and no `SHOW CONSTRAINTS` row reporting them
+    /// as a node key — enforcement outliving its declaration. Routing through
+    /// `set_schema` makes clearing the withdrawal of everything the schema
+    /// declared, which is what a caller asking to clear it means.
+    ///
+    /// DDL-declared constraints are untouched, as they are by any other schema
+    /// install: `CREATE CONSTRAINT` is a separate declaration with its own
+    /// `DROP CONSTRAINT`.
     pub fn clear_schema(&mut self) {
-        self.schema_definition = None;
+        // Withdrawing declarations can never fail on unchanged data — there is
+        // nothing left to violate — so the result carries no information.
+        let _ = self.set_schema(SchemaDefinition::new(), SchemaInstall::Replace);
+        if self.schema_definition.as_ref().is_some_and(|schema| {
+            schema.node_schemas.is_empty() && schema.connection_schemas.is_empty()
+        }) {
+            self.schema_definition = None;
+        }
     }
 
     /// The declared PRIMARY KEY property for `node_type`, if one is set via

--- a/crates/kglite/src/graph/handle.rs
+++ b/crates/kglite/src/graph/handle.rs
@@ -389,6 +389,31 @@ pub fn infer_selection_node_type(
         .map(|n| n.node_type_str(&dir.interner).to_string())
 }
 
+/// Column names a row-oriented exporter emits from a node's **canonical
+/// identity** rather than from its property bag.
+///
+/// A node's `id`, `title`, and structural `type` are virtuals: every table
+/// exporter writes them as leading columns straight from the node header. A
+/// node may *also* carry a stored property under one of these names — Cypher
+/// `CREATE (:T {title: 'a'})` sets `title` both ways — and an exporter that
+/// naively appends every discovered property key then emits that column
+/// twice. See [`is_canonical_node_column`].
+pub const CANONICAL_NODE_COLUMNS: [&str; 3] = ["id", "title", "type"];
+
+/// Whether `key` names a column a row-oriented exporter already emits from
+/// the node's canonical identity.
+///
+/// Property keys that collide with a canonical column are dropped from the
+/// discovered property set: the canonical value wins. This is the rule the
+/// SQL-dump, d3/JSON, and `to_text` exporters have always applied, and the
+/// only rule that keeps a header unique. Emitting the column twice is not a
+/// lossless alternative — a name-keyed column map silently overwrites the
+/// canonical value with the property, so the duplicate *destroys* the
+/// identity it appears to preserve.
+pub fn is_canonical_node_column(key: &str) -> bool {
+    CANONICAL_NODE_COLUMNS.contains(&key)
+}
+
 /// Discover all unique property keys across a slice of typed nodes.
 /// Returns sorted, de-duplicated key names — useful for any
 /// row-oriented exporter (CSV, Parquet, DataFrame, JSON-lines) that
@@ -396,14 +421,36 @@ pub fn infer_selection_node_type(
 /// schema. The function takes only core types (`NodeData`,
 /// `StringInterner`) so every binding's table-export path can call
 /// it directly.
+///
+/// Keys naming a canonical identity column ([`CANONICAL_NODE_COLUMNS`]) are
+/// excluded, so appending the result to the exporter's leading identity
+/// columns always yields a header with unique names.
 pub fn discover_property_keys_from_data(
     nodes: &[(&str, &crate::graph::schema::NodeData)],
     interner: &crate::graph::schema::StringInterner,
+) -> Vec<String> {
+    discover_property_keys_excluding(nodes, interner, &CANONICAL_NODE_COLUMNS)
+}
+
+/// [`discover_property_keys_from_data`] with an explicit exclusion set.
+///
+/// For an exporter that emits only *some* canonical columns — the fluent
+/// `to_df(include_type=False)` drops the structural `type` column — pass the
+/// names actually emitted. A canonical name that is *not* emitted carries no
+/// collision, so a stored property under that name is real user data and must
+/// survive.
+pub fn discover_property_keys_excluding(
+    nodes: &[(&str, &crate::graph::schema::NodeData)],
+    interner: &crate::graph::schema::StringInterner,
+    excluded: &[&str],
 ) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     let mut keys = Vec::new();
     for (_, node) in nodes {
         for key in node.property_keys(interner) {
+            if excluded.contains(&key) {
+                continue;
+            }
             if seen.insert(key.to_string()) {
                 keys.push(key.to_string());
             }
@@ -673,5 +720,70 @@ mod boundary_lift_tests {
             code_entity_context(&graph, "missing", None, 1),
             CodeContextLookup::NotFound
         ));
+    }
+
+    /// A graph whose nodes store `title` (and one storing `type`) in the
+    /// property bag as well as in the canonical header — what Cypher `CREATE`
+    /// produces for any ordinary graph.
+    fn collision_graph() -> Arc<DirGraph> {
+        let mut graph = DirGraph::new();
+        let params = HashMap::new();
+        execute_mut(
+            &mut graph,
+            "CREATE (:T {id:1, title:'a', v:2}), (:T {id:2, title:'b', type:'USER', w:3})",
+            &ExecuteOptions::eager(&params),
+        )
+        .expect("fixture nodes");
+        Arc::new(graph)
+    }
+
+    fn nodes_of(graph: &DirGraph) -> Vec<(&str, &crate::graph::schema::NodeData)> {
+        graph
+            .graph
+            .node_indices()
+            .filter_map(|idx| {
+                graph
+                    .get_node(idx)
+                    .map(|n| (n.node_type_str(&graph.interner), n))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn discovered_property_keys_exclude_canonical_columns() {
+        // Every row exporter emits id/title/type from the node header, so a
+        // stored property of the same name must not become a second column.
+        let graph = collision_graph();
+        let keys = discover_property_keys_from_data(&nodes_of(&graph), &graph.interner);
+        assert_eq!(keys, vec!["v".to_string(), "w".to_string()]);
+        for canonical in CANONICAL_NODE_COLUMNS {
+            assert!(
+                !keys.contains(&canonical.to_string()),
+                "canonical column {canonical} leaked into the property key set"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unemitted_canonical_column_keeps_its_stored_property() {
+        // `to_df(include_type=False)` emits no `type` column, so there is no
+        // collision and the stored `type` property is real user data.
+        let graph = collision_graph();
+        let keys =
+            discover_property_keys_excluding(&nodes_of(&graph), &graph.interner, &["id", "title"]);
+        assert_eq!(
+            keys,
+            vec!["type".to_string(), "v".to_string(), "w".to_string()]
+        );
+    }
+
+    #[test]
+    fn is_canonical_node_column_covers_exactly_the_identity_names() {
+        assert!(is_canonical_node_column("id"));
+        assert!(is_canonical_node_column("title"));
+        assert!(is_canonical_node_column("type"));
+        assert!(!is_canonical_node_column("titles"));
+        assert!(!is_canonical_node_column("node_type"));
+        assert!(!is_canonical_node_column("Title"));
     }
 }

--- a/crates/kglite/src/graph/introspection/topics.rs
+++ b/crates/kglite/src/graph/introspection/topics.rs
@@ -1334,7 +1334,7 @@ pub(super) fn write_fluent_topic_schema(xml: &mut String) {
     xml.push_str(
         "      <m sig=\"describe(types=['...'])\">AI-optimised XML for specific types.</m>\n",
     );
-    xml.push_str("      <m sig=\"define_schema(schema_dict)\">Enforce schema constraints on future loads.</m>\n");
+    xml.push_str("      <m sig=\"define_schema(schema_dict, replace=False)\">Enforce schema constraints. Merges per node/connection type: a type the call names takes the new declaration, a type it omits keeps its own. replace=True makes the incoming schema the whole schema, withdrawing constraints on every type it omits.</m>\n");
     xml.push_str("    </methods>\n");
     xml.push_str("    <examples>\n");
     xml.push_str("      <ex desc=\"full schema\">graph.schema()</ex>\n");

--- a/crates/kglite/src/graph/io/export.rs
+++ b/crates/kglite/src/graph/io/export.rs
@@ -554,6 +554,49 @@ pub struct ExportSummary {
     pub log_lines: Vec<String>,
 }
 
+/// The property columns one node type contributes to its CSV, and the
+/// blueprint type name inferred for each.
+///
+/// Returns `(sorted column names, column -> type name)`. Keys naming a
+/// canonical identity column (`id`/`title`/`type`) are excluded: those are
+/// written from the node header, and repeating one would both duplicate the
+/// CSV column and — for any name-keyed reader such as `pandas.read_csv` —
+/// shadow the identity value behind a phantom `title.1`. Each column's type is
+/// taken from its first non-null value.
+fn node_property_columns(
+    graph: &DirGraph,
+    indices: &[petgraph::graph::NodeIndex],
+) -> (Vec<String>, BTreeMap<String, String>) {
+    let mut prop_names: BTreeSet<String> = BTreeSet::new();
+    for &idx in indices {
+        if let Some(node) = graph.graph.node_weight(idx) {
+            for key in node.property_keys(&graph.interner) {
+                if crate::graph::handle::is_canonical_node_column(key) {
+                    continue;
+                }
+                prop_names.insert(key.to_string());
+            }
+        }
+    }
+    let prop_cols: Vec<String> = prop_names.into_iter().collect();
+
+    let mut prop_types: BTreeMap<String, String> = BTreeMap::new();
+    for col in &prop_cols {
+        for &idx in indices {
+            if let Some(node) = graph.graph.node_weight(idx) {
+                if let Some(val) = node.get_property(col) {
+                    if !matches!(*val, Value::Null) {
+                        prop_types.insert(col.clone(), value_type_name(&val));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    (prop_cols, prop_types)
+}
+
 /// Export the graph (or selection) to an organized CSV directory tree.
 ///
 /// Creates:
@@ -650,31 +693,7 @@ pub fn to_csv_dir(
     let mut node_type_prop_types: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for (node_type, indices) in &nodes_by_type {
-        // First pass: collect the union of all property names
-        let mut prop_names: BTreeSet<String> = BTreeSet::new();
-        for &idx in indices {
-            if let Some(node) = graph.graph.node_weight(idx) {
-                for key in node.property_keys(&graph.interner) {
-                    prop_names.insert(key.to_string());
-                }
-            }
-        }
-        let prop_cols: Vec<String> = prop_names.into_iter().collect();
-
-        // Infer property types from first non-null value of each property
-        let mut prop_types: BTreeMap<String, String> = BTreeMap::new();
-        for col in &prop_cols {
-            for &idx in indices {
-                if let Some(node) = graph.graph.node_weight(idx) {
-                    if let Some(val) = node.get_property(col) {
-                        if !matches!(*val, Value::Null) {
-                            prop_types.insert(col.clone(), value_type_name(&val));
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        let (prop_cols, prop_types) = node_property_columns(graph, indices);
 
         // Build CSV
         let mut csv = String::with_capacity(4096);

--- a/crates/kglite/src/graph/io/ntriples/loader.rs
+++ b/crates/kglite/src/graph/io/ntriples/loader.rs
@@ -966,8 +966,7 @@ fn initialize_spills(graph: &mut DirGraph, config: &NTriplesConfig) -> Result<Lo
             // Windows, which refuses to delete a file with a mapped view.
             if let crate::graph::schema::GraphBackend::Disk(ref mut dg) = graph.graph {
                 let stale = dg.active_write_dir().join("_pending_edges.bin");
-                let mapped_live =
-                    dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
+                let mapped_live = dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
                 if stale.exists() && !mapped_live {
                     let _ = std::fs::remove_file(&stale);
                 }

--- a/crates/kglite/src/graph/io/ntriples/loader.rs
+++ b/crates/kglite/src/graph/io/ntriples/loader.rs
@@ -911,7 +911,7 @@ struct LoadSpills {
     qnum_to_idx: Option<MmapOrVec<u32>>,
 }
 
-fn initialize_spills(graph: &DirGraph, config: &NTriplesConfig) -> Result<LoadSpills, String> {
+fn initialize_spills(graph: &mut DirGraph, config: &NTriplesConfig) -> Result<LoadSpills, String> {
     let use_streaming_build = graph.graph.is_disk() || graph.graph.is_mapped();
     let use_compact = use_streaming_build;
 
@@ -958,10 +958,17 @@ fn initialize_spills(graph: &DirGraph, config: &NTriplesConfig) -> Result<LoadSp
                     }
                 }
             }
-            // Clean up stale pending_edges from previous killed builds
-            if let crate::graph::schema::GraphBackend::Disk(ref dg) = graph.graph {
+            // Clean up stale pending_edges from previous killed builds.
+            //
+            // Never remove the file the live graph is currently mapping: it is
+            // not stale by definition, and unlinking it silently detaches the
+            // active buffer from its path on POSIX while failing outright on
+            // Windows, which refuses to delete a file with a mapped view.
+            if let crate::graph::schema::GraphBackend::Disk(ref mut dg) = graph.graph {
                 let stale = dg.active_write_dir().join("_pending_edges.bin");
-                if stale.exists() {
+                let mapped_live =
+                    dg.pending_edges.get_mut().file_path() == Some(stale.as_path());
+                if stale.exists() && !mapped_live {
                     let _ = std::fs::remove_file(&stale);
                 }
             }

--- a/crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs
@@ -206,6 +206,7 @@ impl<'a> CypherExecutor<'a> {
         }
 
         // Compute results for each group
+        let carried_vars = grouping_variables(&clause.items);
         let mut result_rows = Vec::with_capacity(groups.len());
 
         for (group_idx, (group_key_values, row_indices)) in groups.iter().enumerate() {
@@ -239,26 +240,16 @@ impl<'a> CypherExecutor<'a> {
                 }
             }
 
-            // Preserve node/edge bindings from the first row in the group
-            // for variables that appear in the grouping keys.
-            // This ensures subsequent MATCH/OPTIONAL MATCH clauses can
-            // constrain patterns to the correct nodes.
+            // Preserve node/edge/path bindings from the first row in the group
+            // for every variable the grouping keys read — not just keys spelled
+            // as a bare variable. `RETURN t.title AS title, count(c) AS n`
+            // groups by a property access, and dropping `t` here is what made
+            // a trailing `ORDER BY t.priority` silently return insertion order.
+            // Also lets subsequent MATCH/OPTIONAL MATCH clauses constrain
+            // patterns to the correct nodes.
             let first_row = &result_set.rows[row_indices[0]];
             let mut row = ResultRow::from_projected(projected);
-            for &item_idx in &group_key_indices {
-                let expr = &clause.items[item_idx].expression;
-                if let Expression::Variable(var) = expr {
-                    if let Some(&idx) = first_row.node_bindings.get(var) {
-                        row.node_bindings.insert(var.clone(), idx);
-                    }
-                    if let Some(edge) = first_row.edge_bindings.get(var) {
-                        row.edge_bindings.insert(var.clone(), *edge);
-                    }
-                    if let Some(path) = first_row.path_bindings.get(var) {
-                        row.path_bindings.insert(var.clone(), path.clone());
-                    }
-                }
-            }
+            carry_group_bindings(&carried_vars, first_row, &mut row);
             result_rows.push(row);
         }
 

--- a/crates/kglite/src/graph/languages/cypher/executor/helpers.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/helpers.rs
@@ -7,7 +7,7 @@ use super::super::result::*;
 use crate::datatypes::values::Value;
 use crate::graph::schema::{soft_alias_fallback, DirGraph, NodeData, SoftAliasFallback};
 use crate::graph::storage::GraphRead;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // Re-export the ast aggregate helpers so downstream code can refer to them
 // via the executor namespace (backward compatibility with pre-split code).
@@ -18,6 +18,58 @@ pub use super::super::ast::is_aggregate_expression;
 // ============================================================================
 
 // is_aggregate_expression and is_window_expression are re-exported above.
+
+/// Variables a grouped aggregation still pins down on its output rows.
+///
+/// Every non-aggregate projection item is a grouping key, so any variable it
+/// reads has one representative value per group. Variables that occur *only*
+/// inside aggregate arguments do not — `count(c)` collapses many `c`s into a
+/// scalar — and are deliberately excluded.
+///
+/// The three aggregation implementations
+/// ([`super::CypherExecutor::execute_return_with_aggregation`],
+/// [`super::stream::aggregate::apply`], and
+/// [`super::CypherExecutor::execute_fused_optional_match_aggregate`]) all
+/// rebuild their output rows from scratch, so they must agree on this set or
+/// the same query orders differently depending on which one the planner picked.
+pub(crate) fn grouping_variables(items: &[ReturnItem]) -> HashSet<String> {
+    use crate::graph::languages::cypher::planner::simplification::collect_expression_refs;
+
+    let mut vars = HashSet::new();
+    for item in items {
+        if !is_aggregate_expression(&item.expression) {
+            collect_expression_refs(&item.expression, &mut vars);
+        }
+    }
+    vars
+}
+
+/// Carry a group's representative node/edge/path bindings onto an aggregation
+/// output row.
+///
+/// `source` is the group's first input row; `vars` comes from
+/// [`grouping_variables`]. Without this, `ORDER BY t.priority` after
+/// `RETURN t.title AS title, count(c) AS n` evaluates against a row that has
+/// no `t` binding: every sort key resolves to NULL, the keys all tie, and the
+/// stable sort silently hands back insertion order. Downstream
+/// MATCH/OPTIONAL MATCH clauses need the same bindings to re-anchor patterns.
+pub(crate) fn carry_group_bindings(
+    vars: &HashSet<String>,
+    source: &ResultRow,
+    target: &mut ResultRow,
+) {
+    for var in vars {
+        if let Some(&idx) = source.node_bindings.get(var) {
+            target.node_bindings.insert(var.clone(), idx);
+        }
+        if let Some(edge) = source.edge_bindings.get(var) {
+            target.edge_bindings.insert(var.clone(), *edge);
+        }
+        if let Some(path) = source.path_bindings.get(var) {
+            target.path_bindings.insert(var.clone(), path.clone());
+        }
+    }
+}
 
 /// Augment each row's `projected` with an expression-keyed copy of every
 /// aggregate return item, so HAVING predicates like `count(m) > 1` can
@@ -55,8 +107,12 @@ pub fn return_item_column_name(item: &ReturnItem) -> String {
     }
 }
 
-/// Convert an expression to its string representation (for column naming)
-pub(super) fn expression_to_string(expr: &Expression) -> String {
+/// Convert an expression to its string representation (for column naming).
+///
+/// This rendering *is* the identity the executor uses to resolve an unaliased
+/// projection, so `schema_check` compares ORDER BY keys against RETURN items
+/// with it — matching what the runtime can actually resolve.
+pub(crate) fn expression_to_string(expr: &Expression) -> String {
     match expr {
         Expression::PropertyAccess { variable, property } => format!("{}.{}", variable, property),
         Expression::Variable(name) => name.clone(),

--- a/crates/kglite/src/graph/languages/cypher/executor/match_clause/fused_match.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/match_clause/fused_match.rs
@@ -41,6 +41,7 @@ impl<'a> CypherExecutor<'a> {
             }
         }
 
+        let carried_vars = grouping_variables(&with_clause.items);
         let mut result_rows = Vec::with_capacity(existing.rows.len());
 
         for (scan_count, row) in existing.rows.iter().enumerate() {
@@ -119,21 +120,14 @@ impl<'a> CypherExecutor<'a> {
                 projected.insert(key, Value::Int64(value));
             }
 
-            // Create result row preserving bindings for group-key variables
+            // Create the result row, preserving bindings for every variable the
+            // grouping keys read (see `helpers::carry_group_bindings`). This
+            // operator is what an `OPTIONAL MATCH` + `count()` query fuses
+            // into, so narrowing the carry-over to bare-variable keys here is
+            // what made `ORDER BY t.priority` differ between the OPTIONAL and
+            // non-OPTIONAL spellings of the same query.
             let mut new_row = ResultRow::from_projected(projected);
-            for &idx in &group_key_indices {
-                if let Expression::Variable(var) = &with_clause.items[idx].expression {
-                    if let Some(&node_idx) = row.node_bindings.get(var) {
-                        new_row.node_bindings.insert(var.clone(), node_idx);
-                    }
-                    if let Some(edge) = row.edge_bindings.get(var) {
-                        new_row.edge_bindings.insert(var.clone(), *edge);
-                    }
-                    if let Some(path) = row.path_bindings.get(var) {
-                        new_row.path_bindings.insert(var.clone(), path.clone());
-                    }
-                }
-            }
+            carry_group_bindings(&carried_vars, row, &mut new_row);
 
             result_rows.push(new_row);
         }

--- a/crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs
@@ -19,7 +19,7 @@
 
 use super::super::super::ast::{is_aggregate_expression, Expression, ReturnClause};
 use super::super::super::result::{Bindings, ResultRow};
-use super::super::helpers::return_item_column_name;
+use super::super::helpers::{carry_group_bindings, grouping_variables, return_item_column_name};
 use super::super::CypherExecutor;
 use super::RowStream;
 use crate::datatypes::values::Value;
@@ -249,19 +249,19 @@ impl AggState {
 /// aggregate specs.
 struct GroupAcc {
     states: Vec<AggState>,
-    /// Captured node-binding for the first row in this group, by
-    /// variable name. Used to preserve `node_bindings` on the output
-    /// row so downstream MATCH/OPTIONAL MATCH clauses can constrain
-    /// patterns to the same nodes (matches existing materialized
+    /// Bindings-only row holding the first input row's node/edge/path
+    /// bindings for the variables the grouping keys read. Preserved on the
+    /// output row so a trailing ORDER BY and downstream MATCH/OPTIONAL MATCH
+    /// clauses can still resolve those variables (matches the materialized
     /// behavior in `execute_return_with_aggregation`).
-    first_node_bindings: Bindings<NodeIndex>,
+    carried: ResultRow,
 }
 
 impl GroupAcc {
     fn new(specs: &[AggSpec]) -> Self {
         GroupAcc {
             states: specs.iter().map(AggState::new).collect(),
-            first_node_bindings: Bindings::new(),
+            carried: ResultRow::new(),
         }
     }
 }
@@ -398,17 +398,11 @@ pub fn apply<'q>(
     let mut surrogate_groups: Vec<(Vec<GroupKeyPart>, GroupAcc)> = Vec::new();
     let mut surrogate_index: FxHashMap<Vec<GroupKeyPart>, usize> = FxHashMap::default();
 
-    // Capture variable names of group-key expressions that are pure
-    // variable references — used to copy node bindings forward on the
-    // first row of each group.
-    let group_var_names: Vec<Option<String>> = group_indices
-        .iter()
-        .map(|&i| match &return_clause.items[i].expression {
-            Expression::Variable(v) => Some(v.clone()),
-            Expression::PropertyAccess { variable, .. } => Some(variable.clone()),
-            _ => None,
-        })
-        .collect();
+    // Variables the grouping keys read — copied forward from the first row of
+    // each group so a trailing ORDER BY / downstream MATCH can still resolve
+    // them. Shared with the materialized and fused-OPTIONAL paths so all three
+    // agree on what survives aggregation.
+    let carried_vars = grouping_variables(&return_clause.items);
 
     for (row_count, row_result) in upstream.enumerate() {
         let row = row_result?;
@@ -442,13 +436,9 @@ pub fn apply<'q>(
                 let idx = surrogate_groups.len();
                 surrogate_index.insert(key_parts.clone(), idx);
                 let mut acc = GroupAcc::new(specs);
-                // Capture node bindings for variables that are
-                // group-key expressions (pure Variable or PropertyAccess).
-                for var_opt in group_var_names.iter().flatten() {
-                    if let Some(&node_idx) = row.node_bindings.get(var_opt) {
-                        acc.first_node_bindings.insert(var_opt.clone(), node_idx);
-                    }
-                }
+                // Capture this first row's bindings for every variable the
+                // grouping keys read.
+                carry_group_bindings(&carried_vars, &row, &mut acc.carried);
                 surrogate_groups.push((key_parts, acc));
                 idx
             }
@@ -536,9 +526,7 @@ pub fn apply<'q>(
         }
 
         let mut row = ResultRow::from_projected(projected);
-        for (k, v) in acc.first_node_bindings.iter() {
-            row.node_bindings.insert(k.clone(), *v);
-        }
+        carry_group_bindings(&carried_vars, &acc.carried, &mut row);
         output_rows.push(row);
     }
 
@@ -648,11 +636,11 @@ fn merge_group_accs(mut a: GroupAcc, b: GroupAcc) -> GroupAcc {
         merged_states.push(sa);
     }
     a.states = merged_states;
-    // Keep the first-seen node bindings — matches materialized behavior
+    // Keep the first-seen bindings — matches materialized behavior
     // (execute_return_with_aggregation uses the first row of the group).
     GroupAcc {
         states: a.states,
-        first_node_bindings: a.first_node_bindings,
+        carried: a.carried,
     }
 }
 

--- a/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
@@ -34,7 +34,7 @@ fn test_create_single_node() {
 
 #[test]
 fn test_create_rejects_duplicate_primary_key() {
-    use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition};
+    use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition, SchemaInstall};
 
     let mut graph = DirGraph::new();
     // Declare Person.id as an enforced primary key; Doc has none.
@@ -46,7 +46,9 @@ fn test_create_rejects_duplicate_primary_key() {
             ..Default::default()
         },
     );
-    graph.set_schema(schema).expect("schema install");
+    graph
+        .set_schema(schema, SchemaInstall::Merge)
+        .expect("schema install");
 
     fn run(g: &mut DirGraph, q: &str) -> Result<(), String> {
         let query = parser::parse_cypher(q).unwrap();

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -269,6 +269,21 @@ fn run_clause_pipeline(
     let profiling = ctx.profiling;
     let mut result_set = seed;
 
+    // `result_set.rows.is_empty()` means two opposite things depending on where
+    // the pipeline is. Before any clause has run it means "no binding stream
+    // exists yet", and Cypher's implicit single empty row applies — a leading
+    // `CREATE` runs once. After a clause has run it means "the stream exists and
+    // holds zero rows", and every downstream clause must produce zero rows and
+    // no side effects. Only the pipeline can tell the two apart, so it owns the
+    // distinction here; individual clauses must never re-derive it from
+    // emptiness (doing so is what made `MATCH`-finds-nothing + `CREATE`
+    // fabricate a row and create an unbound node).
+    //
+    // `leading` is non-empty only for the `LOAD CSV` driver, which strips its
+    // own clause and re-enters this pipeline once per batch — those batch rows
+    // are an already-established stream.
+    let mut stream_established = !ctx.leading.is_empty();
+
     for (i, clause) in clauses.iter().enumerate() {
         if interrupt.exceeded() {
             // Deadline passed or the caller flipped the cancel flag (Ctrl-C).
@@ -276,11 +291,13 @@ fn run_clause_pipeline(
             // changes, leaving the graph unchanged.
             return Err("Query interrupted".to_string());
         }
-        // Seed first-clause WITH/UNWIND (same as read-only path)
-        if i == 0
-            && result_set.rows.is_empty()
-            && matches!(clause, Clause::With(_) | Clause::Unwind(_))
-        {
+        // Materialize Cypher's implicit start row for the clauses that consume
+        // one. Deliberately lazy rather than seeding `ResultSet::new()` up
+        // front: MATCH/OPTIONAL MATCH select their leading (scan) form over
+        // their correlated (extend-each-row) form by testing `rows.is_empty()`,
+        // so handing them a row would change how they plan. Same seed the
+        // read-only path applies in `executor/mod.rs`.
+        if !stream_established && clause_needs_implicit_row(clause) {
             result_set.rows.push(ResultRow::new());
         }
 
@@ -291,9 +308,11 @@ fn run_clause_pipeline(
             None
         };
 
-        // If a prior clause produced 0 rows, MATCH/OPTIONAL MATCH cannot
-        // extend an empty pipeline — short-circuit to 0 rows.
-        if i > 0
+        // An established-but-empty stream cannot be extended: MATCH has nothing
+        // to join against, and OPTIONAL MATCH null-pads incoming rows of which
+        // there are none. Short-circuit rather than dispatch, so neither reaches
+        // its leading form and re-scans the graph.
+        if stream_established
             && result_set.rows.is_empty()
             && matches!(clause, Clause::Match(_) | Clause::OptionalMatch(_))
         {
@@ -418,9 +437,34 @@ fn run_clause_pipeline(
                 elapsed_us: s.elapsed().as_micros() as u64,
             });
         }
+
+        // From here on, `rows.is_empty()` means "zero rows", never "not started".
+        stream_established = true;
     }
 
     Ok(result_set)
+}
+
+/// Does `clause` consume Cypher's implicit single empty start row when it opens
+/// a query?
+///
+/// These are the clauses that produce output per incoming row and therefore
+/// need one row to act on even with nothing before them: `CREATE (:T)`,
+/// `MERGE (:T)`, a standalone `FOREACH`, and a leading `WITH`/`UNWIND`. Read
+/// clauses are absent on purpose — MATCH/OPTIONAL MATCH open a query by
+/// scanning, not by extending a row.
+///
+/// Only ever consulted while the stream is unestablished, so it cannot
+/// resurrect a stream that a preceding clause emptied.
+fn clause_needs_implicit_row(clause: &Clause) -> bool {
+    matches!(
+        clause,
+        Clause::With(_)
+            | Clause::Unwind(_)
+            | Clause::Create(_)
+            | Clause::Merge(_)
+            | Clause::Foreach { .. }
+    )
 }
 
 /// Flush staged writes and project the pipeline's rows into a `CypherResult`.
@@ -483,8 +527,9 @@ fn finalize_mutation(
 /// For each incoming row, evaluate `list` in that row's context and run
 /// `body`'s update clauses once per element with `variable` bound to it.
 /// The outer row set is a side-effect input only — it is not modified
-/// and body bindings do not propagate out. A standalone FOREACH (no
-/// incoming rows) still runs once over an empty binding row.
+/// and body bindings do not propagate out. Zero incoming rows means the
+/// body never runs; a standalone FOREACH still runs once, over the implicit
+/// start row the pipeline seeds for it.
 #[allow(clippy::too_many_arguments)]
 fn execute_foreach(
     graph: &mut DirGraph,
@@ -497,16 +542,7 @@ fn execute_foreach(
     interrupt: &Interrupt,
     budget: &super::budget::ExecutionBudget,
 ) -> Result<(), String> {
-    // A FOREACH at the start of a query has no incoming rows; run it once
-    // over a single empty binding row so standalone loops work.
-    let seed = [ResultRow::new()];
-    let rows: &[ResultRow] = if outer.rows.is_empty() {
-        &seed
-    } else {
-        &outer.rows
-    };
-
-    for (row_idx, row) in rows.iter().enumerate() {
+    for (row_idx, row) in outer.rows.iter().enumerate() {
         check_interrupt_periodic(interrupt, row_idx)?;
         // Evaluate the list in this row's context (read-only borrow of the
         // graph, dropped before the per-element mutations below).
@@ -654,12 +690,12 @@ fn execute_create(
     // same mechanism `add_nodes` uses), and the disk read-side is synced once
     // at the end of this function — see the `sync_disk_column_stores` call
     // below. (SET/DELETE/REMOVE already work on disk via the staged-write path.)
-    let source_rows = if existing.rows.is_empty() {
-        // No prior MATCH: execute once with an empty row
-        vec![ResultRow::new()]
-    } else {
-        existing.rows
-    };
+    // One CREATE per incoming row, and nothing at all for zero rows. A leading
+    // CREATE gets its single empty row from the pipeline's implicit-start-row
+    // seed (`clause_needs_implicit_row`) — this function must not synthesize
+    // one, because from here an empty `existing` is indistinguishable from a
+    // preceding MATCH that found nothing.
+    let source_rows = existing.rows;
 
     let mut new_rows = Vec::with_capacity(source_rows.len());
 
@@ -1969,11 +2005,9 @@ fn execute_merge(
     // branch routes through `execute_create` (disk-capable via
     // `DirGraph::insert_node_routed`); ON CREATE/MATCH SET route through
     // `execute_set` (already disk-capable). No disk guard needed.
-    let source_rows = if existing.rows.is_empty() {
-        vec![ResultRow::new()]
-    } else {
-        existing.rows
-    };
+    // As in `execute_create`: one MERGE per incoming row, none for zero rows.
+    // The implicit start row for a leading MERGE is seeded by the pipeline.
+    let source_rows = existing.rows;
 
     let mut new_rows = Vec::with_capacity(source_rows.len());
 

--- a/crates/kglite/src/graph/languages/cypher/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/mod.rs
@@ -19,6 +19,8 @@ pub mod parser;
 pub mod plan_cache;
 pub mod planner;
 pub mod result;
+#[cfg(test)]
+mod stack_probe;
 pub mod tokenizer;
 pub mod value_codec;
 mod window;

--- a/crates/kglite/src/graph/languages/cypher/parser/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/mod.rs
@@ -137,8 +137,18 @@ impl CypherParser {
     /// releases the whole run at once.
     pub(super) fn deepen(&mut self) -> Result<(), String> {
         if self.depth >= MAX_EXPRESSION_DEPTH {
+            // Name the rewrite. The overwhelmingly common way to reach this
+            // limit is generated code — a filter/facet builder emitting one
+            // `OR` term per selected value — and each term costs a nesting
+            // level while the equivalent `IN [...]` costs one level no matter
+            // how many values it holds. "Simplify the query" alone leaves the
+            // author guessing at a limit they did not know existed.
             return Err(format!(
-                "Expression nesting exceeds {} levels; simplify the query",
+                "Expression nesting exceeds {} levels; simplify the query. \
+                 Long chains of OR'd equality tests are the usual cause and \
+                 nest one level per term — rewrite `x = a OR x = b OR ...` as \
+                 `x IN [a, b, ...]`, which nests one level however many \
+                 values the list holds.",
                 MAX_EXPRESSION_DEPTH
             ));
         }

--- a/crates/kglite/src/graph/languages/cypher/parser/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/parser/mod.rs
@@ -61,12 +61,32 @@ pub struct CypherParser {
 /// It does not, however, bound their *stack use* equally. Only
 /// [`CypherParser::descend`] grows the stack on demand (via `stacker`); the
 /// planner, executor and `Drop` walkers recurse on whatever stack their
-/// thread already has. Debug-profile frames are several times larger than
-/// release frames, so the guarantee those stages actually carry is "at most
-/// 512 levels", not "cannot overflow" — a thread with a small stack (Windows
-/// defaults to 1 MB) has not been measured against a 512-level AST. Extending
-/// the `stacker` guard past the parser is deliberately deferred until that
-/// measurement exists.
+/// thread already has. That has now been measured
+/// (`super::stack_probe`, macOS/aarch64, worst shape: an `OR`/`AND`/`NOT`
+/// tree walked by the executor):
+///
+/// | stage | debug | release |
+/// |---|---|---|
+/// | executor `evaluate_predicate`/`evaluate_expression` | 7,248 B/level | 1,056 B/level |
+/// | planner walkers (WHERE chains) | 2,160 B/level | 480 B/level |
+/// | recursive `Drop` | 112 B/level | 64 B/level |
+///
+/// At this budget the deepest accepted query therefore peaks at ~3.7 MiB in
+/// debug and ~0.54 MiB in release, against the 8 MiB every frontend runs on
+/// ([`crate::graph::session::QUERY_THREAD_STACK_SIZE`], and the main-thread
+/// default for the CLI and the Python wheel). So the stages downstream of the
+/// parser do not need their own `stacker` guard — the budget alone keeps them
+/// inside the stack they are given, and
+/// `stack_probe::budget_ceiling_query_fits_the_query_thread_stack` holds that
+/// true on every platform CI runs.
+///
+/// The corollary is that this budget is load-bearing, not decorative: raising
+/// it scales the peak linearly, and the release peak would pass 1 MiB — the
+/// smallest in-process stack in play — somewhere around 1,000 levels. Raising
+/// the budget means adding a guard first, and a guard on the per-row
+/// `evaluate_expression` measured **+14%** on the in-memory expression path.
+/// Growing the stack once at executor entry measured free, and is the shape
+/// to reach for if the budget ever has to move.
 ///
 /// The budget bounds **AST depth, not parser call depth**, and those differ:
 /// the left-associative operator chains (`OR`/`XOR`/`AND`, `+`/`-`/`||`,
@@ -79,7 +99,7 @@ pub struct CypherParser {
 /// walkers themselves have neither a depth guard nor stack growth, and they
 /// run on server worker threads whose stacks are far smaller than the main
 /// thread's.
-const MAX_EXPRESSION_DEPTH: usize = 512;
+pub(super) const MAX_EXPRESSION_DEPTH: usize = 512;
 
 /// Remaining-stack threshold below which [`CypherParser::descend`] allocates
 /// a fresh segment, and the size of that segment. The red zone must cover the

--- a/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
@@ -1744,10 +1744,36 @@ pub(crate) fn mark_return_lazy_eligible(query: &mut CypherQuery) {
     if n == 0 {
         return;
     }
-    // Conservative shape: every clause must be one of MATCH /
-    // OPTIONAL MATCH / WHERE (predicate-only) / RETURN / SKIP / LIMIT. WITH
-    // / UNWIND / CALL / fused-aggregate variants all consume row values
-    // and their consumer paths haven't been audited for the lazy resolver.
+    // Conservative shape: every clause must be one of MATCH / OPTIONAL MATCH /
+    // RETURN / SKIP / LIMIT. WITH / UNWIND / CALL / ORDER BY / fused-aggregate
+    // variants all consume row values and their consumer paths haven't been
+    // audited for the lazy resolver.
+    //
+    // A standalone `Clause::Where` disqualifies too, and that is easy to miss:
+    // `optimize` keeps the WHERE as a safety net even once every predicate has
+    // been pushed into the MATCH pattern (see
+    // `planner_tests::test_predicate_pushdown_simple`), so it is still a clause
+    // here and falls to the catch-all below. This is the gate that decides
+    // whether a result holds an `Arc<DirGraph>` open, so the exact membership
+    // is pinned by `planner_tests::lazy_eligibility_corpus`.
+    //
+    // KNOWN WART, deliberately left alone rather than papered over. The WHERE
+    // rule splits two spellings of the same lookup:
+    //
+    //     MATCH (u:User {id: 1}) RETURN u.name        -> deferred
+    //     MATCH (u:User) WHERE u.id = 1 RETURN u.name -> eager
+    //
+    // They are semantically identical and a caller has no way to know which one
+    // they wrote, yet they take different paths with different performance
+    // characteristics. That unpredictability is a defect in its own right,
+    // independent of what the deferred path costs. Accepting a standalone WHERE
+    // here would be the obvious "fix" and is NOT one: the resolver has not been
+    // audited against pushed-down predicates, so widening the gate on that
+    // assumption would trade an arbitrary cliff for a correctness risk. The
+    // principled repair is to make the two spellings converge — either by
+    // folding a fully-pushed WHERE out of the clause list in `optimize`, or by
+    // auditing the resolver and admitting predicate-only WHERE — and either is a
+    // deliberate change with its own tests, not a one-line arm added here.
     let mut return_idx: Option<usize> = None;
     for (i, c) in query.clauses.iter().enumerate() {
         match c {

--- a/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/fusion/aggregate.rs
@@ -8,16 +8,7 @@ use crate::datatypes::values::Value;
 use crate::graph::core::pattern_matching::PatternElement;
 use crate::graph::languages::cypher::ast::*;
 
-/// Push simple equality predicates from WHERE into MATCH pattern properties.
-/// This enables the pattern executor to filter during matching rather than after.
-///
-/// Fold OR chains of equalities on the same variable.property into IN predicates.
-///
-/// Example: `WHERE n.name = 'A' OR n.name = 'B' OR n.name = 'C'`
-/// Becomes: `WHERE n.name IN ['A', 'B', 'C']`
-///
-/// This enables predicate pushdown into MATCH patterns and index acceleration.
-/// Must run BEFORE `push_where_into_match`.
+/// Fuse `OPTIONAL MATCH` followed by an aggregate into a single pass.
 pub(crate) fn fuse_optional_match_aggregate(query: &mut CypherQuery) {
     let mut i = 0;
     while i + 1 < query.clauses.len() {

--- a/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
@@ -1717,3 +1717,85 @@ fn test_fuse_optional_match_aggregate_bails_on_multi_pattern() {
         "multi-pattern OPTIONAL MATCH must not fuse into FusedOptionalMatchAggregate"
     );
 }
+
+/// The lazy-eligibility contract, pinned as a corpus.
+///
+/// `mark_lazy_eligibility` decides whether a result is returned deferred, and a
+/// deferred result holds an `Arc<DirGraph>` for its whole life — which makes the
+/// next write through the owning graph copy-on-write the entire graph. So this
+/// gate is not merely a projection optimisation: it decides who pays an O(V+E)
+/// fork. Pinning the exact shape keeps that reach visible and honest.
+///
+/// The surprising member is `WHERE`: `optimize` keeps a standalone
+/// `Clause::Where` as a safety net even after pushing every predicate into the
+/// MATCH (see `test_predicate_pushdown_simple`), and the eligibility walk has no
+/// arm for it. So the same point lookup is eligible written with an inline map
+/// and ineligible written with `WHERE`.
+#[test]
+fn lazy_eligibility_corpus() {
+    fn is_lazy(q: &str) -> bool {
+        let mut query = parse_cypher(q).unwrap();
+        let graph = DirGraph::new();
+        let params = HashMap::new();
+        optimize(&mut query, &graph, &params);
+        mark_lazy_eligibility(&mut query);
+        query.clauses.iter().any(|c| match c {
+            Clause::Return(r) => r.lazy_eligible,
+            _ => false,
+        })
+    }
+
+    // Eligible: bare property projections over an unfiltered or inline-filtered
+    // MATCH, with nothing but SKIP/LIMIT after the RETURN.
+    for q in [
+        "MATCH (u:User) RETURN u.name",
+        "MATCH (u:User {id: 1}) RETURN u.name, u.email",
+        "MATCH (u:User {id: 1}) RETURN u.name AS name",
+        "MATCH (u:User) RETURN u.name LIMIT 10",
+        "MATCH (u:User)-[:OWNS]->(t:Task) RETURN u.name, t.title",
+        "OPTIONAL MATCH (u:User) RETURN u.name",
+    ] {
+        assert!(is_lazy(q), "expected lazy-eligible: {q}");
+    }
+
+    // Ineligible. Each of these takes the eager path and therefore never pins
+    // the graph, whatever its size.
+    for q in [
+        // A standalone WHERE survives optimisation and disqualifies.
+        "MATCH (u:User) WHERE u.id = 1 RETURN u.name",
+        // Whole-node returns resolve via NodeRef, not the lazy resolver.
+        "MATCH (u:User) RETURN u",
+        // Any non-PropertyAccess return item.
+        "MATCH (u:User) RETURN u.age + 1",
+        "MATCH (u:User) RETURN count(u)",
+        // Ordering, dedup and multi-stage pipelines all disqualify.
+        "MATCH (u:User) RETURN u.name ORDER BY u.name",
+        "MATCH (u:User) RETURN DISTINCT u.name",
+        "MATCH (u:User) WITH u.name AS n RETURN n",
+        "UNWIND [1, 2] AS x RETURN x",
+    ] {
+        assert!(!is_lazy(q), "expected NOT lazy-eligible: {q}");
+    }
+
+    // The same lookup, two spellings, opposite classifications. Asserted as an
+    // explicit pair because it is the least defensible part of the rule: the
+    // two queries are semantically identical and a user has no way to know
+    // which one they wrote. Whichever way the rule moves, these two should
+    // arrive at the same answer — if a future change makes them agree, delete
+    // this pair rather than "fixing" it.
+    assert!(is_lazy("MATCH (u:User {id: 1}) RETURN u.name"));
+    assert!(!is_lazy("MATCH (u:User) WHERE u.id = 1 RETURN u.name"));
+
+    // The exact shapes the graph-pin benchmark relies on. Pinned here because
+    // measuring the pin with an ineligible read reports no change and looks
+    // like a working fix doing nothing.
+    assert!(is_lazy(
+        "MATCH (p:Person {id: 0}) RETURN p.name AS name, p.age AS age"
+    ));
+    assert!(!is_lazy(
+        "MATCH (p:Person) WHERE p.id = 0 RETURN p.name AS name, p.age AS age"
+    ));
+    assert!(is_lazy(
+        "MATCH (p:Person) RETURN p.name AS name, p.age AS age"
+    ));
+}

--- a/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
@@ -46,6 +46,8 @@
 //! - `crates/kglite-bolt-server/src/backend.rs::execute`
 
 use super::super::ast::*;
+use super::super::executor::helpers::expression_to_string;
+use super::simplification::collect_expression_refs;
 use crate::graph::core::pattern_matching::{Pattern, PatternElement};
 use crate::graph::mutation::validation::did_you_mean;
 use crate::graph::schema::{DirGraph, InternedKey};
@@ -152,9 +154,205 @@ fn bind_row_source(clause: &Clause, scope: &mut HashSet<String>) -> Result<(), S
     Ok(())
 }
 
+/// What a trailing `ORDER BY` may reference after an **aggregating** RETURN.
+///
+/// An aggregating RETURN emits one row per group. Only two kinds of thing have
+/// a defined value on that row: the projected columns, and the variables the
+/// grouping keys pin down (the executor carries their bindings forward — see
+/// `executor::helpers::carry_group_bindings`). Ordering by anything else is
+/// what Neo4j rejects outright: `count(c)` collapses many `c`s into a scalar,
+/// so `ORDER BY c.label` has no single value to sort on.
+///
+/// kglite splits the difference: the well-defined half sorts correctly, the
+/// ambiguous half is rejected with a message naming the fix. What it must
+/// never do — and did before this check existed — is evaluate the sort key to
+/// NULL on every row and hand back insertion order as though the clause had
+/// been honoured.
+struct AggregateOrderScope {
+    /// Projected column names plus every variable the grouping keys read.
+    allowed: HashSet<String>,
+    /// Rendered aggregate projections → their alias, if any. `ORDER BY count(p)`
+    /// resolves at runtime only when `count(p)` is projected *unaliased*, since
+    /// then the result column is literally named `count(p)`; aliasing it moves
+    /// the value to the alias and leaves the expression form unresolvable.
+    aggregates: HashMap<String, Option<String>>,
+    /// Projected aliases, listed in the error message as the way out.
+    aliases: Vec<String>,
+}
+
+impl AggregateOrderScope {
+    /// `None` when no restriction applies — either the projection does not
+    /// aggregate (a plain projection keeps every binding on its rows, so
+    /// ordering by a non-projected expression stays well defined), or it
+    /// contains `*` and we cannot enumerate what it carries.
+    fn for_projection(items: &[ReturnItem]) -> Option<Self> {
+        if !items
+            .iter()
+            .any(|item| is_aggregate_expression(&item.expression))
+        {
+            return None;
+        }
+        if items
+            .iter()
+            .any(|item| matches!(item.expression, Expression::Star))
+        {
+            return None;
+        }
+
+        let mut allowed = HashSet::new();
+        let mut aliases = Vec::new();
+        let mut aggregates = HashMap::new();
+        for item in items {
+            if let Some(alias) = &item.alias {
+                allowed.insert(alias.clone());
+                aliases.push(alias.clone());
+            } else if let Expression::Variable(name) = &item.expression {
+                allowed.insert(name.clone());
+                aliases.push(name.clone());
+            }
+            if is_aggregate_expression(&item.expression) {
+                aggregates.insert(expression_to_string(&item.expression), item.alias.clone());
+            } else {
+                collect_expression_refs(&item.expression, &mut allowed);
+            }
+        }
+        Some(AggregateOrderScope {
+            allowed,
+            aggregates,
+            aliases,
+        })
+    }
+
+    fn projected_hint(&self) -> String {
+        if self.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ", or order by a projected column ({})",
+                self.aliases.join(", ")
+            )
+        }
+    }
+
+    fn validate(&self, order: &OrderByClause) -> Result<(), SchemaError> {
+        for item in &order.items {
+            if is_aggregate_expression(&item.expression) {
+                let rendered = expression_to_string(&item.expression);
+                match self.aggregates.get(&rendered) {
+                    // Projected unaliased — the executor resolves the sort key
+                    // from the identically-named result column.
+                    Some(None) => continue,
+                    Some(Some(alias)) => {
+                        return Err(SchemaError {
+                            kind: SchemaErrorKind::UndefinedVariable,
+                            message: format!(
+                                "ORDER BY '{rendered}' cannot be resolved after an aggregating \
+                                 RETURN because that aggregate is projected as '{alias}'. \
+                                 Order by the alias instead (`ORDER BY {alias}`)."
+                            ),
+                        });
+                    }
+                    None => {
+                        return Err(SchemaError {
+                            kind: SchemaErrorKind::UndefinedVariable,
+                            message: format!(
+                                "ORDER BY cannot compute the aggregate '{rendered}' after an \
+                                 aggregating RETURN. Project it first \
+                                 (e.g. `RETURN ..., {rendered} AS sort_key ORDER BY sort_key`){}.",
+                                self.projected_hint()
+                            ),
+                        });
+                    }
+                }
+            }
+            let mut refs = HashSet::new();
+            collect_expression_refs(&item.expression, &mut refs);
+            for name in refs {
+                if !self.allowed.contains(&name) {
+                    return Err(SchemaError {
+                        kind: SchemaErrorKind::UndefinedVariable,
+                        message: format!(
+                            "ORDER BY cannot use '{name}' after an aggregating RETURN: \
+                             '{name}' is not part of the grouping keys, so it has no single \
+                             value per group. Add the sort key to the RETURN list \
+                             (e.g. `RETURN ..., {name}.<property> AS sort_key ORDER BY sort_key`){}.",
+                            self.projected_hint()
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate a RETURN's own expressions, then produce the scope its trailing
+/// clauses see: everything already in scope plus the projection's aliases.
+///
+/// RETURN is terminal for the pipeline, so unlike WITH it does not narrow the
+/// scope — HAVING and a trailing ORDER BY may still name pre-projection
+/// variables. Whether an *aggregating* RETURN leaves those variables with a
+/// usable value is a separate question, answered by [`AggregateOrderScope`].
+fn scope_after_return(
+    return_clause: &ReturnClause,
+    scope: HashSet<String>,
+) -> Result<HashSet<String>, SchemaError> {
+    for item in &return_clause.items {
+        validate_expression_scope(&item.expression, &scope)?;
+    }
+    let mut having_scope = scope;
+    having_scope.extend(
+        return_clause
+            .items
+            .iter()
+            .filter_map(|item| item.alias.clone()),
+    );
+    if let Some(having) = &return_clause.having {
+        validate_predicate_scope(having, &having_scope)?;
+    }
+    Ok(having_scope)
+}
+
+/// Validate a WITH's own expressions, then produce the scope it projects
+/// forward: only the aliases and bare variables it names, unless it carries
+/// `*` (which preserves the incoming scope wholesale).
+fn scope_after_with(
+    with_clause: &WithClause,
+    scope: HashSet<String>,
+) -> Result<HashSet<String>, SchemaError> {
+    for item in &with_clause.items {
+        validate_expression_scope(&item.expression, &scope)?;
+    }
+    let preserves_all = with_clause
+        .items
+        .iter()
+        .any(|item| matches!(item.expression, Expression::Star));
+    let mut projected = if preserves_all { scope } else { HashSet::new() };
+    for item in &with_clause.items {
+        if let Some(alias) = &item.alias {
+            projected.insert(alias.clone());
+        } else if let Expression::Variable(name) = &item.expression {
+            projected.insert(name.clone());
+        }
+    }
+    if let Some(where_clause) = &with_clause.where_clause {
+        validate_predicate_scope(&where_clause.predicate, &projected)?;
+    }
+    Ok(projected)
+}
+
 fn validate_scope(query: &CypherQuery, initial: &HashSet<String>) -> Result<(), SchemaError> {
     let mut scope = initial.clone();
+    // Set by an aggregating RETURN, consumed by the ORDER BY that follows it.
+    // Rides through a trailing SKIP/LIMIT; any other clause clears it.
+    let mut aggregate_order_scope: Option<AggregateOrderScope> = None;
     for clause in &query.clauses {
+        if !matches!(
+            clause,
+            Clause::OrderBy(_) | Clause::Skip(_) | Clause::Limit(_)
+        ) {
+            aggregate_order_scope = None;
+        }
         match clause {
             Clause::Match(m) | Clause::OptionalMatch(m) => {
                 for pattern in &m.patterns {
@@ -166,49 +364,18 @@ fn validate_scope(query: &CypherQuery, initial: &HashSet<String>) -> Result<(), 
                 validate_predicate_scope(&where_clause.predicate, &scope)?
             }
             Clause::Return(return_clause) => {
-                for item in &return_clause.items {
-                    validate_expression_scope(&item.expression, &scope)?;
-                }
-                let mut having_scope = scope.clone();
-                having_scope.extend(
-                    return_clause
-                        .items
-                        .iter()
-                        .filter_map(|item| item.alias.clone()),
-                );
-                if let Some(having) = &return_clause.having {
-                    validate_predicate_scope(having, &having_scope)?;
-                }
-                scope = having_scope;
+                scope = scope_after_return(return_clause, scope)?;
+                aggregate_order_scope = AggregateOrderScope::for_projection(&return_clause.items);
             }
             Clause::With(with_clause) => {
-                for item in &with_clause.items {
-                    validate_expression_scope(&item.expression, &scope)?;
-                }
-                let preserves_all = with_clause
-                    .items
-                    .iter()
-                    .any(|item| matches!(item.expression, Expression::Star));
-                let mut projected = if preserves_all {
-                    scope.clone()
-                } else {
-                    HashSet::new()
-                };
-                for item in &with_clause.items {
-                    if let Some(alias) = &item.alias {
-                        projected.insert(alias.clone());
-                    } else if let Expression::Variable(name) = &item.expression {
-                        projected.insert(name.clone());
-                    }
-                }
-                if let Some(where_clause) = &with_clause.where_clause {
-                    validate_predicate_scope(&where_clause.predicate, &projected)?;
-                }
-                scope = projected;
+                scope = scope_after_with(with_clause, scope)?;
             }
             Clause::OrderBy(order) => {
                 for item in &order.items {
                     validate_expression_scope(&item.expression, &scope)?;
+                }
+                if let Some(restriction) = &aggregate_order_scope {
+                    restriction.validate(order)?;
                 }
             }
             Clause::Skip(skip) => validate_expression_scope(&skip.count, &scope)?,

--- a/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
@@ -1550,7 +1550,12 @@ fn collect_predicate_refs(pred: &Predicate, out: &mut HashSet<String>) {
     }
 }
 
-fn collect_expression_refs(expr: &Expression, out: &mut HashSet<String>) {
+/// Collect every variable an expression *reads*.
+///
+/// A pure AST utility shared with the executor (`helpers::grouping_variables`)
+/// and with `schema_check`'s post-aggregation ORDER BY scope. Over-collection
+/// is safe for every caller; under-collection is not.
+pub(crate) fn collect_expression_refs(expr: &Expression, out: &mut HashSet<String>) {
     match expr {
         Expression::Variable(v) => {
             out.insert(v.clone());

--- a/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/simplification.rs
@@ -7,6 +7,26 @@ use crate::graph::core::pattern_matching::{Pattern, PatternElement, PropertyMatc
 use crate::graph::schema::DirGraph;
 use std::collections::{HashMap, HashSet};
 
+/// Fold OR chains of equalities on the same `variable.property` into a
+/// single IN predicate.
+///
+/// Example: `WHERE n.name = 'A' OR n.name = 'B' OR n.name = 'C'`
+/// becomes:  `WHERE n.name IN ['A', 'B', 'C']`
+///
+/// This enables predicate pushdown into MATCH patterns and index
+/// acceleration, which is why a second `push_where_into_match` pass is
+/// registered immediately after this one — the first runs before it and
+/// cannot see the IN predicates this creates.
+///
+/// It only folds equalities on one and the same property, with a literal or
+/// parameter on the other side. A chain across *different* properties is left
+/// alone and reaches the executor as a genuine one-level-per-term predicate
+/// tree, which is the shape that costs the most stack (see
+/// `super::super::stack_probe`).
+///
+/// Note this is a *planner* pass, so it cannot rescue a chain long enough to
+/// exhaust the parser's nesting budget: the parse fails first. The budget
+/// error names the `IN [...]` rewrite for exactly that reason.
 pub(super) fn fold_or_to_in(query: &mut CypherQuery) {
     for clause in &mut query.clauses {
         if let Clause::Where(ref mut w) = clause {

--- a/crates/kglite/src/graph/languages/cypher/stack_probe.rs
+++ b/crates/kglite/src/graph/languages/cypher/stack_probe.rs
@@ -1,0 +1,441 @@
+//! How much stack does one level of AST nesting actually cost, and does the
+//! deepest query the parser accepts still fit the stack it runs on?
+//!
+//! `MAX_EXPRESSION_DEPTH` bounds AST *depth*, and only the parser grows its
+//! stack on demand (`stacker`). The planner's expression walkers, the
+//! executor's `evaluate_expression` and the AST's recursive `Drop` run on
+//! whatever stack the caller owns, so "at most 512 levels" only becomes
+//! "cannot overflow" once someone measures the bytes per level. This module
+//! is that measurement, plus the regression test that keeps the answer true.
+//!
+//! Two things live here:
+//!
+//! 1. [`budget_ceiling_query_fits_the_query_thread_stack`] — an always-on
+//!    test. It runs the deepest accepted query end-to-end on a thread sized
+//!    exactly [`QUERY_THREAD_STACK_SIZE`], which is what the Bolt and MCP
+//!    servers give their query threads and what the CLI and Python wheel get
+//!    from the main thread. No `unsafe`, no platform assumptions: it either
+//!    completes or the process aborts, and an abort is the finding.
+//! 2. [`stack_probe`] — an exploratory harness, inert unless
+//!    `KGL_STACK_PROBE` is set, that reports the exact bytes a chosen stage
+//!    consumes at a chosen depth. Re-run it when frame costs might have moved.
+//!
+//! # Method used by the exploratory harness
+//!
+//! Paint the unused stack below the current stack pointer with a known byte
+//! pattern, run the stage, then scan upward from the bottom for the first
+//! word that no longer matches — that address is the deepest point the stage
+//! reached. This yields the real figure in one run without ever overflowing
+//! anything, so there is no crash-and-binary-search loop.
+//!
+//! Painting walks *downward one page at a time*: Windows commits stack pages
+//! through a guard page that must be touched in descending order, and a
+//! straight ascending `memset` from the bottom of the window would fault
+//! there. The numbers on record were taken on macOS/aarch64.
+//!
+//! ```text
+//! KGL_STACK_PROBE=1 KGL_PROBE_STAGE=exec KGL_PROBE_SHAPE=or \
+//! KGL_PROBE_DEPTH=408 <lib-test-binary> \
+//!     --exact graph::languages::cypher::stack_probe::stack_probe --nocapture
+//! ```
+//!
+//! Stages: `parse`, `plan`, `exec`, `drop`, `full`, plus `calibrate` (a
+//! recursion of known frame size, to prove the method) and `bench` (a
+//! release-profile timing of the per-row expression path, for costing any
+//! proposed guard). `KGL_PROBE_STACK_KIB` sizes the measured thread.
+
+use super::ast::CypherQuery;
+use super::executor::CypherExecutor;
+use super::parser::{parse_cypher, MAX_EXPRESSION_DEPTH};
+use super::planner::optimize;
+use crate::datatypes::Value;
+use crate::graph::algorithms::Interrupt;
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::session::QUERY_THREAD_STACK_SIZE;
+use std::collections::HashMap;
+
+/// Stack for the preparation threads, which are never measured.
+const PREP_STACK: usize = 512 * 1024 * 1024;
+const PAINT: u8 = 0xA5;
+const PAINT_WORD: u64 = u64::from_ne_bytes([PAINT; 8]);
+const PAGE: usize = 4096;
+
+fn probe_stack() -> usize {
+    std::env::var("KGL_PROBE_STACK_KIB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|kib| kib * 1024)
+        .unwrap_or(512 * 1024 * 1024)
+}
+
+fn paint_len() -> usize {
+    (probe_stack() / 4 * 3).min(64 * 1024 * 1024) / PAGE * PAGE
+}
+
+/// Query text for `shape` producing `depth` levels of AST nesting.
+fn query(shape: &str, depth: usize) -> String {
+    match shape {
+        // Recursively parsed shapes.
+        "parens" => format!("RETURN {}1{} AS x", "(".repeat(depth), ")".repeat(depth)),
+        "lists" => format!("RETURN {}1{} AS x", "[".repeat(depth), "]".repeat(depth)),
+        "not" => format!("RETURN {}false AS x", "NOT ".repeat(depth)),
+        "neg" => format!("RETURN {}5 AS x", "-".repeat(depth)),
+        // Iteratively parsed left-associative chains (one AST level each).
+        "or" => format!("RETURN {} AS x", vec!["false"; depth + 1].join(" OR ")),
+        "and" => format!("RETURN {} AS x", vec!["true"; depth + 1].join(" AND ")),
+        "add" => format!("RETURN {} AS x", vec!["1"; depth + 1].join(" + ")),
+        "concat" => format!("RETURN {} AS x", vec!["'a'"; depth + 1].join(" || ")),
+        "subscript" => format!("RETURN [1]{} AS x", "[0]".repeat(depth)),
+        // Distinct values on purpose: identical disjuncts get collapsed, which
+        // would hide the recursion this exists to measure. This is also the
+        // literal shape a filter/facet builder emits for a multi-select — and
+        // the planner's `fold_or_to_in` pass rewrites it to `IN [...]`, so the
+        // executor never sees the chain.
+        "where_or" => format!(
+            "MATCH (n:T) WHERE {} RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| format!("n.id = {i}"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ),
+        // ORs across *different* properties: `fold_or_to_in` only folds
+        // same-property equalities, so this shape survives into the executor
+        // as a genuine one-level-per-term predicate tree.
+        "where_or_mixed" => format!(
+            "MATCH (n:T) WHERE {} RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| format!("n.p{i} = {i}"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ),
+        // The rewrite a user should reach for instead: one AST level no
+        // matter how many values the list holds.
+        "where_in" => format!(
+            "MATCH (n:T) WHERE n.id IN [{}] RETURN count(n) AS c",
+            (0..=depth)
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        other => panic!("unknown shape {other}"),
+    }
+}
+
+/// Every nesting shape under test. The always-on stack test walks this list,
+/// so a new nesting construct gets stack coverage by being added in one place.
+const ALL_SHAPES: &[&str] = &[
+    "or",
+    "and",
+    "not",
+    "neg",
+    "lists",
+    "add",
+    "concat",
+    "subscript",
+    "parens",
+    "where_or",
+    "where_or_mixed",
+    "where_in",
+];
+
+/// A one-node `:T` graph, so `MATCH (n:T) WHERE …` actually produces a row
+/// and the executor really walks the predicate tree. On an empty graph the
+/// WHERE shapes measure zero — no rows, no evaluation.
+fn seeded_graph() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let create = parse_cypher("CREATE (:T {id: 1})").expect("seed parses");
+    super::executor::write::execute_mutable(
+        &mut graph,
+        &create,
+        HashMap::new(),
+        Interrupt::default(),
+    )
+    .expect("seed executes");
+    graph
+}
+
+/// Run the whole pipeline — parse, plan, execute, and drop the AST.
+fn run_full_pipeline(graph: &DirGraph, text: &str) {
+    let params: HashMap<String, Value> = HashMap::new();
+    let mut q = parse_cypher(text).expect("query must parse within the budget");
+    optimize(&mut q, graph, &params);
+    let exec = CypherExecutor::with_params(graph, &params, None);
+    exec.execute(&q).expect("query must execute");
+}
+
+/// The load-bearing invariant: the deepest AST the parser accepts still fits
+/// the stack the engine actually runs queries on.
+///
+/// [`QUERY_THREAD_STACK_SIZE`] is what the Bolt and MCP servers hand their
+/// query threads, and it matches the main-thread default the CLI and the
+/// Python wheel get. Only the parser grows its stack on demand; the planner
+/// walkers, `evaluate_expression` and the recursive `Drop` do not, so this is
+/// the only thing standing between a budget-ceiling query and a process
+/// abort. A stack overflow here aborts the test binary rather than failing
+/// cleanly — that is the intended signal, and it is why the bound is checked
+/// on every platform CI runs rather than reasoned about.
+///
+/// Measured headroom when this was written (macOS/aarch64, worst shape `or`,
+/// executor path): 3.7 MiB of 8 MiB in debug, 0.54 MiB in release.
+#[test]
+fn budget_ceiling_query_fits_the_query_thread_stack() {
+    let depth = MAX_EXPRESSION_DEPTH - 1;
+    std::thread::Builder::new()
+        .stack_size(QUERY_THREAD_STACK_SIZE)
+        .spawn(move || {
+            let graph = seeded_graph();
+            for shape in ALL_SHAPES {
+                run_full_pipeline(&graph, &query(shape, depth));
+            }
+        })
+        .expect("spawn query-sized thread")
+        .join()
+        .expect("budget-ceiling query overflowed the query-thread stack");
+}
+
+/// A query past the budget is refused by the parser, so no downstream walker
+/// ever sees it — and the refusal names the rewrite that actually works.
+#[test]
+fn past_budget_is_refused_with_the_in_rewrite_named() {
+    let err = parse_cypher(&query("or", MAX_EXPRESSION_DEPTH + 50))
+        .expect_err("past-budget query must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("nesting exceeds"),
+        "unexpected error text: {msg}"
+    );
+    assert!(
+        msg.contains("IN ["),
+        "the budget error must name the IN [...] rewrite, got: {msg}"
+    );
+}
+
+// ── Exploratory harness ─────────────────────────────────────────────────────
+
+/// Parse (and optionally plan) on a separate generously-sized thread, so the
+/// measured thread only pays for the stage under test.
+fn prepared_off_thread(text: String, plan: bool) -> CypherQuery {
+    std::thread::Builder::new()
+        .stack_size(PREP_STACK)
+        .spawn(move || {
+            let mut q = parse_cypher(&text).expect("probe query must parse");
+            if plan {
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                optimize(&mut q, &graph, &params);
+            }
+            q
+        })
+        .expect("spawn")
+        .join()
+        .expect("prep thread")
+}
+
+/// Paint the free stack below the current frame, run `body`, then report how
+/// far down it reached.
+///
+/// # Safety
+/// Every write lies strictly below the current frame and strictly inside the
+/// thread's own reserved stack, and pages are touched in descending order so
+/// the Windows guard-page protocol is respected. Rust installs its
+/// stack-overflow handler on a `sigaltstack`, so no signal handler runs in
+/// the painted window.
+fn measure(body: impl FnOnce()) -> usize {
+    let anchor = 0u64;
+    // `&anchor` is an address *inside* the current frame, not the true stack
+    // pointer: the compiler may place other live locals of this same frame
+    // (notably `body`) below it, and painting over them corrupts live data.
+    // Skip a margin that clears the whole frame. It is a constant offset in
+    // every reading, so it cancels in the depth-to-depth deltas that matter.
+    const MARGIN: usize = 4 * 1024;
+    let reference = ((&anchor as *const u64 as usize) & !7) - MARGIN;
+    let len = paint_len();
+    let bottom = reference - len;
+
+    let mut page = reference - PAGE;
+    while page >= bottom {
+        // Descending, one page at a time: that is what Windows requires to
+        // commit stack pages through the guard page.
+        //
+        // SAFETY: `page` walks `[bottom, reference)`, which lies below this
+        // frame and inside this thread's own reserved stack. Nothing live is
+        // there — the callee frames that will use it do not exist yet, and
+        // `MARGIN` keeps the write clear of this frame's own locals.
+        unsafe { std::ptr::write_bytes(page as *mut u8, PAINT, PAGE) };
+        page -= PAGE;
+    }
+
+    body();
+
+    let mut deepest = reference;
+    for i in 0..len / 8 {
+        let addr = bottom + i * 8;
+        // SAFETY: `addr` is an 8-byte-aligned address inside the window just
+        // painted, so it is mapped, committed and readable. The read is
+        // volatile so the scan is not optimised against the `write_bytes`
+        // above, whose effect the compiler cannot otherwise see.
+        if unsafe { std::ptr::read_volatile(addr as *const u64) } != PAINT_WORD {
+            deepest = addr;
+            break;
+        }
+    }
+    assert!(
+        deepest > bottom,
+        "stage reached the bottom of the paint window; raise KGL_PROBE_STACK_KIB"
+    );
+    reference - deepest
+}
+
+/// Self-check of the measurement method: a recursion whose frame cost is
+/// knowable independently, so a wrong number here invalidates the rest.
+#[inline(never)]
+fn calibration_recurse(depth: usize, sink: &mut u64) {
+    let mut pad = [0u64; 16]; // 128 bytes, must not be optimised away
+    pad[depth % 16] = depth as u64;
+    if depth > 0 {
+        calibration_recurse(depth - 1, sink);
+    }
+    *sink = sink.wrapping_add(std::hint::black_box(pad)[depth % 16]);
+}
+
+fn on_probe_thread<R: Send + 'static>(body: impl FnOnce() -> R + Send + 'static) -> R {
+    std::thread::Builder::new()
+        .stack_size(probe_stack())
+        .spawn(body)
+        .expect("spawn probe thread")
+        .join()
+        .expect("probe thread panicked")
+}
+
+/// Release-profile timing of the per-row expression path — the cost centre
+/// any `stacker::maybe_grow` inside `evaluate_expression` would tax. Reports
+/// the minimum over rounds (CLAUDE.md: trust min over median for
+/// sub-millisecond work).
+fn run_bench() {
+    let rounds: usize = std::env::var("KGL_PROBE_ROUNDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+    let nodes: usize = std::env::var("KGL_PROBE_NODES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20_000);
+    let mut graph = DirGraph::new();
+    for i in 0..nodes {
+        let create =
+            parse_cypher(&format!("CREATE (:T {{id: {i}, v: {}}})", i * 3)).expect("seed parses");
+        super::executor::write::execute_mutable(
+            &mut graph,
+            &create,
+            HashMap::new(),
+            Interrupt::default(),
+        )
+        .expect("seed executes");
+    }
+    let params: HashMap<String, Value> = HashMap::new();
+    // Arithmetic-heavy projection: several `evaluate_expression` calls per
+    // row, which is precisely the hot path under discussion.
+    let mut q = parse_cypher("MATCH (n:T) RETURN sum(n.id * 2 + n.v * 3 - n.id + 1) AS s")
+        .expect("bench query parses");
+    optimize(&mut q, &graph, &params);
+    let mut best = std::time::Duration::from_secs(3600);
+    for _ in 0..rounds {
+        let exec = CypherExecutor::with_params(&graph, &params, None);
+        let t0 = std::time::Instant::now();
+        let r = exec.execute(&q).expect("bench executes");
+        let dt = t0.elapsed();
+        std::hint::black_box(&r);
+        best = best.min(dt);
+    }
+    println!(
+        "PROBE-BENCH nodes={nodes} rounds={rounds} min_us={}",
+        best.as_micros()
+    );
+}
+
+#[test]
+fn stack_probe() {
+    if std::env::var_os("KGL_STACK_PROBE").is_none() {
+        return;
+    }
+    let env = |k: &str| std::env::var(k).unwrap_or_else(|_| panic!("{k} must be set"));
+    let stage = env("KGL_PROBE_STAGE");
+
+    match stage.as_str() {
+        "calibrate" => {
+            for depth in [1usize, 101, 1101] {
+                let used = on_probe_thread(move || {
+                    measure(|| {
+                        let mut sink = 0u64;
+                        calibration_recurse(depth, &mut sink);
+                        std::hint::black_box(sink);
+                    })
+                });
+                println!("PROBE-RESULT stage=calibrate shape=none depth={depth} bytes={used}");
+            }
+            println!("PROBE-OK");
+            return;
+        }
+        "bench" => {
+            run_bench();
+            println!("PROBE-OK");
+            return;
+        }
+        _ => {}
+    }
+
+    let shape = env("KGL_PROBE_SHAPE");
+    let depth: usize = env("KGL_PROBE_DEPTH").parse().expect("depth");
+    let text = query(&shape, depth);
+
+    let used = match stage.as_str() {
+        // Parser only; the AST is leaked so the recursive Drop never runs
+        // here. On the huge default probe stack `stacker` never fires, so
+        // this reports what the parser *would* need unguarded.
+        "parse" => on_probe_thread(move || {
+            measure(|| {
+                let q = parse_cypher(&text).expect("parse");
+                std::mem::forget(q);
+            })
+        }),
+        "drop" => {
+            let q = prepared_off_thread(text, false);
+            on_probe_thread(move || measure(move || drop(q)))
+        }
+        "plan" => {
+            let q = prepared_off_thread(text, false);
+            on_probe_thread(move || {
+                let mut q = q;
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                let used = measure(|| optimize(&mut q, &graph, &params));
+                std::mem::forget(q);
+                used
+            })
+        }
+        "exec" => {
+            let q = prepared_off_thread(text, true);
+            on_probe_thread(move || {
+                let graph = seeded_graph();
+                let params: HashMap<String, Value> = HashMap::new();
+                let used = measure(|| {
+                    let exec = CypherExecutor::with_params(&graph, &params, None);
+                    let result = exec.execute(&q).expect("execute");
+                    std::mem::forget(result);
+                });
+                std::mem::forget(q);
+                used
+            })
+        }
+        // Set KGL_PROBE_STACK_KIB to a realistic thread stack to see the
+        // parser's `stacker` guard actually engage.
+        "full" => on_probe_thread(move || {
+            let graph = seeded_graph();
+            measure(|| run_full_pipeline(&graph, &text))
+        }),
+        other => panic!("unknown stage {other}"),
+    };
+
+    println!("PROBE-RESULT stage={stage} shape={shape} depth={depth} bytes={used}");
+    println!("PROBE-OK");
+}

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1865,7 +1865,7 @@ mod id_index_tests {
     /// clean batch loads. Undeclared types keep the permissive default.
     #[test]
     fn add_nodes_rejects_within_batch_pk_duplicate() {
-        use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition};
+        use crate::graph::schema::{NodeSchemaDefinition, SchemaDefinition, SchemaInstall};
 
         let mut g = DirGraph::new();
         let mut schema = SchemaDefinition::new();
@@ -1876,7 +1876,8 @@ mod id_index_tests {
                 ..Default::default()
             },
         );
-        g.set_schema(schema).expect("schema install");
+        g.set_schema(schema, SchemaInstall::Merge)
+            .expect("schema install");
 
         let dup = DataFrame::from_cypher_rows(
             vec!["id".to_string()],

--- a/crates/kglite/src/graph/mutation/subgraph.rs
+++ b/crates/kglite/src/graph/mutation/subgraph.rs
@@ -1,7 +1,7 @@
 // src/graph/subgraph.rs
 //! Subgraph extraction and selection expansion operations
 
-use crate::graph::schema::{CurrentSelection, DirGraph, EdgeData};
+use crate::graph::schema::{CurrentSelection, DirGraph, EdgeData, SchemaInstall};
 use crate::graph::storage::{GraphRead, GraphWrite};
 use petgraph::graph::NodeIndex;
 use std::collections::{HashMap, HashSet};
@@ -133,7 +133,10 @@ pub fn extract_subgraph(
     // into a silently unconstrained copy.
     if let Some(schema) = source.get_schema() {
         new_graph
-            .set_schema(schema.clone())
+            // The target is a fresh graph, so merge and replace coincide; merge
+            // states the intent (install this schema) without also asserting
+            // that everything unnamed should be withdrawn.
+            .set_schema(schema.clone(), SchemaInstall::Merge)
             .map_err(|violation| format!("subgraph schema install failed: {violation}"))?;
     }
 

--- a/crates/kglite/src/graph/mutation/validation.rs
+++ b/crates/kglite/src/graph/mutation/validation.rs
@@ -77,15 +77,24 @@ fn validate_single_node(
     };
     // Check required fields
     for required_field in &schema.required_fields {
-        // Skip built-in fields that are always present
-        if required_field == "id" || required_field == "title" || required_field == "type" {
+        // `type` is the node's label rather than a supplied value, so it cannot
+        // be missing. `id`/`title` live in `NodeData` fields rather than the
+        // property map but *can* be explicitly nulled, so they are read
+        // structurally rather than skipped — matching what the write-path
+        // `DirGraph::check_required_fields` enforces, so validation-time and
+        // write-time agree about what a declaration means.
+        if required_field == "type" {
             continue;
         }
 
-        let has_field = node
-            .get_property(required_field)
-            .map(|v| !matches!(*v, Value::Null))
-            .unwrap_or(false);
+        let has_field = match required_field.as_str() {
+            "id" => !matches!(*node.id(), Value::Null),
+            "title" => !matches!(*node_title, Value::Null),
+            other => node
+                .get_property(other)
+                .map(|v| !matches!(*v, Value::Null))
+                .unwrap_or(false),
+        };
 
         if !has_field {
             errors.push(ValidationError::MissingRequiredField {

--- a/crates/kglite/src/graph/schema.rs
+++ b/crates/kglite/src/graph/schema.rs
@@ -2169,12 +2169,46 @@ pub struct SchemaDefinition {
     pub connection_schemas: HashMap<String, ConnectionSchemaDefinition>,
 }
 
+/// How an incoming [`SchemaDefinition`] combines with the one already installed.
+///
+/// The distinction exists because a declaration is also a *withdrawal*: whatever
+/// the outgoing schema declared and the incoming one does not is no longer
+/// enforced. Under [`SchemaInstall::Replace`] that reaches every type in the
+/// graph, so a call naming one type silently stops enforcing every other type's
+/// constraints — the failure mode is duplicates entering the data unnoticed.
+/// Under [`SchemaInstall::Merge`] the withdrawal is scoped to the types the call
+/// actually names, so declaring per module is safe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SchemaInstall {
+    /// Types the incoming schema names replace their previous entry; every other
+    /// type keeps the declaration it had. The default, because it is the mode
+    /// whose mistake is a rejected write rather than an admitted duplicate.
+    #[default]
+    Merge,
+    /// The incoming schema becomes the whole schema — every type it does not
+    /// name loses its declarations, and with them their enforcement.
+    Replace,
+}
+
 impl SchemaDefinition {
     pub fn new() -> Self {
         SchemaDefinition {
             node_schemas: HashMap::new(),
             connection_schemas: HashMap::new(),
         }
+    }
+
+    /// This schema with `incoming`'s entries layered over it: a named type takes
+    /// the incoming declaration wholesale, an unnamed one keeps its own.
+    ///
+    /// Per *type* rather than per *field* on purpose — a type's entry is one
+    /// declaration ("here is what a `Task` is"), so merging field-by-field would
+    /// make a re-declaration unable to withdraw anything and leave no way to
+    /// narrow a type short of replacing the whole schema.
+    pub fn merged_with(mut self, incoming: SchemaDefinition) -> Self {
+        self.node_schemas.extend(incoming.node_schemas);
+        self.connection_schemas.extend(incoming.connection_schemas);
+        self
     }
 
     /// Add a node type schema

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -315,132 +315,8 @@ impl DiskGraph {
         // Merge sort uses only sequential I/O: read → sort chunks → merge → write.
         let step = std::time::Instant::now();
 
-        let in_edges = {
-            // Chunk size for sort: fit in available heap after edge_endpoints mmap.
-            let sort_chunk_mb: usize = std::env::var("KGLITE_CSR_CHUNK_MB")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(5120); // 5 GB default — safe on 16 GB machine
-            let max_entries = (sort_chunk_mb << 20) / std::mem::size_of::<MergeSortEntry>();
-            let sort_chunk_size = max_entries.min(edge_count);
-            let num_sort_chunks = edge_count.div_ceil(sort_chunk_size);
-
-            let sort_dir = out_dir.join("_in_sort");
-            std::fs::create_dir_all(&sort_dir)?;
-
-            if num_sort_chunks == 1 {
-                // Single-chunk: sort in memory, write directly
-                let substep = std::time::Instant::now();
-                let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(edge_count);
-                for i in 0..edge_count {
-                    let ep = edge_endpoints_vec.get(i);
-                    entries.push(MergeSortEntry {
-                        key: ep.target,
-                        conn_type: ep.connection_type,
-                        peer: ep.source,
-                        orig_idx: i as u32,
-                        padding: 0,
-                    });
-                }
-                entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
-
-                let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
-                for entry in &entries {
-                    output.try_push(CsrEdge {
-                        peer: entry.peer,
-                        edge_idx: entry.orig_idx,
-                    })?;
-                }
-                drop(entries);
-                if verbose {
-                    eprintln!(
-                        "      in sort single-chunk: {:.1}s",
-                        substep.elapsed().as_secs_f64()
-                    );
-                }
-                output
-            } else {
-                // Multi-chunk: external merge sort with k-way heap merge
-                let substep = std::time::Instant::now();
-                let mut chunk_mmaps: Vec<MmapOrVec<MergeSortEntry>> = Vec::new();
-                let mut chunk_lens: Vec<usize> = Vec::new();
-
-                for c in 0..num_sort_chunks {
-                    let start = c * sort_chunk_size;
-                    let end = (start + sort_chunk_size).min(edge_count);
-                    let len = end - start;
-
-                    let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(len);
-                    for i in start..end {
-                        let ep = edge_endpoints_vec.get(i);
-                        entries.push(MergeSortEntry {
-                            key: ep.target,
-                            conn_type: ep.connection_type,
-                            peer: ep.source,
-                            orig_idx: i as u32,
-                            padding: 0,
-                        });
-                    }
-                    entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
-
-                    let chunk_path = sort_dir.join(format!("chunk_in_{}.bin", c));
-                    let mut chunk_mmap = MmapOrVec::mapped(&chunk_path, len)?;
-                    for entry in &entries {
-                        chunk_mmap.try_push(*entry)?;
-                    }
-                    drop(entries);
-                    chunk_lens.push(len);
-                    chunk_mmaps.push(chunk_mmap);
-                }
-                if verbose {
-                    eprintln!(
-                        "      in sort {} chunks: {:.1}s",
-                        num_sort_chunks,
-                        substep.elapsed().as_secs_f64()
-                    );
-                }
-
-                // K-way merge via binary heap — all reads and writes sequential
-                let substep = std::time::Instant::now();
-                let mut positions: Vec<usize> = vec![0; num_sort_chunks];
-                let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
-
-                use std::cmp::Reverse;
-                let mut heap: std::collections::BinaryHeap<Reverse<(u32, u64, usize)>> =
-                    std::collections::BinaryHeap::with_capacity(num_sort_chunks);
-                for c in 0..num_sort_chunks {
-                    if chunk_lens[c] > 0 {
-                        let entry = chunk_mmaps[c].get(0);
-                        heap.push(Reverse((entry.key, entry.conn_type, c)));
-                    }
-                }
-
-                for _ in 0..edge_count {
-                    let Reverse((_key, _ct, best_chunk)) = heap.pop().unwrap();
-                    let entry = chunk_mmaps[best_chunk].get(positions[best_chunk]);
-                    positions[best_chunk] += 1;
-                    output.try_push(CsrEdge {
-                        peer: entry.peer,
-                        edge_idx: entry.orig_idx,
-                    })?;
-                    if positions[best_chunk] < chunk_lens[best_chunk] {
-                        let next = chunk_mmaps[best_chunk].get(positions[best_chunk]);
-                        heap.push(Reverse((next.key, next.conn_type, best_chunk)));
-                    }
-                }
-
-                // Cleanup sort chunks. Dropping the mappings first is load
-                // bearing on Windows, which will not delete a mapped file;
-                // the removal is checked so a regression is loud.
-                drop(chunk_mmaps);
-                super::remove_scratch_dir(&sort_dir)?;
-
-                if verbose {
-                    eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
-                }
-                output
-            }
-        };
+        let in_edges =
+            build_in_edges_merge_sort(&edge_endpoints_vec, edge_count, out_dir, verbose)?;
         if verbose {
             eprintln!(
                 "    CSR step 4/4: in_edges merge sort ({:.1}s)",
@@ -839,6 +715,148 @@ pub(super) fn write_peer_count_histogram(
 /// Parallelised via Rayon: each thread scans a partition of nodes and
 /// builds a local `HashMap<conn_type, Vec<node_id>>`; the maps are merged,
 /// each type's sources sorted, then flushed to the three on-disk files.
+/// Build the `in_edges` CSR array by external merge sort on target node.
+///
+/// Split out of [`DiskGraph::build_csr_partitioned`], which handles the four
+/// build steps and had grown past the point where the merge sort could be read
+/// on its own. Scatter is slow here because target degree is power-law
+/// distributed and popular targets thrash the page cache, so this path uses
+/// only sequential I/O: read -> sort chunks -> merge -> write.
+///
+/// Writes `out_dir/in_edges.bin` and spills sort chunks under `out_dir/_in_sort`,
+/// which is removed before returning.
+fn build_in_edges_merge_sort(
+    edge_endpoints_vec: &MmapOrVec<EdgeEndpoints>,
+    edge_count: usize,
+    out_dir: &Path,
+    verbose: bool,
+) -> io::Result<MmapOrVec<CsrEdge>> {
+    // Chunk size for sort: fit in available heap after edge_endpoints mmap.
+    let sort_chunk_mb: usize = std::env::var("KGLITE_CSR_CHUNK_MB")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5120); // 5 GB default — safe on 16 GB machine
+    let max_entries = (sort_chunk_mb << 20) / std::mem::size_of::<MergeSortEntry>();
+    let sort_chunk_size = max_entries.min(edge_count);
+    let num_sort_chunks = edge_count.div_ceil(sort_chunk_size);
+
+    let sort_dir = out_dir.join("_in_sort");
+    std::fs::create_dir_all(&sort_dir)?;
+
+    if num_sort_chunks == 1 {
+        // Single-chunk: sort in memory, write directly
+        let substep = std::time::Instant::now();
+        let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(edge_count);
+        for i in 0..edge_count {
+            let ep = edge_endpoints_vec.get(i);
+            entries.push(MergeSortEntry {
+                key: ep.target,
+                conn_type: ep.connection_type,
+                peer: ep.source,
+                orig_idx: i as u32,
+                padding: 0,
+            });
+        }
+        entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
+
+        let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
+        for entry in &entries {
+            output.try_push(CsrEdge {
+                peer: entry.peer,
+                edge_idx: entry.orig_idx,
+            })?;
+        }
+        drop(entries);
+        if verbose {
+            eprintln!(
+                "      in sort single-chunk: {:.1}s",
+                substep.elapsed().as_secs_f64()
+            );
+        }
+        Ok(output)
+    } else {
+        // Multi-chunk: external merge sort with k-way heap merge
+        let substep = std::time::Instant::now();
+        let mut chunk_mmaps: Vec<MmapOrVec<MergeSortEntry>> = Vec::new();
+        let mut chunk_lens: Vec<usize> = Vec::new();
+
+        for c in 0..num_sort_chunks {
+            let start = c * sort_chunk_size;
+            let end = (start + sort_chunk_size).min(edge_count);
+            let len = end - start;
+
+            let mut entries: Vec<MergeSortEntry> = Vec::with_capacity(len);
+            for i in start..end {
+                let ep = edge_endpoints_vec.get(i);
+                entries.push(MergeSortEntry {
+                    key: ep.target,
+                    conn_type: ep.connection_type,
+                    peer: ep.source,
+                    orig_idx: i as u32,
+                    padding: 0,
+                });
+            }
+            entries.sort_unstable_by_key(|e| (e.key, e.conn_type));
+
+            let chunk_path = sort_dir.join(format!("chunk_in_{}.bin", c));
+            let mut chunk_mmap = MmapOrVec::mapped(&chunk_path, len)?;
+            for entry in &entries {
+                chunk_mmap.try_push(*entry)?;
+            }
+            drop(entries);
+            chunk_lens.push(len);
+            chunk_mmaps.push(chunk_mmap);
+        }
+        if verbose {
+            eprintln!(
+                "      in sort {} chunks: {:.1}s",
+                num_sort_chunks,
+                substep.elapsed().as_secs_f64()
+            );
+        }
+
+        // K-way merge via binary heap — all reads and writes sequential
+        let substep = std::time::Instant::now();
+        let mut positions: Vec<usize> = vec![0; num_sort_chunks];
+        let mut output = MmapOrVec::mapped(&out_dir.join("in_edges.bin"), edge_count)?;
+
+        use std::cmp::Reverse;
+        let mut heap: std::collections::BinaryHeap<Reverse<(u32, u64, usize)>> =
+            std::collections::BinaryHeap::with_capacity(num_sort_chunks);
+        for c in 0..num_sort_chunks {
+            if chunk_lens[c] > 0 {
+                let entry = chunk_mmaps[c].get(0);
+                heap.push(Reverse((entry.key, entry.conn_type, c)));
+            }
+        }
+
+        for _ in 0..edge_count {
+            let Reverse((_key, _ct, best_chunk)) = heap.pop().unwrap();
+            let entry = chunk_mmaps[best_chunk].get(positions[best_chunk]);
+            positions[best_chunk] += 1;
+            output.try_push(CsrEdge {
+                peer: entry.peer,
+                edge_idx: entry.orig_idx,
+            })?;
+            if positions[best_chunk] < chunk_lens[best_chunk] {
+                let next = chunk_mmaps[best_chunk].get(positions[best_chunk]);
+                heap.push(Reverse((next.key, next.conn_type, best_chunk)));
+            }
+        }
+
+        // Cleanup sort chunks. Dropping the mappings first is load
+        // bearing on Windows, which will not delete a mapped file;
+        // the removal is checked so a regression is loud.
+        drop(chunk_mmaps);
+        super::remove_scratch_dir(&sort_dir)?;
+
+        if verbose {
+            eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
+        }
+        Ok(output)
+    }
+}
+
 pub(super) fn write_conn_type_index(
     out_offsets: &MmapOrVec<u64>,
     out_edges: &MmapOrVec<CsrEdge>,

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -429,9 +429,11 @@ impl DiskGraph {
                     }
                 }
 
-                // Cleanup sort chunks
+                // Cleanup sort chunks. Dropping the mappings first is load
+                // bearing on Windows, which will not delete a mapped file;
+                // the removal is checked so a regression is loud.
                 drop(chunk_mmaps);
-                let _ = std::fs::remove_dir_all(&sort_dir);
+                super::remove_scratch_dir(&sort_dir)?;
 
                 if verbose {
                     eprintln!("      in merge: {:.1}s", substep.elapsed().as_secs_f64());
@@ -611,6 +613,16 @@ impl DiskGraph {
         node_bound: usize,
         verbose: bool,
     ) -> io::Result<()> {
+        // `write_conn_type_index` re-creates `conn_type_index_*.bin` in place,
+        // and these three fields still map exactly those paths from the
+        // previous build. Windows refuses to truncate or re-create a file that
+        // has a live mapped view (`ERROR_USER_MAPPED_FILE`); POSIX allows it,
+        // which is why this ordering bug stayed invisible. Release the
+        // mappings first and re-adopt the writer's below — the same discipline
+        // `swap_csr_files` and `save_logical_node_slots` already follow.
+        self.conn_type_index_types = MmapOrVec::new();
+        self.conn_type_index_offsets = MmapOrVec::new();
+        self.conn_type_index_sources = MmapOrVec::new();
         let (types, offsets, sources) = write_conn_type_index(
             &self.out_offsets,
             &self.out_edges,
@@ -647,6 +659,15 @@ impl DiskGraph {
         if total == 0 {
             return Ok(());
         }
+        // Same in-place-rewrite hazard as `build_conn_type_index`:
+        // `write_peer_count_histogram` re-creates `peer_count_*.bin` via
+        // `fs::write`, and these fields still map those paths. Drop the
+        // mappings before the writer runs — Windows cannot re-create a
+        // mapped file — and re-adopt the fresh ones below. This must happen
+        // before `endpoints` borrows `self`.
+        self.peer_count_types = MmapOrVec::new();
+        self.peer_count_offsets = MmapOrVec::new();
+        self.peer_count_entries = MmapOrVec::new();
         let logical_endpoints;
         let endpoints = if self.appended_edge_endpoints.is_empty() && self.removed_edges.is_empty()
         {

--- a/crates/kglite/src/graph/storage/disk/builder.rs
+++ b/crates/kglite/src/graph/storage/disk/builder.rs
@@ -553,7 +553,16 @@ impl DiskGraph {
             }
         }
 
-        // Also swap conn_type_index files if present
+        // Also swap conn_type_index files if present. These fields map the
+        // destination paths whenever a previous build or load populated them,
+        // so they must be released before the destinations are removed and
+        // replaced — the same reason the CSR fields are cleared above. The
+        // block is dormant today (the index writer targets `active_write_dir`,
+        // not `build_dir`, so `src` never exists), but leaving the ordering
+        // wrong would make it a Windows failure the moment it is wired up.
+        self.conn_type_index_types = MmapOrVec::new();
+        self.conn_type_index_offsets = MmapOrVec::new();
+        self.conn_type_index_sources = MmapOrVec::new();
         let index_files = [
             "conn_type_index_types.bin",
             "conn_type_index_offsets.bin",

--- a/crates/kglite/src/graph/storage/disk/csr_build.rs
+++ b/crates/kglite/src/graph/storage/disk/csr_build.rs
@@ -323,12 +323,16 @@ fn merge_sort_build(
         }
     }
 
-    // Cleanup chunk files.
+    // Cleanup chunk files. The mappings must go first: Windows refuses to
+    // delete a file that still has a mapped view open, so removing before the
+    // drop leaked every chunk there (and the failure was swallowed by the old
+    // `let _ =`). Removal is now checked so a future ordering regression
+    // surfaces as an error rather than a pile of stray spill files.
+    drop(chunk_mmaps);
     for c in 0..num_chunks {
         let path = chunk_dir.join(format!("chunk_{}_{}.bin", label, c));
-        let _ = std::fs::remove_file(path);
+        super::remove_scratch_file(&path)?;
     }
-    drop(chunk_mmaps);
 
     if verbose {
         eprintln!(

--- a/crates/kglite/src/graph/storage/disk/generation.rs
+++ b/crates/kglite/src/graph/storage/disk/generation.rs
@@ -273,7 +273,18 @@ fn sync_tree(root: &Path) -> io::Result<()> {
     for entry in walkdir::WalkDir::new(root).follow_links(false) {
         let entry = entry.map_err(io::Error::other)?;
         if entry.file_type().is_file() {
-            File::open(entry.path())?.sync_all()?;
+            // `sync_all` is `FlushFileBuffers` on Windows, which MSDN
+            // documents as requiring `GENERIC_WRITE` on the handle: fsyncing
+            // a staged file through a read-only handle fails there with
+            // `ERROR_ACCESS_DENIED`, aborting `publish` before it ever
+            // reaches the rename. Open the file for writing so the durability
+            // fsync is portable — the stage directory is owned exclusively by
+            // this writer, so write access is always grantable.
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(entry.path())?
+                .sync_all()?;
         } else if entry.file_type().is_dir() {
             dirs.push(entry.path().to_path_buf());
         }

--- a/crates/kglite/src/graph/storage/disk/graph.rs
+++ b/crates/kglite/src/graph/storage/disk/graph.rs
@@ -2024,15 +2024,24 @@ impl DiskGraph {
             .get_mut()
             .file_path()
             .map(|p| p.to_path_buf());
+        // The assignment drops the previous buffer's mapping, so the old
+        // backing file is unmapped before it is deleted.
         *self.pending_edges.get_mut() = new_pending;
         if let Some(path) = old_pending_path {
-            let _ = std::fs::remove_file(path);
+            super::remove_scratch_file(&path)?;
         }
 
         self.build_csr_from_pending()?;
 
-        // Clean up compact temp file
-        let _ = std::fs::remove_file(&pending_path);
+        // Clean up the compaction scratch file. `build_csr_from_pending`
+        // normally clears `pending_edges` (releasing this mapping), but it
+        // returns early when the buffer is empty — so release it explicitly
+        // rather than relying on that. Deleting a still-mapped file is an
+        // error on Windows, and the removal is checked so it stays visible.
+        if self.pending_edges.get_mut().file_path() == Some(pending_path.as_path()) {
+            *self.pending_edges.get_mut() = MmapOrVec::new();
+        }
+        super::remove_scratch_file(&pending_path)?;
 
         if verbose {
             eprintln!(

--- a/crates/kglite/src/graph/storage/disk/graph/bootstrap.rs
+++ b/crates/kglite/src/graph/storage/disk/graph/bootstrap.rs
@@ -21,6 +21,40 @@ impl DiskGraph {
         Ok(())
     }
 
+    /// Paths of every memory-mapped array this graph currently holds.
+    ///
+    /// Exists so the "a published graph maps only its own generation"
+    /// invariant is checkable on every platform. POSIX keeps a mapping valid
+    /// after its file is unlinked, so a mapping left pointing into a
+    /// just-deleted scratch directory is invisible there; Windows refuses to
+    /// delete such a directory at all. Asserting on paths catches the
+    /// regression everywhere rather than only on the platform that complains.
+    ///
+    /// Does not cover the edge-property store, which owns its own handles.
+    #[cfg(test)]
+    pub(crate) fn mapped_file_paths(&mut self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let mut push = |path: Option<&Path>| {
+            if let Some(path) = path {
+                paths.push(path.to_path_buf());
+            }
+        };
+        push(self.node_slots.file_path());
+        push(self.out_offsets.file_path());
+        push(self.out_edges.file_path());
+        push(self.in_offsets.file_path());
+        push(self.in_edges.file_path());
+        push(self.edge_endpoints.file_path());
+        push(self.conn_type_index_types.file_path());
+        push(self.conn_type_index_offsets.file_path());
+        push(self.conn_type_index_sources.file_path());
+        push(self.peer_count_types.file_path());
+        push(self.peer_count_offsets.file_path());
+        push(self.peer_count_entries.file_path());
+        push(self.pending_edges.get_mut().file_path());
+        paths
+    }
+
     pub(crate) fn active_write_dir(&self) -> &Path {
         self.mutation_workspace
             .as_ref()
@@ -36,6 +70,48 @@ impl DiskGraph {
     ) -> std::io::Result<()> {
         self.logical_root = logical_root;
         self.data_dir = snapshot_dir.join(segment_subdir(0));
+
+        // Re-map the CSR arrays onto the generation just published.
+        //
+        // Until this point they map files under the mutation workspace — and,
+        // for a detached copy, under its private root — which are exactly the
+        // directories cleared at the end of this function. POSIX tolerated the
+        // mismatch: removal unlinks files whose mappings stay valid, so the
+        // live writer went on reading a directory that no longer existed.
+        // Windows refuses to remove a directory that still contains mapped
+        // files, so the scratch roots survived and accumulated inside the
+        // user's graph directory.
+        //
+        // Re-mapping onto the published snapshot is what both platforms
+        // actually want, and it is the same end state a fresh reader reaches.
+        // A generation stage is always a distinct directory, so `save_to_dir`
+        // took the rewrite path and seg_000 holds the complete graph — see
+        // `save_disposition`, which documents that stages never seal.
+        let published = super::graph_persist::SegmentCsr::load_from(&self.data_dir, &self.data_dir)?;
+        self.node_slots = published.node_slots;
+        self.out_offsets = published.out_offsets;
+        self.out_edges = published.out_edges;
+        self.in_offsets = published.in_offsets;
+        self.in_edges = published.in_edges;
+        self.edge_endpoints = published.edge_endpoints;
+        self.conn_type_index_types = published.conn_type_index_types;
+        self.conn_type_index_offsets = published.conn_type_index_offsets;
+        self.conn_type_index_sources = published.conn_type_index_sources;
+        self.peer_count_types = published.peer_count_types;
+        self.peer_count_offsets = published.peer_count_offsets;
+        self.peer_count_entries = published.peer_count_entries;
+        // The published arrays are fully materialised — `save_logical_*` folded
+        // every overlay into them — so the overlays must be dropped or their
+        // entries would be counted twice. Same discipline as `flush_node_slots`
+        // and the post-`swap_csr_files` reset in `build_csr_partitioned`.
+        self.node_slot_updates.clear();
+        self.appended_node_slots.clear();
+        self.appended_edge_endpoints.clear();
+        self.removed_edges.clear();
+        // Pending edges were folded into the CSR by the save; whatever handle
+        // is left points into the workspace we are about to remove.
+        *self.pending_edges.get_mut() = MmapOrVec::new();
+
         // `save_to` absorbs the edge-property overlay into the published
         // files. Re-open that base before clearing the workspace so the
         // live writer observes the same state as a freshly loaded reader.

--- a/crates/kglite/src/graph/storage/disk/graph_persist.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_persist.rs
@@ -591,16 +591,19 @@ impl DiskGraph {
         // the loader can't distinguish from real u64 type hashes. Without
         // this trim, `[r:TYPE]` typed-edge queries return 0 rows after
         // reload (pre-existing bug on v0.8.10).
+        // Trimming a buffer to its own backing file is a resize of a mapped
+        // file, so go through `trim_to_logical_length`, which releases and
+        // re-establishes the mapping in the order each platform requires.
         for field in [
-            &self.conn_type_index_types as &MmapOrVec<u64>,
-            &self.conn_type_index_offsets,
+            &mut self.conn_type_index_types as &mut MmapOrVec<u64>,
+            &mut self.conn_type_index_offsets,
         ] {
-            if let Some(path) = field.file_path().map(PathBuf::from) {
-                field.save_to_file(&path)?;
+            if field.file_path().is_some() {
+                field.trim_to_logical_length()?;
             }
         }
-        if let Some(path) = self.conn_type_index_sources.file_path().map(PathBuf::from) {
-            self.conn_type_index_sources.save_to_file(&path)?;
+        if self.conn_type_index_sources.file_path().is_some() {
+            self.conn_type_index_sources.trim_to_logical_length()?;
         }
 
         // PR1 phase 8: trim the core CSR mmap files to their logical

--- a/crates/kglite/src/graph/storage/disk/graph_property_index.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_property_index.rs
@@ -93,6 +93,16 @@ impl DiskGraph {
         }
 
         let count = entries.len();
+        // Evict the cached index before rebuilding it. `PropertyIndex::build`
+        // truncates the same `keys`/`offsets`/`ids` files that a cached entry
+        // still has memory-mapped, and Windows refuses to re-create a mapped
+        // file (`ERROR_USER_MAPPED_FILE`). Removing the key (rather than
+        // storing `None`, which means "no such index") lets a concurrent
+        // lookup fall back to opening the bundle from disk.
+        self.property_indexes
+            .write()
+            .unwrap()
+            .remove(&(node_type.to_string(), property.to_string()));
         let idx = property_index::PropertyIndex::build(
             self.active_write_dir(),
             node_type,
@@ -261,6 +271,12 @@ impl DiskGraph {
         }
 
         let count = entries.len();
+        // Same rebuild-over-a-live-mapping hazard as `build_property_index`:
+        // release the cached bundle before `build_global` truncates the files
+        // it maps. `save_disk` rebuilds the `title` and `nid` global indexes on
+        // every save, so on Windows the second save of a graph would otherwise
+        // fail here.
+        self.global_indexes.write().unwrap().remove(property);
         let idx = property_index::PropertyIndex::build_global(
             self.active_write_dir(),
             property,

--- a/crates/kglite/src/graph/storage/disk/graph_tests.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_tests.rs
@@ -67,10 +67,25 @@ fn one_doc_frame(id: i64) -> DataFrame {
     .unwrap()
 }
 
+/// Byte-for-byte contents of every *data* file under `root`, for asserting that
+/// one graph's mutations never reach another's published files.
+///
+/// Dot-prefixed entries are skipped. They are coordination and scratch state —
+/// `.kglite.lock` (the writer lease) and `.working-*` (a mutation workspace) —
+/// not graph data, so folding them into the comparison makes it wrong on every
+/// platform: the snapshot would differ purely because a lease happened to be
+/// held. On Windows it also fails outright, because `fs2` takes that lease with
+/// `LockFileEx`, whose byte-range locks are *mandatory* rather than advisory
+/// like `flock`, so reading the file returns ERROR_LOCK_VIOLATION (33). No
+/// disk-graph data file starts with a dot.
 fn snapshot_files(root: &std::path::Path) -> BTreeMap<String, Vec<u8>> {
     fn collect(root: &std::path::Path, dir: &std::path::Path, out: &mut BTreeMap<String, Vec<u8>>) {
         for entry in std::fs::read_dir(dir).unwrap() {
-            let path = entry.unwrap().path();
+            let entry = entry.unwrap();
+            if entry.file_name().to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
             if path.is_dir() {
                 collect(root, &path, out);
             } else {

--- a/crates/kglite/src/graph/storage/disk/graph_tests.rs
+++ b/crates/kglite/src/graph/storage/disk/graph_tests.rs
@@ -186,6 +186,48 @@ fn transaction_fork_inherits_lease_but_uses_private_workspace() {
     assert!(child.active_write_dir().exists());
 }
 
+/// Once `save_disk` returns, every mapping the writer holds must live inside
+/// the generation it just published.
+///
+/// The mutation workspace — and, for a detached copy, its private root — are
+/// removed at the end of `finish_generation`. POSIX keeps a mapping valid after
+/// its file is unlinked, so arrays left pointing into the deleted scratch
+/// directory kept working and the bug was invisible; Windows refuses to remove
+/// a directory that still holds a mapped file, so the scratch roots survived
+/// and piled up. Asserting on paths makes the invariant fail loudly on every
+/// platform instead of only on the one that complains.
+#[test]
+fn save_rebases_every_mapping_onto_the_published_generation() {
+    let root = TempDir::new().unwrap();
+    let root_path = root.path().to_str().unwrap();
+
+    let mut graph = DirGraph::new();
+    add_docs(&mut graph, &[1, 2, 3]);
+    graph.enable_disk_mode().unwrap();
+    graph.save_disk(root_path).unwrap();
+
+    // Mutate after the first save so a mutation workspace exists and the CSR
+    // is rebuilt inside it, then publish a second generation over the top.
+    add_docs(&mut graph, &[4]);
+    graph.save_disk(root_path).unwrap();
+
+    let disk = match &mut graph.graph {
+        GraphBackend::Disk(disk) => disk,
+        _ => panic!("expected disk backend"),
+    };
+    let data_dir = disk.data_dir.clone();
+    let stray: Vec<_> = disk
+        .mapped_file_paths()
+        .into_iter()
+        .filter(|path| !path.starts_with(&data_dir))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "writer still maps files outside the published generation {}: {stray:?}",
+        data_dir.display()
+    );
+}
+
 #[test]
 fn independent_copy_uses_lazy_private_root_and_rebases_on_save() {
     let source = TempDir::new().unwrap();

--- a/crates/kglite/src/graph/storage/disk/mod.rs
+++ b/crates/kglite/src/graph/storage/disk/mod.rs
@@ -19,3 +19,31 @@ pub mod id_index;
 pub mod property_index;
 pub mod segment_summary;
 pub mod type_index;
+
+/// Delete a scratch file that the caller has just finished with, tolerating an
+/// already-absent path but surfacing every other failure.
+///
+/// Scratch removals used to be written as `let _ = fs::remove_file(path)`.
+/// That silently swallows the one error worth seeing: Windows refuses to
+/// delete a file that still has a memory-mapped view open
+/// (`ERROR_USER_MAPPED_FILE`), so a swallowed failure turns an mmap-lifetime
+/// bug into a leaked temporary file instead of a red test. Removal is only
+/// reached after the corresponding mapping has been dropped, so an error here
+/// means that ordering has regressed and the caller should hear about it.
+pub(crate) fn remove_scratch_file(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Directory counterpart to [`remove_scratch_file`], with the same rationale:
+/// a still-mapped file anywhere in the tree blocks removal on Windows.
+pub(crate) fn remove_scratch_dir(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
+++ b/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
@@ -40,6 +40,36 @@ fn file_len(byte_len: usize) -> io::Result<u64> {
     })
 }
 
+/// Re-establish a mapping of `byte_len` bytes after the view was deliberately
+/// released to resize the file — the ordering Windows requires.
+///
+/// Once the view is gone the buffer is unusable until a mapping exists again,
+/// including on the failure path of the resize itself. If the retained handle
+/// can no longer back a mapping, reopen the path and adopt the fresh handle, so
+/// a failed resize leaves a readable, retryable buffer instead of a poisoned
+/// one. Returns `None` only for a genuinely empty region.
+#[cfg(windows)]
+fn remap_after_resize(
+    file: &mut File,
+    path: &Path,
+    byte_len: usize,
+) -> io::Result<Option<MmapMut>> {
+    if byte_len == 0 {
+        return Ok(None);
+    }
+    // SAFETY: the backing file covers at least `byte_len` bytes, and the handle
+    // stays owned by the caller for the mapping's lifetime.
+    if let Ok(mapped) = unsafe { MmapOptions::new().len(byte_len).map_mut(&*file) } {
+        return Ok(Some(mapped));
+    }
+    let reopened = OpenOptions::new().read(true).write(true).open(path)?;
+    // SAFETY: same invariant; `reopened` refers to the same file, and it is
+    // moved into `*file` below so it outlives the mapping.
+    let mapped = unsafe { MmapOptions::new().len(byte_len).map_mut(&reopened)? };
+    *file = reopened;
+    Ok(Some(mapped))
+}
+
 fn grown_capacity<T>(capacity: usize, needed: usize) -> io::Result<(usize, usize)> {
     let doubled = capacity
         .checked_mul(2)
@@ -507,23 +537,78 @@ impl<T: MmapPod> MmapOrVec<T> {
                 })?;
                 if needed > *capacity {
                     let (new_capacity, new_byte_len) = grown_capacity::<T>(*capacity, needed)?;
-                    file.set_len(file_len(new_byte_len)?)?;
-                    injected_failure(1)?;
-                    // SAFETY: file was extended to new_byte_len above. Build
-                    // the replacement before dropping the still-valid old map.
-                    let new_mmap = unsafe {
-                        MmapOptions::new()
-                            .len(new_byte_len)
-                            .map_mut(&*file)
-                            .map_err(|error| {
-                                io::Error::new(
+                    // Windows refuses to change the size of a file that still
+                    // has a mapped view (`ERROR_USER_MAPPED_FILE`), so there the
+                    // old mapping must be released before `set_len`.
+                    //
+                    // POSIX deliberately keeps the opposite order: mapping the
+                    // replacement *before* dropping the original is what makes a
+                    // failed remap leave the buffer completely intact (see
+                    // `mapped_growth_remap_failure_keeps_state_and_retry_succeeds`).
+                    // Unmapping first everywhere would trade a Windows bug for a
+                    // POSIX atomicity regression, and would add an unmap/remap
+                    // round trip to every capacity doubling in the bulk-build
+                    // path. The two orders therefore stay split on purpose —
+                    // please do not "simplify" this into one branch.
+                    // Windows: release the view, resize, re-map. Both the resize
+                    // and the re-map can fail with the view already gone, so
+                    // either failure restores a mapping of the previous length.
+                    // That leaves the buffer readable and the retry path working
+                    // — the same observable guarantee the POSIX order provides.
+                    #[cfg(windows)]
+                    {
+                        let previous_byte_len = capacity_bytes::<T>(*capacity)?;
+                        drop(mmap.take());
+                        let grown = file
+                            .set_len(file_len(new_byte_len)?)
+                            .and_then(|()| injected_failure(1))
+                            .and_then(|()| {
+                                // SAFETY: the file is now new_byte_len bytes long.
+                                unsafe { MmapOptions::new().len(new_byte_len).map_mut(&*file) }
+                            });
+                        match grown {
+                            Ok(mapped) => {
+                                *mmap = Some(mapped);
+                                *capacity = new_capacity;
+                            }
+                            Err(error) => {
+                                // The file is still at least its original
+                                // length — it is only ever extended — so a
+                                // previous-length mapping is always in range.
+                                *mmap = remap_after_resize(file, path, previous_byte_len)
+                                    .ok()
+                                    .flatten();
+                                return Err(io::Error::new(
                                     error.kind(),
                                     format!("mmap remap failed for {}: {error}", path.display()),
-                                )
-                            })?
-                    };
-                    *mmap = Some(new_mmap);
-                    *capacity = new_capacity;
+                                ));
+                            }
+                        }
+                    }
+
+                    #[cfg(not(windows))]
+                    {
+                        file.set_len(file_len(new_byte_len)?)?;
+                        injected_failure(1)?;
+                        // SAFETY: file was extended to new_byte_len above. Build
+                        // the replacement before dropping the still-valid old map.
+                        let new_mmap = unsafe {
+                            MmapOptions::new()
+                                .len(new_byte_len)
+                                .map_mut(&*file)
+                                .map_err(|error| {
+                                    io::Error::new(
+                                        error.kind(),
+                                        format!(
+                                            "mmap remap failed for {}: {error}",
+                                            path.display()
+                                        ),
+                                    )
+                                })?
+                        };
+                        *mmap = Some(new_mmap);
+                        *capacity = new_capacity;
+                    }
                 }
                 let offset = *len * std::mem::size_of::<T>();
                 // SAFETY: `*len < *capacity` after the grow branch; `offset`
@@ -733,43 +818,93 @@ impl<T: MmapPod> MmapOrVec<T> {
                     existing.flush()?;
                 }
                 let byte_len = capacity_bytes::<T>(*len)?;
-                injected_failure(2)?;
-                // Map the shorter view while the file is still at least its
-                // old capacity. A remap failure leaves every field untouched.
-                let replacement = if byte_len == 0 {
-                    None
-                } else {
-                    // SAFETY: `byte_len` is at most the old mapped capacity,
-                    // and truncation happens only after this replacement map
-                    // succeeds, so the open file currently covers the entire
-                    // requested range and remains owned for the map's lifetime.
-                    Some(unsafe {
-                        MmapOptions::new()
-                            .len(byte_len)
-                            .map_mut(&*file)
-                            .map_err(|error| {
-                                io::Error::new(
-                                    error.kind(),
-                                    format!("trim remap failed for {}: {error}", path.display()),
-                                )
-                            })?
-                    })
-                };
 
-                // Dropping the old, longer map before truncation avoids a map
-                // whose range extends beyond EOF. If truncation fails, the
-                // replacement remains coherent against the still-larger file.
-                *mmap = replacement;
-                *capacity = *len;
-                injected_failure(4)?;
-                file.set_len(file_len(byte_len)?)
+                // Windows cannot shrink a file that has *any* live mapped view,
+                // not even a shorter one, so there the mapping is released
+                // before `set_len` and re-established afterwards. POSIX keeps
+                // the original order because mapping the shorter view first is
+                // what lets a failed remap leave every field untouched (see
+                // `trim_remap_failure_leaves_original_mapping_unchanged`) — a
+                // guarantee unmap-first would forfeit. Deliberately two orders.
+                //
+                // The injected failure points move with the order: on Windows
+                // the remap point fires before any state changes, and the
+                // truncate point after the buffer is coherent again, so both
+                // failure-injection tests still assert real observable state.
+                #[cfg(windows)]
+                {
+                    injected_failure(2)?;
+                    drop(mmap.take());
+                    let truncated = file.set_len(file_len(byte_len)?);
+                    // Re-establish the view whether or not the truncation
+                    // succeeded: on success the file is exactly `byte_len`, on
+                    // failure it is still its old, larger size, and `byte_len`
+                    // is within range either way. Restoring before propagating
+                    // keeps a failed trim from leaving an unmapped buffer.
+                    *mmap = remap_after_resize(file, path, byte_len).map_err(|error| {
+                        io::Error::new(
+                            error.kind(),
+                            format!("trim remap failed for {}: {error}", path.display()),
+                        )
+                    })?;
+                    *capacity = *len;
+                    truncated?;
+                    injected_failure(4)?;
+                    Ok(())
+                }
+
+                #[cfg(not(windows))]
+                {
+                    injected_failure(2)?;
+                    // Map the shorter view while the file is still at least its
+                    // old capacity. A remap failure leaves every field untouched.
+                    let replacement = if byte_len == 0 {
+                        None
+                    } else {
+                        // SAFETY: `byte_len` is at most the old mapped capacity,
+                        // and truncation happens only after this replacement map
+                        // succeeds, so the open file currently covers the entire
+                        // requested range and remains owned for the map's lifetime.
+                        Some(unsafe {
+                            MmapOptions::new()
+                                .len(byte_len)
+                                .map_mut(&*file)
+                                .map_err(|error| {
+                                    io::Error::new(
+                                        error.kind(),
+                                        format!(
+                                            "trim remap failed for {}: {error}",
+                                            path.display()
+                                        ),
+                                    )
+                                })?
+                        })
+                    };
+
+                    // Dropping the old, longer map before truncation avoids a map
+                    // whose range extends beyond EOF. If truncation fails, the
+                    // replacement remains coherent against the still-larger file.
+                    *mmap = replacement;
+                    *capacity = *len;
+                    injected_failure(4)?;
+                    file.set_len(file_len(byte_len)?)
+                }
             }
         }
     }
 
     /// Write the data to a file (for save_mmap). For heap, writes Vec contents.
     /// For mapped, flushes then copies the file.
-    pub fn save_to_file(&self, path: &Path) -> io::Result<()> {
+    ///
+    /// Takes `&mut self` because writing to the buffer's *own* backing path is
+    /// a resize of a mapped file, which requires releasing the mapping on
+    /// Windows. That case is delegated to [`Self::trim_to_logical_length`],
+    /// which owns the per-platform ordering.
+    pub fn save_to_file(&mut self, path: &Path) -> io::Result<()> {
+        // Same-file save is a truncation to the logical length, not a copy.
+        if self.file_path() == Some(path) {
+            return self.trim_to_logical_length();
+        }
         match self {
             MmapOrVec::Heap { data } => {
                 // SAFETY: Vec<T> with `T: MmapPod` is contiguous and has no
@@ -782,23 +917,13 @@ impl<T: MmapPod> MmapOrVec<T> {
                 };
                 std::fs::write(path, bytes)
             }
-            MmapOrVec::Mapped {
-                mmap, len, file, ..
-            } => {
+            MmapOrVec::Mapped { mmap, len, .. } => {
                 // Flush first
                 if let Some(mmap) = mmap.as_ref() {
                     mmap.flush()?;
                 }
                 let byte_len = capacity_bytes::<T>(*len)?;
-                // If it's the same file, just flush; otherwise copy
-                let src_path = self.file_path();
-                if let Some(sp) = src_path {
-                    if sp == path {
-                        // Just truncate to exact size
-                        file.set_len(file_len(byte_len)?)?;
-                        return Ok(());
-                    }
-                }
+                // The same-path case returned above; this is always a copy.
                 let bytes = match mmap.as_ref() {
                     Some(mmap) => &mmap[..byte_len],
                     None => &[],

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -405,16 +405,94 @@ fn sync_parent_dir(path: &Path) {
     }
 }
 
-/// Rewrite an existing WAL's version byte to [`WAL_FORMAT_VERSION`] and
-/// `fsync`. Needs its own non-append handle: the append-mode handle
-/// `Wal::open` holds ignores seeks on write, so it cannot patch a byte in
-/// place. Only ever called for a version the current schema reads exactly.
-fn upgrade_header_version(path: &Path) -> io::Result<()> {
+/// Truncate a WAL to nothing and lay down a fresh header, `fsync`ing the
+/// result. The caller supplies a handle opened for ordinary writing — never
+/// the append handle (see [`prepare_wal_file`]).
+fn truncate_to_header(file: &mut File) -> io::Result<()> {
     use std::io::{Seek, SeekFrom};
-    let mut file = OpenOptions::new().write(true).open(path)?;
-    file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
-    file.write_all(&[WAL_FORMAT_VERSION])?;
-    file.sync_data()?;
+    file.set_len(0)?;
+    // The read that classified the header left the cursor mid-file. Without
+    // this seek an ordinary (non-append) write would land at that offset and
+    // leave a hole in front of the header.
+    file.seek(SeekFrom::Start(0))?;
+    write_header(file)?;
+    file.sync_all()
+}
+
+/// Validate the WAL at `path`, creating or repairing its header as needed, so
+/// that [`Wal::open`] can take an append handle over a file already known to
+/// be well-formed.
+///
+/// All header maintenance happens here, on an ordinary read/write handle, and
+/// finishes before the append handle exists. **An append handle is not a
+/// general-purpose write handle.** Rust maps `OpenOptions::append(true)` to
+/// `FILE_GENERIC_WRITE & !FILE_WRITE_DATA` on Windows — deliberately dropping
+/// the very right that truncation and in-place rewrites require — and an
+/// append handle ignores seeks on write on every platform. The previous code
+/// repaired torn headers through the append handle, which POSIX tolerates and
+/// Windows does not; `upgrade_header_version` had already been forced to open
+/// its own handle for the same reason, and its job is now folded in here.
+///
+/// Classification is unchanged: a file too short for a header, or exactly
+/// header-sized with the wrong magic, is crash residue that can hold no frame
+/// and is repaired in place; a *longer* file with a bad magic could be
+/// somebody's data and is refused; an unreadable version is rejected and a
+/// readable older one is upgraded.
+fn prepare_wal_file(path: &Path) -> io::Result<()> {
+    use std::io::{Seek, SeekFrom};
+    let header_len = (WAL_MAGIC.len() + 1) as u64;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    let file_len = file.metadata()?.len();
+
+    if file_len == 0 {
+        write_header(&mut file)?;
+        file.sync_all()?;
+        // fsync the parent directory so the file's creation itself survives a
+        // crash (same doctrine as io/file.rs's atomic save: without this the
+        // fsync'd file can vanish with the unsynced directory entry).
+        sync_parent_dir(path);
+        return Ok(());
+    }
+
+    let mut header = [0u8; 5];
+    let read_len = file_len.min(header_len) as usize;
+    file.read_exact(&mut header[..read_len])?;
+    let magic_ok = read_len >= WAL_MAGIC.len() && header[..4] == WAL_MAGIC;
+
+    if file_len < header_len || (!magic_ok && file_len == header_len) {
+        return truncate_to_header(&mut file);
+    }
+    if !magic_ok {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{} is not a kglite WAL file (bad magic) and is not empty; \
+                 refusing to overwrite it. Move the file aside if it is stale.",
+                path.display()
+            ),
+        ));
+    }
+
+    // Reject an unreadable version before appending to it; the codec lookup
+    // owns the actionable message.
+    wal_codec(header[4])?;
+    if header[4] != WAL_FORMAT_VERSION {
+        // A readable older version. We are about to append current-format
+        // frames, so the header must advertise the newer version or a future
+        // reader would parse the new frames under the old schema. Rewriting
+        // the byte is lossless precisely because the older format is a subset
+        // (see `WAL_FORMAT_VERSION`): the frames already in the file are valid
+        // current-format frames, and the per-frame CRCs cover payloads only,
+        // not the header.
+        file.seek(SeekFrom::Start(WAL_MAGIC.len() as u64))?;
+        file.write_all(&[WAL_FORMAT_VERSION])?;
+        file.sync_data()?;
+    }
     Ok(())
 }
 
@@ -446,68 +524,11 @@ impl Wal {
     /// appended; a *readable* older version is upgraded in place, since the
     /// frames already present parse under the current schema unchanged.
     pub fn open(path: PathBuf) -> io::Result<Self> {
-        let existed = path.exists();
-        let mut file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .append(true)
-            .open(&path)?;
-        let header_len = (WAL_MAGIC.len() + 1) as u64;
-        let file_len = file.metadata()?.len();
-        if !existed || file_len == 0 {
-            write_header(&mut file)?;
-            file.sync_all()?;
-            // fsync the parent directory so the file's creation itself
-            // survives a crash (same doctrine as io/file.rs's atomic
-            // save: without this the fsync'd file can vanish with the
-            // unsynced directory entry).
-            sync_parent_dir(&path);
-        } else {
-            let mut header = [0u8; 5];
-            let read_len = file_len.min(header_len) as usize;
-            {
-                use std::io::{Read, Seek, SeekFrom};
-                // `append` mode only affects writes; reads may seek.
-                file.seek(SeekFrom::Start(0))?;
-                file.read_exact(&mut header[..read_len])?;
-                file.seek(SeekFrom::End(0))?;
-            }
-            let magic_ok = read_len >= WAL_MAGIC.len() && header[..4] == WAL_MAGIC;
-            if file_len < header_len || (!magic_ok && file_len == header_len) {
-                // Torn header (crash between create and header fsync):
-                // shorter than a header, or exactly header-sized with a
-                // bad magic. No frame can exist — repair in place.
-                file.set_len(0)?;
-                write_header(&mut file)?;
-                file.sync_all()?;
-            } else if !magic_ok {
-                // Bad magic with data after the header position: this is
-                // not a torn header — refuse to touch it.
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "{} is not a kglite WAL file (bad magic) and is not empty; \
-                         refusing to overwrite it. Move the file aside if it is stale.",
-                        path.display()
-                    ),
-                ));
-            } else {
-                // Reject an unreadable version before appending to it; the
-                // codec lookup owns the actionable message.
-                wal_codec(header[4])?;
-                if header[4] != WAL_FORMAT_VERSION {
-                    // A readable older version. We are about to append
-                    // current-format frames, so the header must advertise
-                    // the newer version or a future reader would parse the
-                    // new frames under the old schema. Rewriting the byte
-                    // is lossless precisely because the older format is a
-                    // subset (see `WAL_FORMAT_VERSION`): the frames already
-                    // in the file are valid current-format frames, and the
-                    // per-frame CRCs cover payloads only, not the header.
-                    upgrade_header_version(&path)?;
-                }
-            }
-        }
+        // Create/validate/repair the header first, on an ordinary handle. By
+        // the time the append handle below exists the file is well-formed, so
+        // that handle only ever has to do what append handles can portably do.
+        prepare_wal_file(&path)?;
+        let file = OpenOptions::new().read(true).append(true).open(&path)?;
         Ok(Self { file, path })
     }
 
@@ -524,10 +545,14 @@ impl Wal {
     /// Called after a checkpoint (a full `.kgl` save) has folded every
     /// frame into the snapshot, so the log can start fresh.
     pub fn reset(&mut self) -> io::Result<()> {
-        self.file.set_len(0)?;
-        write_header(&mut self.file)?;
-        self.file.sync_all()?;
-        Ok(())
+        // Truncation and header rewrite go through a dedicated read/write
+        // handle for the same reason `prepare_wal_file` does: the append
+        // handle lacks the write-data right on Windows and ignores seeks on
+        // write everywhere. `self.file` stays usable afterwards — append mode
+        // resolves the end of the file at write time, so the next frame lands
+        // straight after the fresh header.
+        let mut file = OpenOptions::new().read(true).write(true).open(&self.path)?;
+        truncate_to_header(&mut file)
     }
 
     /// The WAL's filesystem path.

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -67,7 +67,9 @@ pub mod api {
     // (The code-tree handle helpers `resolve_code_entity` / `CODE_TYPES` /
     // `source_location` live in `api::code_entities`.)
     pub use crate::graph::handle::{
-        discover_property_keys_from_data, infer_selection_node_type, KnowledgeGraph,
+        discover_property_keys_excluding, discover_property_keys_from_data,
+        infer_selection_node_type, is_canonical_node_column, KnowledgeGraph,
+        CANONICAL_NODE_COLUMNS,
     };
     /// Core schema data types — the node record (`NodeData`), the projected
     /// `NodeInfo`, geo/temporal validity configs (`SpatialConfig` /

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -77,7 +77,7 @@ pub mod api {
     pub use crate::graph::schema::{
         parse_spatial_column_types_from_pairs, parse_temporal_column_types_from_pairs,
         ConnectionSchemaDefinition, NodeData, NodeInfo, NodeSchemaDefinition, SchemaDefinition,
-        SpatialConfig, TemporalConfig, ValidationError,
+        SchemaInstall, SpatialConfig, TemporalConfig, ValidationError,
     };
     /// The fluent **selection** data model — the cursor state threaded
     /// through the fluent query chain (and through Selection-scoped

--- a/crates/kglite/tests/disk_crash_guarantee.rs
+++ b/crates/kglite/tests/disk_crash_guarantee.rs
@@ -1,0 +1,183 @@
+//! What a `SIGKILL` costs a `storage="disk"` graph.
+//!
+//! Disk mode has no write-ahead log: `kglite.open(path, storage="disk")`
+//! opens non-durable and `durable=True` is refused. That is often read as
+//! "disk mode has no crash safety", which is wrong in a way worth pinning
+//! down with a test rather than prose.
+//!
+//! A disk graph commits by publishing an **immutable generation**: the
+//! staged snapshot is fsync'd file-by-file, renamed into `generations/`,
+//! and only then does an atomically-persisted `CURRENT` pointer select it
+//! (`storage::disk::generation::GenerationTxn::publish`). So the guarantee
+//! disk mode *does* offer is precise:
+//!
+//! > A crash loses exactly the mutations made since the last `save()`, and
+//! > nothing else. The graph reopens at the last published generation,
+//! > complete and uncorrupted — never at a partially-written one.
+//!
+//! Nothing is ever acknowledged as durable in between, so no acknowledged
+//! commit is lost; the boundary is the `save()` call itself. These tests
+//! are the evidence for that sentence, which the disk-mode documentation
+//! now states as the contract.
+//!
+//! The parent asserts the child died on signal 9 (`SIGKILL`) — uncatchable,
+//! so not even Rust `Drop` or the process's own teardown runs. A test that
+//! degraded into a graceful-shutdown test would prove nothing about a
+//! crash, which is why this file is Unix-only rather than substituting a
+//! catchable signal on Windows (the same doctrine as
+//! `tests/test_durability.py::requires_sigkill`).
+
+#![cfg(unix)]
+
+use kglite::api::cypher::{execute_mutable, parse_cypher};
+use kglite::api::io::{load_file, save_graph};
+use kglite::api::storage::{new_dir_graph_in_mode, StorageMode};
+use kglite::api::{DirGraph, GraphRead, Value};
+use std::collections::HashMap;
+use std::os::unix::process::ExitStatusExt;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const CHILD_GRAPH: &str = "KGLITE_DISK_CRASH_GRAPH";
+const CHILD_READY: &str = "KGLITE_DISK_CRASH_READY";
+
+fn run(graph: &mut Arc<DirGraph>, query: &str) {
+    let parsed = parse_cypher(query).expect("parse");
+    let dir = kglite::api::make_dir_graph_mut(graph);
+    execute_mutable(dir, &parsed, HashMap::new(), Default::default()).expect("execute");
+}
+
+/// Every node title in the graph, sorted. Disk-backed reads borrow out of
+/// the arena, so the read guard must outlive the borrows.
+fn titles(graph: &DirGraph) -> Vec<String> {
+    let _guard = graph.begin_read_pass();
+    let mut found: Vec<String> = graph
+        .graph
+        .node_indices()
+        .filter_map(|idx| graph.get_node(idx))
+        .map(|node| match &node.title {
+            Value::String(title) => title.to_string(),
+            other => other.to_string(),
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Child half of the crash tests: publish one generation, then mutate
+/// *without* saving and park until the parent kills it. Not a test on its
+/// own — it returns immediately unless the parent's env vars are set.
+#[test]
+fn disk_crash_child() {
+    let Some(root) = std::env::var_os(CHILD_GRAPH) else {
+        return;
+    };
+    let ready = std::env::var_os(CHILD_READY).expect("ready path");
+    let root = Path::new(&root);
+
+    let mut graph =
+        Arc::new(new_dir_graph_in_mode(StorageMode::Disk, Some(root)).expect("create disk graph"));
+    run(&mut graph, "CREATE (:Person {id: 1, title: 'saved'})");
+    save_graph(&mut graph, &root.to_string_lossy()).expect("publish generation");
+
+    // Committed to the process's heap overlay only — no generation is
+    // published for these, so they are exactly what the crash must lose.
+    run(&mut graph, "CREATE (:Person {id: 2, title: 'unsaved'})");
+    run(&mut graph, "CREATE (:Person {id: 3, title: 'unsaved-too'})");
+
+    std::fs::write(ready, b"ready").expect("signal readiness");
+    // The parent kills us here. Long enough that a hang is a test failure,
+    // not a race.
+    std::thread::sleep(Duration::from_secs(60));
+}
+
+/// Spawn the child, wait for it to park, and `SIGKILL` it.
+fn crash_child(root: &Path, ready: &Path) {
+    let mut child = Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "disk_crash_child", "--nocapture"])
+        .env(CHILD_GRAPH, root)
+        .env(CHILD_READY, ready)
+        .spawn()
+        .expect("spawn child");
+
+    let started = Instant::now();
+    while !ready.exists() && started.elapsed() < Duration::from_secs(30) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(ready.exists(), "child never reached its unsaved mutations");
+
+    child.kill().expect("SIGKILL child");
+    let status = child.wait().expect("reap child");
+    assert_eq!(
+        status.signal(),
+        Some(9),
+        "child must die on SIGKILL, or this is not a crash test"
+    );
+}
+
+#[test]
+fn sigkill_loses_exactly_the_mutations_since_the_last_save() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    let recovered = load_file(&root.to_string_lossy()).expect("reopen after crash");
+    assert_eq!(
+        titles(&recovered),
+        vec!["saved".to_string()],
+        "the published generation survives intact; the unsaved mutations are gone"
+    );
+}
+
+#[test]
+fn sigkill_leaves_current_selecting_a_complete_generation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    // `CURRENT` must name a real, complete generation — never a `.stage-*`
+    // directory and never a half-written one. `resolve_snapshot` rejects an
+    // incomplete target, so a successful load *is* that assertion; check the
+    // pointer's shape directly too, so a regression names the pointer rather
+    // than surfacing as a confusing load error.
+    let current = std::fs::read_to_string(root.join("CURRENT")).expect("CURRENT survives");
+    let name = current
+        .strip_suffix('\n')
+        .expect("CURRENT ends in a newline");
+    assert!(
+        name.starts_with("gen_"),
+        "CURRENT must select a published generation, got {name:?}"
+    );
+    let selected = root.join("generations").join(name);
+    assert!(
+        selected.join("metadata.json").is_file(),
+        "the selected generation must carry its completion marker"
+    );
+    assert!(
+        !name.contains(".stage-"),
+        "CURRENT must never select a staging directory"
+    );
+}
+
+#[test]
+fn a_crashed_writer_releases_its_lease_to_the_next_process() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("graph");
+    crash_child(&root, &tmp.path().join("ready"));
+
+    // The killed writer's `.kglite.lock` file is still on disk, but liveness
+    // is OS advisory-lock based, so a fresh writer takes over and can publish
+    // a new generation on top of the recovered one.
+    let mut recovered = load_file(&root.to_string_lossy()).expect("reopen after crash");
+    run(&mut recovered, "CREATE (:Person {id: 4, title: 'after'})");
+    save_graph(&mut recovered, &root.to_string_lossy()).expect("publish after recovery");
+
+    let reloaded = load_file(&root.to_string_lossy()).expect("reopen after republish");
+    assert_eq!(
+        titles(&reloaded),
+        vec!["after".to_string(), "saved".to_string()],
+        "recovery is writable: the next save publishes on top of the survivor"
+    );
+}

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -30,8 +30,9 @@ KGLite stores nodes and relationships in a Rust graph structure ([petgraph](http
   results are already materialized in Rust (Python values convert on access)
 - **Fluent API** chains build a *selection* (a set of node indices) — no data is copied until you call `collect()`, `to_df()`, etc.
 - **Persistence** uses `save()`/`load()` snapshots; `open()` is crash-safe by
-  default via a write-ahead log (`durable=False` opts out), and
-  context-managed `open()` also persists on clean exit
+  default via a write-ahead log (`durable=False` opts out; `storage="disk"`
+  is the exception — see [Choosing a storage mode](#choosing-a-storage-mode)),
+  and context-managed `open()` also persists on clean exit
 
 ## Storage Modes
 
@@ -61,15 +62,26 @@ everything that fits in RAM. Reach for `mapped` only when the graph
 stops fitting comfortably on the heap, and for `disk` only at the
 Wikidata scale where you want the OS to page data in lazily.
 
-| If your graph is… | …and you want | Use |
-|---|---|---|
-| Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) |
-| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** |
-| 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** |
+| If your graph is… | …and you want | Use | `open()` crash safety |
+|---|---|---|---|
+| Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) | Per-commit WAL, on by default |
+| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL, on by default |
+| 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** | **No WAL** — durability is your `save()` calls |
 
 When in doubt, stay in-memory; switch only once you hit a real RAM
 ceiling. Both larger-than-RAM modes keep the identical Python and
 Cypher API, so moving up is a one-line constructor change.
+
+**The two larger-than-RAM modes differ in durability, not just in layout.**
+`mapped` keeps the same per-commit crash safety as in-memory, so growing out
+of RAM costs you nothing there. `disk` commits by publishing an immutable
+generation instead of by logging a write: `kglite.open(path, storage="disk")`
+opens **non-durable** (passing `durable=True` raises rather than pretending),
+and a crash loses every mutation made since the last `save()`. That is a real
+and bounded guarantee — the published generation always survives intact — but
+it is *your* `save()` calls, not the engine, that decide how much a crash can
+cost. Pick `disk` for its scale, not because a graph outgrew RAM; `mapped`
+covers that case with the guarantee intact. See {doc}`guides/durable-apps`.
 
 ## Return Types
 

--- a/docs/python/guides/durable-apps.md
+++ b/docs/python/guides/durable-apps.md
@@ -134,13 +134,20 @@ optimising for:
 |---|---|---|
 | Every committed write to survive a hard crash | `open(path)` (the default) | One `fsync` per commit; reopen is O(graph) (loads the whole graph). |
 | Maximum write throughput on rebuildable data | `open(path, durable=False)` | No `fsync` per write; a crash loses work since the last checkpoint. |
-| Graphs larger than RAM, cheap reopen | `open(path, storage="disk")` | Paged mmap, lazy load; not a crash-safe-per-write WAL mode. |
+| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` | Same per-commit WAL guarantee; property columns spill to mmap. |
+| 100 M+ nodes (Wikidata-scale), cheap cold-open | `open(path, storage="disk")` | Paged mmap, lazy load; **no per-commit WAL** — durability is your `save()` calls. |
 
 The first two are **in-memory** — the whole graph lives in RAM, which is what
 makes traversal and multi-hop queries fast. Durability adds crash-safety on
-top of that model without changing the in-memory read path. `storage="disk"`
-(see {doc}`/python/core-concepts`) is the separate answer for *larger-than-RAM*
-graphs and cheap cold-open; it is not combined with the WAL.
+top of that model without changing the in-memory read path.
+
+**If your app is simply growing, reach for `mapped`, not `disk`.** `mapped`
+is the larger-than-RAM mode that keeps this guide's guarantee: it is durable by
+default and its crash recovery is kill-9 tested alongside in-memory. `disk` is
+a different trade — a Wikidata-scale exploration mode whose commit boundary is
+an explicit `save()`, not a logged write (see the Limitations below). Choosing
+`disk` because a graph got big means giving up per-commit crash safety you
+did not have to give up.
 
 ## Serving concurrent reads
 
@@ -194,9 +201,32 @@ model.
   logical log; reconciling a replayed frame against a published generation needs
   a generation-aware log this release does not have. `open(path,
   storage="disk")` therefore opens **non-durable**, and passing an explicit
-  `durable=True` raises `ValueError` rather than pretending. Use `save()`
-  checkpoints there. The in-memory default and `storage="mapped"` are both
-  fully durable.
+  `durable=True` raises `ValueError` rather than pretending. The in-memory
+  default and `storage="mapped"` are both fully durable — if you want crash
+  safety on a graph that outgrew RAM, `mapped` is the answer.
+
+  What disk mode *does* guarantee is worth stating exactly, because it is
+  stronger than "no crash safety" and is kill-9 tested
+  (`crates/kglite/tests/disk_crash_guarantee.rs`):
+
+  > A crash loses exactly the mutations made since the last `save()`, and
+  > nothing else. The graph reopens at the last published generation, complete
+  > and uncorrupted — never at a partially-written one.
+
+  Between `save()` calls, disk-mode mutations live only in the process's heap
+  overlay; nothing is written, so nothing can be half-written. The publish
+  itself is crash-atomic: the staged snapshot is `fsync`'d, renamed into place,
+  and only then does an atomically-replaced `CURRENT` pointer select it, so a
+  crash mid-publish leaves the previous generation selected. No acknowledged
+  commit is ever lost — the acknowledgement point is your `save()` call.
+
+  **Budget for the checkpoint's cost before you sprinkle `save()` calls.**
+  Every disk `save()` writes a complete new generation and the superseded ones
+  are retained, so *N* checkpoints leave *N* full copies of the graph on disk.
+  That is deliberate — readers hold their generation mmap'd and must not have
+  it deleted underneath them — but there is no retention policy yet, so
+  checkpoint on a schedule you have the disk budget for, and prune old
+  `generations/gen_*` directories yourself once no reader is using them.
 - **Some state is checkpoint-only.** The log describes nodes, edges, and
   labels. Schema and config metadata, user-created indexes, embeddings, and
   timeseries have no log entry, so they are persisted by `save()` rather than

--- a/docs/python/guides/import-export.md
+++ b/docs/python/guides/import-export.md
@@ -161,21 +161,82 @@ so a dump can be committed and diffed.
 
 KGLite does **not** export Parquet directly, and this is a deliberate scope
 decision rather than a gap. Doing it in Rust means taking on the
-`arrow` + `parquet` dependency tree, which is large; an earlier review of
-columnar/Arrow export reached the same conclusion and dropped it. KGLite has
-been steadily *shedding* dependencies, and re-adding a heavy one for a format
-already one line away would cut against that.
+`arrow` + `parquet` dependency tree — measured at **+35 crates** on top of the
+CLI's 143 for a minimal Arrow-backed writer, and +336 lines of `Cargo.lock`.
+KGLite has been steadily *shedding* dependencies (309 → 171 across 0.14.x), and
+`arrow` in particular is a library this project already keeps at arm's length:
+kglite pins its bundled allocator to mimalloc v2 specifically to survive being
+imported alongside `pyarrow`.
 
-If you want Parquet, go through the DataFrame you already have — the
-dependency then lives in your environment, where you control it:
+Parquet is a format you can reach with tools you already have. Pick whichever
+end of the pipe you prefer.
+
+**One table, from a query.** The dependency lives in your environment, where
+you control it:
 
 ```python
 graph.cypher("MATCH (p:Person) RETURN p.id, p.title, p.age").to_df().to_parquet('people.parquet')
 ```
 
-For a whole-graph dump, {meth}`~kglite.KnowledgeGraph.export_csv` writes one
-CSV per node and connection type plus a `blueprint.json` for re-import, and
-SQLite (above) covers the "give me a real database" case.
+**The whole graph, no Python at all.** The SQLite dump above already turns
+every node type and connection type into a table, and DuckDB writes Parquet
+from those tables directly:
+
+```bash
+kglite export-sqlite mygraph.kgl dump.sql
+sqlite3 mygraph.db < dump.sql
+duckdb -c "INSTALL sqlite; LOAD sqlite; ATTACH 'mygraph.db' AS g (TYPE sqlite);
+           COPY (SELECT * FROM g.Person)   TO 'Person.parquet'   (FORMAT PARQUET);
+           COPY (SELECT * FROM g.WORKS_AT) TO 'WORKS_AT.parquet' (FORMAT PARQUET);"
+```
+
+**The whole graph, from Python.** `to_df()` covers nodes; edges come from a
+Cypher query in the same link-table shape the SQLite export uses. Drive both
+off the graph's own type lists rather than hand-writing a query per type:
+
+```python
+import pathlib
+import pandas as pd
+
+def export_parquet(graph, out_dir):
+    out = pathlib.Path(out_dir)
+    (out / 'nodes').mkdir(parents=True, exist_ok=True)
+    (out / 'edges').mkdir(exist_ok=True)
+
+    for node_type in graph.node_types:
+        graph.select(node_type).to_df().to_parquet(out / 'nodes' / f'{node_type}.parquet')
+
+    for conn in graph.connection_types():
+        ct = conn['type']
+        df = graph.cypher(f"""
+            MATCH (a)-[r:{ct}]->(b)
+            RETURN labels(a)[0] AS source_type, a.id AS source_id,
+                   labels(b)[0] AS target_type, b.id AS target_id,
+                   properties(r) AS props
+        """).to_df()
+        props = pd.json_normalize(df.pop('props')).drop(columns=['type'], errors='ignore')
+        pd.concat([df, props], axis=1).to_parquet(out / 'edges' / f'{ct}.parquet')
+```
+
+This produces `nodes/Person.parquet` with columns `type, title, id, age, city`
+and `edges/WORKS_AT.parquet` with `source_type, source_id, target_type,
+target_id, salary, since` — the same mapping the SQLite table/link-table export
+uses. Properties absent on a given node or edge become nulls, and integers,
+floats, booleans and datetimes keep their types through the round-trip.
+
+Two things to know when you write your own variant:
+
+- **`properties(r)` includes the connection type under a `type` key**; drop it
+  (as above) or it becomes a redundant column.
+- **A node's `id`, `title` and `type` come from its canonical identity**, not
+  from its property bag. If a node also stores a property under one of those
+  names, the canonical value wins and the column is not repeated — a
+  duplicated column name would make `to_parquet()` fail outright.
+
+For a whole-graph dump without a DataFrame,
+{meth}`~kglite.KnowledgeGraph.export_csv` writes one CSV per node and
+connection type plus a `blueprint.json` for re-import, and SQLite (above)
+covers the "give me a real database" case.
 
 ## Back up before upgrading
 

--- a/docs/python/guides/index.md
+++ b/docs/python/guides/index.md
@@ -26,7 +26,7 @@ Domain-specific surfaces — pull them in when your data has the shape:
 
 | Guide | Read this if… |
 |---|---|
-| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default, checkpoint-on-close, and when to opt out with `durable=False`. |
+| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default (in-memory and `mapped`; `disk` checkpoints on `save()`), checkpoint-on-close, and when to opt out with `durable=False`. |
 | {doc}`derived-index` | …the authoritative copy of your data lives elsewhere — a warehouse, an API, a directory — and the graph is a rebuildable projection you query. Rebuild-and-swap, incremental refresh, carrying embeddings across a rebuild. |
 | {doc}`primary-store` | …the graph *is* the authoritative copy. What holds (statement atomicity, WAL crash safety, snapshot isolation), what is opt-in, and the limits stated plainly. |
 | {doc}`okf` | …your "data" is a markdown knowledge base — an OKF bundle, a Claude memory dir, a skills folder, an Obsidian vault. Frontmatter → nodes, links → typed edges. |

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -300,8 +300,13 @@ rebuild would use.
 **The large-graph modes are still the weaker ones.** `mapped` now gets the same
 per-commit crash safety as in-memory — the kill-9 suites are parametrised over
 both — but `disk` does not: its durability boundary is the generation publish, so
-it relies on `save()` checkpoints, and its crash survival is untested and
-unsupported by design. Both keep the whole-graph write checkpoint described above.
+it relies on `save()` checkpoints. That boundary is a real primitive rather than
+an absence of one, and it is kill-9 tested in its own right
+(`crates/kglite/tests/disk_crash_guarantee.rs`): a crash loses exactly the
+mutations made since the last `save()`, and the last published generation always
+reopens complete — never half-written, and never with a partially-applied commit.
+What `disk` does not give you is a *smaller* unit of durability than a whole
+`save()`. Both keep the whole-graph write checkpoint described above.
 In-memory is the product; the disk modes are for exploring graphs too big for it,
 and that is the trade-off you are accepting.
 

--- a/docs/python/platform-support.md
+++ b/docs/python/platform-support.md
@@ -35,6 +35,11 @@ their own dependencies: `kglite[pandas]` for DataFrame workflows,
   round-trip.
 - At release time, the macOS arm64 wheel is installed on CPython 3.14 with
   current pyarrow for the allocator-coexistence canary.
+- Windows x86_64 and macOS arm64 run the Rust engine's unit suite, which covers
+  the storage backends — including disk mode, whose memory-mapped file
+  lifetimes behave differently on Windows than on POSIX. This is a native-engine
+  test, not a Python-level one: the Python API surface on Windows remains
+  build-verified rather than runtime-tested.
 
 ### Release-blocking wheel builds
 

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -3504,13 +3504,31 @@ class KnowledgeGraph:
     # Schema Definition & Validation
     # ====================================================================
 
-    def define_schema(self, schema_dict: dict[str, Any]) -> KnowledgeGraph:
+    def define_schema(self, schema_dict: dict[str, Any], *, replace: bool = False) -> KnowledgeGraph:
         """Define the expected schema for the graph.
 
-        **Replaces** the entire schema — this is not a merge. Any previous
-        ``define_schema`` call is fully superseded, so a call with a *subset* of
-        types drops the types it omits. Redefine all types each call (or read
-        the current schema via :meth:`schema_definition` and merge yourself).
+        **Merges per node/connection type.** A type named in ``schema_dict``
+        takes the new declaration *entire*; a type it does not name keeps the
+        declaration it already had. So declaring per module or per type is safe
+        — it cannot affect the constraints of a type this call never mentions::
+
+            g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+            g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+            # User.email is still a NODE KEY and still enforced.
+
+        Merging is per *type*, not per field, so re-declaring a type is still
+        how you narrow it — declare ``Task`` without a ``required`` entry it
+        used to have and that requirement is withdrawn.
+
+        Pass ``replace=True`` for the whole-schema semantics: the incoming
+        schema becomes the entire schema and every type it does not name loses
+        its declarations. Because that withdraws enforcement from types the
+        caller never mentioned, it emits a ``UserWarning`` naming each
+        constraint it stops enforcing. :meth:`clear_schema` removes everything.
+
+        Constraints declared through Cypher DDL (``CREATE CONSTRAINT``) are not
+        schema declarations and are unaffected by either mode — they are
+        withdrawn only by ``DROP CONSTRAINT``.
 
         Args:
             schema_dict: Schema definition with ``nodes`` and ``connections`` keys.
@@ -3540,8 +3558,14 @@ class KnowledgeGraph:
                 ``required`` is enforced at **write time**, not only by
                 :meth:`validate_schema`: a ``CREATE`` that omits the property, a
                 ``SET`` that nulls it, and a ``REMOVE`` that drops it all raise.
-                ``id``/``title``/``type`` are structural and always present, so
-                requiring them is a no-op. Auto-vivified edge stubs are deferred
+                ``type`` is the node's label and cannot be absent, so requiring
+                it is a no-op; ``id`` and ``title`` are auto-supplied when
+                omitted (so omitting them satisfies the requirement) but *can*
+                be explicitly nulled, and that is rejected. Unlike
+                ``CREATE CONSTRAINT ... IS NOT NULL``, which verifies stored data
+                before installing, ``required`` declares intent without
+                re-checking what is already there — :meth:`validate_schema`
+                reports existing violations. Auto-vivified edge stubs are deferred
                 rather than exempt — vivification may create an incomplete
                 placeholder, but the ``add_nodes`` upsert that promotes it is a
                 normal enforced write, and an unpromoted stub stays reportable via
@@ -3598,7 +3622,15 @@ class KnowledgeGraph:
         ...
 
     def clear_schema(self) -> KnowledgeGraph:
-        """Remove the schema definition from the graph."""
+        """Remove the schema definition from the graph, and with it every
+        constraint the schema declared.
+
+        The unique indexes a ``primary_key``/``unique`` declaration installed are
+        withdrawn too — enforcement never outlives the declaration that
+        explains it. Constraints declared through Cypher DDL
+        (``CREATE CONSTRAINT``) are separate declarations and survive; drop them
+        with ``DROP CONSTRAINT``.
+        """
         ...
 
     def set_instructions(self, text: str, *, channel: str | None = None) -> KnowledgeGraph:

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -318,21 +318,28 @@ class ResultView:
     ``cypher()`` calls fast even for large result sets — the cost is deferred
     to when you consume the data.
 
-    **Large deferred results hold the graph open.** To serve rows later, a
-    deferred view keeps a reference to the graph it was queried from. Writing
-    to that graph while such a view is still alive copies the whole graph
-    (every node, edge, index and embedding) so the view keeps seeing the data
-    it was built from. Results up to a few thousand rows are converted up
-    front and never do this, so ordinary read-then-write code is unaffected::
+    **Deferred results hold the graph open.** To serve rows later, a deferred
+    view keeps a reference to the graph it was queried from. Writing to that
+    graph while such a view is still alive copies the whole graph (every node,
+    edge, index and embedding) so the view keeps seeing the data it was built
+    from. On a large graph that copy costs tens of milliseconds and it repeats
+    every time the pattern recurs.
 
-        rows = graph.cypher("MATCH (u:User) RETURN u.name")  # small: eager
-        graph.cypher("MATCH (u:User) SET u.seen = true")     # no copy
+    Very small results — roughly a couple of dozen values, so a single-entity
+    lookup or a handful of rows — are converted up front and hold no graph
+    reference, which covers the usual read-modify-write handler::
 
-    For a genuinely large result, finish with it before writing — consume it
-    (``to_df()``, ``to_list()``) or let it go out of scope::
+        row = graph.cypher("MATCH (u:User {id: 1}) RETURN u.name, u.balance")
+        graph.cypher("MATCH (u:User {id: 1}) SET u.balance = 0")  # no copy
+
+    Anything larger stays deferred, so finish with it before writing — consume
+    it (``to_df()``, ``to_list()``) or let it go out of scope::
 
         big = graph.cypher("MATCH (n:Event) RETURN n.ts").to_df()  # no view kept
         graph.cypher("MATCH (n:Event) SET n.archived = true")      # no copy
+
+    The cutoff is kept deliberately small because every deferred-eligible query
+    pays it, while only a result held across a write benefits.
 
     Supports:
       - ``len(result)`` — row count (O(1), no conversion)

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -1864,12 +1864,22 @@ class KnowledgeGraph:
         Each node becomes a row with columns for title, type, id, and all
         properties. Missing properties across different node types become None.
 
+        ``id``, ``title`` and ``type`` come from the node's canonical identity.
+        A node may also *store* a property under one of those names —
+        ``CREATE (:T {title: 'a'})`` sets ``title`` both ways — in which case
+        the canonical value wins and the property is not repeated as a second
+        column. Opt a canonical column out to read the stored property
+        instead: with ``include_type=False`` there is no ``type`` column to
+        collide with, so a stored ``type`` property is returned as itself.
+
         Args:
             include_type: Include ``type`` column. Default ``True``.
             include_id: Include ``id`` column. Default ``True``.
 
         Returns:
-            DataFrame with one row per selected node.
+            DataFrame with one row per selected node. Column names are unique,
+            so the frame is directly writable with ``to_parquet()`` /
+            ``to_csv()``.
         """
         ...
 

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -318,6 +318,22 @@ class ResultView:
     ``cypher()`` calls fast even for large result sets — the cost is deferred
     to when you consume the data.
 
+    **Large deferred results hold the graph open.** To serve rows later, a
+    deferred view keeps a reference to the graph it was queried from. Writing
+    to that graph while such a view is still alive copies the whole graph
+    (every node, edge, index and embedding) so the view keeps seeing the data
+    it was built from. Results up to a few thousand rows are converted up
+    front and never do this, so ordinary read-then-write code is unaffected::
+
+        rows = graph.cypher("MATCH (u:User) RETURN u.name")  # small: eager
+        graph.cypher("MATCH (u:User) SET u.seen = true")     # no copy
+
+    For a genuinely large result, finish with it before writing — consume it
+    (``to_df()``, ``to_list()``) or let it go out of scope::
+
+        big = graph.cypher("MATCH (n:Event) RETURN n.ts").to_df()  # no view kept
+        graph.cypher("MATCH (n:Event) SET n.archived = true")      # no copy
+
     Supports:
       - ``len(result)`` — row count (O(1), no conversion)
       - ``bool(result)`` — True if non-empty

--- a/tests/api-baselines/lint-allowances.json
+++ b/tests/api-baselines/lint-allowances.json
@@ -237,7 +237,7 @@
       "classification": "test"
     },
     {
-      "identity": "crates/kglite/src/graph/dir_graph/schema_ops.rs::fn:set_schema:pub fn set_schema(&mut self, schema: SchemaDefinition) -> Result<(), KgError>::clippy::result_large_err",
+      "identity": "crates/kglite/src/graph/dir_graph/schema_ops.rs::fn:set_schema:pub fn set_schema( &mut self, schema: SchemaDefinition, mode: SchemaInstall, ) -> Result<(), KgError>::clippy::result_large_err",
       "classification": "api-shape"
     },
     {

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -512,7 +512,7 @@
         },
         "define_schema": {
           "kind": "method",
-          "signature": "(self, /, schema_dict)"
+          "signature": "(self, /, schema_dict, *, replace=False)"
         },
         "degree_centrality": {
           "kind": "method",

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -1840,6 +1840,20 @@ impl core::hash::Hash for kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
+pub enum kglite::api::SchemaInstall
+pub kglite::api::SchemaInstall::Merge
+pub kglite::api::SchemaInstall::Replace
+impl core::clone::Clone for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::clone(&self) -> kglite::api::SchemaInstall
+impl core::cmp::Eq for kglite::api::SchemaInstall
+impl core::cmp::PartialEq for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::eq(&self, other: &kglite::api::SchemaInstall) -> bool
+impl core::default::Default for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::default() -> kglite::api::SchemaInstall
+impl core::fmt::Debug for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::SchemaInstall
+impl core::marker::StructuralPartialEq for kglite::api::SchemaInstall
 pub enum kglite::api::SelectionOperation
 pub kglite::api::SelectionOperation::Custom(alloc::string::String)
 pub kglite::api::SelectionOperation::Filter(std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::FilterCondition>)
@@ -2094,12 +2108,13 @@ impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::auto_timestamp_for(&self, node_type: &str) -> bool
 pub fn kglite::api::DirGraph::auto_timestamp_for_connection(&self, conn_type: &str) -> bool
 pub fn kglite::api::DirGraph::clear_schema(&mut self)
+pub fn kglite::api::DirGraph::constraints_dropped_by_replace(&self, incoming: &kglite::api::SchemaDefinition) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::DirGraph::get_instructions(&self, channel: core::option::Option<&str>) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::get_schema(&self) -> core::option::Option<&kglite::api::SchemaDefinition>
 pub fn kglite::api::DirGraph::layer_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::primary_key_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::set_instructions(&mut self, text: &str, channel: core::option::Option<&str>)
-pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition) -> core::result::Result<(), kglite::error::KgError>
+pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition, mode: kglite::api::SchemaInstall) -> core::result::Result<(), kglite::error::KgError>
 pub fn kglite::api::DirGraph::with_write_provenance<R>(&mut self, git_sha: core::option::Option<&str>, modified_by: core::option::Option<&str>, write: impl core::ops::function::FnOnce(&mut Self) -> R) -> R
 impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::compact_disk(&mut self) -> core::result::Result<usize, alloc::string::String>
@@ -2403,6 +2418,7 @@ pub kglite::api::SchemaDefinition::node_schemas: std::collections::hash::map::Ha
 impl kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::add_connection_schema(&mut self, connection_type: alloc::string::String, schema: kglite::api::ConnectionSchemaDefinition)
 pub fn kglite::api::SchemaDefinition::add_node_schema(&mut self, node_type: alloc::string::String, schema: kglite::api::NodeSchemaDefinition)
+pub fn kglite::api::SchemaDefinition::merged_with(self, incoming: kglite::api::SchemaDefinition) -> Self
 pub fn kglite::api::SchemaDefinition::new() -> Self
 impl core::clone::Clone for kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::clone(&self) -> kglite::api::SchemaDefinition
@@ -2479,6 +2495,7 @@ impl serde_core::ser::Serialize for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const kglite::api::CANONICAL_NODE_COLUMNS: [&str; 3]
 pub trait kglite::api::Embedder: core::marker::Send + core::marker::Sync
 pub fn kglite::api::Embedder::dimension(&self) -> usize
 pub fn kglite::api::Embedder::embed(&self, texts: &[alloc::string::String]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<f32>>, alloc::string::String>
@@ -2707,10 +2724,12 @@ pub fn kglite::api::durable::RecordingGraph<G>::node_weight(&self, idx: petgraph
 pub fn kglite::api::durable::RecordingGraph<G>::reset_arenas(&self)
 pub fn kglite::api::durable::RecordingGraph<G>::sources_for_conn_type_bounded(&self, conn_type: kglite::api::InternedKey, max: core::option::Option<usize>) -> core::option::Option<alloc::vec::Vec<u32>>
 pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph::graph_impl::NodeIndex, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
+pub fn kglite::api::discover_property_keys_excluding(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner, excluded: &[&str]) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::discover_property_keys_from_data(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::explore_markdown(dir: &kglite::api::DirGraph, query: &str, opts: &kglite::api::ExploreOptions, source_roots: &[std::path::PathBuf]) -> alloc::string::String
 pub fn kglite::api::graphgen(cfg: &kglite::graphgen::GraphGenConfig, out_dir: &std::path::Path) -> core::io::error::Result<kglite::graphgen::GraphGenStats>
 pub fn kglite::api::infer_selection_node_type(selection: &kglite::api::CowSelection, dir: &alloc::sync::Arc<kglite::api::DirGraph>) -> core::option::Option<alloc::string::String>
+pub fn kglite::api::is_canonical_node_column(key: &str) -> bool
 pub fn kglite::api::make_dir_graph_mut(arc: &mut alloc::sync::Arc<kglite::api::DirGraph>) -> &mut kglite::api::DirGraph
 pub fn kglite::api::parse_spatial_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::SpatialConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>
 pub fn kglite::api::parse_temporal_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::TemporalConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -1825,6 +1825,20 @@ impl core::hash::Hash for kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
+pub enum kglite::api::SchemaInstall
+pub kglite::api::SchemaInstall::Merge
+pub kglite::api::SchemaInstall::Replace
+impl core::clone::Clone for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::clone(&self) -> kglite::api::SchemaInstall
+impl core::cmp::Eq for kglite::api::SchemaInstall
+impl core::cmp::PartialEq for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::eq(&self, other: &kglite::api::SchemaInstall) -> bool
+impl core::default::Default for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::default() -> kglite::api::SchemaInstall
+impl core::fmt::Debug for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::SchemaInstall
+impl core::marker::StructuralPartialEq for kglite::api::SchemaInstall
 pub enum kglite::api::SelectionOperation
 pub kglite::api::SelectionOperation::Custom(alloc::string::String)
 pub kglite::api::SelectionOperation::Filter(std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::FilterCondition>)
@@ -2079,12 +2093,13 @@ impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::auto_timestamp_for(&self, node_type: &str) -> bool
 pub fn kglite::api::DirGraph::auto_timestamp_for_connection(&self, conn_type: &str) -> bool
 pub fn kglite::api::DirGraph::clear_schema(&mut self)
+pub fn kglite::api::DirGraph::constraints_dropped_by_replace(&self, incoming: &kglite::api::SchemaDefinition) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::DirGraph::get_instructions(&self, channel: core::option::Option<&str>) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::get_schema(&self) -> core::option::Option<&kglite::api::SchemaDefinition>
 pub fn kglite::api::DirGraph::layer_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::primary_key_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::set_instructions(&mut self, text: &str, channel: core::option::Option<&str>)
-pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition) -> core::result::Result<(), kglite::error::KgError>
+pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition, mode: kglite::api::SchemaInstall) -> core::result::Result<(), kglite::error::KgError>
 pub fn kglite::api::DirGraph::with_write_provenance<R>(&mut self, git_sha: core::option::Option<&str>, modified_by: core::option::Option<&str>, write: impl core::ops::function::FnOnce(&mut Self) -> R) -> R
 impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::compact_disk(&mut self) -> core::result::Result<usize, alloc::string::String>
@@ -2379,6 +2394,7 @@ pub kglite::api::SchemaDefinition::node_schemas: std::collections::hash::map::Ha
 impl kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::add_connection_schema(&mut self, connection_type: alloc::string::String, schema: kglite::api::ConnectionSchemaDefinition)
 pub fn kglite::api::SchemaDefinition::add_node_schema(&mut self, node_type: alloc::string::String, schema: kglite::api::NodeSchemaDefinition)
+pub fn kglite::api::SchemaDefinition::merged_with(self, incoming: kglite::api::SchemaDefinition) -> Self
 pub fn kglite::api::SchemaDefinition::new() -> Self
 impl core::clone::Clone for kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::clone(&self) -> kglite::api::SchemaDefinition
@@ -2455,6 +2471,7 @@ impl serde_core::ser::Serialize for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const kglite::api::CANONICAL_NODE_COLUMNS: [&str; 3]
 pub trait kglite::api::Embedder: core::marker::Send + core::marker::Sync
 pub fn kglite::api::Embedder::dimension(&self) -> usize
 pub fn kglite::api::Embedder::embed(&self, texts: &[alloc::string::String]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<f32>>, alloc::string::String>
@@ -2677,10 +2694,12 @@ pub fn kglite::api::durable::RecordingGraph<G>::node_weight(&self, idx: petgraph
 pub fn kglite::api::durable::RecordingGraph<G>::reset_arenas(&self)
 pub fn kglite::api::durable::RecordingGraph<G>::sources_for_conn_type_bounded(&self, conn_type: kglite::api::InternedKey, max: core::option::Option<usize>) -> core::option::Option<alloc::vec::Vec<u32>>
 pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph::graph_impl::NodeIndex, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
+pub fn kglite::api::discover_property_keys_excluding(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner, excluded: &[&str]) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::discover_property_keys_from_data(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::explore_markdown(dir: &kglite::api::DirGraph, query: &str, opts: &kglite::api::ExploreOptions, source_roots: &[std::path::PathBuf]) -> alloc::string::String
 pub fn kglite::api::graphgen(cfg: &kglite::graphgen::GraphGenConfig, out_dir: &std::path::Path) -> core::io::error::Result<kglite::graphgen::GraphGenStats>
 pub fn kglite::api::infer_selection_node_type(selection: &kglite::api::CowSelection, dir: &alloc::sync::Arc<kglite::api::DirGraph>) -> core::option::Option<alloc::string::String>
+pub fn kglite::api::is_canonical_node_column(key: &str) -> bool
 pub fn kglite::api::make_dir_graph_mut(arc: &mut alloc::sync::Arc<kglite::api::DirGraph>) -> &mut kglite::api::DirGraph
 pub fn kglite::api::parse_spatial_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::SpatialConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>
 pub fn kglite::api::parse_temporal_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::TemporalConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -1825,6 +1825,20 @@ impl core::hash::Hash for kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
+pub enum kglite::api::SchemaInstall
+pub kglite::api::SchemaInstall::Merge
+pub kglite::api::SchemaInstall::Replace
+impl core::clone::Clone for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::clone(&self) -> kglite::api::SchemaInstall
+impl core::cmp::Eq for kglite::api::SchemaInstall
+impl core::cmp::PartialEq for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::eq(&self, other: &kglite::api::SchemaInstall) -> bool
+impl core::default::Default for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::default() -> kglite::api::SchemaInstall
+impl core::fmt::Debug for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::SchemaInstall
+impl core::marker::StructuralPartialEq for kglite::api::SchemaInstall
 pub enum kglite::api::SelectionOperation
 pub kglite::api::SelectionOperation::Custom(alloc::string::String)
 pub kglite::api::SelectionOperation::Filter(std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::FilterCondition>)
@@ -2079,12 +2093,13 @@ impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::auto_timestamp_for(&self, node_type: &str) -> bool
 pub fn kglite::api::DirGraph::auto_timestamp_for_connection(&self, conn_type: &str) -> bool
 pub fn kglite::api::DirGraph::clear_schema(&mut self)
+pub fn kglite::api::DirGraph::constraints_dropped_by_replace(&self, incoming: &kglite::api::SchemaDefinition) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::DirGraph::get_instructions(&self, channel: core::option::Option<&str>) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::get_schema(&self) -> core::option::Option<&kglite::api::SchemaDefinition>
 pub fn kglite::api::DirGraph::layer_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::primary_key_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::set_instructions(&mut self, text: &str, channel: core::option::Option<&str>)
-pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition) -> core::result::Result<(), kglite::error::KgError>
+pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition, mode: kglite::api::SchemaInstall) -> core::result::Result<(), kglite::error::KgError>
 pub fn kglite::api::DirGraph::with_write_provenance<R>(&mut self, git_sha: core::option::Option<&str>, modified_by: core::option::Option<&str>, write: impl core::ops::function::FnOnce(&mut Self) -> R) -> R
 impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::compact_disk(&mut self) -> core::result::Result<usize, alloc::string::String>
@@ -2388,6 +2403,7 @@ pub kglite::api::SchemaDefinition::node_schemas: std::collections::hash::map::Ha
 impl kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::add_connection_schema(&mut self, connection_type: alloc::string::String, schema: kglite::api::ConnectionSchemaDefinition)
 pub fn kglite::api::SchemaDefinition::add_node_schema(&mut self, node_type: alloc::string::String, schema: kglite::api::NodeSchemaDefinition)
+pub fn kglite::api::SchemaDefinition::merged_with(self, incoming: kglite::api::SchemaDefinition) -> Self
 pub fn kglite::api::SchemaDefinition::new() -> Self
 impl core::clone::Clone for kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::clone(&self) -> kglite::api::SchemaDefinition
@@ -2464,6 +2480,7 @@ impl serde_core::ser::Serialize for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const kglite::api::CANONICAL_NODE_COLUMNS: [&str; 3]
 pub trait kglite::api::Embedder: core::marker::Send + core::marker::Sync
 pub fn kglite::api::Embedder::dimension(&self) -> usize
 pub fn kglite::api::Embedder::embed(&self, texts: &[alloc::string::String]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<f32>>, alloc::string::String>
@@ -2692,10 +2709,12 @@ pub fn kglite::api::durable::RecordingGraph<G>::node_weight(&self, idx: petgraph
 pub fn kglite::api::durable::RecordingGraph<G>::reset_arenas(&self)
 pub fn kglite::api::durable::RecordingGraph<G>::sources_for_conn_type_bounded(&self, conn_type: kglite::api::InternedKey, max: core::option::Option<usize>) -> core::option::Option<alloc::vec::Vec<u32>>
 pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph::graph_impl::NodeIndex, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
+pub fn kglite::api::discover_property_keys_excluding(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner, excluded: &[&str]) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::discover_property_keys_from_data(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::explore_markdown(dir: &kglite::api::DirGraph, query: &str, opts: &kglite::api::ExploreOptions, source_roots: &[std::path::PathBuf]) -> alloc::string::String
 pub fn kglite::api::graphgen(cfg: &kglite::graphgen::GraphGenConfig, out_dir: &std::path::Path) -> core::io::error::Result<kglite::graphgen::GraphGenStats>
 pub fn kglite::api::infer_selection_node_type(selection: &kglite::api::CowSelection, dir: &alloc::sync::Arc<kglite::api::DirGraph>) -> core::option::Option<alloc::string::String>
+pub fn kglite::api::is_canonical_node_column(key: &str) -> bool
 pub fn kglite::api::make_dir_graph_mut(arc: &mut alloc::sync::Arc<kglite::api::DirGraph>) -> &mut kglite::api::DirGraph
 pub fn kglite::api::parse_spatial_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::SpatialConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>
 pub fn kglite::api::parse_temporal_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::TemporalConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -1825,6 +1825,20 @@ impl core::hash::Hash for kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
+pub enum kglite::api::SchemaInstall
+pub kglite::api::SchemaInstall::Merge
+pub kglite::api::SchemaInstall::Replace
+impl core::clone::Clone for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::clone(&self) -> kglite::api::SchemaInstall
+impl core::cmp::Eq for kglite::api::SchemaInstall
+impl core::cmp::PartialEq for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::eq(&self, other: &kglite::api::SchemaInstall) -> bool
+impl core::default::Default for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::default() -> kglite::api::SchemaInstall
+impl core::fmt::Debug for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::SchemaInstall
+impl core::marker::StructuralPartialEq for kglite::api::SchemaInstall
 pub enum kglite::api::SelectionOperation
 pub kglite::api::SelectionOperation::Custom(alloc::string::String)
 pub kglite::api::SelectionOperation::Filter(std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::FilterCondition>)
@@ -2079,12 +2093,13 @@ impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::auto_timestamp_for(&self, node_type: &str) -> bool
 pub fn kglite::api::DirGraph::auto_timestamp_for_connection(&self, conn_type: &str) -> bool
 pub fn kglite::api::DirGraph::clear_schema(&mut self)
+pub fn kglite::api::DirGraph::constraints_dropped_by_replace(&self, incoming: &kglite::api::SchemaDefinition) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::DirGraph::get_instructions(&self, channel: core::option::Option<&str>) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::get_schema(&self) -> core::option::Option<&kglite::api::SchemaDefinition>
 pub fn kglite::api::DirGraph::layer_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::primary_key_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::set_instructions(&mut self, text: &str, channel: core::option::Option<&str>)
-pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition) -> core::result::Result<(), kglite::error::KgError>
+pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition, mode: kglite::api::SchemaInstall) -> core::result::Result<(), kglite::error::KgError>
 pub fn kglite::api::DirGraph::with_write_provenance<R>(&mut self, git_sha: core::option::Option<&str>, modified_by: core::option::Option<&str>, write: impl core::ops::function::FnOnce(&mut Self) -> R) -> R
 impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::compact_disk(&mut self) -> core::result::Result<usize, alloc::string::String>
@@ -2379,6 +2394,7 @@ pub kglite::api::SchemaDefinition::node_schemas: std::collections::hash::map::Ha
 impl kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::add_connection_schema(&mut self, connection_type: alloc::string::String, schema: kglite::api::ConnectionSchemaDefinition)
 pub fn kglite::api::SchemaDefinition::add_node_schema(&mut self, node_type: alloc::string::String, schema: kglite::api::NodeSchemaDefinition)
+pub fn kglite::api::SchemaDefinition::merged_with(self, incoming: kglite::api::SchemaDefinition) -> Self
 pub fn kglite::api::SchemaDefinition::new() -> Self
 impl core::clone::Clone for kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::clone(&self) -> kglite::api::SchemaDefinition
@@ -2455,6 +2471,7 @@ impl serde_core::ser::Serialize for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const kglite::api::CANONICAL_NODE_COLUMNS: [&str; 3]
 pub trait kglite::api::Embedder: core::marker::Send + core::marker::Sync
 pub fn kglite::api::Embedder::dimension(&self) -> usize
 pub fn kglite::api::Embedder::embed(&self, texts: &[alloc::string::String]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<f32>>, alloc::string::String>
@@ -2677,10 +2694,12 @@ pub fn kglite::api::durable::RecordingGraph<G>::node_weight(&self, idx: petgraph
 pub fn kglite::api::durable::RecordingGraph<G>::reset_arenas(&self)
 pub fn kglite::api::durable::RecordingGraph<G>::sources_for_conn_type_bounded(&self, conn_type: kglite::api::InternedKey, max: core::option::Option<usize>) -> core::option::Option<alloc::vec::Vec<u32>>
 pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph::graph_impl::NodeIndex, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
+pub fn kglite::api::discover_property_keys_excluding(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner, excluded: &[&str]) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::discover_property_keys_from_data(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::explore_markdown(dir: &kglite::api::DirGraph, query: &str, opts: &kglite::api::ExploreOptions, source_roots: &[std::path::PathBuf]) -> alloc::string::String
 pub fn kglite::api::graphgen(cfg: &kglite::graphgen::GraphGenConfig, out_dir: &std::path::Path) -> core::io::error::Result<kglite::graphgen::GraphGenStats>
 pub fn kglite::api::infer_selection_node_type(selection: &kglite::api::CowSelection, dir: &alloc::sync::Arc<kglite::api::DirGraph>) -> core::option::Option<alloc::string::String>
+pub fn kglite::api::is_canonical_node_column(key: &str) -> bool
 pub fn kglite::api::make_dir_graph_mut(arc: &mut alloc::sync::Arc<kglite::api::DirGraph>) -> &mut kglite::api::DirGraph
 pub fn kglite::api::parse_spatial_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::SpatialConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>
 pub fn kglite::api::parse_temporal_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::TemporalConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -1840,6 +1840,20 @@ impl core::hash::Hash for kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
+pub enum kglite::api::SchemaInstall
+pub kglite::api::SchemaInstall::Merge
+pub kglite::api::SchemaInstall::Replace
+impl core::clone::Clone for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::clone(&self) -> kglite::api::SchemaInstall
+impl core::cmp::Eq for kglite::api::SchemaInstall
+impl core::cmp::PartialEq for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::eq(&self, other: &kglite::api::SchemaInstall) -> bool
+impl core::default::Default for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::default() -> kglite::api::SchemaInstall
+impl core::fmt::Debug for kglite::api::SchemaInstall
+pub fn kglite::api::SchemaInstall::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::SchemaInstall
+impl core::marker::StructuralPartialEq for kglite::api::SchemaInstall
 pub enum kglite::api::SelectionOperation
 pub kglite::api::SelectionOperation::Custom(alloc::string::String)
 pub kglite::api::SelectionOperation::Filter(std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::FilterCondition>)
@@ -2094,12 +2108,13 @@ impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::auto_timestamp_for(&self, node_type: &str) -> bool
 pub fn kglite::api::DirGraph::auto_timestamp_for_connection(&self, conn_type: &str) -> bool
 pub fn kglite::api::DirGraph::clear_schema(&mut self)
+pub fn kglite::api::DirGraph::constraints_dropped_by_replace(&self, incoming: &kglite::api::SchemaDefinition) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::DirGraph::get_instructions(&self, channel: core::option::Option<&str>) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::get_schema(&self) -> core::option::Option<&kglite::api::SchemaDefinition>
 pub fn kglite::api::DirGraph::layer_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::primary_key_for(&self, node_type: &str) -> core::option::Option<&str>
 pub fn kglite::api::DirGraph::set_instructions(&mut self, text: &str, channel: core::option::Option<&str>)
-pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition) -> core::result::Result<(), kglite::error::KgError>
+pub fn kglite::api::DirGraph::set_schema(&mut self, schema: kglite::api::SchemaDefinition, mode: kglite::api::SchemaInstall) -> core::result::Result<(), kglite::error::KgError>
 pub fn kglite::api::DirGraph::with_write_provenance<R>(&mut self, git_sha: core::option::Option<&str>, modified_by: core::option::Option<&str>, write: impl core::ops::function::FnOnce(&mut Self) -> R) -> R
 impl kglite::api::DirGraph
 pub fn kglite::api::DirGraph::compact_disk(&mut self) -> core::result::Result<usize, alloc::string::String>
@@ -2394,6 +2409,7 @@ pub kglite::api::SchemaDefinition::node_schemas: std::collections::hash::map::Ha
 impl kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::add_connection_schema(&mut self, connection_type: alloc::string::String, schema: kglite::api::ConnectionSchemaDefinition)
 pub fn kglite::api::SchemaDefinition::add_node_schema(&mut self, node_type: alloc::string::String, schema: kglite::api::NodeSchemaDefinition)
+pub fn kglite::api::SchemaDefinition::merged_with(self, incoming: kglite::api::SchemaDefinition) -> Self
 pub fn kglite::api::SchemaDefinition::new() -> Self
 impl core::clone::Clone for kglite::api::SchemaDefinition
 pub fn kglite::api::SchemaDefinition::clone(&self) -> kglite::api::SchemaDefinition
@@ -2470,6 +2486,7 @@ impl serde_core::ser::Serialize for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::TemporalConfig
 pub fn kglite::api::TemporalConfig::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub const kglite::api::CANONICAL_NODE_COLUMNS: [&str; 3]
 pub trait kglite::api::Embedder: core::marker::Send + core::marker::Sync
 pub fn kglite::api::Embedder::dimension(&self) -> usize
 pub fn kglite::api::Embedder::embed(&self, texts: &[alloc::string::String]) -> core::result::Result<alloc::vec::Vec<alloc::vec::Vec<f32>>, alloc::string::String>
@@ -2692,10 +2709,12 @@ pub fn kglite::api::durable::RecordingGraph<G>::node_weight(&self, idx: petgraph
 pub fn kglite::api::durable::RecordingGraph<G>::reset_arenas(&self)
 pub fn kglite::api::durable::RecordingGraph<G>::sources_for_conn_type_bounded(&self, conn_type: kglite::api::InternedKey, max: core::option::Option<usize>) -> core::option::Option<alloc::vec::Vec<u32>>
 pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph::graph_impl::NodeIndex, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
+pub fn kglite::api::discover_property_keys_excluding(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner, excluded: &[&str]) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::discover_property_keys_from_data(nodes: &[(&str, &kglite::api::NodeData)], interner: &kglite::api::StringInterner) -> alloc::vec::Vec<alloc::string::String>
 pub fn kglite::api::explore_markdown(dir: &kglite::api::DirGraph, query: &str, opts: &kglite::api::ExploreOptions, source_roots: &[std::path::PathBuf]) -> alloc::string::String
 pub fn kglite::api::graphgen(cfg: &kglite::graphgen::GraphGenConfig, out_dir: &std::path::Path) -> core::io::error::Result<kglite::graphgen::GraphGenStats>
 pub fn kglite::api::infer_selection_node_type(selection: &kglite::api::CowSelection, dir: &alloc::sync::Arc<kglite::api::DirGraph>) -> core::option::Option<alloc::string::String>
+pub fn kglite::api::is_canonical_node_column(key: &str) -> bool
 pub fn kglite::api::make_dir_graph_mut(arc: &mut alloc::sync::Arc<kglite::api::DirGraph>) -> &mut kglite::api::DirGraph
 pub fn kglite::api::parse_spatial_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::SpatialConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>
 pub fn kglite::api::parse_temporal_column_types_from_pairs(pairs: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>) -> core::result::Result<(core::option::Option<kglite::api::TemporalConfig>, alloc::vec::Vec<(alloc::string::String, alloc::string::String)>), alloc::string::String>

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -252,8 +252,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/aggregation/materialized.rs",
       "qualified_name": "crate::CypherExecutor<'a>::execute_return_with_aggregation",
-      "lines": 246,
-      "branches": 39,
+      "lines": 237,
+      "branches": 34,
       "nesting": 5
     },
     {
@@ -390,13 +390,6 @@
       "nesting": 3
     },
     {
-      "path": "crates/kglite/src/graph/languages/cypher/executor/stream/aggregate.rs",
-      "qualified_name": "crate::apply",
-      "lines": 204,
-      "branches": 26,
-      "nesting": 4
-    },
-    {
       "path": "crates/kglite/src/graph/languages/cypher/executor/where_clause.rs",
       "qualified_name": "crate::CypherExecutor<'a>::evaluate_predicate_tristate",
       "lines": 321,
@@ -476,8 +469,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/planner/schema_check.rs",
       "qualified_name": "crate::validate_scope",
-      "lines": 201,
-      "branches": 79,
+      "lines": 179,
+      "branches": 72,
       "nesting": 6
     },
     {
@@ -516,6 +509,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +535,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -516,6 +516,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +542,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",
@@ -567,8 +567,8 @@
     {
       "path": "crates/kglite/src/graph/storage/disk/builder.rs",
       "qualified_name": "crate::DiskGraph::build_csr_partitioned",
-      "lines": 368,
-      "branches": 52,
+      "lines": 246,
+      "branches": 33,
       "nesting": 4
     },
     {

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -196,9 +196,9 @@
     {
       "path": "crates/kglite/src/graph/io/export.rs",
       "qualified_name": "crate::to_csv_dir",
-      "lines": 307,
-      "branches": 40,
-      "nesting": 6
+      "lines": 283,
+      "branches": 32,
+      "nesting": 5
     },
     {
       "path": "crates/kglite/src/graph/io/file.rs",
@@ -516,6 +516,13 @@
       "nesting": 6
     },
     {
+      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
+      "qualified_name": "crate::add_properties_aggregate",
+      "lines": 165,
+      "branches": 36,
+      "nesting": 10
+    },
+    {
       "path": "crates/kglite/src/graph/mutation/extend.rs",
       "qualified_name": "crate::extend_graph",
       "lines": 218,
@@ -535,13 +542,6 @@
       "lines": 275,
       "branches": 32,
       "nesting": 4
-    },
-    {
-      "path": "crates/kglite/src/graph/mutation/add_properties.rs",
-      "qualified_name": "crate::add_properties_aggregate",
-      "lines": 165,
-      "branches": 36,
-      "nesting": 10
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",

--- a/tests/test_canonical_column_collision.py
+++ b/tests/test_canonical_column_collision.py
@@ -1,0 +1,201 @@
+"""A property named ``id``/``title``/``type`` must not duplicate its column.
+
+Every row-oriented node exporter leads each row with the node's **canonical
+identity** — ``id``, ``title``, and the structural ``type`` — taken from the
+node header rather than from its property bag. A node may *also* store a
+property under one of those names: ``CREATE (:T {title: 'a'})`` sets ``title``
+both ways, which is the ordinary way to build a graph in Cypher.
+
+An exporter that appends every discovered property key to those leading
+columns then emits the column twice. That is not a cosmetic wart:
+
+* the column map backing a DataFrame is keyed by name, so the second write
+  **overwrites the canonical value** — the duplicate destroys the identity it
+  appears to preserve (``add_nodes(df, 'T', 'id', 'name')`` plus a separate
+  ``title`` column silently lost the canonical title);
+* ``DataFrame.to_parquet()`` rejects a non-unique header outright with
+  ``ValueError: Duplicate column names found``, so the documented
+  ``to_df().to_parquet(...)`` recipe failed on any Cypher-built graph;
+* ``pandas.read_csv``/DuckDB silently rename the second column to
+  ``title.1``/``title_1``, inventing a phantom column in what
+  ``export_csv`` documents as the portable **backup** format.
+
+The rule, which the SQL-dump, d3/JSON and ``to_text`` exporters have always
+applied and which the three surfaces below now share: **a property colliding
+with an emitted canonical column is dropped; the canonical value wins.** A
+canonical column the caller opted out of (``to_df(include_type=False)``) is
+not emitted, so there is no collision and the stored property survives.
+"""
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+from kglite import KnowledgeGraph
+
+# Cypher `CREATE` stores `title` in the property bag *and* as the canonical
+# title — the collision is the normal case, not an exotic one.
+COLLIDING = "CREATE (n:T {id: 1, title: 'a', v: 2})"
+
+
+def _dupes(columns):
+    """Column names appearing more than once, in order."""
+    seen, dupes = set(), []
+    for c in columns:
+        if c in seen and c not in dupes:
+            dupes.append(c)
+        seen.add(c)
+    return dupes
+
+
+@pytest.fixture
+def graph():
+    g = KnowledgeGraph()
+    g.cypher(COLLIDING)
+    return g
+
+
+# --------------------------------------------------------------- DataFrame path
+
+
+def test_fluent_to_df_emits_title_once(graph):
+    df = graph.select("T").to_df()
+    assert _dupes(df.columns) == [], f"duplicate columns: {list(df.columns)}"
+    assert list(df.columns) == ["type", "title", "id", "v"]
+
+
+def test_fluent_to_df_keeps_canonical_values(graph):
+    """The surviving column carries real values, not a shadowed blank."""
+    row = graph.select("T").to_df().to_dict("records")[0]
+    assert row == {"type": "T", "title": "a", "id": 1, "v": 2}
+
+
+def test_collect_and_sample_emit_title_once(graph):
+    """`collect()`/`sample()` build their columns on a separate code path."""
+    for name in ("collect", "sample"):
+        cols = list(getattr(graph.select("T"), name)().columns)
+        assert _dupes(cols) == [], f"{name}() duplicate columns: {cols}"
+        assert cols == ["type", "title", "id", "v"]
+
+
+def test_schema_fast_path_emits_title_once():
+    """Above 50 same-type nodes, key discovery switches to the TypeSchema."""
+    g = KnowledgeGraph()
+    g.cypher('UNWIND range(1, 60) AS i CREATE (:B {id: i, title: "t" + toString(i), v: i})')
+    for cols in (
+        list(g.select("B").to_df().columns),
+        list(g.select("B").collect().columns),
+    ):
+        assert _dupes(cols) == [], f"duplicate columns on schema fast path: {cols}"
+        assert cols == ["type", "title", "id", "v"]
+
+
+def test_canonical_title_survives_a_differing_title_property():
+    """The regression that silently destroyed data.
+
+    `add_nodes(..., 'id', 'name')` makes `name` the canonical title, so a
+    separate `title` column is an ordinary property whose value *differs*
+    from the canonical title. The old duplicate-column output overwrote the
+    canonical value with the property; the canonical one must win.
+    """
+    pd = pytest.importorskip("pandas")
+    g = KnowledgeGraph()
+    g.add_nodes(
+        pd.DataFrame([{"id": 1, "name": "FromName", "title": "FromTitleCol", "v": 9}]),
+        "T",
+        "id",
+        "name",
+    )
+    df = g.select("T").to_df()
+    assert _dupes(df.columns) == [], f"duplicate columns: {list(df.columns)}"
+    assert df.to_dict("records")[0]["title"] == "FromName"
+
+
+def test_opted_out_canonical_column_leaves_the_property_intact():
+    """No emitted `type` column means no collision — the property is real data."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (n:T {id: 1, title: 'a', type: 'USER', v: 2})")
+
+    with_type = g.select("T").to_df()
+    assert _dupes(with_type.columns) == []
+    assert with_type.to_dict("records")[0]["type"] == "T"  # structural type wins
+
+    without_type = g.select("T").to_df(include_type=False)
+    assert _dupes(without_type.columns) == []
+    # The stored property survives, with its own value.
+    assert without_type.to_dict("records")[0]["type"] == "USER"
+
+
+# --------------------------------------------------------------------- CSV path
+
+
+def test_export_csv_header_is_unique(tmp_path, graph):
+    """`export_csv` is the documented portable backup — its header must be sane."""
+    graph.export_csv(str(tmp_path), selection_only=False)
+    header = (tmp_path / "nodes" / "T.csv").read_text(encoding="utf-8").splitlines()[0]
+    cols = header.split(",")
+    assert _dupes(cols) == [], f"duplicate CSV columns: {header}"
+    assert cols == ["id", "title", "v"]
+
+
+def test_export_csv_roundtrips_through_blueprint(tmp_path, graph):
+    """The backup path must still restore values after the de-duplication."""
+    import kglite
+
+    graph.export_csv(str(tmp_path), selection_only=False)
+    restored = kglite.from_blueprint(str(tmp_path / "blueprint.json"))
+    rows = restored.cypher("MATCH (n:T) RETURN n.id, n.title, n.v").to_list()
+    assert rows == [{"n.id": 1, "n.title": "a", "n.v": 2}]
+
+
+# ----------------------------------------------------------------- Parquet path
+#
+# The documented recipe is `to_df().to_parquet(...)`, and a non-unique header
+# is exactly what pandas refuses. We assert it end to end — but never import
+# pyarrow into the pytest runner: that arms the dual-mimalloc teardown SIGSEGV
+# the project pins mimalloc v2 to avoid (see test_pyarrow_coexistence.py).
+# Detection is import-free via find_spec; the real write happens in a
+# subprocess, run from a neutral cwd so the installed wheel wins over the
+# source tree.
+
+_PARQUET_SNIPPET = """
+import kglite
+g = kglite.KnowledgeGraph()
+g.cypher("CREATE (n:T {id: 1, title: 'a', v: 2})")
+df = g.select('T').to_df()
+assert list(df.columns) == ['type', 'title', 'id', 'v'], list(df.columns)
+
+path = 'out.parquet'
+df.to_parquet(path)
+
+import pandas as pd
+back = pd.read_parquet(path)
+assert list(back.columns) == ['type', 'title', 'id', 'v'], list(back.columns)
+assert back.to_dict('records')[0] == {'type': 'T', 'title': 'a', 'id': 1, 'v': 2}
+# Types must survive the round-trip, not just the values.
+assert str(back['id'].dtype) == 'int64', back['id'].dtype
+assert str(back['v'].dtype) == 'int64', back['v'].dtype
+print('OK')
+"""
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pyarrow") is None,
+    reason="pyarrow not installed — the documented to_parquet recipe needs it",
+)
+def test_to_df_to_parquet_recipe_roundtrips(tmp_path):
+    """`to_df().to_parquet(...)` — the documented Parquet exit — must work."""
+    result = subprocess.run(
+        [sys.executable, "-c", _PARQUET_SNIPPET],
+        cwd=str(tmp_path),  # neutral cwd: installed wheel, not the source tree
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"to_df().to_parquet() recipe failed (exit {result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -2092,6 +2092,70 @@ MUTATION_QUERIES: list[tuple[str, str]] = [
         "many_labels_one_node",
         "MATCH (p:Person {person_id: 2}) SET p:A SET p:B SET p:C WITH p REMOVE p:B RETURN labels(p) AS ls",
     ),
+    # ── Write clauses fed an empty binding stream ────────────────────────
+    #
+    # A clause that produced zero rows must leave every downstream write with
+    # nothing to do. What these pin for the optimizer specifically: no pass may
+    # drop, hoist, or fuse a write clause out from behind the emptying clause,
+    # because doing so would restore the write to a *leading* position — where
+    # Cypher's implicit start row legitimately applies and one node really is
+    # created. Optimized and naive therefore have to agree on post-state node
+    # and edge counts, which is what the harness compares.
+    #
+    # `person_id: 999` and the `Ghost` label are chosen to match nothing in the
+    # fixture; `Ghost` also makes the pattern's node type unknown, the shape the
+    # planner emits an "unknown node label … returns no rows" warning for.
+    (
+        "create_after_empty_inline_map_match",
+        "MATCH (p:Person {person_id: 999}) CREATE (t:Task {person_id: 900}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_where_match",
+        "MATCH (p:Person) WHERE p.person_id = 999 CREATE (t:Task {person_id: 901}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_match_with",
+        "MATCH (p:Person {person_id: 999}) WITH p CREATE (t:Task {person_id: 902}) RETURN t.person_id AS pid",
+    ),
+    (
+        "create_after_empty_relationship_match",
+        "MATCH (p:Person)-[:NO_SUCH_EDGE]->(q:Person) CREATE (t:Task {person_id: 903}) RETURN t.person_id AS pid",
+    ),
+    (
+        # The phantom-endpoint shape: `g` binds nothing, so creating the edge
+        # would have to invent its target node. Post-state edge count is the
+        # assertion that bites.
+        "create_edge_after_partially_unmatched_multi_pattern",
+        "MATCH (p:Person {person_id: 1}), (g:Ghost {person_id: 999}) "
+        "CREATE (p)-[:ASSIGNED_TO]->(g) RETURN count(*) AS n",
+    ),
+    (
+        "merge_after_empty_match",
+        "MATCH (p:Person {person_id: 999}) MERGE (t:Task {person_id: 904}) RETURN t.person_id AS pid",
+    ),
+    (
+        "foreach_after_empty_match",
+        "MATCH (p:Person {person_id: 999}) FOREACH (i IN [910, 911] | CREATE (:Task {person_id: i})) "
+        "WITH 1 AS done MATCH (n) RETURN count(n) AS n",
+    ),
+    (
+        "create_after_unwind_empty_list",
+        "UNWIND [] AS x CREATE (t:Task {person_id: 905}) RETURN t.person_id AS pid",
+    ),
+    (
+        # The control living in the corpus: a *leading* CREATE still gets
+        # Cypher's implicit start row. Pins that the empty-stream rule was not
+        # over-applied to writes that open a query.
+        "leading_create_still_runs_once",
+        "CREATE (t:Task {person_id: 906}) WITH 1 AS done MATCH (n) RETURN count(n) AS n",
+    ),
+    (
+        # OPTIONAL MATCH is the deliberate opposite: it null-pads rather than
+        # emptying, so the CREATE downstream of it must still run.
+        "create_after_optional_match_miss",
+        "MATCH (p:Person {person_id: 1}) OPTIONAL MATCH (g:Ghost) "
+        "CREATE (t:Task {person_id: 907}) RETURN t.person_id AS pid, g AS g",
+    ),
 ]
 
 

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -589,6 +589,40 @@ DIFFERENTIAL_QUERIES: list[tuple[str, str, str, dict | None]] = [
         "ORDER BY count(p) DESC, company LIMIT 3",
         None,
     ),
+    # ORDER BY a non-projected property of a *grouping* variable, after an
+    # aggregate. Aggregation rebuilds its output rows, so `p` survives only
+    # if the operator carries its binding forward — and the three
+    # aggregation operators (streaming, materialized, fused OPTIONAL) used
+    # to disagree about that. Where the binding was dropped the sort key
+    # evaluated to NULL on every row and the ORDER BY was silently ignored.
+    # The optimizer decides which operator runs, so opt-vs-naive is exactly
+    # the axis that exposed it. Row-order assertions live in
+    # tests/test_cypher_order_by_after_aggregate.py; these entries guard the
+    # row-set equality the corpus is responsible for.
+    (
+        "optional_match_aggregate_order_by_non_projected",
+        "social_graph",
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:WORKS_AT]->(c:Company) "
+        "RETURN p.name AS person, count(c) AS jobs ORDER BY p.age DESC",
+        None,
+    ),
+    (
+        "optional_match_aggregate_order_by_non_projected_paged",
+        "social_graph",
+        "MATCH (p:Person) OPTIONAL MATCH (p)-[:KNOWS]->(f:Person) "
+        "RETURN p.name AS person, count(f) AS friends "
+        "ORDER BY p.age DESC SKIP 5 LIMIT 5",
+        None,
+    ),
+    # `collect()` is outside the streaming aggregate's reach, so this one
+    # takes the materialized path — the same defect with no OPTIONAL MATCH
+    # involved at all.
+    (
+        "collect_aggregate_order_by_non_projected",
+        "social_graph",
+        "MATCH (p:Person) RETURN p.city AS city, collect(p.name) AS names ORDER BY p.city DESC",
+        None,
+    ),
     # Aggregate on the EDGE variable (not a node variable). Pre-fix the
     # gate at fuse_match_return_aggregate only accepted count(<other-node>);
     # count(<edge_var>) silently fell out of fusion despite being

--- a/tests/test_cypher_differential.py
+++ b/tests/test_cypher_differential.py
@@ -2026,6 +2026,15 @@ MUTATION_QUERIES: list[tuple[str, str]] = [
     ("create_constraint_not_null_ddl", "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL"),
     ("create_constraint_node_key_ddl", "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NODE KEY"),
     ("drop_constraint_ddl_missing_if_exists", "DROP CONSTRAINT person_name_u IF EXISTS"),
+    # Declaring one half of a node key on a property that already carries the
+    # other must *add* to it rather than replace it, so the post-statement graph
+    # state carries both. A pass that dropped or reordered the second statement
+    # would leave only one half enforced — which this harness sees as diverging
+    # post-state once a later write is rejected on one path and not the other.
+    # Both orders, because the merge is order-sensitive code.
+    # Multi-statement constraint shapes live in CONSTRAINT_DDL_SEQUENCES below:
+    # a schema command is a standalone statement, so a merge (declaring one half
+    # of a node key over the other) cannot be expressed as one query here.
     # ── Shapes whose rollback checkpoint is an undo journal ──────────────
     #
     # Statement atomicity is bought with an inverse-op journal rather than a
@@ -2367,6 +2376,106 @@ def test_mutation_optimized_matches_naive(name: str, query: str) -> None:
     assert rows_opt == rows_naive, f"Mutation `{name}` rows: opt={rows_opt}, naive={rows_naive}"
     assert nodes_opt == nodes_naive, f"Mutation `{name}` post-state node count: opt={nodes_opt}, naive={nodes_naive}"
     assert edges_opt == edges_naive, f"Mutation `{name}` post-state edge count: opt={edges_opt}, naive={edges_naive}"
+
+
+# ---------------------------------------------------------------------------
+# Constraint DDL sequences
+# ---------------------------------------------------------------------------
+#
+# A fourth corpus, separate for one mechanical reason: a schema command is a
+# standalone statement, so the shapes that matter here — declaring one half of a
+# node key on a property that already carries the other, then dropping one half
+# again — need *several* statements, which MUTATION_QUERIES cannot express.
+#
+# What these pin: constraint declaration is state accumulation, not replacement.
+# Comparing `SHOW CONSTRAINTS` after the sequence catches a divergence in what
+# is *reported*; the enforcement probes catch a divergence in what is actually
+# in force. Both halves are needed — the audit that produced this corpus found a
+# listing reporting NODE_KEY for a pair whose presence half was not enforced,
+# and a report whose constraint name changed across a save/load round-trip.
+CONSTRAINT_DDL_SEQUENCES: list[tuple[str, list[str], list[str]]] = [
+    (
+        "not_null_over_existing_unique",
+        [
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL",
+        ],
+        # Both halves in force: a duplicate name and a missing name are refused.
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})", "CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "unique_over_existing_not_null",
+        [
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE",
+        ],
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})", "CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "drop_the_unique_half_of_a_pair",
+        [
+            "CREATE CONSTRAINT pn_u FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT pn_nn FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "DROP CONSTRAINT pn_u",
+        ],
+        ["CREATE (p:Person {person_id: 901, age: 1})"],
+    ),
+    (
+        "drop_the_not_null_half_of_a_pair",
+        [
+            "CREATE CONSTRAINT pn_u FOR (p:Person) REQUIRE p.name IS UNIQUE",
+            "CREATE CONSTRAINT pn_nn FOR (p:Person) REQUIRE p.name IS NOT NULL",
+            "DROP CONSTRAINT pn_nn",
+        ],
+        ["CREATE (p:Person {person_id: 900, name: 'Alice', age: 1})"],
+    ),
+]
+
+
+def _constraint_state(g, probes: list[str]) -> tuple[list[dict], list[bool]]:
+    """What the graph reports, and what it actually enforces.
+
+    A fix to either half alone is not a fix, so the differential compares both.
+    """
+    reported = _normalize(g.cypher("SHOW CONSTRAINTS").to_list())
+    enforced = []
+    for probe in probes:
+        try:
+            g.cypher(probe)
+            enforced.append(False)
+        except Exception:
+            enforced.append(True)
+    return reported, enforced
+
+
+@pytest.mark.differential
+@pytest.mark.parametrize(
+    "name,statements,probes",
+    CONSTRAINT_DDL_SEQUENCES,
+    ids=[entry[0] for entry in CONSTRAINT_DDL_SEQUENCES],
+)
+def test_constraint_ddl_sequence_optimized_matches_naive(name: str, statements: list[str], probes: list[str]) -> None:
+    opt_reported, opt_enforced = _constraint_state(
+        _run_constraint_sequence(statements, disable_optimizer=False), probes
+    )
+    naive_reported, naive_enforced = _constraint_state(
+        _run_constraint_sequence(statements, disable_optimizer=True), probes
+    )
+
+    assert opt_reported == naive_reported, f"`{name}` SHOW CONSTRAINTS: opt={opt_reported}, naive={naive_reported}"
+    assert opt_enforced == naive_enforced, f"`{name}` enforcement: opt={opt_enforced}, naive={naive_enforced}"
+    # Every sequence above leaves at least one constraint declared and every
+    # probe violating it, so a run that silently enforced nothing is a failure
+    # rather than a vacuous pass.
+    assert opt_reported, f"`{name}` declared no constraint at all"
+    assert all(opt_enforced), f"`{name}` reported constraints it does not enforce: {opt_enforced}"
+
+
+def _run_constraint_sequence(statements: list[str], *, disable_optimizer: bool):
+    g = _build_mutation_graph()
+    for statement in statements:
+        g.cypher(statement, disable_optimizer=disable_optimizer)
+    return g
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cypher_empty_stream_writes.py
+++ b/tests/test_cypher_empty_stream_writes.py
@@ -1,0 +1,231 @@
+"""A write clause fed zero rows must write nothing.
+
+Cypher's pipeline conceptually starts with one implicit empty row, so a
+*leading* `CREATE`/`MERGE`/`FOREACH` runs once. Once any clause has run,
+though, an empty row set means genuinely zero rows and every downstream
+clause — read or write — must produce zero rows and no side effects.
+
+The engine used to conflate the two states: `execute_create`,
+`execute_merge`, and `execute_foreach` each re-derived "am I leading?" from
+`rows.is_empty()`, which is also what a MATCH that found nothing leaves
+behind. So `MATCH (p:Project {key:'NOPE'}) CREATE (t:Task)` fabricated a row
+and created an unbound node. `SET`/`DELETE`/`REMOVE` never had the bug
+because they simply iterate the incoming rows.
+
+Why this matters beyond row counts: with no referential-integrity
+constraints, "MATCH the parent, then CREATE the child" is the only mechanism
+an application has to enforce a foreign key. The two-variable form was worse
+than a spurious row — it fabricated the *unmatched endpoint* as a real node,
+leaving an edge pointing at a label-less, property-less node.
+
+The fix moved the implicit-start-row seed up into `run_clause_pipeline`,
+which is the only place that can tell "not started" from "zero rows".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import kglite
+
+
+def _graph_with_project():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (:Project {key: 'WEB'})").to_list()
+    return graph
+
+
+def _node_count(graph, pattern="(n)"):
+    return graph.cypher(f"MATCH {pattern} RETURN count(*) AS c").to_list()[0]["c"]
+
+
+def _edge_count(graph):
+    return graph.cypher("MATCH ()-[r]->() RETURN count(*) AS c").to_list()[0]["c"]
+
+
+# Every shape here ends in a MATCH-produced empty stream feeding a CREATE.
+# Parametrized rather than written out so a future clause form is one line.
+EMPTY_STREAM_CREATE_QUERIES = {
+    "inline_map_match": ("MATCH (p:Project {key: 'NOPE'}) CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "where_match": ("MATCH (p:Project) WHERE p.key = 'NOPE' CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "match_with_create": ("MATCH (p:Project {key: 'NOPE'}) WITH p CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"),
+    "relationship_pattern_match": (
+        "MATCH (p:Project)-[:HAS]->(q:Project) CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"
+    ),
+    "with_where_filters_to_zero": (
+        "MATCH (p:Project) WITH p WHERE p.key = 'NOPE' CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id"
+    ),
+    "unwind_empty_list": "UNWIND [] AS x CREATE (t:Task {title: 'orphan'}) RETURN t.id AS id",
+}
+
+
+@pytest.mark.parametrize("query", EMPTY_STREAM_CREATE_QUERIES.values(), ids=EMPTY_STREAM_CREATE_QUERIES)
+def test_create_after_empty_stream_returns_no_rows_and_creates_nothing(query):
+    graph = _graph_with_project()
+    before = _node_count(graph)
+
+    rows = graph.cypher(query).to_list()
+
+    assert rows == [], "a CREATE fed zero rows must return zero rows"
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph) == before
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_create_after_empty_stream_does_not_run_twice_for_two_create_clauses():
+    """Two chained CREATEs after an empty MATCH create neither node.
+
+    The first CREATE must leave the stream empty rather than re-seeding it,
+    otherwise the second one inherits a fabricated row.
+    """
+    graph = _graph_with_project()
+    rows = graph.cypher(
+        "MATCH (p:Project {key: 'NOPE'}) CREATE (t:Task {title: 'a'}) CREATE (u:Task {title: 'b'}) RETURN count(*) AS c"
+    ).to_list()
+
+    assert rows == [{"c": 0}]
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_two_variable_match_does_not_fabricate_the_unmatched_endpoint():
+    """The phantom-endpoint case: neither the missing node nor the edge.
+
+    `(u:User {...})` matches nothing, so the whole MATCH is empty. Creating
+    the relationship would have to invent `u`, producing an edge that points
+    at a node carrying no label and no email — unreachable by any label scan
+    but reachable by traversal.
+    """
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (:Task {title: 'a'})").to_list()
+
+    rows = graph.cypher(
+        "MATCH (t:Task {title: 'a'}), (u:User {email: 'ghost@x.com'}) "
+        "CREATE (t)-[:ASSIGNED_TO]->(u) RETURN count(*) AS n"
+    ).to_list()
+
+    # count(*) over zero rows is one row holding 0 — the aggregate is the row,
+    # not the match. What must be zero is the writes.
+    assert rows == [{"n": 0}]
+    stats = graph.last_mutation_stats
+    assert stats["nodes_created"] == 0
+    assert stats["relationships_created"] == 0
+    assert _node_count(graph) == 1
+    assert _edge_count(graph) == 0
+    assert _node_count(graph, "(u:User)") == 0
+
+
+def test_merge_after_empty_stream_creates_nothing():
+    graph = _graph_with_project()
+    rows = graph.cypher("MATCH (p:Project {key: 'NOPE'}) MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == []
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_merge_after_empty_unwind_creates_nothing():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("UNWIND [] AS x MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == []
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_foreach_after_empty_stream_never_runs_its_body():
+    """FOREACH is a side-effect loop, so the evidence is the graph, not rows."""
+    graph = _graph_with_project()
+    graph.cypher("MATCH (p:Project {key: 'NOPE'}) FOREACH (i IN [1, 2] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 0
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_foreach_after_empty_unwind_never_runs_its_body():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("UNWIND [] AS x FOREACH (i IN [1] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+# ---------------------------------------------------------------------------
+# Controls — the behaviour the fix must NOT change.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_create_still_creates_exactly_one_node():
+    """No preceding clause means the implicit start row applies."""
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (t:Task {title: 'x'})").to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 1
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_leading_merge_still_creates():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("MERGE (t:Task {title: 'm'}) RETURN t.title AS t").to_list()
+
+    assert rows == [{"t": "m"}]
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_standalone_foreach_still_runs_once():
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("FOREACH (i IN [1, 2] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 2
+
+
+def test_foreach_over_empty_list_creates_nothing_but_still_runs():
+    """The inner loop, not the outer stream, is what's empty here."""
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("FOREACH (i IN [] | CREATE (:Task {title: 'f'}))").to_list()
+
+    assert _node_count(graph, "(t:Task)") == 0
+
+
+def test_leading_unwind_and_with_still_seed_a_row():
+    graph = kglite.KnowledgeGraph()
+    rows = graph.cypher("UNWIND [1, 2, 3] AS x CREATE (t:Task {n: x}) RETURN count(*) AS c").to_list()
+    assert rows == [{"c": 3}]
+    assert _node_count(graph, "(t:Task)") == 3
+
+    other = kglite.KnowledgeGraph()
+    assert other.cypher("WITH 5 AS v CREATE (t:Task {n: v}) RETURN t.n AS n").to_list() == [{"n": 5}]
+
+
+def test_optional_match_still_yields_one_null_padded_row():
+    """The deliberate opposite of this fix — OPTIONAL MATCH must NOT go empty.
+
+    Guarding this here because the fix touches the same pipeline branch that
+    decides whether a clause sees a row.
+    """
+    graph = _graph_with_project()
+    rows = graph.cypher("MATCH (p:Project) OPTIONAL MATCH (u:User) RETURN p.key AS k, u AS u").to_list()
+
+    assert len(rows) == 1
+    assert rows[0]["k"] == "WEB"
+    assert rows[0]["u"] is None
+
+
+def test_optional_match_row_can_still_drive_a_create():
+    """A null-padded OPTIONAL MATCH row is a real row, so CREATE runs."""
+    graph = _graph_with_project()
+    graph.cypher(
+        "MATCH (p:Project) OPTIONAL MATCH (u:User) CREATE (t:Task {title: 'ok'}) RETURN t.title AS t"
+    ).to_list()
+
+    assert graph.last_mutation_stats["nodes_created"] == 1
+    assert _node_count(graph, "(t:Task)") == 1
+
+
+def test_set_and_delete_after_empty_stream_stay_no_ops():
+    """These were already correct; pinned so the shared path can't regress them."""
+    graph = _graph_with_project()
+    assert graph.cypher("MATCH (p:Project {key: 'NOPE'}) SET p.x = 1 RETURN p.x AS x").to_list() == []
+    assert graph.last_mutation_stats["properties_set"] == 0
+
+    graph.cypher("MATCH (p:Project {key: 'NOPE'}) DELETE p").to_list()
+    assert graph.last_mutation_stats["nodes_deleted"] == 0
+    assert _node_count(graph, "(p:Project)") == 1

--- a/tests/test_cypher_order_by_after_aggregate.py
+++ b/tests/test_cypher_order_by_after_aggregate.py
@@ -1,0 +1,262 @@
+"""ORDER BY after an aggregating RETURN.
+
+Aggregation rebuilds its output rows from scratch, so a variable only
+survives onto them if the executor deliberately carries its binding
+forward. Three implementations produce those rows — the streaming
+aggregate, the materialized aggregate, and the fused
+`OPTIONAL MATCH` + `count()` operator — and they used to disagree about
+which variables survive. Where a variable was dropped,
+`execute_order_by` evaluated the sort key to NULL on *every* row, every
+key tied, and the stable sort handed back insertion order: the ORDER BY
+clause was silently ignored.
+
+The contract these tests pin down:
+
+* A variable read by a **grouping key** keeps a value on the aggregated
+  row, so ordering by any of its properties works — regardless of which
+  aggregation path the planner picked.
+* A variable that appears **only inside an aggregate argument** has no
+  single value per group. Ordering by it is rejected with a message
+  naming the fix, never silently ignored.
+* Ordering by a projected alias keeps working.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+
+# priority is a total order with no ties, so the expected sequence below
+# is the only correct answer — an assertion on it cannot pass by luck.
+_TASKS = [
+    ("t1", 5),
+    ("t2", 2),
+    ("t3", 7),
+    ("t4", 4),
+    ("t5", 3),
+    ("t6", 8),
+    ("t7", 9),
+]
+# Insertion order, which is what a silently-dropped ORDER BY returns.
+INSERTION_ORDER = [title for title, _ in _TASKS]
+PRIORITY_DESC = [title for title, _ in sorted(_TASKS, key=lambda t: -t[1])]
+PRIORITY_ASC = list(reversed(PRIORITY_DESC))
+
+assert PRIORITY_DESC != INSERTION_ORDER, "fixture must distinguish sorted from insertion order"
+
+
+def build_task_graph() -> kglite.KnowledgeGraph:
+    """Tasks with a comment count — the list-view shape this bug broke."""
+    g = kglite.KnowledgeGraph()
+    g.add_nodes(
+        pd.DataFrame(
+            {
+                "tid": list(range(1, len(_TASKS) + 1)),
+                "title": [title for title, _ in _TASKS],
+                "priority": [priority for _, priority in _TASKS],
+            }
+        ),
+        "Task",
+        "tid",
+        "title",
+    )
+    g.add_nodes(
+        pd.DataFrame({"cid": [1, 2, 3], "label": ["c1", "c2", "c3"]}),
+        "Comment",
+        "cid",
+        "label",
+    )
+    # t1 has two comments, t3 has one, the rest have none — so the
+    # OPTIONAL MATCH genuinely produces null-padded rows.
+    g.add_connections(
+        pd.DataFrame({"from_id": [1, 1, 3], "to_id": [1, 2, 3]}),
+        "X",
+        "Task",
+        "from_id",
+        "Comment",
+        "to_id",
+    )
+    return g
+
+
+@pytest.fixture
+def task_graph() -> kglite.KnowledgeGraph:
+    return build_task_graph()
+
+
+def titles(graph: kglite.KnowledgeGraph, query: str, **kwargs) -> list[str]:
+    return [row["title"] for row in graph.cypher(query, **kwargs).to_list()]
+
+
+# ── The reported bug ────────────────────────────────────────────────
+#
+# OPTIONAL MATCH + aggregate + ORDER BY on a non-projected expression.
+# Asserts the row *order*, not just the row set — the bug returned every
+# correct row in the wrong sequence.
+
+REPRO = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY t.priority DESC"
+
+
+def test_optional_match_aggregate_orders_by_non_projected_key(task_graph):
+    assert titles(task_graph, REPRO) == PRIORITY_DESC
+
+
+def test_repro_is_not_merely_insertion_order(task_graph):
+    """Guards the guard: a fix that ignored ORDER BY would return this."""
+    assert titles(task_graph, REPRO) != INSERTION_ORDER
+
+
+def test_optional_match_aggregate_orders_ascending(task_graph):
+    query = REPRO.replace("DESC", "ASC")
+    assert titles(task_graph, query) == PRIORITY_ASC
+
+
+def test_repro_matches_with_optimizer_disabled(task_graph):
+    """The optimizer picked a different aggregation operator for the
+    OPTIONAL shape; both must now agree, order included."""
+    assert titles(task_graph, REPRO) == titles(task_graph, REPRO, disable_optimizer=True)
+
+
+# ── Pagination ──────────────────────────────────────────────────────
+#
+# The practical damage: with the order unspecified, SKIP/LIMIT pages
+# could repeat rows and skip others.
+
+
+def test_pagination_pages_are_disjoint_and_ordered(task_graph):
+    page_size = 3
+    pages = [titles(task_graph, f"{REPRO} SKIP {skip} LIMIT {page_size}") for skip in range(0, len(_TASKS), page_size)]
+    seen = [title for page in pages for title in page]
+
+    assert seen == PRIORITY_DESC, "concatenated pages must reproduce the full ordering"
+    assert len(seen) == len(set(seen)), f"pages overlap: {pages}"
+    assert sorted(seen) == sorted(INSERTION_ORDER), "pagination dropped or duplicated rows"
+
+
+# ── Controls: shapes that already worked must keep working ──────────
+
+
+def test_order_by_projected_alias(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, t.priority AS p, count(c) AS n ORDER BY p DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_order_by_aggregate_alias(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY n DESC, title ASC"
+    )
+    assert titles(task_graph, query) == ["t1", "t3", "t2", "t4", "t5", "t6", "t7"]
+
+
+def test_plain_match_aggregate_still_correct(task_graph):
+    """The audit's working counter-example — must not regress."""
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_projection_without_aggregate_still_correct(task_graph):
+    query = "MATCH (t:Task) RETURN t.title AS title ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_group_by_bare_variable(task_graph):
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, t AS node, count(c) AS n ORDER BY t.priority DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+
+
+def test_unaliased_aggregate_ordered_by_its_expression_form(task_graph):
+    """`ORDER BY count(c)` resolves against the identically-named column
+    when the aggregate is projected without an alias."""
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, count(c) ORDER BY count(c) DESC, title ASC"
+    )
+    assert titles(task_graph, query) == ["t1", "t3", "t2", "t4", "t5", "t6", "t7"]
+
+
+# ── The same defect outside OPTIONAL MATCH ──────────────────────────
+#
+# `collect()` is not computable by the streaming aggregate, so it falls
+# to the materialized path — which dropped the binding too. This shape
+# was silently unordered with no OPTIONAL MATCH and no optimizer.
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    ["collect(t.tid)", "count(*)", "max(t.tid)", "avg(t.tid)"],
+    ids=["collect", "count_star", "max", "avg"],
+)
+def test_every_aggregate_kind_honours_order_by(task_graph, aggregate):
+    query = f"MATCH (t:Task) RETURN t.title AS title, {aggregate} AS agg ORDER BY t.priority DESC"
+    assert titles(task_graph, query) == PRIORITY_DESC
+    assert titles(task_graph, query) == titles(task_graph, query, disable_optimizer=True)
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    ["collect(c.label)", "count(c)"],
+    ids=["collect", "count"],
+)
+def test_every_aggregate_kind_honours_order_by_under_optional(task_graph, aggregate):
+    query = (
+        f"MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        f"RETURN t.title AS title, {aggregate} AS agg ORDER BY t.priority DESC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC
+    assert titles(task_graph, query) == titles(task_graph, query, disable_optimizer=True)
+
+
+# ── The ambiguous half: rejected, never silently reordered ──────────
+
+
+def test_order_by_variable_only_inside_aggregate_is_rejected(task_graph):
+    """`c` collapses into `count(c)`, so `c.label` has no single value
+    per group. Neo4j rejects this shape; so do we."""
+    query = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+
+    message = str(excinfo.value)
+    assert "'c'" in message, message
+    assert "grouping keys" in message, message
+    # The message must name a way out, not just refuse.
+    assert "sort_key" in message or "projected column" in message, message
+
+
+def test_rejection_is_identical_with_optimizer_disabled(task_graph):
+    query = "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY c.label DESC"
+    with pytest.raises(kglite.SchemaError):
+        task_graph.cypher(query, disable_optimizer=True).to_list()
+
+
+def test_order_by_unprojected_aggregate_is_rejected(task_graph):
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY max(t.priority) DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+    assert "max(t.priority)" in str(excinfo.value)
+
+
+def test_order_by_aliased_aggregate_expression_names_the_alias(task_graph):
+    """`count(*) AS n` moves the value to `n`; ordering by the expression
+    form can no longer resolve, so the error points at the alias."""
+    query = "MATCH (t:Task) RETURN t.title AS title, count(*) AS n ORDER BY count(*) DESC"
+    with pytest.raises(kglite.SchemaError) as excinfo:
+        task_graph.cypher(query).to_list()
+    assert "ORDER BY n" in str(excinfo.value)
+
+
+def test_ordering_by_grouping_variable_expression_is_allowed(task_graph):
+    """Derived expressions over a grouping variable stay well defined."""
+    query = (
+        "MATCH (t:Task) OPTIONAL MATCH (t)-[:X]->(c) "
+        "RETURN t.title AS title, count(c) AS n ORDER BY t.priority * -1 ASC"
+    )
+    assert titles(task_graph, query) == PRIORITY_DESC

--- a/tests/test_lazy_materialization.py
+++ b/tests/test_lazy_materialization.py
@@ -56,3 +56,59 @@ def test_lazy_resultview_access_forms(graph):
         {"name": "Bob", "age": 25},
     ]
     assert "Alice" in repr(lazy(graph))
+
+
+@pytest.fixture(params=(64, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
+def sized_graph(request):
+    """A memory graph whose Person count straddles EAGER_MATERIALISE_MAX_ROWS.
+
+    Small lazy-eligible results are materialised at construction and drop the
+    graph reference; large ones stay deferred. The two paths must be
+    indistinguishable through the public API — this fixture is what makes the
+    boundary testable from Python at all, since the difference is otherwise
+    only observable as a whole-graph copy.
+    """
+    count = request.param
+    graph = kglite.KnowledgeGraph()
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": list(range(count)),
+                "title": [f"P{i}" for i in range(count)],
+                "age": [i % 90 for i in range(count)],
+            }
+        ),
+        "Person",
+        "id",
+        "title",
+        columns=["age"],
+    )
+    return graph, count
+
+
+def test_streaming_matches_eager_across_the_threshold(sized_graph):
+    """Deferred and up-front materialisation agree on both sides of the cutoff."""
+    graph, count = sized_graph
+    query = "MATCH (n:Person) RETURN n.title AS name, n.age AS age"
+    streamed = graph.cypher(query, streaming=True)
+    eager = graph.cypher(query, streaming=False)
+    assert len(streamed) == count
+    assert streamed.to_dicts() == eager.to_dicts()
+
+
+def test_streaming_result_survives_an_intervening_write(sized_graph):
+    """A held result keeps its pre-write rows whether or not it was deferred.
+
+    Below the threshold the rows are already materialised; above it the view
+    still holds the graph it was built from and the write copies-on-write.
+    Either way the caller sees the data as of query time — the guarantee that
+    lets the eager path drop the graph reference without changing semantics.
+    """
+    graph, count = sized_graph
+    query = "MATCH (n:Person) RETURN n.title AS name, n.age AS age"
+    held = graph.cypher(query, streaming=True)
+    graph.cypher("MATCH (n:Person) SET n.age = 999")
+    rows = held.to_dicts()
+    assert len(rows) == count
+    assert all(row["age"] != 999 for row in rows)
+    assert graph.cypher("MATCH (n:Person) RETURN DISTINCT n.age AS age").to_dicts() == [{"age": 999}]

--- a/tests/test_lazy_materialization.py
+++ b/tests/test_lazy_materialization.py
@@ -58,15 +58,17 @@ def test_lazy_resultview_access_forms(graph):
     assert "Alice" in repr(lazy(graph))
 
 
-@pytest.fixture(params=(64, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
+@pytest.fixture(params=(8, 8192), ids=("under-eager-threshold", "over-eager-threshold"))
 def sized_graph(request):
-    """A memory graph whose Person count straddles EAGER_MATERIALISE_MAX_ROWS.
+    """A memory graph straddling EAGER_MATERIALISE_MAX_CELLS.
 
-    Small lazy-eligible results are materialised at construction and drop the
-    graph reference; large ones stay deferred. The two paths must be
-    indistinguishable through the public API — this fixture is what makes the
-    boundary testable from Python at all, since the difference is otherwise
-    only observable as a whole-graph copy.
+    The budget is rows x columns, and the query below returns two columns, so
+    8 rows (16 cells) is under and 8192 rows is far over. Small lazy-eligible
+    results are materialised at construction and drop the graph reference;
+    large ones stay deferred. The two paths must be indistinguishable through
+    the public API — this fixture is what makes the boundary testable from
+    Python at all, since the difference is otherwise only observable as a
+    whole-graph copy.
     """
     count = request.param
     graph = kglite.KnowledgeGraph()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,9 @@
 """Tests for schema definition and validation."""
 
+import warnings
+
 import pandas as pd
+import pytest
 
 from kglite import KnowledgeGraph
 
@@ -228,14 +231,43 @@ class TestManagedReloadGuard:
         except ValueError as e:
             assert "'managed' or 'runtime'" in str(e)
 
-    def test_define_schema_replaces_not_merges(self):
-        """define_schema replaces the whole schema — a subset call drops omitted
-        types (documented behaviour; locks against an accidental switch to merge)."""
+    def test_define_schema_merges_leaving_undeclared_types_alone(self):
+        """define_schema merges per node type: a subset call keeps the types it
+        does not name. Declaring per module is the natural pattern, and under the
+        old replace default it silently un-enforced every type a call omitted."""
         g = KnowledgeGraph()
         g.define_schema({"nodes": {"A": {"primary_key": "id"}, "B": {"layer": "runtime"}}})
         assert set(g.schema_definition()["nodes"]) == {"A", "B"}
         g.define_schema({"nodes": {"A": {"primary_key": "id"}}})  # subset
-        assert set(g.schema_definition()["nodes"]) == {"A"}  # B dropped
+        assert set(g.schema_definition()["nodes"]) == {"A", "B"}  # B retained
+
+    def test_define_schema_replaces_a_named_type_wholesale(self):
+        """Merging is per *type*, not per field: a type the call names takes the
+        new declaration entire, so re-declaring it is still how you narrow it."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"required": ["x", "y"], "layer": "runtime"}}})
+        g.define_schema({"nodes": {"A": {"required": ["x"]}}})
+        assert g.schema_definition()["nodes"]["A"]["required"] == ["x"]
+        assert "layer" not in g.schema_definition()["nodes"]["A"]
+
+    def test_define_schema_replace_true_drops_omitted_types_and_warns(self):
+        """replace=True restores whole-schema replacement — and names every
+        constraint it stops enforcing, so the loss is never silent."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"primary_key": "email"}, "B": {"required": ["t"]}}})
+        with pytest.warns(UserWarning, match=r"A\.email \(PRIMARY KEY\)"):
+            g.define_schema({"nodes": {"B": {"required": ["t"]}}}, replace=True)
+        assert set(g.schema_definition()["nodes"]) == {"B"}
+
+    def test_define_schema_replace_true_is_quiet_when_nothing_is_enforced(self):
+        """The warning tracks lost *enforcement*, not merely lost declarations,
+        so a replace that drops nothing enforced stays quiet."""
+        g = KnowledgeGraph()
+        g.define_schema({"nodes": {"A": {"optional": ["x"]}}})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            g.define_schema({"nodes": {"B": {"optional": ["y"]}}}, replace=True)
+        assert set(g.schema_definition()["nodes"]) == {"B"}
 
     def test_auto_timestamp_tag_roundtrips(self, tmp_path):
         g = KnowledgeGraph()

--- a/tests/test_schema_constraint_lifecycle.py
+++ b/tests/test_schema_constraint_lifecycle.py
@@ -1,0 +1,352 @@
+"""Declaration paths must never *silently* discard enforcement.
+
+Every case here is one shape of a single failure mode: a call returns success
+while some integrity guarantee the user believes is in force has quietly stopped
+being enforced — or `SHOW CONSTRAINTS` reports one that is not. That listing is
+what an operator reads during a migration review, so it lying is the worst
+version of the bug.
+
+The audit that produced these tests found four distinct instances:
+
+1. `define_schema` replaced the whole schema, so a per-module call naming one
+   type withdrew every other type's constraints.
+2. `define_schema` wiped a NOT NULL declared through `CREATE CONSTRAINT`,
+   because `required_fields` live inside the schema being replaced — while the
+   uniqueness half survived, whose index does not.
+3. `required: ["title"]` (and `id`) reported itself as enforced while admitting
+   `CREATE (:T {title: null})`, `SET t.title = null` and `REMOVE t.title`.
+4. `clear_schema()` dropped the declaration but left the unique indexes it had
+   installed still rejecting writes — enforcement outliving its declaration.
+
+Each test asserts **both** halves: what is actually enforced, and what
+`SHOW CONSTRAINTS` reports about it. A fix to one half alone is not a fix.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+
+def constraints(g: KnowledgeGraph) -> list[tuple[str, str]]:
+    """`SHOW CONSTRAINTS` as `(name, type)` pairs — what an operator sees."""
+    return [(row["name"], row["type"]) for row in g.cypher("SHOW CONSTRAINTS").to_list()]
+
+
+def rejects(g: KnowledgeGraph, query: str) -> bool:
+    """Whether `query` is refused. The enforcement half of every assertion."""
+    try:
+        g.cypher(query)
+        return False
+    except Exception:
+        return True
+
+
+# ── 1. define_schema must not withdraw constraints on types it never named ──
+
+
+def test_a_second_define_schema_keeps_the_first_calls_constraints():
+    """The audit reproducer, verbatim.
+
+    Declaring per module is the natural pattern. Under the old replace default
+    the second call — which mentions only `Task` — withdrew `User`'s primary key,
+    and the duplicate that had just been correctly rejected was then admitted.
+    """
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}, "Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})"), "the primary key must reject a duplicate"
+
+    g.define_schema({"nodes": {"Task": {"required": ["title", "status"]}}})  # names only Task
+
+    assert ("User.email", "NODE_KEY") in constraints(g), "User's key must still be reported"
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})"), "and must still be enforced"
+    assert g.cypher("MATCH (u:User) RETURN count(u) AS c").to_list()[0]["c"] == 1
+
+
+def test_replace_true_still_withdraws_but_says_what_it_withdrew():
+    """The escape hatch stays available — it just cannot be silent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}, "Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+
+    with pytest.warns(UserWarning, match=r"User\.email \(PRIMARY KEY\)"):
+        g.define_schema({"nodes": {"Task": {"required": ["title"]}}}, replace=True)
+
+    assert ("User.email", "NODE_KEY") not in constraints(g)
+    assert not rejects(g, "CREATE (:User {email:'a@x.com'})")
+
+
+# ── 2. A DDL declaration is withdrawn only by DROP CONSTRAINT ──
+
+
+@pytest.mark.parametrize(
+    "ddl,violation",
+    [
+        ("CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.name IS NOT NULL", "CREATE (:Task {x:1})"),
+        ("CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.name IS UNIQUE", "CREATE (:Task {name:'a'})"),
+    ],
+    ids=["not_null", "unique"],
+)
+def test_define_schema_does_not_wipe_a_ddl_constraint(ddl: str, violation: str):
+    """`required_fields` live inside the SchemaDefinition, so installing a schema
+    used to withdraw a DDL-declared NOT NULL — while the uniqueness half, whose
+    index lives outside the schema, survived. The asymmetry meant an unrelated
+    `define_schema` silently un-enforced half of what `CREATE CONSTRAINT` set up.
+    """
+    g = KnowledgeGraph()
+    g.cypher(ddl)
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.define_schema({"nodes": {"Unrelated": {"required": ["z"]}}})
+
+    assert ("c", "UNIQUENESS") in constraints(g) or ("c", "NODE_PROPERTY_EXISTENCE") in constraints(g)
+    assert rejects(g, violation), "a DDL constraint is withdrawn only by DROP CONSTRAINT"
+
+
+def test_drop_constraint_still_withdraws_a_ddl_not_null():
+    """Preserving DDL provenance must not make a constraint undroppable."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("DROP CONSTRAINT nn")
+    g.define_schema({"nodes": {"Unrelated": {"required": ["z"]}}})
+
+    assert constraints(g) == [("Unrelated.z", "NODE_PROPERTY_EXISTENCE")]
+    assert not rejects(g, "CREATE (:Task {x:1})")
+
+
+# ── 3. Merging uniqueness and presence, in both orders, plus DROP ──
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        (
+            "CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE",
+            "CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL",
+        ),
+        (
+            "CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL",
+            "CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE",
+        ),
+    ],
+    ids=["unique_then_not_null", "not_null_then_unique"],
+)
+def test_declaring_the_second_half_adds_to_the_first(first: str, second: str):
+    """Declaring one half on a property that already carries the other must
+    *add* to it. Order must not matter, and the merged pair reports as NODE_KEY
+    — which is honest only because both halves are still enforced."""
+    g = KnowledgeGraph()
+    g.cypher(first)
+    g.cypher(second)
+
+    assert [kind for _, kind in constraints(g)] == ["NODE_KEY"]
+    g.cypher("CREATE (:Task {name:'a'})")
+    assert rejects(g, "CREATE (:Task {name:'a'})"), "uniqueness half"
+    assert rejects(g, "CREATE (:Task {x:1})"), "presence half"
+
+
+@pytest.mark.parametrize(
+    "dropped,expected_kind,still_rejected,now_allowed",
+    [
+        (
+            "u",
+            "NODE_PROPERTY_EXISTENCE",
+            "CREATE (:Task {name:null})",
+            "CREATE (:Task {name:'a'})",
+        ),
+        (
+            "nn",
+            "UNIQUENESS",
+            "CREATE (:Task {name:'a'})",
+            "CREATE (:Task {name:null})",
+        ),
+    ],
+    ids=["drop_unique_half", "drop_not_null_half"],
+)
+def test_dropping_one_half_leaves_the_other_enforced_and_reported(
+    dropped: str, expected_kind: str, still_rejected: str, now_allowed: str
+):
+    """Dropping half a merged pair must demote the row rather than remove it, and
+    the surviving half must still be enforced. A row that kept claiming NODE_KEY
+    would overstate enforcement at exactly the moment an operator checks."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.cypher(f"DROP CONSTRAINT {dropped}")
+
+    assert [kind for _, kind in constraints(g)] == [expected_kind]
+    assert rejects(g, still_rejected), "the surviving half must still be enforced"
+    assert not rejects(g, now_allowed), "the dropped half must stop being enforced"
+
+
+def test_a_merged_pair_survives_save_load_and_reports_the_same_name(tmp_path):
+    """Constraint state is persisted, so the round-trip must preserve both halves
+    *and* report them identically. The reported name was previously taken from
+    the first `HashMap` match, so the same graph named the row differently before
+    and after a reload."""
+    path = str(tmp_path / "merged.kgl")
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.cypher("CREATE (:Task {name:'a'})")
+    before = constraints(g)
+    g.save(path)
+
+    reloaded = kglite.load(path)
+
+    assert constraints(reloaded) == before
+    assert [kind for _, kind in before] == ["NODE_KEY"]
+    assert rejects(reloaded, "CREATE (:Task {name:'a'})"), "uniqueness half survived the reload"
+    assert rejects(reloaded, "CREATE (:Task {x:1})"), "presence half survived the reload"
+
+
+def test_a_define_schema_primary_key_survives_save_load(tmp_path):
+    path = str(tmp_path / "pk.kgl")
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    g.save(path)
+
+    reloaded = kglite.load(path)
+
+    assert constraints(reloaded) == [("User.email", "NODE_KEY")]
+    assert rejects(reloaded, "CREATE (:User {email:'a@x.com'})")
+
+
+# ── 4. A reported presence constraint must actually reject a null ──
+
+
+@pytest.mark.parametrize("prop", ["title", "id"])
+def test_a_required_structural_field_rejects_an_explicit_null(prop: str):
+    """`id`/`title` are `NodeData` fields, but a write can null them explicitly
+    and the resulting node genuinely carries a null. Skipping them made the
+    declaration report itself through `SHOW CONSTRAINTS` while enforcing
+    nothing — success reported, guarantee absent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": [prop]}}})
+
+    assert constraints(g) == [(f"Task.{prop}", "NODE_PROPERTY_EXISTENCE")]
+    assert rejects(g, f"CREATE (:Task {{{prop}:null}})"), "an explicit null must be rejected"
+    # Omitting it is still fine: every write path resolves it first (CREATE
+    # auto-assigns an id and synthesizes a title), so the requirement is met.
+    g.cypher("CREATE (:Task {x:1})")
+    assert g.cypher("MATCH (t:Task) RETURN count(t) AS c").to_list()[0]["c"] == 1
+
+
+def test_a_required_title_is_enforced_on_the_set_and_remove_paths():
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+    g.cypher("CREATE (:Task {title:'ok'})")
+
+    assert rejects(g, "MATCH (t:Task) SET t.title = null")
+    assert rejects(g, "MATCH (t:Task) REMOVE t.title")
+    assert g.cypher("MATCH (t:Task) RETURN t.title AS v").to_list()[0]["v"] == "ok"
+
+
+def test_a_required_title_is_enforced_on_the_bulk_path():
+    """`add_nodes` is how blueprints and every loader reach storage, so a
+    constraint the batch engine skipped would be theatre."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["title"]}}})
+    with pytest.raises(Exception):
+        g.add_nodes(pd.DataFrame({"pid": [1], "title": [None]}), "Task", "pid", "title")
+
+
+@pytest.mark.parametrize("prop", ["title", "name"])
+def test_ddl_refuses_a_presence_constraint_the_stored_data_violates(prop: str):
+    """`CREATE CONSTRAINT` verifies against stored data before installing, so a
+    constraint that would silently exempt the rows already present is refused
+    instead. `title` must behave exactly as an ordinary property here — it was
+    waved through while the data carried a null."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (:Task {title:null, x:1})")
+
+    with pytest.raises(Exception, match="cannot declare"):
+        g.cypher(f"CREATE CONSTRAINT c FOR (t:Task) REQUIRE t.{prop} IS NOT NULL")
+    assert constraints(g) == []
+
+
+@pytest.mark.parametrize("prop", ["title", "name"])
+def test_validate_schema_reports_a_required_field_the_data_lacks(prop: str):
+    """`define_schema` declares intent without re-verifying stored data — for
+    every property alike — and `validate_schema()` is the audit that reports what
+    the data violates. It must see a null `title` too, or the write path and the
+    validator disagree about what the same declaration means."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (:Task {title:null, x:1})")
+
+    g.define_schema({"nodes": {"Task": {"required": [prop]}}})
+
+    errors = g.validate_schema()
+    assert [e["field"] for e in errors] == [prop]
+    assert errors[0]["error_type"] == "missing_required_field"
+
+
+def test_requiring_type_stays_a_no_op():
+    """`type` is the node's label rather than a supplied value, so nothing a
+    write does can leave it absent."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"Task": {"required": ["type"]}}})
+    g.cypher("CREATE (:Task {x:1})")
+    g.cypher("CREATE (:Task {type:null})")
+    assert g.cypher("MATCH (t:Task) RETURN count(t) AS c").to_list()[0]["c"] == 2
+
+
+# ── 5. Clearing a schema must clear its enforcement too ──
+
+
+def test_clear_schema_withdraws_the_constraints_it_installed():
+    """Dropping the declaration but keeping the unique index left writes being
+    rejected by a constraint nothing reported and nothing could drop."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+
+    g.clear_schema()
+
+    assert constraints(g) == []
+    assert not g.has_schema()
+    assert not rejects(g, "CREATE (:User {email:'a@x.com'})")
+
+
+def test_clear_schema_leaves_ddl_constraints_alone():
+    """`CREATE CONSTRAINT` is a separate declaration with its own `DROP`, so
+    clearing the *schema* must not take it down."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE CONSTRAINT u FOR (t:Task) REQUIRE t.name IS UNIQUE")
+    g.cypher("CREATE CONSTRAINT nn FOR (t:Task) REQUIRE t.name IS NOT NULL")
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:Task {name:'a'})")
+
+    g.clear_schema()
+
+    assert [kind for _, kind in constraints(g)] == ["NODE_KEY"]
+    assert rejects(g, "CREATE (:Task {name:'a'})")
+    assert rejects(g, "CREATE (:Task {x:1})")
+
+
+def test_a_failed_define_schema_changes_nothing():
+    """A declaration the data violates is refused, and the refusal must leave
+    the previous constraints exactly as they were."""
+    g = KnowledgeGraph()
+    g.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    g.cypher("CREATE (:User {email:'a@x.com'})")
+    g.cypher("CREATE (:Task {name:'dup'})")
+    g.cypher("CREATE (:Task {name:'dup'})")
+
+    with pytest.raises(Exception):
+        g.define_schema({"nodes": {"Task": {"primary_key": "name"}}})
+
+    assert constraints(g) == [("User.email", "NODE_KEY")]
+    assert rejects(g, "CREATE (:User {email:'a@x.com'})")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a merge must never warn
+        g.define_schema({"nodes": {"Other": {"required": ["z"]}}})


### PR DESCRIPTION
Integrates the seven fixes produced by the boring-app audit and the three build-or-not evaluations. **No version bump (0.14.5); CHANGELOG stays under `[Unreleased]`.**

Each branch is merged with a real merge commit, so **all seven tips are ancestors** — merging this marks PRs #73, #74, #75, #76, #77, #78 and #80 as merged. Every individual commit survives for bisectability.

**#79 (`fix/lazy-result-graph-pin`) is deliberately excluded** — CI's perf gate caught a real +114% regression on `test_bench_cypher_match` and `test_bench_columnar_cypher_match`, the bare-property-projection shape its eager materialisation touches. That's being re-measured with the threshold as the variable; shipping a 2× read regression would undo more than the fix gains.

## What's in here

**Silent-wrong-answer bugs, all found by building a realistic CRUD app against kglite:**

- **A `MATCH` matching zero rows still executed its `CREATE`** (#75) — and the two-variable form fabricated a phantom edge endpoint. Since kglite has no referential constraints, "MATCH the parent, CREATE the child" is the *only* foreign-key mechanism an app has. Root cause: three clause bodies tested `existing.rows.is_empty()` to decide whether to supply Cypher's implicit start row, and that predicate is true both at query start *and* after a clause produced zero rows. Fixed by moving the seed into the pipeline — the only place that can tell those apart — deleting three branches rather than adding one. Sweep found `MERGE`, `UNWIND []` and `FOREACH` shared it.
- **`ORDER BY` silently dropped after an aggregating `RETURN`** (#77), which made `SKIP`/`LIMIT` pagination incoherent. Three aggregation operators re-attached different subsets of row bindings; `evaluate_expression(...).unwrap_or(Value::Null)` then made every sort key tie. Now carries grouping bindings where the key is determined by the grouping, and errors where it genuinely isn't.
- **`define_schema` silently voided constraints on types it didn't mention** (#78) — it computed its withdrawal set from the *outgoing* schema. Now merges per type, with `replace=True` opting back in and warning by name. The sweep found three more silent-void bugs, including DDL-declared NOT NULL being wiped while the uniqueness half of the same statement survived.
- **A property named `id`/`title`/`type` overwrote its canonical column** in `to_df`, `collect`/`sample` and **`export_csv`** (#74) — the path documented as *backup before upgrading*. Silent data loss in the format we tell people to trust.

**Platform and durability:**

- **Disk mode was broken on Windows** (#80). The `publish` failure was *not* an mmap bug: `sync_tree` fsynced staged files through a **read-only handle**, and `sync_all` is `FlushFileBuffers`, which Windows requires write access for — so the durability pass aborted before the atomic rename it protects. The rest was mapping-lifetime ordering, including a live property-index rebuild that would have failed **every second save**. Verified by running the whole engine suite with the `windows` cfg predicates rewritten to a locally-true one: **1241 tests pass under both orderings**.
- **The Windows CI job now runs the engine suite** (#76 + #80, merged into one step here carrying both rationales). It already compiled the test binary and ran two filtered tests; no Windows job runs pytest, yet Windows wheels ship. It caught the disk bug on its first run.
- **Disk-mode crash behaviour is now tested and documented** (#73). A crash loses only unsaved, never-acknowledged mutations. Four Unix-gated kill-9 tests assert `status.signal() == Some(9)` so they can't degrade into shutdown tests.

**Usability:**

- The expression-nesting error now **names the `IN [...]` rewrite** (#76). The planner already had a `fold_or_to_in` pass for exactly that shape, but it runs after parsing so it can never rescue an over-long chain — the engine knew the answer and didn't say it.

## Three evaluations that concluded "don't build it"

Each was asked to decide, not to implement — and each found a real defect in the thing it was sent to justify skipping:

- **Disk-mode WAL — rejected.** Measured: 5 saves produce 5 full retained graph copies, exactly linear, so a WAL could never checkpoint affordably. Found instead that the durability guide steered ordinary long-lived apps at `disk` for ">RAM" while omitting the durable `mapped` mode entirely.
- **Parquet export — rejected** (+35 crates measured; `arrow` has crashed this project twice and kglite pins mimalloc v2 to coexist with pyarrow). Found that the "one line away" justification **didn't work at all** — which is how the canonical-column data loss surfaced.
- **Extending the `stacker` guard — rejected.** Measured 7,248 B/level debug and 1,056 B/level release, so a budget-ceiling query peaks at 534 KiB against 8 MiB; guarding `evaluate_expression` costs **+14%**. Also established that 512 is well-chosen: raising it scales the peak linearly, so a bigger budget would *require* a guard first.

## Verification

`make gate` exit 0 · `cargo clippy --all-targets -- -D warnings` exit 0 · `make source-quality` (both scripts) clean, 162 lint-allowance identities · `cargo test -p kglite` **1253 passed / 0 failed** · full `pytest tests/` **4848 passed, 108 skipped, 0 failed** · `pytest -m parity` **109 passed** · **`GOLDEN_V3_DIGEST` unchanged** · version **0.14.5**, no CHANGELOG promotion (73 bullets under `[Unreleased]`).

Conflicts resolved: `CHANGELOG.md` by union at each merge (no duplicate section headers), and `.github/workflows/ci.yml` where two branches independently added the same Windows step — collapsed to one, with a comment carrying both rationales.
