### PR TITLE
fix: type constraint violations and commit conflicts on the Python surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A stable `.code` on every kglite exception.** `exc.code` is the wire-stable
+  classifier (`"ConstraintViolation"`, `"TransactionConflict"`,
+  `"CypherSyntax"`, …) that the C ABI already exposed as `KGLITE_STATUS_*` and
+  the Bolt server already mapped to `Neo.*`, but which had no way of reaching
+  Python — `dir(exc)` previously showed only `add_note`, `args`, and
+  `with_traceback`, so applications had no choice but to match on message prose.
+  It is readable on the classes too (`kglite.ConstraintViolationError.code`), so
+  a dispatch table can be built without an instance, and is `None` on the three
+  abstract bases (`KgError`, `CypherError`, `ConstraintError`) which span
+  several codes.
+- **`kglite.TransactionConflictError`**, raised when `Transaction.commit()`
+  loses an optimistic-concurrency race. This previously arrived as
+  `ArgumentError` — "Invalid argument: Transaction conflict…" — which is the
+  wrong class for a condition whose correct handling is "retry the transaction",
+  not "fix the call". The message now also reports the version gap, and the C
+  ABI gains `KGLITE_STATUS_CODE_TRANSACTION_CONFLICT = 20` (appended, so
+  existing discriminants are unchanged). The Bolt status string
+  `Neo.ClientError.Transaction.ConflictDetected` is unchanged.
+- **`kglite.retry_on_conflict(graph, work)`** — the commit-retry loop every
+  concurrent writer needs, with exponential backoff and full jitter. `work(tx)`
+  is re-run against a fresh `begin()` on each attempt; only conflicts are
+  retried, and the final conflict is re-raised unchanged. Conflicts are ordinary
+  rather than rare here, because OCC compares a whole-graph version counter (see
+  the documentation fix below).
 - `kglite-bolt-server --neo4j-compat` (or `KGLITE_BOLT_NEO4J_COMPAT=1`) makes the
   server present a Neo4j-compatible agent in the Bolt handshake, so official
   drivers that refuse to connect to a non-Neo4j server will talk to it. The
@@ -397,6 +421,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A constraint violation is now catchable by type from every write path.**
+  `ConstraintViolationError` existed but was reachable from nowhere: a violation
+  raised through Cypher surfaced as `CypherExecutionError`, and one raised
+  through the bulk loaders (`add_nodes`, and everything funnelling through it)
+  as `ArgumentError`. The only handler an application could write was therefore
+  a substring match on the message — in a signup path, for the single most
+  common error a web application has. Both paths now raise
+  `ConstraintViolationError`, so `except kglite.ConstraintViolationError` works
+  and `except kglite.ConstraintError` still catches that or
+  `ConstraintCreationError`. The messages are unchanged: they still name the
+  constraint, the property, the offending value, and the remedy.
+
+  The structured violation is carried out of the engine's `Result<_, String>`
+  write channel on the graph itself and drained by the adapter that builds the
+  typed error, paired with the exact message it produced — if an intermediate
+  frame rewrites the message the pair is discarded and the untyped error is
+  used, so a mismatch fails safe rather than mis-attributing a violation.
+- The exception-hierarchy diagram in `docs/python/error-handling.md` omitted the
+  entire constraint family (`ConstraintError`, `ConstraintViolationError`,
+  `ConstraintCreationError`). It now lists them alongside
+  `TransactionConflictError`, with new sections covering stable codes,
+  constraint violations, and commit conflicts.
+- `docs/python/guides/primary-store.md` stated that independent transactions
+  proceed concurrently, and that a Cypher constraint violation must be caught by
+  matching the message. Neither was true. OCC compares a **whole-graph version
+  counter**, not read/write sets, because a commit publishes the transaction's
+  working copy by pointer swap — so two transactions touching unrelated nodes do
+  conflict, and the loser's snapshot genuinely does not contain the winner's
+  write, which is why rejecting it is correct rather than over-cautious. The
+  guide now says so plainly, points at `retry_on_conflict`, and suggests
+  `session()` for workloads with many short concurrent writers.
+- The Bolt `neo4j_status_code` coverage test enumerated its codes by hand and
+  had silently stopped covering `Cancelled`, `ConstraintViolation`, and
+  `ConstraintCreationFailed`; all are now included.
 - `ORDER BY` is no longer silently ignored after an aggregating `RETURN` when
   the sort key is not one of the projected columns. `MATCH (t:Task) OPTIONAL
   MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY

--- a/crates/kglite-bolt-server/src/error_map.rs
+++ b/crates/kglite-bolt-server/src/error_map.rs
@@ -89,6 +89,12 @@ mod tests {
             KgErrorCode::InvalidArgument,
             KgErrorCode::MissingArgument,
             KgErrorCode::Internal,
+            // Appended after the original list was written; without these the
+            // check silently stopped covering newly-added codes.
+            KgErrorCode::Cancelled,
+            KgErrorCode::ConstraintViolation,
+            KgErrorCode::ConstraintCreationFailed,
+            KgErrorCode::TransactionConflict,
         ] {
             let s = code.neo4j_status_code();
             assert!(

--- a/crates/kglite-c/include/kglite.h
+++ b/crates/kglite-c/include/kglite.h
@@ -69,6 +69,13 @@ enum KgliteStatusCode
    */
   KGLITE_STATUS_CODE_CONSTRAINT_CREATION_FAILED = 19,
   /**
+   * An optimistic-concurrency commit lost its race: the graph advanced
+   * between `begin()` and `commit()`, so nothing was applied. Retry the
+   * whole transaction. Appended to keep the existing discriminants
+   * stable across this ABI major version.
+   */
+  KGLITE_STATUS_CODE_TRANSACTION_CONFLICT = 20,
+  /**
    * A string argument failed UTF-8 validation. The C-side
    * caller passed a `*const c_char` whose bytes didn't decode
    * as UTF-8 — typically a corrupted buffer or a non-UTF-8

--- a/crates/kglite-c/src/status.rs
+++ b/crates/kglite-c/src/status.rs
@@ -51,6 +51,11 @@ pub enum KgliteStatusCode {
     /// Declaring a constraint failed because the stored data already
     /// violates it. Deduplicate the node type, then re-declare.
     ConstraintCreationFailed = 19,
+    /// An optimistic-concurrency commit lost its race: the graph advanced
+    /// between `begin()` and `commit()`, so nothing was applied. Retry the
+    /// whole transaction. Appended to keep the existing discriminants
+    /// stable across this ABI major version.
+    TransactionConflict = 20,
 
     // 100+: C-ABI-only errors.
     /// A string argument failed UTF-8 validation. The C-side
@@ -88,6 +93,7 @@ impl KgliteStatusCode {
             KgErrorCode::Cancelled => Self::Cancelled,
             KgErrorCode::ConstraintViolation => Self::ConstraintViolation,
             KgErrorCode::ConstraintCreationFailed => Self::ConstraintCreationFailed,
+            KgErrorCode::TransactionConflict => Self::TransactionConflict,
         }
     }
 
@@ -105,6 +111,7 @@ impl KgliteStatusCode {
             Self::Schema => KgErrorCode::Schema,
             Self::ConstraintViolation => KgErrorCode::ConstraintViolation,
             Self::ConstraintCreationFailed => KgErrorCode::ConstraintCreationFailed,
+            Self::TransactionConflict => KgErrorCode::TransactionConflict,
             Self::Validation => KgErrorCode::Validation,
             Self::Expr => KgErrorCode::Expr,
             Self::NodeNotFound => KgErrorCode::NodeNotFound,

--- a/crates/kglite-py/src/error_py.rs
+++ b/crates/kglite-py/src/error_py.rs
@@ -12,6 +12,10 @@
 //! from `Exception`. Wrapper operations that implement conventional Python
 //! protocols may raise built-in exceptions directly.
 //!
+//! Every instance carries a stable `.code` string (the
+//! [`KgErrorCode`](crate::error::KgErrorCode) name, e.g. `"ConstraintViolation"`)
+//! so applications branch on a classifier rather than on message prose.
+//!
 //! ```text
 //! Exception
 //! └── kglite.KgError                          (base)
@@ -23,6 +27,10 @@
 //!     ├── kglite.SchemaError
 //!     ├── kglite.ValidationError
 //!     ├── kglite.ExprError
+//!     ├── kglite.ConstraintError            (declared-integrity base)
+//!     │   ├── kglite.ConstraintViolationError
+//!     │   └── kglite.ConstraintCreationError
+//!     ├── kglite.TransactionConflictError
 //!     ├── kglite.NodeNotFoundError
 //!     ├── kglite.ConnectionNotFoundError
 //!     ├── kglite.PropertyNotFoundError
@@ -149,6 +157,15 @@ pyo3::create_exception!(
     "Declaring a constraint failed because the stored data already violates it. Deduplicate the node type, then re-declare."
 );
 
+// ── Concurrency ──────────────────────────────────────────────────────
+
+pyo3::create_exception!(
+    kglite,
+    TransactionConflictError,
+    KgError,
+    "An optimistic-concurrency commit lost its race — the graph advanced between `begin()` and `commit()`, so nothing was applied. Retry the whole transaction against a fresh `begin()`; `kglite.retry_on_conflict` does this for you."
+);
+
 // ── Resource / access ────────────────────────────────────────────────
 
 pyo3::create_exception!(
@@ -240,6 +257,25 @@ pyo3::create_exception!(
 /// `.map_err(kg_to_pyerr)?`.
 pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
     let message = e.to_string();
+    // Stable classifier, captured before `e` is consumed by the match. Every
+    // `kglite.*` exception instance carries it as `.code`, so an application
+    // can branch on a wire-stable string (`"ConstraintViolation"`) instead of
+    // the message prose — the promise `docs/python/guides/primary-store.md`
+    // makes. `Cancelled` is excluded: it maps to the builtin
+    // `KeyboardInterrupt`, which is deliberately outside the KgError family.
+    let code = e.code().as_str();
+    let is_cancelled = matches!(e, RustKgError::Cancelled);
+    let err = kg_to_pyerr_class(e, message);
+    if is_cancelled {
+        return err;
+    }
+    with_code_attr(err, code)
+}
+
+/// Pick the most specific Python exception class for `e` and construct it with
+/// `message`. Split from [`kg_to_pyerr`] so the `.code` decoration applies
+/// uniformly to every arm rather than being repeated 20 times.
+fn kg_to_pyerr_class(e: RustKgError, message: String) -> PyErr {
     match e {
         RustKgError::CypherSyntax { line, col, .. } => {
             // `.line` / `.col` are always present on CypherSyntaxError —
@@ -265,6 +301,7 @@ pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
         RustKgError::Validation(_) => ValidationError::new_err(message),
         RustKgError::ConstraintViolation { .. } => ConstraintViolationError::new_err(message),
         RustKgError::ConstraintCreationFailed { .. } => ConstraintCreationError::new_err(message),
+        RustKgError::TransactionConflict { .. } => TransactionConflictError::new_err(message),
         RustKgError::Expr(_) => ExprError::new_err(message),
         RustKgError::NodeNotFound { .. } => NodeNotFoundError::new_err(message),
         RustKgError::ConnectionNotFound { .. } => ConnectionNotFoundError::new_err(message),
@@ -291,6 +328,17 @@ pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
 /// normalizes the exception first; attribute assignment on an exception
 /// instance can't reasonably fail, but any failure is swallowed rather
 /// than masking the original error.
+/// Set the stable `.code` classifier on the exception *value*. Same
+/// normalize-then-setattr shape as [`with_position_attrs`]; a failure here
+/// would mask the real error, so it is swallowed.
+fn with_code_attr(err: PyErr, code: &'static str) -> PyErr {
+    Python::attach(|py| {
+        let value = err.value(py);
+        let _ = value.setattr("code", code);
+    });
+    err
+}
+
 fn with_position_attrs(err: PyErr, line: Option<usize>, col: Option<usize>) -> PyErr {
     Python::attach(|py| {
         let value = err.value(py);
@@ -345,6 +393,12 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         py.get_type::<ConstraintCreationError>(),
     )?;
 
+    // Concurrency
+    m.add(
+        "TransactionConflictError",
+        py.get_type::<TransactionConflictError>(),
+    )?;
+
     // Resource / access
     m.add("NodeNotFoundError", py.get_type::<NodeNotFoundError>())?;
     m.add(
@@ -374,6 +428,71 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         py.get_type::<InternerCollisionError>(),
     )?;
     m.add("InternalError", py.get_type::<InternalError>())?;
+
+    register_class_codes(py)?;
+
+    Ok(())
+}
+
+/// Publish the stable [`KgErrorCode`](crate::error::KgErrorCode) string as a
+/// **class-level** `.code` on each concrete exception class, so callers can
+/// compare against `kglite.ConstraintViolationError.code` without an instance
+/// and `.code` is readable even on an exception constructed by hand.
+///
+/// Instances raised by the engine shadow these with the code of the actual
+/// `KgError` variant (see `with_code_attr`); the two always agree because both
+/// come from `KgError::code()`. The three abstract bases — `KgError`,
+/// `CypherError`, `ConstraintError` — cover several codes, so they get `None`
+/// rather than an arbitrary pick.
+fn register_class_codes(py: Python<'_>) -> PyResult<()> {
+    use crate::error::KgErrorCode as C;
+
+    py.get_type::<KgError>().setattr("code", py.None())?;
+    py.get_type::<CypherError>().setattr("code", py.None())?;
+    py.get_type::<ConstraintError>()
+        .setattr("code", py.None())?;
+
+    py.get_type::<CypherSyntaxError>()
+        .setattr("code", C::CypherSyntax.as_str())?;
+    py.get_type::<CypherTimeoutError>()
+        .setattr("code", C::CypherTimeout.as_str())?;
+    py.get_type::<CypherExecutionError>()
+        .setattr("code", C::CypherExecution.as_str())?;
+    py.get_type::<CypherTypeMismatchError>()
+        .setattr("code", C::CypherTypeMismatch.as_str())?;
+    py.get_type::<SchemaError>()
+        .setattr("code", C::Schema.as_str())?;
+    py.get_type::<ValidationError>()
+        .setattr("code", C::Validation.as_str())?;
+    py.get_type::<ExprError>()
+        .setattr("code", C::Expr.as_str())?;
+    py.get_type::<ConstraintViolationError>()
+        .setattr("code", C::ConstraintViolation.as_str())?;
+    py.get_type::<ConstraintCreationError>()
+        .setattr("code", C::ConstraintCreationFailed.as_str())?;
+    py.get_type::<TransactionConflictError>()
+        .setattr("code", C::TransactionConflict.as_str())?;
+    py.get_type::<NodeNotFoundError>()
+        .setattr("code", C::NodeNotFound.as_str())?;
+    py.get_type::<ConnectionNotFoundError>()
+        .setattr("code", C::ConnectionNotFound.as_str())?;
+    py.get_type::<PropertyNotFoundError>()
+        .setattr("code", C::PropertyNotFound.as_str())?;
+    py.get_type::<FileError>()
+        .setattr("code", C::FileNotFound.as_str())?;
+    py.get_type::<FileFormatError>()
+        .setattr("code", C::FileFormat.as_str())?;
+    py.get_type::<FileIoError>()
+        .setattr("code", C::FileIo.as_str())?;
+    py.get_type::<ArgumentError>()
+        .setattr("code", C::InvalidArgument.as_str())?;
+    py.get_type::<MissingArgumentError>()
+        .setattr("code", C::MissingArgument.as_str())?;
+    // Both collapse to `Internal` in `KgError::code()`.
+    py.get_type::<InternerCollisionError>()
+        .setattr("code", C::Internal.as_str())?;
+    py.get_type::<InternalError>()
+        .setattr("code", C::Internal.as_str())?;
 
     Ok(())
 }

--- a/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
@@ -607,7 +607,7 @@ fn apply_node_batch(
     provenance: (Option<String>, Option<String>),
 ) -> PyResult<NodeOperationReport> {
     let (git_sha, modified_by) = provenance;
-    detach_mutation(py, || {
+    let outcome = py.detach(|| {
         graph.with_write_provenance(git_sha.as_deref(), modified_by.as_deref(), |graph| {
             kglite_core::api::mutation::add_nodes(
                 graph,
@@ -618,6 +618,16 @@ fn apply_node_batch(
                 input.conflict_handling,
             )
         })
+    });
+    // The mutable borrow ends with the detach closure, so the structured
+    // violation `add_nodes` parked is recoverable here: a constraint failure
+    // raises `kglite.ConstraintViolationError`, anything else keeps the
+    // existing `ArgumentError`.
+    outcome.map_err(|message| {
+        let error = graph
+            .take_constraint_error(&message)
+            .unwrap_or(crate::error::KgError::Argument(message));
+        crate::error_py::kg_to_pyerr(error)
     })
 }
 

--- a/crates/kglite-py/src/graph/pyapi/transaction.rs
+++ b/crates/kglite-py/src/graph/pyapi/transaction.rs
@@ -281,11 +281,10 @@ impl Transaction {
         let current_version = Python::attach(|py| self.owner.borrow(py).inner.version);
         if current_version != base_version {
             return Err(crate::error_py::kg_to_pyerr(
-                crate::error::KgError::Argument(
-                    "Transaction conflict: graph was modified since begin(). \
-                     Retry the transaction."
-                        .to_string(),
-                ),
+                crate::error::KgError::TransactionConflict {
+                    base_version,
+                    current_version,
+                },
             ));
         }
 

--- a/crates/kglite/src/error.rs
+++ b/crates/kglite/src/error.rs
@@ -85,6 +85,12 @@ pub enum KgErrorCode {
     ConstraintViolation,
     ConstraintCreationFailed,
 
+    // Optimistic concurrency control. Split from `InvalidArgument` because a
+    // conflict is the one error in the taxonomy whose correct handling is
+    // "retry the whole transaction" rather than "fix the call" — bindings and
+    // drivers route on that difference.
+    TransactionConflict,
+
     // Resource / access
     NodeNotFound,
     ConnectionNotFound,
@@ -118,6 +124,7 @@ impl KgErrorCode {
             KgErrorCode::Expr => "Expr",
             KgErrorCode::ConstraintViolation => "ConstraintViolation",
             KgErrorCode::ConstraintCreationFailed => "ConstraintCreationFailed",
+            KgErrorCode::TransactionConflict => "TransactionConflict",
             KgErrorCode::NodeNotFound => "NodeNotFound",
             KgErrorCode::ConnectionNotFound => "ConnectionNotFound",
             KgErrorCode::PropertyNotFound => "PropertyNotFound",
@@ -140,6 +147,7 @@ impl KgErrorCode {
     /// - `NodeNotFound`, `ConnectionNotFound`, `PropertyNotFound`,
     ///   `FileNotFound` → 404 Not Found
     /// - `CypherTimeout` → 408 Request Timeout
+    /// - `TransactionConflict` → 409 Conflict
     /// - `Schema`, `Validation`, `Expr` → 422 Unprocessable Entity
     /// - `CypherExecution`, `FileFormat`, `FileIo`, `Internal` →
     ///   500 Internal Server Error
@@ -163,6 +171,11 @@ impl KgErrorCode {
             | KgErrorCode::FileNotFound => 404,
 
             KgErrorCode::CypherTimeout => 408,
+
+            // 409 Conflict — the request was well-formed but lost an
+            // optimistic-concurrency race. Retriable as-is, unlike every
+            // other 4xx here.
+            KgErrorCode::TransactionConflict => 409,
 
             // 499 Client Closed Request (nginx convention) — the caller
             // interrupted the query before it finished.
@@ -205,6 +218,10 @@ impl KgErrorCode {
             KgErrorCode::ConstraintCreationFailed => {
                 "Neo.ClientError.Schema.ConstraintCreationFailed"
             }
+            // Matches the string `kglite-bolt-server` has published for OCC
+            // conflicts since the transaction work landed; the driver
+            // conformance suite pins it (tests/test_bolt_server_transactions.py).
+            KgErrorCode::TransactionConflict => "Neo.ClientError.Transaction.ConflictDetected",
             KgErrorCode::Validation | KgErrorCode::Expr => {
                 "Neo.ClientError.Statement.ArgumentError"
             }
@@ -320,6 +337,26 @@ pub enum KgError {
         message: String,
     },
 
+    // ── Concurrency ──────────────────────────────────────────────────
+    /// An optimistic-concurrency commit lost its race: the graph advanced
+    /// between `begin()` and `commit()`, so the transaction's working copy is
+    /// stale and applying it would silently discard the newer commit.
+    ///
+    /// The transaction is spent — the caller re-runs its work against a fresh
+    /// `begin()`. Both versions are carried so a binding can report the gap
+    /// (and a retry loop can log how far behind it was) without parsing
+    /// `message`.
+    ///
+    /// Note this is a *whole-graph* version check, not a read/write-set
+    /// intersection: commit publishes the transaction's working copy by
+    /// pointer swap, so any concurrent commit — even one touching entirely
+    /// different nodes — makes this transaction's copy stale. See
+    /// `docs/concepts/concurrency.md`.
+    TransactionConflict {
+        base_version: u64,
+        current_version: u64,
+    },
+
     /// Blueprint expression evaluation failure. Wraps the existing
     /// 7-variant [`ExprError`] enum verbatim.
     Expr(ExprError),
@@ -430,6 +467,7 @@ impl KgError {
             KgError::Validation(_) => KgErrorCode::Validation,
             KgError::ConstraintViolation { .. } => KgErrorCode::ConstraintViolation,
             KgError::ConstraintCreationFailed { .. } => KgErrorCode::ConstraintCreationFailed,
+            KgError::TransactionConflict { .. } => KgErrorCode::TransactionConflict,
             KgError::Expr(_) => KgErrorCode::Expr,
             KgError::NodeNotFound { .. } => KgErrorCode::NodeNotFound,
             KgError::ConnectionNotFound { .. } => KgErrorCode::ConnectionNotFound,
@@ -509,6 +547,18 @@ impl fmt::Display for KgError {
             // in a prefix that would bury the actionable part.
             KgError::ConstraintViolation { message, .. }
             | KgError::ConstraintCreationFailed { message, .. } => f.write_str(message),
+            KgError::TransactionConflict {
+                base_version,
+                current_version,
+            } => write!(
+                f,
+                "Transaction conflict: the graph was modified since begin() \
+                 (began at version {}, now at version {}), so this \
+                 transaction's changes are based on a stale snapshot and were \
+                 not applied. Retry the transaction — re-run the work against \
+                 a fresh begin().",
+                base_version, current_version
+            ),
             KgError::Expr(e) => write!(f, "Expression error: {}", e),
             KgError::NodeNotFound { node_type, id } => {
                 write!(f, "Node not found: {} with id {:?}", node_type, id)

--- a/crates/kglite/src/graph/dir_graph/constraints.rs
+++ b/crates/kglite/src/graph/dir_graph/constraints.rs
@@ -413,7 +413,27 @@ impl DirGraph {
     ///
     /// Empty on both sides when the type declares no unique constraint, which is
     /// the common case.
+    ///
+    /// A rejection is *also* parked on the graph by
+    /// [`DirGraph::record_constraint_violation`], so callers whose error channel
+    /// is a `String` (the Cypher `SET` / `REMOVE` tree) still surface a typed
+    /// `ConstraintViolationError`. Recording here rather than at each call site
+    /// keeps the violation attached to the code that produced it.
     pub(crate) fn plan_property_write(
+        &mut self,
+        node_type: &str,
+        node_idx: NodeIndex,
+        property: &str,
+        new_value: Option<&Value>,
+    ) -> Result<PropertyWritePlan, ConstraintViolation> {
+        let planned = self.plan_property_write_uncaught(node_type, node_idx, property, new_value);
+        if let Err(violation) = &planned {
+            self.record_constraint_violation(violation.clone());
+        }
+        planned
+    }
+
+    fn plan_property_write_uncaught(
         &mut self,
         node_type: &str,
         node_idx: NodeIndex,

--- a/crates/kglite/src/graph/dir_graph/independent_copy.rs
+++ b/crates/kglite/src/graph/dir_graph/independent_copy.rs
@@ -35,6 +35,7 @@ impl DirGraph {
         copy.active_write_scope = None;
         copy.active_git_sha = None;
         copy.active_modified_by = None;
+        copy.pending_constraint_violation = None;
         copy
     }
 }

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -274,6 +274,31 @@ pub struct DirGraph {
     pub(crate) active_git_sha: Option<String>,
     #[serde(skip, default)]
     pub(crate) active_modified_by: Option<String>,
+    /// Transient, **execution-scoped** carrier for the structured constraint
+    /// violation behind the write error currently unwinding.
+    ///
+    /// The Cypher mutation tree (`executor/write.rs`, `executor/schema_ddl.rs`)
+    /// and the bulk-loader gate (`mutation/maintain.rs`) both report failures
+    /// over a `Result<_, String>` channel, so a `ConstraintViolation` — which
+    /// already has an `impl From<ConstraintViolation> for KgError` — would
+    /// otherwise be flattened to prose and surface as a generic
+    /// `CypherExecutionError` / `ArgumentError`. Rather than retype ~535 call
+    /// sites across the executor, the violation is parked here by
+    /// [`Self::record_constraint_violation`] at the moment it is stringified
+    /// and drained by the adapter that builds the typed error.
+    ///
+    /// Stored **with the exact message it produced**, and the drain only
+    /// accepts it when the string that arrived is byte-identical: if any
+    /// intermediate frame wrapped or rewrote the message, the pair is
+    /// discarded and the caller falls back to the untyped error. That makes a
+    /// desync fail *safe* rather than fail *wrong*.
+    ///
+    /// Same lifecycle as `active_write_scope`: installed for one execution,
+    /// cleared unconditionally, never serialized, never copied (see
+    /// `independent_copy`).
+    #[serde(skip, default)]
+    pub(crate) pending_constraint_violation:
+        Option<Box<(String, crate::graph::constraints::ConstraintViolation)>>,
     /// Monotonically increasing version counter — incremented on every mutation.
     /// Used for optimistic concurrency control in transactions.
     #[serde(skip, default)]
@@ -418,6 +443,61 @@ impl DirGraph {
         self.version = self.version.wrapping_add(1);
     }
 
+    /// Stringify `violation` for the `Result<_, String>` error channel while
+    /// parking the structured value in
+    /// [`Self::pending_constraint_violation`], so the adapter that ultimately
+    /// builds the typed error can recover the constraint kind, node type,
+    /// properties, and descriptor instead of only the prose.
+    ///
+    /// Returns the message to hand to `Err(..)`; call it at every site that
+    /// would otherwise write `.map_err(|v| v.to_string())`.
+    pub(crate) fn record_constraint_violation(
+        &mut self,
+        violation: crate::graph::constraints::ConstraintViolation,
+    ) -> String {
+        let message = violation.to_string();
+        self.pending_constraint_violation = Some(Box::new((message.clone(), violation)));
+        message
+    }
+
+    /// Clear any parked violation. Called before an execution begins so a
+    /// violation left by an earlier run on the same working copy can never be
+    /// attributed to a later, unrelated error.
+    pub(crate) fn clear_pending_constraint_violation(&mut self) {
+        self.pending_constraint_violation = None;
+    }
+
+    /// Take the parked violation **only if** it is the one behind `message`.
+    ///
+    /// The identity check is what makes the side channel safe: the `String` is
+    /// still the control-flow channel, so if any intermediate frame wrapped or
+    /// replaced the message, the parked violation no longer describes the error
+    /// being reported and is dropped rather than mis-attributed. This is an
+    /// equality test against a string this graph itself produced — not a
+    /// pattern match on error prose.
+    pub(crate) fn take_constraint_violation_for(
+        &mut self,
+        message: &str,
+    ) -> Option<crate::graph::constraints::ConstraintViolation> {
+        let parked = self.pending_constraint_violation.take()?;
+        let (recorded, violation) = *parked;
+        (recorded == message).then_some(violation)
+    }
+
+    /// Typed [`KgError`] for a write that failed with `message`, when that
+    /// failure was a declared-constraint violation.
+    ///
+    /// Returns `None` when the error was something else, so each caller keeps
+    /// its own fallback: the Cypher path degrades to
+    /// [`KgError::CypherExecution`], the bulk-loader path to
+    /// [`KgError::Argument`]. Every binding that surfaces a write error over
+    /// the engine's `Result<_, String>` channel needs exactly this step, so it
+    /// lives here rather than being re-derived per binding.
+    pub fn take_constraint_error(&mut self, message: &str) -> Option<crate::error::KgError> {
+        self.take_constraint_violation_for(message)
+            .map(crate::error::KgError::from)
+    }
+
     pub fn new() -> Self {
         DirGraph {
             graph_id: next_graph_id(),
@@ -464,6 +544,7 @@ impl DirGraph {
             active_write_scope: None,
             active_git_sha: None,
             active_modified_by: None,
+            pending_constraint_violation: None,
             version: 0,
             interner: StringInterner::new(),
             type_schemas: HashMap::new(),
@@ -520,6 +601,7 @@ impl DirGraph {
             active_write_scope: None,
             active_git_sha: None,
             active_modified_by: None,
+            pending_constraint_violation: None,
             version: 0,
             interner: StringInterner::new(),
             type_schemas: HashMap::new(),

--- a/crates/kglite/src/graph/languages/cypher/executor/schema_ddl.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/schema_ddl.rs
@@ -722,10 +722,11 @@ fn install_constraint(
 
 fn declare_unique(graph: &mut DirGraph, label: &str, properties: &[String]) -> Result<(), String> {
     let refs: Vec<&str> = properties.iter().map(String::as_str).collect();
-    graph
-        .create_unique_constraint(label, &refs)
-        .map(|_| ())
-        .map_err(|violation| violation.to_string())
+    let declared = graph.create_unique_constraint(label, &refs);
+    match declared {
+        Ok(_) => Ok(()),
+        Err(violation) => Err(graph.record_constraint_violation(violation)),
+    }
 }
 
 /// Declare every property NOT NULL, recording which ones landed so a failed
@@ -741,9 +742,10 @@ fn declare_not_null<'p>(
     installed: &mut Vec<&'p String>,
 ) -> Result<(), String> {
     for property in properties {
-        graph
-            .create_not_null_constraint(label, property)
-            .map_err(|violation| violation.to_string())?;
+        let declared = graph.create_not_null_constraint(label, property);
+        if let Err(violation) = declared {
+            return Err(graph.record_constraint_violation(violation));
+        }
         installed.push(property);
     }
     Ok(())

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -948,13 +948,17 @@ fn create_node(
             },
         }
     };
-    graph
-        .check_required_fields(&label, constraint_read)
-        .map_err(|violation| violation.to_string())?;
+    // Bind before reporting: `record_constraint_violation` needs `&mut graph`,
+    // so the immutable borrow held by the check must end at the semicolon.
+    let required = graph.check_required_fields(&label, constraint_read);
+    if let Err(violation) = required {
+        return Err(graph.record_constraint_violation(violation));
+    }
     let unique_claims = graph.unique_claims(&label, constraint_read);
-    graph
-        .check_unique_claims(&unique_claims, None)
-        .map_err(|violation| violation.to_string())?;
+    let unique = graph.check_unique_claims(&unique_claims, None);
+    if let Err(violation) = unique {
+        return Err(graph.record_constraint_violation(violation));
+    }
 
     // Clone the id for incremental index maintenance below (it is moved into
     // insert_node_routed). The id-index is maintained incrementally whenever it

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1,6 +1,6 @@
 // src/graph/maintain.rs
 use crate::datatypes::{DataFrame, Value};
-use crate::graph::constraints::UniqueConstraintKey;
+use crate::graph::constraints::{ConstraintViolation, UniqueConstraintKey};
 use crate::graph::introspection::reporting::{ConnectionOperationReport, NodeOperationReport};
 use crate::graph::mutation::batch::{
     BatchProcessor, ConflictHandling, ConnectionBatchProcessor, NodeAction,
@@ -63,9 +63,32 @@ impl ConstraintColumns {
     /// reach storage. Returning `None` for an unconstrained type is what keeps
     /// the common path free — one `is_empty` and one `Option` check per call
     /// rather than per row.
-    fn for_batch(graph: &DirGraph, node_type: &str, df_data: &DataFrame) -> Option<Self> {
+    fn for_batch(graph: &mut DirGraph, node_type: &str, df_data: &DataFrame) -> Option<Self> {
+        // Batch entry point: no violation parked by an earlier load may be
+        // attributed to this one.
+        graph.clear_pending_constraint_violation();
         (graph.has_unique_constraints() || graph.has_required_fields(node_type))
             .then(|| Self::new(df_data))
+    }
+
+    /// [`Self::gate_row`] for callers on the `Result<_, String>` channel: parks
+    /// the structured violation so the binding raises
+    /// `ConstraintViolationError` instead of a generic argument error, and
+    /// returns the prose the caller would have produced itself.
+    fn gate_row_parked(
+        &self,
+        graph: &mut DirGraph,
+        node_type: &str,
+        row: GateRow<'_>,
+        existing_idx: Option<NodeIndex>,
+        batch_claims: &mut HashSet<(UniqueConstraintKey, CompositeValue)>,
+    ) -> Result<(), String> {
+        // Bound before reporting: recording needs a second mutable borrow.
+        let gated = self.gate_row(graph, node_type, row, existing_idx, batch_claims);
+        match gated {
+            Ok(()) => Ok(()),
+            Err(violation) => Err(graph.record_constraint_violation(violation)),
+        }
     }
 
     fn new(df_data: &DataFrame) -> Self {
@@ -101,7 +124,7 @@ impl ConstraintColumns {
         row: GateRow<'_>,
         existing_idx: Option<NodeIndex>,
         batch_claims: &mut HashSet<(UniqueConstraintKey, CompositeValue)>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ConstraintViolation> {
         // Both identity spellings are accepted, and identity wins over a
         // same-named ordinary column — matching `DirGraph::resolve_alias` on the
         // read side.
@@ -114,16 +137,15 @@ impl ConstraintColumns {
             }
             self.read(row.df_data, row.row_idx, property)
         };
-        graph
-            .check_required_fields(node_type, read)
-            .map_err(|violation| violation.to_string())?;
+        // Every failure this gate can report is a declared-constraint
+        // violation, so it returns the structured value and lets `add_nodes`
+        // decide how to render it.
+        graph.check_required_fields(node_type, read)?;
         let claims = graph.unique_claims(node_type, read);
-        graph
-            .check_unique_claims(&claims, existing_idx)
-            .map_err(|violation| violation.to_string())?;
+        graph.check_unique_claims(&claims, existing_idx)?;
         for claim in &claims {
             if !batch_claims.insert((claim.key.clone(), claim.value.clone())) {
-                return Err(graph.unique_batch_conflict(claim).to_string());
+                return Err(graph.unique_batch_conflict(claim));
             }
         }
         Ok(())
@@ -464,7 +486,7 @@ pub fn add_nodes(
         // rollback needed and no half-applied load.
         let existing_idx = type_lookup.check_uid(&id);
         if let Some(columns) = &constraint_columns {
-            columns.gate_row(
+            columns.gate_row_parked(
                 graph,
                 &node_type,
                 GateRow {

--- a/crates/kglite/src/graph/session/execute.rs
+++ b/crates/kglite/src/graph/session/execute.rs
@@ -177,11 +177,14 @@ impl<'a> ExecuteOptions<'a> {
 /// execution error. `cancel == None` (every server binding) always
 /// takes the `CypherExecution` branch, so behaviour is unchanged there.
 #[inline]
-fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
-    if opts
-        .cancel
+fn is_cancelled(opts: &ExecuteOptions<'_>) -> bool {
+    opts.cancel
         .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
-    {
+}
+
+#[inline]
+fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
+    if is_cancelled(opts) {
         KgError::Cancelled
     } else {
         KgError::CypherExecution {
@@ -189,6 +192,26 @@ fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
             position: None,
         }
     }
+}
+
+/// [`exec_err`] for the mutation path, which can additionally recover the
+/// structured constraint violation parked by
+/// [`DirGraph::record_constraint_violation`].
+///
+/// Cancellation keeps precedence: an interrupt is a user action and stays
+/// `KgError::Cancelled` regardless of what the aborted statement had parked.
+/// The park is drained on every path so nothing survives into a later run.
+fn mutation_err(graph: &mut DirGraph, opts: &ExecuteOptions<'_>, message: String) -> KgError {
+    if is_cancelled(opts) {
+        graph.clear_pending_constraint_violation();
+        return KgError::Cancelled;
+    }
+    graph
+        .take_constraint_error(&message)
+        .unwrap_or(KgError::CypherExecution {
+            message,
+            position: None,
+        })
 }
 
 /// Result of a successful execute. Wraps `CypherResult` with the
@@ -386,6 +409,9 @@ pub fn execute_mut(
         // mutation, then clear it unconditionally (even on error) so it never
         // leaks into a later execution on the same working copy.
         graph.active_write_scope = opts.write_scope.cloned();
+        // Same lifecycle as the write scope: no violation parked by an earlier
+        // execution on this working copy may be read by this one.
+        graph.clear_pending_constraint_violation();
         let r = graph.with_write_provenance(opts.git_sha, opts.modified_by, |graph| {
             cypher::executor::write::execute_mutable_with_csv(
                 graph,
@@ -400,8 +426,12 @@ pub fn execute_mut(
         let r = match r {
             Ok(result) => result,
             Err(message) => {
+                // Recover the structured violation *before* rolling back, so
+                // the typed error never depends on what a checkpoint restore
+                // does to the graph's transient fields.
+                let error = mutation_err(graph, opts, message);
                 checkpoint.rollback(graph);
-                return Err(exec_err(opts, message));
+                return Err(error);
             }
         };
         checkpoint.commit(graph);

--- a/docs/python/error-handling.md
+++ b/docs/python/error-handling.md
@@ -18,6 +18,10 @@ Exception
     ├── kglite.SchemaError
     ├── kglite.ValidationError
     ├── kglite.ExprError
+    ├── kglite.ConstraintError
+    │   ├── kglite.ConstraintViolationError
+    │   └── kglite.ConstraintCreationError
+    ├── kglite.TransactionConflictError
     ├── kglite.NodeNotFoundError
     ├── kglite.ConnectionNotFoundError
     ├── kglite.PropertyNotFoundError
@@ -33,6 +37,57 @@ Exception
 `CypherSyntaxError` always has `.line` and `.col` attributes (either may be
 `None`). `CypherExecutionError` has them when the executor can identify the
 source position. Timeout messages report the elapsed and configured limit.
+
+## Stable codes
+
+Every instance carries `.code`, a stable classifier string — branch on that
+rather than on message prose, which is free to improve between releases:
+
+```python
+try:
+    graph.cypher(query)
+except kglite.KgError as exc:
+    log.warning("kglite failed", extra={"kglite_code": exc.code})
+```
+
+`.code` is also readable on the concrete classes themselves
+(`kglite.ConstraintViolationError.code == "ConstraintViolation"`), so a
+dispatch table can be built up front. It is `None` on the three abstract bases
+— `KgError`, `CypherError`, `ConstraintError` — which each span several codes.
+The same strings appear as `KGLITE_STATUS_*` in the C ABI and drive the Bolt
+`Neo.*` status mapping, so one code means the same thing in every binding.
+
+## Constraint violations
+
+A write that breaks a declared UNIQUE / NOT NULL / NODE KEY constraint raises
+`ConstraintViolationError` — from **every** write path, `cypher()` and the bulk
+loaders alike. Declaring a constraint the stored data already violates is a
+different problem with a different fix, so it raises the sibling
+`ConstraintCreationError`; both subclass `ConstraintError`.
+
+```python
+try:
+    graph.cypher("CREATE (u:User {email: $email})", params={"email": email})
+except kglite.ConstraintViolationError:
+    raise Conflict("that email is already registered")
+```
+
+The message names the constraint, the property, and the offending value, so it
+is worth logging — but the type and `.code` are the contract.
+
+## Transaction conflicts
+
+`Transaction.commit()` raises `TransactionConflictError` when the graph moved
+since `begin()`. Nothing was applied, so the fix is to re-run the work against
+a fresh `begin()` — see {doc}`transactions` for `retry_on_conflict`, which is
+that loop.
+
+```python
+try:
+    tx.commit()
+except kglite.TransactionConflictError:
+    ...  # rebuild the transaction and try again
+```
 
 ## Catching errors
 

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -92,10 +92,33 @@ rather than silently truncated.
 snapshot; a `session()` serializes writers, begins each from the last committed
 state, and publishes with a pointer swap only on success — though note the
 durable-graph restriction on `Session` writes below. Explicit transactions
-are optimistically concurrent: independent work proceeds, and a commit against a
-state that moved underneath returns a conflict rather than winning silently.
-{doc}`/concepts/concurrency` is the full model, and worth reading before you rely
-on any of it.
+are optimistically concurrent: a commit against a state that moved underneath
+raises `TransactionConflictError` rather than winning silently.
+
+Be precise about how coarse that check is, because it is coarser than most
+databases you have used. It compares a **whole-graph version counter**, not the
+read/write sets of the two transactions — a commit publishes the transaction's
+working copy by pointer swap, so a transaction that began before *any* other
+commit is working from a stale snapshot regardless of which nodes it touched.
+Two transactions editing entirely unrelated nodes therefore conflict, and the
+second one loses. That is not over-caution: its working copy genuinely does not
+contain the first one's write, so applying it would silently revert that write.
+
+The practical consequence is that conflicts are ordinary rather than rare, and
+every concurrent writer needs a retry loop. Use `kglite.retry_on_conflict`
+rather than writing one:
+
+```python
+def signup(tx):
+    tx.cypher("CREATE (u:User {email: $email})", params={"email": email})
+
+kglite.retry_on_conflict(graph, signup)
+```
+
+If your workload has many short concurrent writers, prefer `session()` — it
+serializes writers and begins each from the last committed state, so they queue
+instead of colliding. {doc}`/concepts/concurrency` is the full model, and worth
+reading before you rely on any of it.
 
 **Failures are typed.** Errors arrive as a `KgError` hierarchy with stable
 codes, not as strings to match on — see {doc}`/python/error-handling`.
@@ -138,18 +161,26 @@ embedding-carry path. A graph filled through those can hold data that violates a
 declared constraint; `verify_unique_constraints()` exists to audit exactly that
 case.
 
-Two things about the error surface are worth knowing before you write `except`
-clauses. A declaration that cannot be installed raises `ConstraintCreationError`,
-and a violation from the bulk writers raises `ConstraintViolationError`; both
-subclass `ConstraintError`, so `except ConstraintError` catches either. Note that
-`define_schema` *can* now fail this way, because installing a schema installs the
+One thing about the error surface is worth knowing before you write `except`
+clauses. A violation raises `ConstraintViolationError` and a declaration that
+cannot be installed raises `ConstraintCreationError`; both subclass
+`ConstraintError`, so `except ConstraintError` catches either. This holds on
+every write path — `cypher()` and the bulk writers alike — so the duplicate-signup
+handler is a type check, not a substring match:
+
+```python
+try:
+    graph.cypher("CREATE (u:User {email: $email})", params={"email": email})
+except kglite.ConstraintViolationError:
+    raise Conflict("that email is already registered")
+```
+
+Each carries a stable `.code` (`"ConstraintViolation"` /
+`"ConstraintCreationFailed"`) for logging and cross-binding dispatch. Note that
+`define_schema` *can* fail this way, because installing a schema installs the
 constraints it declares — nothing is changed when it does, so you can fix the data
-and retry. A violation raised through **Cypher**, however, arrives as
-`CypherExecutionError` rather than the typed exception: the executor's internal
-error channel is a string, so the structured violation is rendered to text before
-any binding sees it. The message is stable and names the constraint, the property,
-and the offending value — match on that. Enforcement is identical either way; only
-the exception type differs.
+and retry. The message still names the constraint, the property, and the
+offending value, and is worth logging; the type and code are the contract.
 
 ## Defaults, and how to change them
 

--- a/kglite/__init__.py
+++ b/kglite/__init__.py
@@ -33,6 +33,7 @@ from .kglite import (  # explicit re-exports — names listed in __all__ below
     SchemaError,
     Session,
     Transaction,
+    TransactionConflictError,
     ValidationError,
     __version__,
     cypher_pass_names,
@@ -42,6 +43,7 @@ from .kglite import (  # explicit re-exports — names listed in __all__ below
     open,
     open_session,
 )
+from .retry import retry_on_conflict
 
 
 class Agg:
@@ -568,6 +570,8 @@ __all__ = [
     "ConstraintError",
     "ConstraintViolationError",
     "ConstraintCreationError",
+    "TransactionConflictError",
+    "retry_on_conflict",
     "NodeNotFoundError",
     "ConnectionNotFoundError",
     "PropertyNotFoundError",

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -22,6 +22,20 @@ class KgError(Exception):
     Query, schema, graph-engine, transaction, and storage failures use this
     hierarchy. Python lookup, argument-shape, filesystem, and object-lifecycle
     protocols may instead raise their conventional built-in exceptions.
+
+    Every instance carries :attr:`code`, a stable classifier string, so an
+    application can branch on the failure kind without matching message prose.
+    """
+
+    code: str | None
+    """Stable error classifier — e.g. ``"ConstraintViolation"``,
+    ``"TransactionConflict"``, ``"CypherSyntax"``.
+
+    Set on every raised instance, and also readable on the concrete classes
+    themselves (``kglite.ConstraintViolationError.code``). It is ``None`` only
+    on the three abstract bases — ``KgError``, ``CypherError``,
+    ``ConstraintError`` — which span several codes. The same strings appear as
+    ``KGLITE_STATUS_*`` in the C ABI and drive the Bolt ``Neo.*`` mapping.
     """
 
 class CypherError(KgError):
@@ -115,6 +129,65 @@ class ConstraintCreationError(ConstraintError):
     ``unique`` tuple or ``primary_key`` that existing nodes already duplicate.
     Nothing is changed, so deduplicate the node type and call it again.
     """
+
+class TransactionConflictError(KgError):
+    """A transaction's commit lost an optimistic-concurrency race.
+
+    The graph advanced between :meth:`KnowledgeGraph.begin` and
+    :meth:`Transaction.commit`, so the transaction's working copy is stale and
+    **nothing was applied**. Re-run the work against a fresh ``begin()``;
+    :func:`retry_on_conflict` is that loop.
+
+    Note this is a whole-graph version check, not a read/write-set
+    intersection: a commit publishes the transaction's working copy by pointer
+    swap, so *any* concurrent commit conflicts — including one that touched
+    entirely different nodes. See :doc:`/concepts/concurrency`.
+    """
+
+def retry_on_conflict(
+    graph: KnowledgeGraph,
+    work: Callable[[Transaction], Any],
+    *,
+    attempts: int = 5,
+    base_delay: float = 0.005,
+    max_delay: float = 0.5,
+    jitter: bool = True,
+) -> Any:
+    """Run ``work`` in a transaction, retrying the whole unit on conflict.
+
+    ``work`` is called as ``work(tx)`` with a fresh :class:`Transaction` and is
+    re-invoked from the start on each attempt, so it must be safe to run more
+    than once — read what you need *inside* it rather than closing over values
+    read beforehand. The transaction commits when ``work`` returns and rolls
+    back if it raises.
+
+    Args:
+        graph: The graph to transact against.
+        work: Callable taking the transaction and returning the result.
+        attempts: Maximum tries, including the first.
+        base_delay: Seconds before the second attempt; doubles each further
+            attempt (exponential backoff).
+        max_delay: Upper bound on any single wait.
+        jitter: Spread each wait randomly over ``[0, delay]`` so competing
+            writers don't retry in lockstep. Disable only for deterministic
+            tests.
+
+    Returns:
+        Whatever ``work`` returned on the successful attempt.
+
+    Raises:
+        TransactionConflictError: Every attempt conflicted; the final error is
+            re-raised unchanged.
+        ValueError: ``attempts`` is less than 1.
+
+    Example:
+        >>> def signup(tx):
+        ...     tx.cypher("CREATE (u:User {email: $e})", params={"e": email})
+        ...     return "created"
+        >>> kglite.retry_on_conflict(graph, signup)
+        'created'
+    """
+    ...
 
 @runtime_checkable
 class EmbeddingModel(Protocol):

--- a/kglite/retry.py
+++ b/kglite/retry.py
@@ -1,0 +1,91 @@
+"""Optimistic-concurrency retry helper.
+
+KGLite commits a transaction by publishing its working copy with a pointer
+swap, so *any* commit that lands between ``begin()`` and ``commit()`` makes
+this transaction's snapshot stale — even one that touched entirely different
+nodes. Conflicts are therefore an ordinary outcome under concurrency rather
+than a rare edge case, and every correct writer needs a retry loop.
+
+The loop is short but easy to get subtly wrong: a conflicted transaction is
+already spent, so it must be *rebuilt* (not reused) on each attempt, the work
+must be re-run against the fresh snapshot rather than replayed from the stale
+one, and unbounded immediate retries livelock under contention.
+:func:`retry_on_conflict` is that loop, done once.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable, TypeVar
+
+from .kglite import TransactionConflictError
+
+__all__ = ["retry_on_conflict"]
+
+T = TypeVar("T")
+
+
+def retry_on_conflict(
+    graph: Any,
+    work: Callable[[Any], T],
+    *,
+    attempts: int = 5,
+    base_delay: float = 0.005,
+    max_delay: float = 0.5,
+    jitter: bool = True,
+) -> T:
+    """Run ``work`` in a transaction, retrying the whole unit on conflict.
+
+    ``work`` is called as ``work(tx)`` with a fresh :class:`Transaction` and is
+    re-invoked from the start on each attempt, so it must be safe to run more
+    than once — read what you need *inside* it rather than closing over values
+    read before the call. The transaction is committed when ``work`` returns
+    and rolled back if it raises.
+
+    Args:
+        graph: The :class:`KnowledgeGraph` to transact against.
+        work: Callable taking the transaction and returning the result.
+        attempts: Maximum number of tries, including the first.
+        base_delay: Seconds to wait before the second attempt. Doubles each
+            further attempt (exponential backoff).
+        max_delay: Upper bound on any single wait.
+        jitter: Spread the backoff randomly over ``[0, delay]`` (full jitter).
+            Keeps competing writers from retrying in lockstep; turn it off only
+            for deterministic tests.
+
+    Returns:
+        Whatever ``work`` returned on the successful attempt.
+
+    Raises:
+        TransactionConflictError: Every attempt conflicted. The final error is
+            re-raised unchanged, so ``.code`` and the version gap survive.
+        ValueError: ``attempts`` is less than 1.
+        Exception: Anything ``work`` raises is propagated immediately and the
+            transaction rolled back — only conflicts are retried.
+
+    Example:
+        >>> def signup(tx):
+        ...     tx.cypher("CREATE (u:User {email: $e})", params={"e": email})
+        ...     return "created"
+        >>> kglite.retry_on_conflict(graph, signup)
+        'created'
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            with graph.begin() as tx:
+                result = work(tx)
+            return result
+        except TransactionConflictError:
+            # The transaction is spent either way; the last attempt re-raises
+            # so the caller sees a real conflict rather than a silent failure.
+            if attempt == attempts:
+                raise
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+            time.sleep(random.uniform(0, delay) if jitter else delay)
+
+    # Unreachable: the final attempt either returns or re-raises.
+    raise AssertionError("retry_on_conflict exhausted its loop without returning")

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -35,6 +35,8 @@
     "ConstraintError",
     "ConstraintViolationError",
     "ConstraintCreationError",
+    "TransactionConflictError",
+    "retry_on_conflict",
     "NodeNotFoundError",
     "ConnectionNotFoundError",
     "PropertyNotFoundError",
@@ -98,7 +100,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConnectionNotFoundError": {
@@ -108,7 +115,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintCreationError": {
@@ -118,7 +130,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintError": {
@@ -128,7 +145,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintViolationError": {
@@ -138,7 +160,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "CypherError": {
@@ -148,7 +175,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "CypherExecutionError": {
@@ -159,6 +191,10 @@
       "constructor": null,
       "kind": "class",
       "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        },
         "col": {
           "kind": "attribute",
           "type": "NoneType"
@@ -178,6 +214,10 @@
       "constructor": null,
       "kind": "class",
       "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        },
         "col": {
           "kind": "attribute",
           "type": "NoneType"
@@ -196,7 +236,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "CypherTypeMismatchError": {
@@ -206,7 +251,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ExprError": {
@@ -216,7 +266,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileError": {
@@ -226,7 +281,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileFormatError": {
@@ -236,7 +296,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileIoError": {
@@ -246,7 +311,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FrozenGraph": {
@@ -279,7 +349,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "InternerCollisionError": {
@@ -289,7 +364,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "KgError": {
@@ -299,7 +379,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "KnowledgeGraph": {
@@ -1100,7 +1185,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "NodeNotFoundError": {
@@ -1110,7 +1200,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "PropertyNotFoundError": {
@@ -1120,7 +1215,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ResultIter": {
@@ -1220,7 +1320,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "Session": {
@@ -1328,6 +1433,21 @@
       },
       "module": "kglite"
     },
+    "TransactionConflictError": {
+      "bases": [
+        "KgError"
+      ],
+      "constructible": true,
+      "constructor": null,
+      "kind": "class",
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
+      "module": "kglite"
+    },
     "ValidationError": {
       "bases": [
         "KgError"
@@ -1335,7 +1455,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "__version__": {
@@ -1389,6 +1514,10 @@
     "outline": {
       "kind": "function",
       "signature": "(graph: 'KnowledgeGraph', root, edge: str, *, max_depth: int | None = None, body: str | None = None) -> str"
+    },
+    "retry_on_conflict": {
+      "kind": "function",
+      "signature": "(graph: 'Any', work: 'Callable[[Any], T]', *, attempts: 'int' = 5, base_delay: 'float' = 0.005, max_delay: 'float' = 0.5, jitter: 'bool' = True) -> 'T'"
     },
     "stamp_file_freshness": {
       "kind": "function",

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -1785,6 +1785,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1822,6 +1825,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2092,6 +2096,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3058,6 +3063,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3095,6 +3103,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3028,6 +3033,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3065,6 +3073,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3043,6 +3048,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3080,6 +3088,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3028,6 +3033,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3065,6 +3073,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -1785,6 +1785,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1822,6 +1825,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2092,6 +2096,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3043,6 +3048,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3080,6 +3088,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,309 @@
+"""The typed-error contract an application actually writes `except` clauses against.
+
+Two guarantees are under test, and both were broken before this suite existed:
+
+1. **A constraint violation is catchable by type, from every write path.**
+   `ConstraintViolationError` was previously unreachable — a violation raised
+   through Cypher arrived as `CypherExecutionError`, and one raised through the
+   bulk loader as `ArgumentError`, so the only handler an app could write was a
+   substring match on the message in its signup path.
+
+2. **A commit conflict is catchable by type and carries a stable code.**
+   It was previously `ArgumentError` ("Invalid argument: Transaction
+   conflict…"), with no `.code` anywhere on the surface.
+
+The message quality is asserted alongside the type on purpose: these messages
+name the constraint, the property, and the offending value, and adding a type
+must not be an excuse to regress them.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+
+# ─── A. Constraint violations are typed, on every write path ────────────────
+
+
+@pytest.fixture
+def users() -> kglite.KnowledgeGraph:
+    """A graph whose `User.email` is a NODE KEY (unique *and* present)."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"User": {"primary_key": "email", "required": ["email"]}}})
+    return kg
+
+
+def test_duplicate_signup_via_cypher_is_catchable_by_type(users):
+    """The signup case: `except kglite.ConstraintViolationError`, no substring match."""
+    users.cypher("CREATE (u:User {email: 'a@b.com', name: 'A'})")
+
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {email: 'a@b.com', name: 'B'})")
+
+    exc = excinfo.value
+    # Catchable at every level of the hierarchy an app might use.
+    assert isinstance(exc, kglite.ConstraintError)
+    assert isinstance(exc, kglite.KgError)
+    # ...and *not* as the generic execution error it used to be.
+    assert not isinstance(exc, kglite.CypherExecutionError)
+    assert exc.code == "ConstraintViolation"
+
+    # Message quality must survive the retyping: it still names the constraint,
+    # the property, the offending value, and the remedy.
+    message = str(exc)
+    assert "already exists" in message
+    assert "NODE KEY constraint on User.email" in message
+    assert "'a@b.com'" in message
+    assert "MERGE" in message
+
+
+def test_not_null_via_cypher_is_catchable_by_type(users):
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {name: 'no email'})")
+
+    message = str(excinfo.value)
+    assert "must have the property 'email'" in message
+    assert "NODE KEY constraint on User.email" in message
+    assert excinfo.value.code == "ConstraintViolation"
+
+
+def test_set_to_null_via_cypher_is_catchable_by_type(users):
+    users.cypher("CREATE (u:User {email: 'c@d.com'})")
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("MATCH (u:User) SET u.email = null")
+
+
+def test_remove_required_property_via_cypher_is_catchable_by_type(users):
+    users.cypher("CREATE (u:User {email: 'e@f.com'})")
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("MATCH (u:User) REMOVE u.email")
+
+
+def test_bulk_loader_violation_is_catchable_by_type():
+    """`add_nodes` is the funnel users trust most for volume; it raised
+    `ArgumentError` before, despite the docs promising the typed class."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"P": {"primary_key": "id", "required": ["email"]}}})
+
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        kg.add_nodes(pd.DataFrame([{"id": 1}]), "P", "id")
+
+    assert "NOT NULL constraint on P.email" in str(excinfo.value)
+    assert excinfo.value.code == "ConstraintViolation"
+
+
+def test_constraint_creation_failure_is_typed_and_distinct():
+    """Declaring a constraint the data already violates is a *different* fix
+    (deduplicate, then re-declare), so it stays a distinct sibling class."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:U {id: 1, email: 'd@d.com'})")
+    kg.cypher("CREATE (:U {id: 2, email: 'd@d.com'})")
+
+    with pytest.raises(kglite.ConstraintCreationError) as excinfo:
+        kg.define_schema({"nodes": {"U": {"unique": [["email"]]}}})
+
+    exc = excinfo.value
+    assert isinstance(exc, kglite.ConstraintError)
+    assert not isinstance(exc, kglite.ConstraintViolationError)
+    assert exc.code == "ConstraintCreationFailed"
+
+
+def test_cypher_create_constraint_ddl_violation_is_typed():
+    """The `CREATE CONSTRAINT` DDL path goes through its own raise sites."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:W {id: 1, email: 'x@x.com'})")
+    kg.cypher("CREATE (:W {id: 2, email: 'x@x.com'})")
+
+    with pytest.raises(kglite.ConstraintError) as excinfo:
+        kg.cypher("CREATE CONSTRAINT FOR (w:W) REQUIRE w.email IS UNIQUE")
+
+    assert excinfo.value.code in {"ConstraintViolation", "ConstraintCreationFailed"}
+
+
+def test_a_non_constraint_cypher_failure_is_still_a_cypher_error(users):
+    """The side channel must not mistype unrelated failures."""
+    users.cypher("CREATE (u:User {email: 'g@h.com'})")
+
+    with pytest.raises(kglite.CypherExecutionError) as excinfo:
+        users.cypher("MATCH (u:User) RETURN nonexistent_function(u)")
+
+    assert not isinstance(excinfo.value, kglite.ConstraintError)
+    assert excinfo.value.code == "CypherExecution"
+
+
+def test_a_successful_write_after_a_violation_is_unaffected(users):
+    """A parked violation must never leak into a later, successful execution."""
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("CREATE (u:User {name: 'no email'})")
+
+    users.cypher("CREATE (u:User {email: 'ok@ok.com'})")
+    assert users.cypher("MATCH (u:User) RETURN count(u) AS n").to_list() == [{"n": 1}]
+
+    # ...and the *next* failure is still classified correctly, not stale.
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {email: 'ok@ok.com'})")
+    assert "already exists" in str(excinfo.value)
+
+
+# ─── B. Transaction conflicts are typed and carry a code ────────────────────
+
+
+def _two_node_graph() -> kglite.KnowledgeGraph:
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:N {id: 1, v: 0})")
+    kg.cypher("CREATE (:N {id: 2, v: 0})")
+    return kg
+
+
+def test_commit_conflict_raises_transaction_conflict_error():
+    kg = _two_node_graph()
+    t1 = kg.begin()
+    t2 = kg.begin()
+    t1.cypher("MATCH (n:N {id: 1}) SET n.v = 1")
+    t2.cypher("MATCH (n:N {id: 1}) SET n.v = 2")
+    t1.commit()
+
+    with pytest.raises(kglite.TransactionConflictError) as excinfo:
+        t2.commit()
+
+    exc = excinfo.value
+    assert isinstance(exc, kglite.KgError)
+    assert not isinstance(exc, kglite.ArgumentError)
+    assert exc.code == "TransactionConflict"
+    # The advice that was already good, plus the version gap.
+    message = str(exc)
+    assert "Retry the transaction" in message
+    assert "were not applied" in message
+
+
+def test_conflict_code_is_readable_without_an_instance():
+    """`.code` is a class constant too, so a dispatch table can be built up
+    front rather than inside an `except` block."""
+    assert kglite.TransactionConflictError.code == "TransactionConflict"
+    assert kglite.ConstraintViolationError.code == "ConstraintViolation"
+    assert kglite.CypherSyntaxError.code == "CypherSyntax"
+    # The abstract bases span several codes and so carry None.
+    assert kglite.KgError.code is None
+    assert kglite.ConstraintError.code is None
+
+
+def test_every_raised_error_carries_a_code():
+    """`.code` is a property of the surface, not of one lucky path."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:U {id: 1})")
+
+    with pytest.raises(kglite.CypherSyntaxError) as syntax:
+        kg.cypher("MATCH (((")
+    assert syntax.value.code == "CypherSyntax"
+
+    with pytest.raises(kglite.KgError) as missing:
+        kg.cypher("MATCH (u:U) RETURN $undefined_param")
+    assert isinstance(missing.value.code, str) and missing.value.code
+
+
+def test_disjoint_transactions_still_conflict_by_design():
+    """Characterization test for a documented limitation.
+
+    OCC here is a whole-graph version check, not a read/write-set
+    intersection: a commit publishes the transaction's working copy by pointer
+    swap, so t2's copy does not contain t1's write and applying it would
+    silently revert t1. Rejecting is therefore *correct* for this commit model,
+    not a spurious failure — see docs/concepts/concurrency.md. If KGLite ever
+    gains a merging commit, this test is the one that should change.
+    """
+    kg = _two_node_graph()
+    t1 = kg.begin()
+    t2 = kg.begin()
+    t1.cypher("MATCH (n:N {id: 1}) SET n.v = 111")
+    t2.cypher("MATCH (n:N {id: 2}) SET n.v = 222")  # a different node
+    t1.commit()
+
+    # The lost update this rejection prevents: t2 still sees the pre-t1 value.
+    assert t2.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 0}]
+
+    with pytest.raises(kglite.TransactionConflictError):
+        t2.commit()
+
+    # t1's write survived precisely because t2 was refused.
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 111}]
+
+
+# ─── C. The retry loop, end to end ──────────────────────────────────────────
+
+
+def test_retry_on_conflict_succeeds_after_a_conflicting_commit():
+    """The loop every correct app needs: a writer that lost one race and won
+    on the retry, without the caller writing any retry code."""
+    kg = _two_node_graph()
+    attempts = []
+
+    def work(tx):
+        attempts.append(len(attempts) + 1)
+        # Interleave one competing commit, but only on the first attempt, so
+        # the first commit conflicts and the second succeeds.
+        if len(attempts) == 1:
+            kg.cypher("MATCH (n:N {id: 2}) SET n.v = 99")
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 42")
+        return "done"
+
+    result = kglite.retry_on_conflict(kg, work, base_delay=0, jitter=False)
+
+    assert result == "done"
+    assert len(attempts) == 2, "expected exactly one retry"
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 42}]
+
+
+def test_retry_on_conflict_commits_without_contention():
+    kg = _two_node_graph()
+    calls = []
+
+    def work(tx):
+        calls.append(1)
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 7")
+        return tx
+
+    kglite.retry_on_conflict(kg, work, base_delay=0, jitter=False)
+
+    assert len(calls) == 1, "no conflict means no retry"
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 7}]
+
+
+def test_retry_on_conflict_reraises_after_exhausting_attempts():
+    kg = _two_node_graph()
+
+    def work(tx):
+        # Guarantee a conflict on every single attempt.
+        kg.cypher("MATCH (n:N {id: 2}) SET n.v = 1")
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 2")
+
+    with pytest.raises(kglite.TransactionConflictError) as excinfo:
+        kglite.retry_on_conflict(kg, work, attempts=3, base_delay=0, jitter=False)
+
+    # The real error survives the loop, codes and all.
+    assert excinfo.value.code == "TransactionConflict"
+
+
+def test_retry_on_conflict_does_not_retry_other_errors():
+    """Only conflicts are retried — a constraint violation is the caller's bug
+    and must surface immediately rather than being hammered `attempts` times."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    kg.cypher("CREATE (u:User {email: 'dup@x.com'})")
+    calls = []
+
+    def work(tx):
+        calls.append(1)
+        tx.cypher("CREATE (u:User {email: 'dup@x.com'})")
+
+    with pytest.raises(kglite.ConstraintViolationError):
+        kglite.retry_on_conflict(kg, work, attempts=4, base_delay=0, jitter=False)
+
+    assert len(calls) == 1, "a non-conflict error must not be retried"
+
+
+def test_retry_on_conflict_rejects_a_nonsense_attempt_count():
+    kg = _two_node_graph()
+    with pytest.raises(ValueError, match="attempts must be >= 1"):
+        kglite.retry_on_conflict(kg, lambda tx: None, attempts=0)


### PR DESCRIPTION
Fixes the two error-handling gaps the boring-app audit called "the code every CRUD app has to write" — plus a third neither of us knew about. No version bump.

## Before

```python
# duplicate email on signup — the single most common error in a web app
except kglite.CypherExecutionError as exc:
    if "already exists" in str(exc):      # string matching, in a signup path
        raise Conflict(...)

# and the OCC retry loop, which every correct app needs
except kglite.ArgumentError as exc:       # semantically wrong class
    ...                                   # no .code, no retry helper
```

## The type was already there — six lines destroyed it

`ConstraintViolation` is a rich struct with `impl From<ConstraintViolation> for KgError` **already at `error.rs:602`**, and the producing functions already return `Result<_, ConstraintViolation>`. Only six `.map_err(|v| v.to_string())` calls flattened it. So this is **not message re-classification** — the structured value now reaches the binding.

Three designs were measured before choosing:

| Design | Verdict |
|---|---|
| Retype the Cypher error channel | **302 signatures + ~233 construction sites ≈ 535 edits**, ~90 in the parser. Disproportionate. |
| Slot on `ExecuteOptions` | **Not implementable** — `ExecuteOptions` is decomposed at `execute.rs:390` and never enters `cypher/`; all six sites are free functions over `&mut DirGraph`. `CypherExecutor` can't work either, since it holds `&DirGraph` (it's the *read* engine). |
| **Typed slot on `DirGraph`** ✅ | Mirrors `active_write_scope`, an established convention in this exact path. |

Two things make it safe rather than merely convenient:

- **The violation is parked with the exact message it produced**, and the drain accepts it only if the arriving string is byte-identical. A rewritten message falls back to the untyped error — desync fails **safe**, never **wrong**. That's an identity check on a string we produced, not prose matching.
- **Recording happens in the code that produces the violation** (`plan_property_write` parks its own rejection), so `SET`/`REMOVE` call sites are byte-identical to before. Cancellation keeps precedence — Ctrl-C still yields `Cancelled`.

## The false-conflict verdict: leave it — and it isn't false

The audit reported that disjoint transactions wrongly conflict. **Measured, it is correct behaviour:**

```
after t1.commit():  graph sees node1.v = 111
                    t2's working copy sees node1.v = 0    <- stale
```

Commit is a **whole-graph pointer swap** (`kg.inner = Arc::new(working)`). t2's copy does not contain t1's write, so committing it would silently revert `111 → 0`. **Read/write-set tracking would not fix this — it would introduce lost updates.** A real fix needs a merging/rebasing commit: different architecture, not a tracking tweak.

So the type, the code and the docs were fixed instead, and the behaviour is pinned by `test_disjoint_transactions_still_conflict_by_design`, which asserts the stale read *and* that t1's write survived. `primary-store.md` no longer claims "independent work proceeds" — it explains the version-counter model, says unrelated nodes do conflict and why, and points at `retry_on_conflict` and `session()`.

## What shipped

- **`ConstraintViolationError` from every write path**, with messages intact.
- **`TransactionConflictError`**, replacing a semantically wrong `ArgumentError`.
- **`.code` on every exception**, delivering the promise `primary-store.md` already made. C ABI gained `KGLITE_STATUS_CODE_TRANSACTION_CONFLICT = 20` (appended; header regenerated by cbindgen).
- **`kglite.retry_on_conflict`** — pure Python, no Rust surface. Rationale: given the commit model conflicts are *ordinary* rather than rare, so the retry loop is the normal path; it is easy to get wrong (a conflicted transaction is spent and must be *rebuilt*, and unbounded retries livelock); and the boundary principle puts retry/lifecycle idiom explicitly on the binding.
- `error-handling.md`'s hierarchy diagram updated with the constraint family.

## The third bug

**`ConstraintViolationError` was unreachable from *every* path, not just Cypher** — the bulk loader raised `ArgumentError` too. Both `primary-store.md:143` and the `.pyi` docstring already claimed otherwise, so the docs were lying about a type nobody could catch. Fixed.

## Verification

`tests/test_error_taxonomy.py`, 18 tests — **all 18 fail on unmodified `origin/main`** (verified by reverting source only, keeping the tests, rebuilding), all 18 pass with the fix. Message quality is asserted alongside every type so it cannot silently regress.

`make gate` 0 · clippy `-D warnings` clean across 4 crates · `make source-quality` clean · `make stubtest` clean (13 modules) · `cargo test -p kglite` **1255** · `pytest -m parity` **109** · full `pytest tests/` **4870 passed / 0 failed** · `sphinx -W` clean · kglite-c both feature sets.

Five-place checklist: pyapi ✔ · `__init__.pyi` ✔ · `describe()` **N/A, verified** (no error-taxonomy references in `introspection/`) · MCP `tools.rs` **N/A, verified** (no `KgError` handling) · CHANGELOG ✔. Python API baseline: `+TransactionConflictError`, `+retry_on_conflict`, `code` on every exception object.

**Stub integrity double-checked** after today's incident where three exception classes landed inside a Protocol and no gate noticed: AST confirms 49 top-level defs with `EmbeddingModel` retaining all four members and no nested `ClassDef`; rendered autoapi confirms the same. The hazard did not recur.

The source-quality gate caught a first attempt growing two already-oversized functions. Rather than raise the allowance, the recording was pushed down into `plan_property_write` — which passed the gate *and* produced the better design.

## Surfaced, not fixed

- **Bolt hand-rolls its conflict error** (`backend.rs:668-699`) rather than routing through `KgError::TransactionConflict`. Same status string, so no behaviour difference; routing it would change a wire-visible message for no user benefit.
- **`KgErrorCode::Internal` absorbs `InternerCollision`**, so C ABI and Bolt can't distinguish it while Python can. Pre-existing asymmetry.
- **Division by zero returns `null`** (`1/0`, `1.0/0`, `1%0`) where Neo4j raises. Consistent across all three operators, so intentional null-propagation — a portability note, not a defect.
- **`execute_set` is 536 lines / 75 branches; `add_nodes` 275.** Both tripped the growth gate; splitting them is its own task.

---

## Update: the CI perf regression was runner noise, measured

CI flagged `test_bench_return_node_10k` at +27.5%/+30.2% and a text filter at +22.1%. A 2×2 release measurement (two builds each of `origin/main` and this branch, `--benchmark-min-rounds=100 --benchmark-warmup=on`), with a **build-identity assertion on every run**, puts them at **−1.3%** and **−0.8%** — this branch is *faster*. Across all 27 tracked benchmarks: max +3.6%, median +0.7%, none over the gate.

**The load-bearing number is the noise floor.** Comparing two runs of *identical code* across 54 pairs: median 1.0%, p90 5.3%, **max 17.0%**. The instrument swings up to 17% with no code change at all.

**A caution about the "consistent across two baselines" reasoning** (mine, and it was wrong): `current.linux.json` and the 0.13.2 reference are two *references* compared against **one** candidate run. A single slow candidate inflates both together, so that agreement cannot distinguish a real regression from a slow run. It is one data point, not two.

**Code-path attribution agrees independently.** `take_constraint_error` is called only in the `Err(message)` arm, never on a successful statement; `clear_pending_constraint_violation` sits inside the `is_mutation` branch; `execute_read` is untouched. `MATCH (n:Person) RETURN n` executes none of the new code — the only read-visible change is `DirGraph` growing 8 bytes for one `Option<Box<…>>`.

## API baseline refreshed and reviewed

`take_constraint_error` **must** stay public: it is called from `kglite-py`'s `kg_mutation.rs`, a different crate, so `pub(crate)` cannot reach it — the same situation as `create_property_index_routed`. The mechanism did not leak wholesale: `record_constraint_violation`, `clear_pending_constraint_violation` and `take_constraint_violation_for` are all `pub(crate)` and absent from the public surface. Only the drain crosses the boundary, which by the boundary principle is the right thing to lift.

Refreshed with the manifest-pinned `cargo-public-api` **0.49.0**; `rust_api_profiles.py check` reports exact match on all profiles. Exactly **9 lines per profile**, reviewed line by line.