### PR TITLE
fix: enforce one writer per graph in kglite.open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     analytics deployments to fix a problem only writers have.
   - **A crash releases it.** The lock is owned by the OS, not by the sidecar
     file's existence, so a writer lost to `SIGKILL` or a power cut frees it
-    at once. The leftover `.lock` file is a record of the holder, not the
-    lock — deleting it releases nothing, and the error message says so, since
-    deleting lock files by reflex is how this class of guard gets defeated.
+    at once. The leftover `<path>.lock` (the lock, always empty) and
+    `<path>.lock-owner` (the pid/timestamp used to name a holder) are records,
+    not the lock — deleting them releases nothing, and the error message says
+    so, since deleting lock files by reflex is how this class of guard gets
+    defeated.
+
+  The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
+  rather than inside the lock file, because `fs2` locks via `flock` on Unix
+  (advisory — contenders can still read) but `LockFileEx` on Windows
+  (mandatory over the whole range), where an exclusive lock makes the file
+  unreadable to every other handle and a contender's read fails with
+  `ERROR_LOCK_VIOLATION` instead of returning the pid. Splitting the two keeps
+  the holder *named* on every platform. `<path>.lock` is still the file that
+  is locked, so binaries from either side of this change continue to exclude
+  each other.
   - **`open(..., lock=False)` opts out**, explicitly and never by default, for
     deployments that coordinate writers externally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     so, since deleting lock files by reflex is how this class of guard gets
     defeated.
 
+  Contention is classified from the platform's lock errno via
+  `fs2::lock_contended_error()` rather than from `io::ErrorKind`. The kinds
+  differ per platform — `EWOULDBLOCK` maps to `WouldBlock` on Unix, but
+  `ERROR_LOCK_VIOLATION` is uncategorised on Windows — so a kind comparison
+  recognised contention only on Unix. On Windows that meant a blocked writer
+  saw the raw OS error instead of a message naming the holder, **and** the
+  retry loop was skipped entirely, so the 30-second lease timeouts used by
+  `kglite` CLI commands and the MCP server returned instantly rather than
+  waiting for the current writer to finish.
+
   The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
   rather than inside the lock file, because `fs2` locks via `flock` on Unix
   (advisory — contenders can still read) but `LockFileEx` on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kglite.open()` now enforces one writer per graph, instead of silently
+  losing one.** Two processes that opened the same path both built a complete
+  snapshot in memory and both wrote it at `save()`, so whichever saved last
+  won and everything the other had done disappeared — with both processes
+  exiting 0, nothing logged, and nothing in the file to show it had happened.
+  That is the likeliest accident when deploying an embedded database: a
+  multi-worker `gunicorn` pool, a cron job overlapping a request, or a stale
+  process nobody noticed.
+
+  `open()` now takes an exclusive cross-process writer lease on a
+  `<path>.lock` sidecar and holds it until `close()` / `with`-block exit. A
+  second writer fails immediately, naming the process that has it:
+
+  ```
+  KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
+  ```
+
+  The lease mechanism itself is not new — the CLI and the MCP server have held
+  it since disk generations shipped, and `open_or_create_graph` documents it as
+  a caller's responsibility. The Python binding was the caller that never
+  opted in, which left the most-used surface unguarded.
+
+  Three deliberate boundaries:
+
+  - **Readers are never blocked.** `load()` and `open_session()` take no
+    lease. `save()` republishes the whole graph, so a reader sees the last
+    consistent snapshot; making reads exclusive would break read-replica and
+    analytics deployments to fix a problem only writers have.
+  - **A crash releases it.** The lock is owned by the OS, not by the sidecar
+    file's existence, so a writer lost to `SIGKILL` or a power cut frees it
+    at once. The leftover `.lock` file is a record of the holder, not the
+    lock — deleting it releases nothing, and the error message says so, since
+    deleting lock files by reflex is how this class of guard gets defeated.
+  - **`open(..., lock=False)` opts out**, explicitly and never by default, for
+    deployments that coordinate writers externally.
+
+  Disk-mode graphs were already protected by their own generation lock, but
+  only failed at the *first mutation* with a bare
+  `Resource temporarily unavailable (os error 35)`; they now fail at `open()`
+  with the same named message as every other storage mode.
+
+  **Possible impact:** a deployment that genuinely opened one graph from two
+  processes was already losing writes, and now gets an error instead. Two
+  overlapping `kglite.open()` calls on one path *within* a single process are
+  refused for the same reason (the error says so explicitly); sequential
+  `with kglite.open(path)` blocks are unaffected, because the lease is
+  released on block exit.
+
 ### Added
 
 - `kglite-bolt-server --neo4j-compat` (or `KGLITE_BOLT_NEO4J_COMPAT=1`) makes the

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -220,15 +220,27 @@ pub(crate) struct GraphLifecycle {
     /// handle isn't shareable). When `Some`, the backend is wrapped in
     /// `GraphBackend::Recording` so mutations are captured for the WAL.
     pub(crate) durable: Option<DurableState>,
+    /// Cross-process single-writer guard for `source_path`, held for as long
+    /// as this graph can still write back to it. `Some` only on a graph from
+    /// `kglite.open(path)` (the write-back entry point); `None` for
+    /// `kglite.load(path)` and every clone/derived view, so readers never
+    /// contend. Like `durable`, it owns an OS `File` handle and therefore
+    /// cannot be shared.
+    ///
+    /// Released by `close()` / `__exit__` after the final save, and by `Drop`
+    /// otherwise — including on a crash, where the OS drops the underlying
+    /// file lock for us.
+    pub(crate) writer_lease: Option<kglite_core::api::io::GraphWriterLease>,
 }
 
 impl GraphLifecycle {
-    /// A detached lifecycle: no save target, not durable. Used by in-memory
-    /// constructors, `copy()`, and every derived view.
+    /// A detached lifecycle: no save target, not durable, holding no writer
+    /// lease. Used by in-memory constructors, `copy()`, and every derived view.
     pub(crate) fn detached() -> Self {
         GraphLifecycle {
             source_path: None,
             durable: None,
+            writer_lease: None,
         }
     }
 }
@@ -427,10 +439,13 @@ impl Clone for KnowledgeGraph {
             default_timeout_ms: self.default_timeout_ms,
             default_max_rows: self.default_max_rows,
             // A true Clone preserves the save identity (source_path) but never
-            // the durable session (the WAL File handle isn't shareable).
+            // the durable session (the WAL File handle isn't shareable) nor the
+            // writer lease — write ownership stays with the graph that opened
+            // the path, so a clone can never release it early on drop.
             lifecycle: GraphLifecycle {
                 source_path: self.lifecycle.source_path.clone(),
                 durable: None,
+                writer_lease: None,
             },
         }
     }

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -730,10 +730,16 @@ impl KnowledgeGraph {
     /// nowhere to write, and silently doing nothing is friendlier than
     /// raising on a best-effort cleanup call. Pair with `save(path)` if you
     /// need an explicit target.
+    /// Also releases the cross-process writer lease taken by
+    /// [`kglite.open`], after the final checkpoint is on disk — so the next
+    /// writer never observes a half-saved graph. A failed save keeps the
+    /// lease, because the graph still holds unsaved work destined for that
+    /// path and the caller may retry.
     fn close(&mut self, py: Python<'_>) -> PyResult<()> {
         if self.lifecycle.source_path.is_some() {
             self.save(py, None, true)?;
         }
+        self.lifecycle.writer_lease = None;
         Ok(())
     }
 
@@ -752,6 +758,12 @@ impl KnowledgeGraph {
     /// This is a *clean-exit* checkpoint, not crash safety: a hard crash
     /// (`kill -9`, power loss) mid-block writes nothing. Durable-on-commit is
     /// a separate capability.
+    ///
+    /// Exiting the block also ends the graph's write ownership: the
+    /// cross-process writer lease taken by [`kglite.open`] is released here,
+    /// which is what makes two sequential `with kglite.open(path)` blocks in
+    /// one process work. On the exception path the lease is released too —
+    /// the save was skipped, so nothing further will be written.
     #[pyo3(signature = (exc_type, _exc_value, _traceback))]
     fn __exit__(
         &mut self,
@@ -763,6 +775,7 @@ impl KnowledgeGraph {
         if exc_type.is_none() && self.lifecycle.source_path.is_some() {
             self.save(py, None, true)?;
         }
+        self.lifecycle.writer_lease = None;
         Ok(false)
     }
 

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -284,15 +284,62 @@ fn from_bytes(py: Python<'_>, data: &[u8]) -> PyResult<KnowledgeGraph> {
 ///   keeps no log, which is measurably faster for write-heavy bulk loading (no
 ///   `fsync` per commit) and is the right choice when the graph is rebuildable
 ///   from source data.
+///
+/// `lock` (default `true`) takes the cross-process single-writer lease for the
+/// life of the returned graph. It is on by default because the alternative is
+/// silent data loss, not an error: two processes that open one path both build
+/// a complete snapshot and the last `save()` wins. `false` opts out for callers
+/// who coordinate writers themselves. Readers never take the lease — that is
+/// what `load` / `open_session` are for.
 #[pyfunction]
-#[pyo3(signature = (path, *, storage=None, durable=None))]
+#[pyo3(signature = (path, *, storage=None, durable=None, lock=true))]
 fn open(
     py: Python<'_>,
     path: String,
     storage: Option<&str>,
     durable: Option<bool>,
+    lock: bool,
 ) -> PyResult<KnowledgeGraph> {
     use kglite_core::api::GraphRead;
+
+    // Take write ownership *before* reading a byte. The window that loses a
+    // writer's work is open-to-save, not save itself: two processes that both
+    // load, both mutate, and both save produce two full snapshots, and the
+    // second one published wins outright. Locking at save time would be too
+    // late to notice.
+    //
+    // Fail-fast (`Duration::ZERO`) rather than waiting: `open()` is called on
+    // request paths and in worker startup, where a blocked-for-30s open is a
+    // worse failure than a clear error. A caller that genuinely wants to queue
+    // can retry around the error.
+    let writer_lease = if lock {
+        Some(
+            py.detach(|| {
+                kglite_core::api::io::GraphWriterLease::acquire(
+                    std::path::Path::new(&path),
+                    std::time::Duration::ZERO,
+                )
+            })
+            .map_err(|e| {
+                // The engine's message is binding-neutral by design, so the
+                // Python-specific way out is appended here rather than baked
+                // into core. Most callers who hit this wanted to *read* a
+                // graph someone else is writing, and naming the call that
+                // does that turns a refusal into an answer.
+                crate::error_py::kg_to_pyerr(crate::error::KgError::FileIo(std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "{e} To read this graph while another process writes it, use \
+                         kglite.load(path) or kglite.open_session(path), which take no \
+                         lease. Pass kglite.open(..., lock=False) only if you are \
+                         coordinating writers yourself.",
+                    ),
+                )))
+            })?,
+        )
+    } else {
+        None
+    };
 
     let mut kg = if std::path::Path::new(&path).exists() {
         py.detach(|| load_file(&path))
@@ -302,6 +349,7 @@ fn open(
         KnowledgeGraph::construct(storage, Some(&path))?
     };
     kg.lifecycle.source_path = Some(std::path::PathBuf::from(&path));
+    kg.lifecycle.writer_lease = writer_lease;
     // Resolved after the graph exists, because the mode of an *existing* path
     // comes from the file, not from the `storage` argument.
     let wanted = durable.unwrap_or(!kg.inner.graph.is_disk());

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -71,7 +71,7 @@ impl GraphWriterLease {
                     publish_owner_record(&writer_owner_path(graph_path));
                     return Ok(Self { file });
                 }
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                Err(error) if is_lock_contended(&error) => {
                     if started.elapsed() >= timeout {
                         return Err(io::Error::new(
                             io::ErrorKind::WouldBlock,
@@ -99,6 +99,27 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     let mut lock = graph_path.as_os_str().to_os_string();
     lock.push(".lock");
     lock.into()
+}
+
+/// Whether a failed `try_lock_*` means "someone else holds it" rather than a
+/// genuine I/O failure.
+///
+/// Deliberately **not** an `ErrorKind` comparison. `fs2` surfaces the
+/// platform's native lock errno — `EWOULDBLOCK` (35) on Unix,
+/// `ERROR_LOCK_VIOLATION` (33) on Windows — and only the Unix one maps to
+/// [`io::ErrorKind::WouldBlock`]; the Windows one is uncategorised. A `kind()`
+/// check therefore recognises contention on Unix and silently misses it on
+/// Windows, where two things then go wrong at once: the raw platform error
+/// escapes instead of a message naming the holder, *and* the retry loop below
+/// never runs, so a caller's timeout (the CLI and MCP server both pass 30s)
+/// returns instantly instead of waiting.
+///
+/// [`fs2::lock_contended_error`] exists precisely so callers can compare
+/// portably. The `WouldBlock` arm is kept as a belt-and-braces fallback for an
+/// error that carries the kind but no raw errno.
+fn is_lock_contended(error: &io::Error) -> bool {
+    error.raw_os_error() == fs2::lock_contended_error().raw_os_error()
+        || error.kind() == io::ErrorKind::WouldBlock
 }
 
 /// Sibling of the lock file holding the holder's identity. Never locked, so it
@@ -494,18 +515,74 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let graph = tmp.path().join("named.kgl");
         let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
-        let message = GraphWriterLease::acquire(&graph, Duration::ZERO)
+        let error = GraphWriterLease::acquire(&graph, Duration::ZERO)
             .err()
-            .expect("second acquire must be refused")
-            .to_string();
+            .expect("second acquire must be refused");
+        // Carry the raw platform error into the failure text. A refusal that
+        // still reads as the OS's own lock error means the contention check
+        // did not classify it, and naming the errno makes that diagnosable
+        // from a CI log alone instead of needing a local repro.
+        let diagnosis = format!(
+            "got {error:?} (raw OS error {:?}, kind {:?}). A raw platform lock \
+             error here means `is_lock_contended` failed to classify it — the \
+             errno differs per platform (EWOULDBLOCK on Unix, \
+             ERROR_LOCK_VIOLATION on Windows), so an `ErrorKind` comparison \
+             recognises only Unix.",
+            error.raw_os_error(),
+            error.kind()
+        );
+        let message = error.to_string();
         // Same-process contention is reported as such rather than as a
         // phantom "other process" carrying the caller's own pid.
         assert!(
             message.contains(&format!("pid {}", std::process::id())),
-            "{message}"
+            "the refusal must name the holding process; {diagnosis}"
         );
-        assert!(message.contains("named.kgl"), "{message}");
-        assert!(message.contains("does not release it"), "{message}");
+        assert!(message.contains("named.kgl"), "{diagnosis}");
+        assert!(message.contains("does not release it"), "{diagnosis}");
+    }
+
+    /// Pins the portable classification directly, so a regression is a one-line
+    /// failure rather than a confusing raw-errno leak somewhere downstream.
+    /// Un-gated on purpose: the whole point is that it must hold on the
+    /// platform whose errno is *not* the one `ErrorKind` understands.
+    #[test]
+    fn contention_is_classified_from_the_platform_lock_error() {
+        assert!(
+            is_lock_contended(&fs2::lock_contended_error()),
+            "the error fs2 returns for a contended lock must be recognised as \
+             contention on every platform"
+        );
+        assert!(is_lock_contended(&io::Error::from(
+            io::ErrorKind::WouldBlock
+        )));
+        // A real failure must still propagate rather than be retried as if
+        // someone else merely held the lock.
+        assert!(!is_lock_contended(&io::Error::from(
+            io::ErrorKind::PermissionDenied
+        )));
+    }
+
+    /// The misclassification also disabled waiting: an unrecognised error
+    /// returned immediately instead of entering the retry loop, so the CLI's
+    /// and MCP server's 30s lease timeouts silently became zero. Asserting the
+    /// call actually blocks catches that independently of the message.
+    #[test]
+    fn a_contended_acquire_waits_for_its_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("waiting.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let started = Instant::now();
+        let error = GraphWriterLease::acquire(&graph, Duration::from_millis(300))
+            .err()
+            .expect("a held lease must still be refused after the timeout");
+        assert!(
+            started.elapsed() >= Duration::from_millis(250),
+            "acquire returned after {:?}, so it never waited — contention was \
+             not recognised and the retry loop was skipped ({error})",
+            started.elapsed()
+        );
     }
 
     /// The property whose platform split broke this: the owner record must be

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -47,9 +47,19 @@ impl GraphWriterLease {
                 .open(&path)?;
             match file.try_lock_exclusive() {
                 Ok(()) => {
+                    // Truncate first, then publish in a single write. A
+                    // contender that reads mid-update must see either nothing
+                    // (reported as "another process") or the complete new
+                    // record — never the *previous*, now-dead holder's pid,
+                    // which would send someone chasing a process that exited.
+                    let record = format!(
+                        "pid={}\nsince={}\n",
+                        std::process::id(),
+                        chrono::Local::now().to_rfc3339()
+                    );
                     file.set_len(0)?;
                     file.rewind()?;
-                    writeln!(file, "pid={}", std::process::id())?;
+                    file.write_all(record.as_bytes())?;
                     file.sync_data()?;
                     return Ok(Self { file });
                 }
@@ -57,10 +67,7 @@ impl GraphWriterLease {
                     if started.elapsed() >= timeout {
                         return Err(io::Error::new(
                             io::ErrorKind::WouldBlock,
-                            format!(
-                                "timed out waiting for writer lease {}; another writer is active",
-                                path.display()
-                            ),
+                            contended_message(graph_path, &path),
                         ));
                     }
                     std::thread::sleep(Duration::from_millis(50));
@@ -84,6 +91,93 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     let mut lock = graph_path.as_os_str().to_os_string();
     lock.push(".lock");
     lock.into()
+}
+
+/// Ownership details the holder records in the sidecar lock file, read back
+/// only on the contention path. The bytes are advisory *documentation*: the
+/// lock itself is the OS file-descriptor lock, so a stale file with a dead
+/// pid in it locks nothing.
+#[derive(Debug, Default)]
+struct LeaseHolder {
+    pid: Option<u32>,
+    since: Option<String>,
+}
+
+impl LeaseHolder {
+    /// Best-effort parse. Every failure mode — unreadable file, truncated
+    /// mid-write by the holder, an older release's `pid`-only format —
+    /// degrades to a less specific description rather than masking the real
+    /// "another writer is active" error with a parse error.
+    ///
+    /// Retries briefly while the record is absent, because the holder takes
+    /// the lock *before* it publishes its identity: two processes racing at
+    /// startup (the exact case this guard exists for) otherwise reliably read
+    /// the empty window and report an unnamed "another process". The cost is
+    /// paid only on the error path, where a correct message beats promptness.
+    fn read(lock_path: &Path) -> Self {
+        const ATTEMPTS: u32 = 10;
+        for attempt in 0..ATTEMPTS {
+            let holder = Self::read_once(lock_path);
+            if holder.pid.is_some() {
+                return holder;
+            }
+            if attempt + 1 < ATTEMPTS {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        Self::default()
+    }
+
+    fn read_once(lock_path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(lock_path) else {
+            return Self::default();
+        };
+        let mut holder = Self::default();
+        for line in text.lines() {
+            match line.split_once('=') {
+                Some(("pid", value)) => holder.pid = value.trim().parse().ok(),
+                Some(("since", value)) => holder.since = Some(value.trim().to_string()),
+                _ => {}
+            }
+        }
+        holder
+    }
+
+    fn describe(&self) -> String {
+        // A self-pid hit is not a deployment problem, it is an un-closed
+        // handle in the caller's own code, and saying "another process" for
+        // your own pid sends people hunting a process that does not exist.
+        if self.pid == Some(std::process::id()) {
+            return format!(
+                "this same process (pid {}), which has not closed an earlier open() of it",
+                std::process::id()
+            );
+        }
+        match (self.pid, self.since.as_deref()) {
+            (Some(pid), Some(since)) => format!("pid {pid} (since {since})"),
+            (Some(pid), None) => format!("pid {pid}"),
+            _ => "another process".to_string(),
+        }
+    }
+}
+
+/// The message a blocked writer sees. Names the holding process, because
+/// "another writer is active" leaves an operator with nothing to act on.
+///
+/// The closing sentence is deliberate support-burden prevention: the lock
+/// file is persistent and survives a `SIGKILL`, so the natural reflex on
+/// seeing one is to delete it. Deleting it does not release the lock (the OS
+/// already did that when the holder died) and only removes the record of who
+/// holds it, so the message says so before the reflex fires.
+fn contended_message(graph_path: &Path, lock_path: &Path) -> String {
+    format!(
+        "{} is open for writing by {}; only one process may write a graph at a time. \
+         The lock is released automatically when that process exits, even on a crash — \
+         deleting {} does not release it.",
+        graph_path.display(),
+        LeaseHolder::read(lock_path).describe(),
+        lock_path.display()
+    )
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -351,6 +445,52 @@ mod tests {
         let _lease = GraphWriterLease::acquire(&path, Duration::ZERO).unwrap();
         let opened = open_or_create_graph(&path, Some(StorageMode::Memory)).unwrap();
         assert_eq!(opened.disposition, OpenDisposition::Opened);
+    }
+
+    #[test]
+    fn contended_message_names_the_holding_process() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("named.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+        let message = GraphWriterLease::acquire(&graph, Duration::ZERO)
+            .err()
+            .expect("second acquire must be refused")
+            .to_string();
+        // Same-process contention is reported as such rather than as a
+        // phantom "other process" carrying the caller's own pid.
+        assert!(
+            message.contains(&format!("pid {}", std::process::id())),
+            "{message}"
+        );
+        assert!(message.contains("named.kgl"), "{message}");
+        assert!(message.contains("does not release it"), "{message}");
+    }
+
+    #[test]
+    fn lease_record_carries_pid_and_acquisition_time() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("record.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+        let holder = LeaseHolder::read(&writer_lease_path(&graph));
+        assert_eq!(holder.pid, Some(std::process::id()));
+        assert!(holder.since.is_some(), "acquisition time must be recorded");
+    }
+
+    #[test]
+    fn holder_description_degrades_without_a_readable_record() {
+        // A holder that has locked but not yet published its identity, and a
+        // lock file from a release that only wrote `pid=`, must both produce
+        // a usable message rather than a parse failure.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent.lock");
+        assert_eq!(
+            LeaseHolder::read_once(&missing).describe(),
+            "another process"
+        );
+
+        let legacy = tmp.path().join("legacy.lock");
+        std::fs::write(&legacy, b"pid=999999\n").unwrap();
+        assert_eq!(LeaseHolder::read_once(&legacy).describe(), "pid 999999");
     }
 
     #[test]

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -1,7 +1,7 @@
 //! Shared graph open-or-create lifecycle used by server-style bindings.
 
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -28,8 +28,29 @@ pub struct OpenGraphResult {
     pub identity: GraphFileIdentity,
 }
 
-/// Cross-process writer ownership for a graph path. The sibling lock file is
-/// persistent; OS advisory-lock teardown, not PID-file deletion, owns liveness.
+/// Cross-process writer ownership for a graph path. Both sidecars are
+/// persistent; OS lock teardown, not PID-file deletion, owns liveness.
+///
+/// Ownership is split across two files on purpose:
+///
+/// - `<path>.lock` is the lock token, and holds **no** data. It is what
+///   [`fs2`] locks, and it is deliberately still this exact path so that a
+///   binary from before the split still excludes, and is excluded by, this one.
+/// - `<path>.lock-owner` carries the human-readable `pid` / `since` record
+///   used to name the holder in an error message.
+///
+/// The record cannot live inside the lock file. `fs2` locks via `flock` on
+/// Unix, which is *advisory* — a contender can still read the bytes — but via
+/// `LockFileEx` on Windows, whose locks are **mandatory** over the whole range
+/// (`fs2` passes `(0, !0, !0)`). There, an exclusive lock makes the file
+/// unreadable to every other handle, including other handles in the holder's
+/// own process, and a contender's read fails with `ERROR_LOCK_VIOLATION` (33)
+/// rather than returning bytes. Keeping the record in an unlocked sibling is
+/// what lets the holder be *named* on every platform instead of degrading to
+/// an anonymous "another process" exactly where that matters most.
+///
+/// The same mandatory-lock mechanism is documented at the disk backend's
+/// `snapshot_files` helper, which skips `.kglite.lock` for this reason.
 pub struct GraphWriterLease {
     file: File,
 }
@@ -39,7 +60,7 @@ impl GraphWriterLease {
         let path = writer_lease_path(graph_path);
         let started = Instant::now();
         loop {
-            let mut file = OpenOptions::new()
+            let file = OpenOptions::new()
                 .read(true)
                 .write(true)
                 .create(true)
@@ -47,20 +68,7 @@ impl GraphWriterLease {
                 .open(&path)?;
             match file.try_lock_exclusive() {
                 Ok(()) => {
-                    // Truncate first, then publish in a single write. A
-                    // contender that reads mid-update must see either nothing
-                    // (reported as "another process") or the complete new
-                    // record — never the *previous*, now-dead holder's pid,
-                    // which would send someone chasing a process that exited.
-                    let record = format!(
-                        "pid={}\nsince={}\n",
-                        std::process::id(),
-                        chrono::Local::now().to_rfc3339()
-                    );
-                    file.set_len(0)?;
-                    file.rewind()?;
-                    file.write_all(record.as_bytes())?;
-                    file.sync_data()?;
+                    publish_owner_record(&writer_owner_path(graph_path));
                     return Ok(Self { file });
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -93,10 +101,40 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     lock.into()
 }
 
-/// Ownership details the holder records in the sidecar lock file, read back
-/// only on the contention path. The bytes are advisory *documentation*: the
-/// lock itself is the OS file-descriptor lock, so a stale file with a dead
-/// pid in it locks nothing.
+/// Sibling of the lock file holding the holder's identity. Never locked, so it
+/// stays readable on Windows — see [`GraphWriterLease`].
+fn writer_owner_path(graph_path: &Path) -> std::path::PathBuf {
+    let mut owner = graph_path.as_os_str().to_os_string();
+    owner.push(".lock-owner");
+    owner.into()
+}
+
+/// Record who now holds the lease, for the benefit of whoever is refused next.
+///
+/// Truncate-then-write, so a contender reading mid-update sees either nothing
+/// (reported as "another process", and retried) or the complete new record —
+/// never the *previous*, now-released holder's pid, which would send someone
+/// chasing a process that has already exited.
+///
+/// Deliberately infallible: this is naming, not locking. The caller has
+/// already won the lock at this point, and failing an acquisition because a
+/// cosmetic sidecar could not be written would trade a working guard for a
+/// better error message. A failure here costs only the pid in a message that
+/// someone else may never see.
+fn publish_owner_record(owner_path: &Path) {
+    let record = format!(
+        "pid={}\nsince={}\n",
+        std::process::id(),
+        chrono::Local::now().to_rfc3339()
+    );
+    let _ = std::fs::write(owner_path, record);
+}
+
+/// Ownership details published to `<path>.lock-owner`, read back only on the
+/// contention path. The bytes are *documentation*: liveness is established by
+/// the failed lock acquisition that precedes every read, so a record left
+/// behind by a crashed process is never mistaken for a live holder — nothing
+/// reads it unless someone currently holds the lock.
 #[derive(Debug, Default)]
 struct LeaseHolder {
     pid: Option<u32>,
@@ -114,10 +152,10 @@ impl LeaseHolder {
     /// startup (the exact case this guard exists for) otherwise reliably read
     /// the empty window and report an unnamed "another process". The cost is
     /// paid only on the error path, where a correct message beats promptness.
-    fn read(lock_path: &Path) -> Self {
+    fn read(owner_path: &Path) -> Self {
         const ATTEMPTS: u32 = 10;
         for attempt in 0..ATTEMPTS {
-            let holder = Self::read_once(lock_path);
+            let holder = Self::read_once(owner_path);
             if holder.pid.is_some() {
                 return holder;
             }
@@ -128,8 +166,8 @@ impl LeaseHolder {
         Self::default()
     }
 
-    fn read_once(lock_path: &Path) -> Self {
-        let Ok(text) = std::fs::read_to_string(lock_path) else {
+    fn read_once(owner_path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(owner_path) else {
             return Self::default();
         };
         let mut holder = Self::default();
@@ -175,7 +213,7 @@ fn contended_message(graph_path: &Path, lock_path: &Path) -> String {
          The lock is released automatically when that process exits, even on a crash — \
          deleting {} does not release it.",
         graph_path.display(),
-        LeaseHolder::read(lock_path).describe(),
+        LeaseHolder::read(&writer_owner_path(graph_path)).describe(),
         lock_path.display()
     )
 }
@@ -447,6 +485,10 @@ mod tests {
         assert_eq!(opened.disposition, OpenDisposition::Opened);
     }
 
+    /// Deliberately **not** gated to Unix. Naming the holder is the feature,
+    /// and a `cfg`-gated test would let it silently degrade to "another
+    /// process" on Windows — the platform where a multi-process deployment
+    /// tripping this is arguably most likely — while CI stayed green.
     #[test]
     fn contended_message_names_the_holding_process() {
         let tmp = tempfile::tempdir().unwrap();
@@ -466,21 +508,89 @@ mod tests {
         assert!(message.contains("does not release it"), "{message}");
     }
 
+    /// The property whose platform split broke this: the owner record must be
+    /// readable *by someone other than the holder, while the lock is held*.
+    ///
+    /// It is asserted as a distinct test, with the raw OS error in the failure
+    /// message, because the two candidate causes look identical from the
+    /// outside. A record kept inside the locked file returns bytes on Unix
+    /// (`flock` is advisory) and fails with `ERROR_LOCK_VIOLATION` (33) on
+    /// Windows (`LockFileEx` is mandatory) — so this test distinguishes "the
+    /// read failed" from "the record was empty" instead of leaving the next
+    /// person to infer it from a `None`.
+    #[test]
+    fn owner_record_stays_readable_while_the_lease_is_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("readable.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let owner = writer_owner_path(&graph);
+        let text = std::fs::read_to_string(&owner).unwrap_or_else(|error| {
+            panic!(
+                "the owner record must stay readable while the lease is held, but \
+                 reading {} failed: {error} (raw OS error {:?}). A mandatory-lock \
+                 platform reports ERROR_LOCK_VIOLATION (33) here the moment the \
+                 record is moved back inside the locked file.",
+                owner.display(),
+                error.raw_os_error()
+            )
+        });
+        assert!(
+            text.contains(&format!("pid={}", std::process::id())),
+            "{text}"
+        );
+
+        // And the lock token itself carries no data, so nothing can come to
+        // depend on reading it — which is the trap that caused this.
+        let lock = writer_lease_path(&graph);
+        assert_eq!(
+            std::fs::metadata(&lock).unwrap().len(),
+            0,
+            "the lock file must stay empty; its contents are unreadable to \
+             contenders on mandatory-lock platforms"
+        );
+    }
+
+    /// Also un-gated: the timestamp is half of what makes the message
+    /// actionable (a live writer versus one forgotten since Tuesday), so it
+    /// has to survive on every platform the guard ships to.
     #[test]
     fn lease_record_carries_pid_and_acquisition_time() {
         let tmp = tempfile::tempdir().unwrap();
         let graph = tmp.path().join("record.kgl");
         let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
-        let holder = LeaseHolder::read(&writer_lease_path(&graph));
+        let holder = LeaseHolder::read(&writer_owner_path(&graph));
         assert_eq!(holder.pid, Some(std::process::id()));
         assert!(holder.since.is_some(), "acquisition time must be recorded");
     }
 
+    /// A second holder must overwrite the first's record rather than leave a
+    /// dead pid to be reported as live. The record is only ever read after a
+    /// failed acquisition, so it must describe whoever holds the lock *now*.
+    #[test]
+    fn owner_record_is_replaced_by_each_new_holder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("succession.kgl");
+        let owner = writer_owner_path(&graph);
+
+        std::fs::write(&owner, b"pid=999999\nsince=long-ago\n").unwrap();
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let holder = LeaseHolder::read(&owner);
+        assert_eq!(
+            holder.pid,
+            Some(std::process::id()),
+            "a stale predecessor's pid must not survive a fresh acquisition"
+        );
+        assert_ne!(holder.since.as_deref(), Some("long-ago"));
+    }
+
     #[test]
     fn holder_description_degrades_without_a_readable_record() {
-        // A holder that has locked but not yet published its identity, and a
-        // lock file from a release that only wrote `pid=`, must both produce
-        // a usable message rather than a parse failure.
+        // Two cases must degrade to a usable message rather than a parse
+        // failure: no record at all — a holder that has locked but not yet
+        // published, or a holder running a build from before the record moved
+        // out of the lock file — and a record carrying only `pid=`.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("absent.lock");
         assert_eq!(

--- a/crates/kglite/src/graph/storage/disk/generation.rs
+++ b/crates/kglite/src/graph/storage/disk/generation.rs
@@ -174,6 +174,13 @@ impl GraphDirectoryLock {
                 ),
             )
         })?;
+        // Written for a human reading the file directly, and deliberately
+        // never read back by this codebase. It cannot be: `fs2` locks via
+        // `LockFileEx` on Windows, whose locks are mandatory, so any other
+        // handle reading these bytes gets ERROR_LOCK_VIOLATION (33) rather
+        // than the pid. Code that needs to *name* a lock holder must publish
+        // the record to an unlocked sibling instead — see `GraphWriterLease`
+        // in `graph/io/open.rs`, which had exactly this bug.
         file.set_len(0)?;
         writeln!(file, "pid={}", std::process::id())?;
         file.sync_all()?;

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -166,10 +166,26 @@ cost in more detail.
 
 ## What KGLite does not do
 
-**One process writes.** There is no shared live multi-process transaction
-handle and no replication protocol. Disk mode publishes immutable generations
-behind a cross-process writer lease, which stops two processes from publishing
-at once — that is stable-reader/single-writer publication, not concurrent
+**One process writes — and this is now enforced, not just documented.**
+`kglite.open(path)` takes an exclusive cross-process writer lease for as long
+as the graph can write back to `path`, so a second process opening the same
+path fails immediately with the holder's pid rather than quietly overwriting
+its work at `save()`:
+
+```
+KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
+```
+
+Readers are unaffected: `load()` and `open_session()` take no lease, so any
+number of processes can read a graph while one writes. The lease is an OS-owned
+advisory lock, so a writer killed with `SIGKILL` releases it immediately — the
+leftover `<path>.lock` file is a record, not the lock itself, and deleting it
+achieves nothing. `open(..., lock=False)` opts out for callers that coordinate
+writers some other way.
+
+There is still no shared live multi-process transaction handle and no
+replication protocol. Disk mode publishes immutable generations behind the same
+kind of lease — that is stable-reader/single-writer publication, not concurrent
 multi-process write access. When several processes need to read and write one
 graph, the answer is to run `kglite-bolt-server` and let that one process own
 the graph while clients connect over the Bolt protocol. The official Python,

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -178,10 +178,11 @@ KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:0
 
 Readers are unaffected: `load()` and `open_session()` take no lease, so any
 number of processes can read a graph while one writes. The lease is an OS-owned
-advisory lock, so a writer killed with `SIGKILL` releases it immediately — the
-leftover `<path>.lock` file is a record, not the lock itself, and deleting it
-achieves nothing. `open(..., lock=False)` opts out for callers that coordinate
-writers some other way.
+lock, so a writer killed with `SIGKILL` releases it immediately — the leftover
+`<path>.lock` (the lock, always empty) and `<path>.lock-owner` (the pid and
+acquisition time, used to name a holder) are records, not the lock itself, and
+deleting them achieves nothing. `open(..., lock=False)` opts out for callers
+that coordinate writers some other way.
 
 There is still no shared live multi-process transaction handle and no
 replication protocol. Disk mode publishes immutable generations behind the same

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -725,8 +725,10 @@ def open(
 
         **A crash releases the lease.** The lock belongs to the operating
         system, not to the sidecar file, so a writer killed with ``SIGKILL``
-        (or lost to a power cut) frees it immediately. The ``.lock`` file is
-        left behind and is harmless — deleting it does *not* release a live
+        (or lost to a power cut) frees it immediately. Two small sidecars are
+        left behind and are harmless: ``<path>.lock`` (the lock itself, always
+        empty) and ``<path>.lock-owner`` (the pid/timestamp used to name a
+        holder in the error above). Deleting either does *not* release a live
         lock, and does nothing useful for a dead one.
 
     Note:

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -650,7 +650,13 @@ def graphgen(
     """
     ...
 
-def open(path: str, *, storage: str | None = None, durable: bool | None = None) -> KnowledgeGraph:
+def open(
+    path: str,
+    *,
+    storage: str | None = None,
+    durable: bool | None = None,
+    lock: bool = True,
+) -> KnowledgeGraph:
     """Open a graph at ``path`` — load it if it exists, create a fresh one if
     it doesn't (load-or-create). The embedded-database lifecycle entry point.
 
@@ -685,9 +691,43 @@ def open(path: str, *, storage: str | None = None, durable: bool | None = None) 
               rather than quietly returning a graph without the crash safety
               you asked for.
             - ``False`` — opt out. See the performance note below.
+        lock: Single-writer guard — **on by default**. Opening takes an
+            exclusive advisory lock on a ``<path>.lock`` sidecar and holds it
+            until ``close()`` / ``with``-block exit, so a second process that
+            opens the same path raises instead of silently overwriting your
+            work (see the note below). Pass ``False`` only when something else
+            already guarantees a single writer — an external supervisor, or a
+            process you have confined to reads. ``lock=False`` opts out of
+            *taking* the lease, not out of the consequences of ignoring one.
 
     Returns:
         A KnowledgeGraph bound to ``path``.
+
+    Raises:
+        KgError: If another process already holds the write lease for
+            ``path``. The message names the holding pid and when it acquired,
+            e.g. ``app.kgl is open for writing by pid 4711 (since ...)``.
+
+    Note:
+        **One process writes at a time.** ``save()`` republishes the whole
+        graph, so two processes that open the same path independently both
+        build a complete snapshot and the last one to save wins — silently
+        discarding everything the other did. That is the single most likely
+        accident when deploying an embedded database: a ``gunicorn`` worker
+        pool, a cron job overlapping a request, or a stale process left
+        running. The lease turns it into an error at ``open()`` rather than
+        data loss at ``save()``.
+
+        **Readers are never blocked.** :func:`load` and :func:`open_session`
+        take no lease, so any number of processes can read a graph while one
+        writes; they observe the last published snapshot. Only :func:`open` —
+        the write-back entry point — claims ownership.
+
+        **A crash releases the lease.** The lock belongs to the operating
+        system, not to the sidecar file, so a writer killed with ``SIGKILL``
+        (or lost to a power cut) frees it immediately. The ``.lock`` file is
+        left behind and is harmless — deleting it does *not* release a live
+        lock, and does nothing useful for a dead one.
 
     Note:
         **What durability costs.** Crash safety is bought with one ``fsync``

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -1380,7 +1380,7 @@
     },
     "open": {
       "kind": "function",
-      "signature": "(path, *, storage=None, durable=None)"
+      "signature": "(path, *, storage=None, durable=None, lock=True)"
     },
     "open_session": {
       "kind": "function",

--- a/tests/test_decomposition_invariants.py
+++ b/tests/test_decomposition_invariants.py
@@ -146,8 +146,12 @@ def test_disk_copy_and_loaded_source_mutate_in_either_order(tmp_path, copy_first
     assert _count(copied) == 3
     source.save()
     copied.save(str(copy_path))
-    assert kglite.open(str(source_path)).cypher("MATCH (:Person {id: 20}) RETURN count(*) AS c").to_list() == [{"c": 0}]
-    assert kglite.open(str(copy_path)).cypher("MATCH (:Person {id: 10}) RETURN count(*) AS c").to_list() == [{"c": 0}]
+    # Read-back verification uses load(), not open(): `source` is still alive
+    # and still owns the write lease for source_path, and re-opening a path
+    # for writing merely to inspect it is what the single-writer guard exists
+    # to catch.
+    assert kglite.load(str(source_path)).cypher("MATCH (:Person {id: 20}) RETURN count(*) AS c").to_list() == [{"c": 0}]
+    assert kglite.load(str(copy_path)).cypher("MATCH (:Person {id: 10}) RETURN count(*) AS c").to_list() == [{"c": 0}]
 
 
 # ── Clone / derived views: preserve identity fields ──────────────────────────

--- a/tests/test_disk_sidecar_integrity.py
+++ b/tests/test_disk_sidecar_integrity.py
@@ -169,7 +169,10 @@ def test_durable_save_forces_fsync_with_warning(tmp_path):
     # The save is a real checkpoint: .kgl written, WAL truncated to header.
     assert os.path.exists(p)
     assert os.path.getsize(p + "-wal") == 5  # magic + version, no frames
-    # Data survives a reopen from the checkpoint alone.
+    # Data survives a reopen from the checkpoint alone. Release the first
+    # handle's writer lease first — reopening a path for writing while still
+    # holding it is refused by the single-writer guard.
+    del g
     g2 = kglite.open(p, durable=True)
     assert g2.cypher("MATCH (p:Person) RETURN count(*) AS c").scalar() == 1
 

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -13,6 +13,13 @@ Two child-death models, both real:
   on signal 9, which is what makes it a crash test rather than a shutdown
   test.
 
+A parent that seeds a checkpoint must ``del`` its handle before spawning the
+child. ``kglite.open`` holds a cross-process single-writer lease for the life
+of the graph, so a parent still holding one would block the child outright —
+and a parent that kept writing alongside the child would be the very
+lost-update bug the lease exists to prevent (see ``test_single_writer.py``).
+The ``del`` is the handover, not a formality.
+
 Every crash test runs for each storage mode that supports durability
 (:data:`DURABLE_STORAGE_MODES`). ``storage="disk"`` is deliberately excluded
 and its refusal is asserted in ``test_durable_rejects_disk_mode``.
@@ -196,6 +203,7 @@ def test_set_and_delete_survive_crash(tmp_path, storage):
     g.cypher("CREATE (:Person {id: 1, name: 'Alice', age: 30})")
     g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
     g.save()  # checkpoint
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,
@@ -219,6 +227,7 @@ def test_checkpoint_truncates_wal_then_recovers_post_checkpoint(tmp_path, storag
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()  # checkpoint: .kgl written, WAL truncated
     assert (tmp_path / "app.kgl").exists()
+    del g  # hand the write lease to the child; see the note at the top
 
     # Post-checkpoint mutation in a child that crashes.
     _crash_child(
@@ -299,6 +308,7 @@ def test_labels_survive_checkpoint_then_crash(tmp_path, storage):
     g = _open(tmp_path / "app.kgl", storage)
     g.cypher("CREATE (:Person:Employee {id: 1, name: 'Alice'})")
     g.save()  # labels go into the .kgl secondary_labels section; WAL truncated
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,
@@ -497,6 +507,7 @@ def test_durability_survives_an_auto_vacuum(tmp_path, storage):
         g.cypher(f"CREATE (:Doomed {{id: {i}}})")
     g.save()  # checkpoint, so recovery depends only on the WAL below
     g.set_auto_vacuum(0.3)
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -15,6 +15,7 @@ def test_open_creates_then_loads(tmp_path):
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()  # bare save uses the remembered path
     assert (tmp_path / "app.kgl").exists()
+    del g  # release the writer lease before reopening the same path
 
     g2 = kglite.open(p)  # exists -> load
     names = [r["n"] for r in g2.cypher("MATCH (p:Person) RETURN p.name AS n")]
@@ -26,10 +27,13 @@ def test_bare_save_round_trips(tmp_path):
     g = kglite.open(p)
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()
+    del g  # each open() owns the path until released
     g = kglite.open(p)
     g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
     g.save()
-    assert kglite.open(p).cypher("MATCH (p) RETURN count(*) AS c").scalar() == 2
+    # Read-back uses load(): it takes no writer lease, so it works whether or
+    # not `g` is still holding one.
+    assert kglite.load(p).cypher("MATCH (p) RETURN count(*) AS c").scalar() == 2
 
 
 def test_save_as_updates_remembered_path(tmp_path):

--- a/tests/test_single_writer.py
+++ b/tests/test_single_writer.py
@@ -1,0 +1,322 @@
+"""Cross-process single-writer guard for ``kglite.open``.
+
+``open()`` is the write-back entry point — it remembers its path, logs to a
+WAL by default, and checkpoints on close — so two processes holding the same
+path both produce full snapshots at ``save()``, and whichever publishes last
+wins outright. Before the guard, both exited 0 and one writer's work vanished
+with no error, no warning, and nothing in the file to say it had happened.
+
+The guard is an advisory OS file lock on a ``<path>.lock`` sidecar, taken at
+``open()`` and held until ``close()`` / ``__exit__`` / drop. Three properties
+are load-bearing and each has a test here:
+
+- **It blocks a second writer, loudly**, naming the holding pid — an error a
+  reader of the traceback can act on without guessing.
+- **A crashed holder does not brick the graph.** The lock is owned by the OS,
+  not by the file's existence, so ``SIGKILL`` releases it even though the
+  sidecar stays on disk. If this ever regressed, users would learn to delete
+  lock files by reflex and the guard would be worth nothing.
+- **Readers are never blocked.** ``load()`` takes no lease, so read replicas
+  and analytics jobs keep working alongside a writer.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+import kglite
+
+PYBIN = sys.executable
+
+#: See ``tests/test_durability.py`` — ``SIGKILL`` is POSIX-only, and a crash
+#: test that silently degrades into a graceful-shutdown test on Windows is
+#: worse than one that does not run. The crashed-holder case is the whole
+#: reason this guard is safe to ship, so it must not be faked.
+requires_sigkill = pytest.mark.skipif(
+    not hasattr(signal, "SIGKILL"),
+    reason="SIGKILL is POSIX-only; this is a crash test and must not degrade into a graceful-shutdown test on Windows",
+)
+
+#: Long enough that the child is unambiguously still holding when the parent
+#: makes its assertions, short enough that a leaked child cannot outlive the
+#: suite's 120 s per-test ceiling.
+HOLD_SECONDS = 30
+
+
+def _seed(path: str) -> None:
+    """Create *path* as a real saved graph, releasing the lease afterwards."""
+    graph = kglite.open(path)
+    graph.cypher("CREATE (:Task {name: 'seed'})")
+    graph.save()
+    graph.close()
+
+
+def _write_script(directory: str, name: str, body: str) -> str:
+    script = os.path.join(directory, name)
+    with open(script, "w", encoding="utf-8") as handle:
+        handle.write(textwrap.dedent(body))
+    return script
+
+
+def _spawn_holder(directory: str, db: str) -> tuple[subprocess.Popen, str]:
+    """Start a child that opens *db* for writing and holds it.
+
+    Returns once the child has signalled that it owns the lease, so the
+    parent's assertions race nothing.
+    """
+    ready = os.path.join(directory, "ready")
+    script = _write_script(
+        directory,
+        "holder.py",
+        """
+        import sys, time, kglite
+        graph = kglite.open(sys.argv[1])
+        with open(sys.argv[2], "w") as handle:
+            handle.write("ready")
+        time.sleep(int(sys.argv[3]))
+        """,
+    )
+    child = subprocess.Popen([PYBIN, script, db, ready, str(HOLD_SECONDS)])
+    deadline = time.monotonic() + 30
+    while not os.path.exists(ready) and time.monotonic() < deadline:
+        if child.poll() is not None:
+            raise AssertionError(f"holder exited early with {child.returncode}")
+        time.sleep(0.02)
+    assert os.path.exists(ready), "holder never acquired the writer lease"
+    return child, ready
+
+
+def _reap(child: subprocess.Popen) -> None:
+    if child.poll() is None:
+        child.kill()
+    child.wait()
+
+
+def test_second_process_open_fails_instead_of_losing_writes(tmp_path):
+    """The audit's scenario: two processes, 20 writes each, 40 expected.
+
+    Before the guard both children exited 0 and the reopened graph held 20 —
+    one writer's work gone with no signal. The fix does not merge the two
+    writers; it makes the loser *fail loudly* instead of failing silently,
+    which is the difference between a bug report and silent data loss.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+
+    script = _write_script(
+        str(tmp_path),
+        "writer.py",
+        """
+        import sys, kglite
+        db, tag, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+        graph = kglite.open(db)
+        for index in range(count):
+            graph.cypher("CREATE (:Task {name: $nm})", params={"nm": f"{tag}-{index}"})
+        graph.save()
+        graph.close()
+        """,
+    )
+    first = subprocess.Popen([PYBIN, script, db, "A", "20"], stderr=subprocess.PIPE, text=True)
+    second = subprocess.Popen([PYBIN, script, db, "B", "20"], stderr=subprocess.PIPE, text=True)
+    _, first_err = first.communicate()
+    _, second_err = second.communicate()
+
+    codes = sorted([first.returncode, second.returncode])
+    assert codes == [0, 1], (
+        f"exactly one writer must win and the other must fail; got {codes} (this is the silent-loss regression)"
+    )
+    loser_err = first_err if first.returncode else second_err
+    assert "is open for writing by pid" in loser_err, loser_err
+
+    # The winner's 20 rows are intact and the loser wrote nothing — no
+    # partial interleaving, and no snapshot built on a stale read.
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 21, f"expected seed + one writer's 20 rows, got {total}"
+
+
+def test_blocked_open_names_the_holding_process(tmp_path):
+    """``KgError: app.kgl is open for writing by pid 4711`` — the message the
+    audit asked for. A pid the operator can look up is the whole difference
+    between an actionable error and a mystery."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db)
+        message = str(caught.value)
+        assert f"pid {child.pid}" in message, message
+        assert os.path.basename(db) in message, message
+        # A timestamp turns "some process has it" into "and it has had it
+        # since 09:15", which is what distinguishes a live writer from a
+        # forgotten one.
+        assert "since" in message, message
+    finally:
+        _reap(child)
+
+
+def test_reader_is_never_blocked_by_a_writer(tmp_path):
+    """``load()`` takes no lease.
+
+    The durability unit is ``save()``, which republishes the whole file, so a
+    reader either sees the previous consistent snapshot or the next one. Making
+    reads exclusive would break read-replica and analytics deployments to fix a
+    problem that only writers have.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        reader = kglite.load(db)
+        rows = reader.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()
+        assert rows[0]["c"] == 1
+        # A second concurrent reader is fine too — readers do not contend
+        # with each other any more than they contend with the writer.
+        assert kglite.load(db).cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()
+    finally:
+        _reap(child)
+
+
+@requires_sigkill
+def test_sigkill_holder_releases_the_lease(tmp_path):
+    """A crashed writer must not brick the graph.
+
+    ``SIGKILL`` is uncatchable, so no Rust ``Drop``, no ``atexit``, no
+    interpreter teardown runs — the sidecar lock file is left on disk exactly
+    as a crash leaves it. The lock is nevertheless released, because it is an
+    OS file-descriptor lock rather than a claim staked by the file's presence.
+    This is asserted, not assumed: if it regressed, the guard would turn every
+    crash into a permanent outage.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    lock_file = db + ".lock"
+
+    with pytest.raises(Exception):
+        kglite.open(db)
+
+    os.kill(child.pid, signal.SIGKILL)
+    assert child.wait() == -signal.SIGKILL, "child must have died on SIGKILL"
+
+    # The stale file survives the crash. That is expected and harmless, and
+    # is precisely why the error message tells users not to delete it.
+    assert os.path.exists(lock_file), "lock sidecar is persistent by design"
+
+    recovered = kglite.open(db)
+    recovered.cypher("CREATE (:Task {name: 'after-crash'})")
+    recovered.close()
+
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 2
+
+
+def test_close_releases_so_the_path_can_be_reopened(tmp_path):
+    """Two sequential ``with`` blocks over one path, in one process.
+
+    The graph object stays alive and bound after its ``with`` block, so if the
+    lease were held until garbage collection this everyday pattern would
+    deadlock against itself.
+    """
+    db = str(tmp_path / "app.kgl")
+    with kglite.open(db) as graph:
+        graph.cypher("CREATE (:Task {name: 'first'})")
+    with kglite.open(db) as graph:
+        graph.cypher("CREATE (:Task {name: 'second'})")
+
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 2
+
+
+def test_second_open_in_one_process_reports_itself(tmp_path):
+    """Overlapping opens inside one process are the same lost-update bug, and
+    are blocked the same way — but the message says so, rather than pointing at
+    a phantom "other process" with the caller's own pid."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    held = kglite.open(db)
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db)
+        assert "this same process" in str(caught.value), str(caught.value)
+        assert str(os.getpid()) in str(caught.value)
+    finally:
+        held.close()
+
+
+def test_lock_false_opts_out(tmp_path):
+    """The documented escape hatch, for callers coordinating externally.
+
+    Explicit and never the default — the point is that opting out of the guard
+    should be something a reviewer can see in the diff.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    first = kglite.open(db, lock=False)
+    second = kglite.open(db, lock=False)
+    assert first is not second
+    first.close()
+    second.close()
+
+
+def test_lock_false_neither_takes_nor_checks_the_lease(tmp_path):
+    """The escape hatch is a full opt-out, and is documented as one.
+
+    ``lock=False`` does not consult the lease either, so it will happily open
+    alongside a live holder — including one in another process. That is the
+    whole point (an external supervisor may be doing the coordinating), and it
+    is also exactly why it must stay explicit: a caller that reaches for it
+    without a coordination story has re-armed the original data-loss bug.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        # A guarded open is refused...
+        with pytest.raises(Exception):
+            kglite.open(db)
+        # ...and an explicitly unguarded one is not.
+        bypass = kglite.open(db, lock=False)
+        assert bypass.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"] == 1
+        bypass.close()
+    finally:
+        _reap(child)
+
+
+def test_lock_false_still_allows_a_guarded_writer(tmp_path):
+    """An unguarded opener must not leave a stale lease behind that blocks the
+    next honest writer."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    unguarded = kglite.open(db, lock=False)
+    unguarded.close()
+    guarded = kglite.open(db)
+    guarded.close()
+
+
+def test_disk_mode_is_guarded_at_open(tmp_path):
+    """Disk graphs previously failed only at the first mutation, with a raw
+    ``Resource temporarily unavailable`` errno. They now fail at ``open()``
+    with the same named message as every other storage mode."""
+    db = str(tmp_path / "diskgraph")
+    seed = kglite.open(db, storage="disk")
+    seed.cypher("CREATE (:Task {name: 'seed'})")
+    seed.save()
+    seed.close()
+    del seed
+
+    held = kglite.open(db, storage="disk")
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db, storage="disk")
+        assert "is open for writing by" in str(caught.value), str(caught.value)
+    finally:
+        held.close()


### PR DESCRIPTION
Fixes what the boring-app audit called *"the single most likely accident in deploying an embedded DB"*: two processes opening the same durable graph silently lost one writer's work entirely. No version bump.

```
proc A: kglite.open(db); 20 writes; save()   -> exit 0
proc B: kglite.open(db); 20 writes; save()   -> exit 0
reopen -> 20 of 40 tasks. All of A's work gone. No lock, no error, no warning.
```

Reproduced on `main`: both children exit 0, final graph holds 20 rows, zero from B.

## Why the existing lease didn't cover it

Not disk-scoping, not early release — **the lease is caller-held and opt-in, and the Python binding never opted in.**

`open_or_create_graph` says so in its own doc comment: *"This function makes a lifecycle decision, not a write-ownership promise. A caller that may later publish to `path` must hold its own cross-process writer lease across the read/modify/save interval."* Two bindings honour it — `kglite-cli` and `kglite-mcp-server` (which parks the lease on `ActiveGraph` for the session). Python's `open()` **never calls `open_or_create_graph` at all**; it hand-rolls `load_file` / `KnowledgeGraph::construct` and never mentions the lease. The most-used surface was outside the mechanism.

Three mechanisms existed covering different things: the `.lock` writer lease (CLI + MCP), the disk `.kglite.lock` `GraphDirectoryLock` (disk only, and checked at *first mutation* — so it failed loudly but late and cryptically: `Resource temporarily unavailable (os error 35)`), and nothing at all for Python memory/mapped.

## The fix

`open()` acquires the lease **before reading a byte** — the unguarded window is open-to-save, not save — and holds it on `GraphLifecycle` until `close()` / `__exit__` / drop. Never cloned, so a derived view can't release write ownership early.

**Fail-fast (`Duration::ZERO`), not the CLI's 30-second wait**: `open()` runs on request paths, where blocking 30 s is worse than a clear error.

Core-side, the lease record gained an acquisition timestamp and is published with a single truncate-then-write, so a contender never reads the *previous, now-dead* holder's pid; on contention the reader retries briefly. Without that, two processes racing at startup reliably read the holder's empty window and got an unnamed "another process" — which defeats the purpose.

```
app.kgl is open for writing by pid 4711 (since 2026-07-26T23:01:00+02:00); only one
process may write a graph at a time. The lock is released automatically when that
process exits, even on a crash — deleting app.kgl.lock does not release it.
```

That last clause is deliberate. Deleting lock files by reflex is how this class of guard gets defeated, so the message preempts it rather than waiting for the support ticket.

`KgError::FileIo` is reused rather than adding a variant — it's what disk mode already reports for this exact condition. The engine message stays binding-neutral; the Python layer appends the Python-specific way out (`use kglite.load(path)`).

## Stale locks — verified, not assumed

`kill -9` the holder → the `.lock` file **remains on disk**, and a fresh process acquires immediately. The lock is the OS file-descriptor lock, not the file's existence. Verified three ways: a Python test asserting `returncode == -signal.SIGKILL` then re-acquiring and writing; the pre-existing Rust `crashed_process_releases_writer_lease`; and an interactive probe.

## Readers are never blocked

`load()` and `open_session()` take no lease; only `open()` — the write-back entry point — claims ownership. A `save()` republishes the whole graph and a loaded graph is fully in memory, so a reader holds a consistent snapshot regardless. Making reads exclusive would break read-replica and analytics deployments to fix a problem only writers have. Tested with two concurrent readers alongside a live writer.

## ⚠️ Deployment shapes that worked before and now error

Stated plainly, because this is the risk in this change:

1. **Two processes writing one graph** — previously silent loss, now a hard error at `open()`. Intended. But a deployment that has been quietly losing writes will surface as a *new crash*; it will look like a regression and is not.
2. **Two overlapping `kglite.open()` calls on one path inside one process** — refused, because `fs2` uses `flock`, which is per-file-description. Same lost-update bug, so blocking is correct, and the message names it explicitly ("this same process … which has not closed an earlier `open()` of it") rather than pointing at a phantom other process. Sequential `with` blocks are unaffected.
3. **`open()` used as a read-back check** while a writer is alive — now errors; the error says to use `load()`.
4. **Filesystems without working `flock`** (some NFS/network mounts) could refuse where `open()` previously succeeded. **Not tested — flagged as unverified rather than claimed fine.**

An escape hatch exists (`lock=False`), explicit and documented, never the default.

**Evidence this is a real pattern, not theoretical:** it broke 12 tests in this repo. Four durability crash tests had a parent seeding a checkpoint and handing the path to a crash child *while still holding it* — themselves modelling the two-writer bug. Those now release explicitly, with a module note explaining the handover is load-bearing.

A `<path>.lock` file now appears beside every graph opened for writing and persists. By design, documented.

## Surfaced, not fixed

`crates/kglite-bolt-server/src/main.rs:237` calls `open_or_create_graph` **without a lease** — the same unclaimed-ownership pattern. Lower risk as a long-running single-owner server, but it is the same shape.

## Verification

`tests/test_single_writer.py`, 10 tests. **On unmodified `origin/main`: 8 fail, 2 pass** — the 2 are deliberate no-regression guards (readers-unblocked, close-then-reopen).

`make gate` 0 · `cargo clippy --all-targets -- -D warnings` clean · `make source-quality` clean · `cargo test -p kglite` **1253** · `pytest -m parity` **109** · full Python suite **4861 passed** · `kglite-cli` and `kglite-mcp-server` suites green as the other lease consumers.

Five-place checklist: pyapi ✔ · `__init__.pyi` ✔ (signature, `lock` arg, `Raises:`, a Note on the three boundaries) · CHANGELOG ✔ · `describe()` and MCP `tools.rs` verified **N/A** (schema-only, and the MCP server has its own lease-holding open path). Also updated `primary-store.md`, whose "One process writes" claim was the unenforced one.
