### PR TITLE
Merge #82 (single-writer guard) + #83 (typed constraint/conflict errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     analytics deployments to fix a problem only writers have.
   - **A crash releases it.** The lock is owned by the OS, not by the sidecar
     file's existence, so a writer lost to `SIGKILL` or a power cut frees it
-    at once. The leftover `.lock` file is a record of the holder, not the
-    lock — deleting it releases nothing, and the error message says so, since
-    deleting lock files by reflex is how this class of guard gets defeated.
+    at once. The leftover `<path>.lock` (the lock, always empty) and
+    `<path>.lock-owner` (the pid/timestamp used to name a holder) are records,
+    not the lock — deleting them releases nothing, and the error message says
+    so, since deleting lock files by reflex is how this class of guard gets
+    defeated.
+
+  The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
+  rather than inside the lock file, because `fs2` locks via `flock` on Unix
+  (advisory — contenders can still read) but `LockFileEx` on Windows
+  (mandatory over the whole range), where an exclusive lock makes the file
+  unreadable to every other handle and a contender's read fails with
+  `ERROR_LOCK_VIOLATION` instead of returning the pid. Splitting the two keeps
+  the holder *named* on every platform. `<path>.lock` is still the file that
+  is locked, so binaries from either side of this change continue to exclude
+  each other.
   - **`open(..., lock=False)` opts out**, explicitly and never by default, for
     deployments that coordinate writers externally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     so, since deleting lock files by reflex is how this class of guard gets
     defeated.
 
+  Contention is classified from the platform's lock errno via
+  `fs2::lock_contended_error()` rather than from `io::ErrorKind`. The kinds
+  differ per platform — `EWOULDBLOCK` maps to `WouldBlock` on Unix, but
+  `ERROR_LOCK_VIOLATION` is uncategorised on Windows — so a kind comparison
+  recognised contention only on Unix. On Windows that meant a blocked writer
+  saw the raw OS error instead of a message naming the holder, **and** the
+  retry loop was skipped entirely, so the 30-second lease timeouts used by
+  `kglite` CLI commands and the MCP server returned instantly rather than
+  waiting for the current writer to finish.
+
   The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
   rather than inside the lock file, because `fs2` locks via `flock` on Unix
   (advisory — contenders can still read) but `LockFileEx` on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A stable `.code` on every kglite exception.** `exc.code` is the wire-stable
+  classifier (`"ConstraintViolation"`, `"TransactionConflict"`,
+  `"CypherSyntax"`, …) that the C ABI already exposed as `KGLITE_STATUS_*` and
+  the Bolt server already mapped to `Neo.*`, but which had no way of reaching
+  Python — `dir(exc)` previously showed only `add_note`, `args`, and
+  `with_traceback`, so applications had no choice but to match on message prose.
+  It is readable on the classes too (`kglite.ConstraintViolationError.code`), so
+  a dispatch table can be built without an instance, and is `None` on the three
+  abstract bases (`KgError`, `CypherError`, `ConstraintError`) which span
+  several codes.
+- **`kglite.TransactionConflictError`**, raised when `Transaction.commit()`
+  loses an optimistic-concurrency race. This previously arrived as
+  `ArgumentError` — "Invalid argument: Transaction conflict…" — which is the
+  wrong class for a condition whose correct handling is "retry the transaction",
+  not "fix the call". The message now also reports the version gap, and the C
+  ABI gains `KGLITE_STATUS_CODE_TRANSACTION_CONFLICT = 20` (appended, so
+  existing discriminants are unchanged). The Bolt status string
+  `Neo.ClientError.Transaction.ConflictDetected` is unchanged.
+- **`kglite.retry_on_conflict(graph, work)`** — the commit-retry loop every
+  concurrent writer needs, with exponential backoff and full jitter. `work(tx)`
+  is re-run against a fresh `begin()` on each attempt; only conflicts are
+  retried, and the final conflict is re-raised unchanged. Conflicts are ordinary
+  rather than rare here, because OCC compares a whole-graph version counter (see
+  the documentation fix below).
 - `kglite-bolt-server --neo4j-compat` (or `KGLITE_BOLT_NEO4J_COMPAT=1`) makes the
   server present a Neo4j-compatible agent in the Bolt handshake, so official
   drivers that refuse to connect to a non-Neo4j server will talk to it. The
@@ -397,6 +421,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A constraint violation is now catchable by type from every write path.**
+  `ConstraintViolationError` existed but was reachable from nowhere: a violation
+  raised through Cypher surfaced as `CypherExecutionError`, and one raised
+  through the bulk loaders (`add_nodes`, and everything funnelling through it)
+  as `ArgumentError`. The only handler an application could write was therefore
+  a substring match on the message — in a signup path, for the single most
+  common error a web application has. Both paths now raise
+  `ConstraintViolationError`, so `except kglite.ConstraintViolationError` works
+  and `except kglite.ConstraintError` still catches that or
+  `ConstraintCreationError`. The messages are unchanged: they still name the
+  constraint, the property, the offending value, and the remedy.
+
+  The structured violation is carried out of the engine's `Result<_, String>`
+  write channel on the graph itself and drained by the adapter that builds the
+  typed error, paired with the exact message it produced — if an intermediate
+  frame rewrites the message the pair is discarded and the untyped error is
+  used, so a mismatch fails safe rather than mis-attributing a violation.
+- The exception-hierarchy diagram in `docs/python/error-handling.md` omitted the
+  entire constraint family (`ConstraintError`, `ConstraintViolationError`,
+  `ConstraintCreationError`). It now lists them alongside
+  `TransactionConflictError`, with new sections covering stable codes,
+  constraint violations, and commit conflicts.
+- `docs/python/guides/primary-store.md` stated that independent transactions
+  proceed concurrently, and that a Cypher constraint violation must be caught by
+  matching the message. Neither was true. OCC compares a **whole-graph version
+  counter**, not read/write sets, because a commit publishes the transaction's
+  working copy by pointer swap — so two transactions touching unrelated nodes do
+  conflict, and the loser's snapshot genuinely does not contain the winner's
+  write, which is why rejecting it is correct rather than over-cautious. The
+  guide now says so plainly, points at `retry_on_conflict`, and suggests
+  `session()` for workloads with many short concurrent writers.
+- The Bolt `neo4j_status_code` coverage test enumerated its codes by hand and
+  had silently stopped covering `Cancelled`, `ConstraintViolation`, and
+  `ConstraintCreationFailed`; all are now included.
 - `ORDER BY` is no longer silently ignored after an aggregating `RETURN` when
   the sort key is not one of the projected columns. `MATCH (t:Task) OPTIONAL
   MATCH (t)-[:X]->(c) RETURN t.title AS title, count(c) AS n ORDER BY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kglite.open()` now enforces one writer per graph, instead of silently
+  losing one.** Two processes that opened the same path both built a complete
+  snapshot in memory and both wrote it at `save()`, so whichever saved last
+  won and everything the other had done disappeared — with both processes
+  exiting 0, nothing logged, and nothing in the file to show it had happened.
+  That is the likeliest accident when deploying an embedded database: a
+  multi-worker `gunicorn` pool, a cron job overlapping a request, or a stale
+  process nobody noticed.
+
+  `open()` now takes an exclusive cross-process writer lease on a
+  `<path>.lock` sidecar and holds it until `close()` / `with`-block exit. A
+  second writer fails immediately, naming the process that has it:
+
+  ```
+  KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
+  ```
+
+  The lease mechanism itself is not new — the CLI and the MCP server have held
+  it since disk generations shipped, and `open_or_create_graph` documents it as
+  a caller's responsibility. The Python binding was the caller that never
+  opted in, which left the most-used surface unguarded.
+
+  Three deliberate boundaries:
+
+  - **Readers are never blocked.** `load()` and `open_session()` take no
+    lease. `save()` republishes the whole graph, so a reader sees the last
+    consistent snapshot; making reads exclusive would break read-replica and
+    analytics deployments to fix a problem only writers have.
+  - **A crash releases it.** The lock is owned by the OS, not by the sidecar
+    file's existence, so a writer lost to `SIGKILL` or a power cut frees it
+    at once. The leftover `.lock` file is a record of the holder, not the
+    lock — deleting it releases nothing, and the error message says so, since
+    deleting lock files by reflex is how this class of guard gets defeated.
+  - **`open(..., lock=False)` opts out**, explicitly and never by default, for
+    deployments that coordinate writers externally.
+
+  Disk-mode graphs were already protected by their own generation lock, but
+  only failed at the *first mutation* with a bare
+  `Resource temporarily unavailable (os error 35)`; they now fail at `open()`
+  with the same named message as every other storage mode.
+
+  **Possible impact:** a deployment that genuinely opened one graph from two
+  processes was already losing writes, and now gets an error instead. Two
+  overlapping `kglite.open()` calls on one path *within* a single process are
+  refused for the same reason (the error says so explicitly); sequential
+  `with kglite.open(path)` blocks are unaffected, because the lease is
+  released on block exit.
+
 ### Added
 
 - `kglite-bolt-server --neo4j-compat` (or `KGLITE_BOLT_NEO4J_COMPAT=1`) makes the

--- a/crates/kglite-bolt-server/src/error_map.rs
+++ b/crates/kglite-bolt-server/src/error_map.rs
@@ -89,6 +89,12 @@ mod tests {
             KgErrorCode::InvalidArgument,
             KgErrorCode::MissingArgument,
             KgErrorCode::Internal,
+            // Appended after the original list was written; without these the
+            // check silently stopped covering newly-added codes.
+            KgErrorCode::Cancelled,
+            KgErrorCode::ConstraintViolation,
+            KgErrorCode::ConstraintCreationFailed,
+            KgErrorCode::TransactionConflict,
         ] {
             let s = code.neo4j_status_code();
             assert!(

--- a/crates/kglite-c/include/kglite.h
+++ b/crates/kglite-c/include/kglite.h
@@ -69,6 +69,13 @@ enum KgliteStatusCode
    */
   KGLITE_STATUS_CODE_CONSTRAINT_CREATION_FAILED = 19,
   /**
+   * An optimistic-concurrency commit lost its race: the graph advanced
+   * between `begin()` and `commit()`, so nothing was applied. Retry the
+   * whole transaction. Appended to keep the existing discriminants
+   * stable across this ABI major version.
+   */
+  KGLITE_STATUS_CODE_TRANSACTION_CONFLICT = 20,
+  /**
    * A string argument failed UTF-8 validation. The C-side
    * caller passed a `*const c_char` whose bytes didn't decode
    * as UTF-8 — typically a corrupted buffer or a non-UTF-8

--- a/crates/kglite-c/src/status.rs
+++ b/crates/kglite-c/src/status.rs
@@ -51,6 +51,11 @@ pub enum KgliteStatusCode {
     /// Declaring a constraint failed because the stored data already
     /// violates it. Deduplicate the node type, then re-declare.
     ConstraintCreationFailed = 19,
+    /// An optimistic-concurrency commit lost its race: the graph advanced
+    /// between `begin()` and `commit()`, so nothing was applied. Retry the
+    /// whole transaction. Appended to keep the existing discriminants
+    /// stable across this ABI major version.
+    TransactionConflict = 20,
 
     // 100+: C-ABI-only errors.
     /// A string argument failed UTF-8 validation. The C-side
@@ -88,6 +93,7 @@ impl KgliteStatusCode {
             KgErrorCode::Cancelled => Self::Cancelled,
             KgErrorCode::ConstraintViolation => Self::ConstraintViolation,
             KgErrorCode::ConstraintCreationFailed => Self::ConstraintCreationFailed,
+            KgErrorCode::TransactionConflict => Self::TransactionConflict,
         }
     }
 
@@ -105,6 +111,7 @@ impl KgliteStatusCode {
             Self::Schema => KgErrorCode::Schema,
             Self::ConstraintViolation => KgErrorCode::ConstraintViolation,
             Self::ConstraintCreationFailed => KgErrorCode::ConstraintCreationFailed,
+            Self::TransactionConflict => KgErrorCode::TransactionConflict,
             Self::Validation => KgErrorCode::Validation,
             Self::Expr => KgErrorCode::Expr,
             Self::NodeNotFound => KgErrorCode::NodeNotFound,

--- a/crates/kglite-py/src/error_py.rs
+++ b/crates/kglite-py/src/error_py.rs
@@ -12,6 +12,10 @@
 //! from `Exception`. Wrapper operations that implement conventional Python
 //! protocols may raise built-in exceptions directly.
 //!
+//! Every instance carries a stable `.code` string (the
+//! [`KgErrorCode`](crate::error::KgErrorCode) name, e.g. `"ConstraintViolation"`)
+//! so applications branch on a classifier rather than on message prose.
+//!
 //! ```text
 //! Exception
 //! └── kglite.KgError                          (base)
@@ -23,6 +27,10 @@
 //!     ├── kglite.SchemaError
 //!     ├── kglite.ValidationError
 //!     ├── kglite.ExprError
+//!     ├── kglite.ConstraintError            (declared-integrity base)
+//!     │   ├── kglite.ConstraintViolationError
+//!     │   └── kglite.ConstraintCreationError
+//!     ├── kglite.TransactionConflictError
 //!     ├── kglite.NodeNotFoundError
 //!     ├── kglite.ConnectionNotFoundError
 //!     ├── kglite.PropertyNotFoundError
@@ -149,6 +157,15 @@ pyo3::create_exception!(
     "Declaring a constraint failed because the stored data already violates it. Deduplicate the node type, then re-declare."
 );
 
+// ── Concurrency ──────────────────────────────────────────────────────
+
+pyo3::create_exception!(
+    kglite,
+    TransactionConflictError,
+    KgError,
+    "An optimistic-concurrency commit lost its race — the graph advanced between `begin()` and `commit()`, so nothing was applied. Retry the whole transaction against a fresh `begin()`; `kglite.retry_on_conflict` does this for you."
+);
+
 // ── Resource / access ────────────────────────────────────────────────
 
 pyo3::create_exception!(
@@ -240,6 +257,25 @@ pyo3::create_exception!(
 /// `.map_err(kg_to_pyerr)?`.
 pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
     let message = e.to_string();
+    // Stable classifier, captured before `e` is consumed by the match. Every
+    // `kglite.*` exception instance carries it as `.code`, so an application
+    // can branch on a wire-stable string (`"ConstraintViolation"`) instead of
+    // the message prose — the promise `docs/python/guides/primary-store.md`
+    // makes. `Cancelled` is excluded: it maps to the builtin
+    // `KeyboardInterrupt`, which is deliberately outside the KgError family.
+    let code = e.code().as_str();
+    let is_cancelled = matches!(e, RustKgError::Cancelled);
+    let err = kg_to_pyerr_class(e, message);
+    if is_cancelled {
+        return err;
+    }
+    with_code_attr(err, code)
+}
+
+/// Pick the most specific Python exception class for `e` and construct it with
+/// `message`. Split from [`kg_to_pyerr`] so the `.code` decoration applies
+/// uniformly to every arm rather than being repeated 20 times.
+fn kg_to_pyerr_class(e: RustKgError, message: String) -> PyErr {
     match e {
         RustKgError::CypherSyntax { line, col, .. } => {
             // `.line` / `.col` are always present on CypherSyntaxError —
@@ -265,6 +301,7 @@ pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
         RustKgError::Validation(_) => ValidationError::new_err(message),
         RustKgError::ConstraintViolation { .. } => ConstraintViolationError::new_err(message),
         RustKgError::ConstraintCreationFailed { .. } => ConstraintCreationError::new_err(message),
+        RustKgError::TransactionConflict { .. } => TransactionConflictError::new_err(message),
         RustKgError::Expr(_) => ExprError::new_err(message),
         RustKgError::NodeNotFound { .. } => NodeNotFoundError::new_err(message),
         RustKgError::ConnectionNotFound { .. } => ConnectionNotFoundError::new_err(message),
@@ -291,6 +328,17 @@ pub fn kg_to_pyerr(e: RustKgError) -> PyErr {
 /// normalizes the exception first; attribute assignment on an exception
 /// instance can't reasonably fail, but any failure is swallowed rather
 /// than masking the original error.
+/// Set the stable `.code` classifier on the exception *value*. Same
+/// normalize-then-setattr shape as [`with_position_attrs`]; a failure here
+/// would mask the real error, so it is swallowed.
+fn with_code_attr(err: PyErr, code: &'static str) -> PyErr {
+    Python::attach(|py| {
+        let value = err.value(py);
+        let _ = value.setattr("code", code);
+    });
+    err
+}
+
 fn with_position_attrs(err: PyErr, line: Option<usize>, col: Option<usize>) -> PyErr {
     Python::attach(|py| {
         let value = err.value(py);
@@ -345,6 +393,12 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         py.get_type::<ConstraintCreationError>(),
     )?;
 
+    // Concurrency
+    m.add(
+        "TransactionConflictError",
+        py.get_type::<TransactionConflictError>(),
+    )?;
+
     // Resource / access
     m.add("NodeNotFoundError", py.get_type::<NodeNotFoundError>())?;
     m.add(
@@ -374,6 +428,71 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
         py.get_type::<InternerCollisionError>(),
     )?;
     m.add("InternalError", py.get_type::<InternalError>())?;
+
+    register_class_codes(py)?;
+
+    Ok(())
+}
+
+/// Publish the stable [`KgErrorCode`](crate::error::KgErrorCode) string as a
+/// **class-level** `.code` on each concrete exception class, so callers can
+/// compare against `kglite.ConstraintViolationError.code` without an instance
+/// and `.code` is readable even on an exception constructed by hand.
+///
+/// Instances raised by the engine shadow these with the code of the actual
+/// `KgError` variant (see `with_code_attr`); the two always agree because both
+/// come from `KgError::code()`. The three abstract bases — `KgError`,
+/// `CypherError`, `ConstraintError` — cover several codes, so they get `None`
+/// rather than an arbitrary pick.
+fn register_class_codes(py: Python<'_>) -> PyResult<()> {
+    use crate::error::KgErrorCode as C;
+
+    py.get_type::<KgError>().setattr("code", py.None())?;
+    py.get_type::<CypherError>().setattr("code", py.None())?;
+    py.get_type::<ConstraintError>()
+        .setattr("code", py.None())?;
+
+    py.get_type::<CypherSyntaxError>()
+        .setattr("code", C::CypherSyntax.as_str())?;
+    py.get_type::<CypherTimeoutError>()
+        .setattr("code", C::CypherTimeout.as_str())?;
+    py.get_type::<CypherExecutionError>()
+        .setattr("code", C::CypherExecution.as_str())?;
+    py.get_type::<CypherTypeMismatchError>()
+        .setattr("code", C::CypherTypeMismatch.as_str())?;
+    py.get_type::<SchemaError>()
+        .setattr("code", C::Schema.as_str())?;
+    py.get_type::<ValidationError>()
+        .setattr("code", C::Validation.as_str())?;
+    py.get_type::<ExprError>()
+        .setattr("code", C::Expr.as_str())?;
+    py.get_type::<ConstraintViolationError>()
+        .setattr("code", C::ConstraintViolation.as_str())?;
+    py.get_type::<ConstraintCreationError>()
+        .setattr("code", C::ConstraintCreationFailed.as_str())?;
+    py.get_type::<TransactionConflictError>()
+        .setattr("code", C::TransactionConflict.as_str())?;
+    py.get_type::<NodeNotFoundError>()
+        .setattr("code", C::NodeNotFound.as_str())?;
+    py.get_type::<ConnectionNotFoundError>()
+        .setattr("code", C::ConnectionNotFound.as_str())?;
+    py.get_type::<PropertyNotFoundError>()
+        .setattr("code", C::PropertyNotFound.as_str())?;
+    py.get_type::<FileError>()
+        .setattr("code", C::FileNotFound.as_str())?;
+    py.get_type::<FileFormatError>()
+        .setattr("code", C::FileFormat.as_str())?;
+    py.get_type::<FileIoError>()
+        .setattr("code", C::FileIo.as_str())?;
+    py.get_type::<ArgumentError>()
+        .setattr("code", C::InvalidArgument.as_str())?;
+    py.get_type::<MissingArgumentError>()
+        .setattr("code", C::MissingArgument.as_str())?;
+    // Both collapse to `Internal` in `KgError::code()`.
+    py.get_type::<InternerCollisionError>()
+        .setattr("code", C::Internal.as_str())?;
+    py.get_type::<InternalError>()
+        .setattr("code", C::Internal.as_str())?;
 
     Ok(())
 }

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -220,15 +220,27 @@ pub(crate) struct GraphLifecycle {
     /// handle isn't shareable). When `Some`, the backend is wrapped in
     /// `GraphBackend::Recording` so mutations are captured for the WAL.
     pub(crate) durable: Option<DurableState>,
+    /// Cross-process single-writer guard for `source_path`, held for as long
+    /// as this graph can still write back to it. `Some` only on a graph from
+    /// `kglite.open(path)` (the write-back entry point); `None` for
+    /// `kglite.load(path)` and every clone/derived view, so readers never
+    /// contend. Like `durable`, it owns an OS `File` handle and therefore
+    /// cannot be shared.
+    ///
+    /// Released by `close()` / `__exit__` after the final save, and by `Drop`
+    /// otherwise — including on a crash, where the OS drops the underlying
+    /// file lock for us.
+    pub(crate) writer_lease: Option<kglite_core::api::io::GraphWriterLease>,
 }
 
 impl GraphLifecycle {
-    /// A detached lifecycle: no save target, not durable. Used by in-memory
-    /// constructors, `copy()`, and every derived view.
+    /// A detached lifecycle: no save target, not durable, holding no writer
+    /// lease. Used by in-memory constructors, `copy()`, and every derived view.
     pub(crate) fn detached() -> Self {
         GraphLifecycle {
             source_path: None,
             durable: None,
+            writer_lease: None,
         }
     }
 }
@@ -427,10 +439,13 @@ impl Clone for KnowledgeGraph {
             default_timeout_ms: self.default_timeout_ms,
             default_max_rows: self.default_max_rows,
             // A true Clone preserves the save identity (source_path) but never
-            // the durable session (the WAL File handle isn't shareable).
+            // the durable session (the WAL File handle isn't shareable) nor the
+            // writer lease — write ownership stays with the graph that opened
+            // the path, so a clone can never release it early on drop.
             lifecycle: GraphLifecycle {
                 source_path: self.lifecycle.source_path.clone(),
                 durable: None,
+                writer_lease: None,
             },
         }
     }

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -730,10 +730,16 @@ impl KnowledgeGraph {
     /// nowhere to write, and silently doing nothing is friendlier than
     /// raising on a best-effort cleanup call. Pair with `save(path)` if you
     /// need an explicit target.
+    /// Also releases the cross-process writer lease taken by
+    /// [`kglite.open`], after the final checkpoint is on disk — so the next
+    /// writer never observes a half-saved graph. A failed save keeps the
+    /// lease, because the graph still holds unsaved work destined for that
+    /// path and the caller may retry.
     fn close(&mut self, py: Python<'_>) -> PyResult<()> {
         if self.lifecycle.source_path.is_some() {
             self.save(py, None, true)?;
         }
+        self.lifecycle.writer_lease = None;
         Ok(())
     }
 
@@ -752,6 +758,12 @@ impl KnowledgeGraph {
     /// This is a *clean-exit* checkpoint, not crash safety: a hard crash
     /// (`kill -9`, power loss) mid-block writes nothing. Durable-on-commit is
     /// a separate capability.
+    ///
+    /// Exiting the block also ends the graph's write ownership: the
+    /// cross-process writer lease taken by [`kglite.open`] is released here,
+    /// which is what makes two sequential `with kglite.open(path)` blocks in
+    /// one process work. On the exception path the lease is released too —
+    /// the save was skipped, so nothing further will be written.
     #[pyo3(signature = (exc_type, _exc_value, _traceback))]
     fn __exit__(
         &mut self,
@@ -763,6 +775,7 @@ impl KnowledgeGraph {
         if exc_type.is_none() && self.lifecycle.source_path.is_some() {
             self.save(py, None, true)?;
         }
+        self.lifecycle.writer_lease = None;
         Ok(false)
     }
 

--- a/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
@@ -607,7 +607,7 @@ fn apply_node_batch(
     provenance: (Option<String>, Option<String>),
 ) -> PyResult<NodeOperationReport> {
     let (git_sha, modified_by) = provenance;
-    detach_mutation(py, || {
+    let outcome = py.detach(|| {
         graph.with_write_provenance(git_sha.as_deref(), modified_by.as_deref(), |graph| {
             kglite_core::api::mutation::add_nodes(
                 graph,
@@ -618,6 +618,16 @@ fn apply_node_batch(
                 input.conflict_handling,
             )
         })
+    });
+    // The mutable borrow ends with the detach closure, so the structured
+    // violation `add_nodes` parked is recoverable here: a constraint failure
+    // raises `kglite.ConstraintViolationError`, anything else keeps the
+    // existing `ArgumentError`.
+    outcome.map_err(|message| {
+        let error = graph
+            .take_constraint_error(&message)
+            .unwrap_or(crate::error::KgError::Argument(message));
+        crate::error_py::kg_to_pyerr(error)
     })
 }
 

--- a/crates/kglite-py/src/graph/pyapi/transaction.rs
+++ b/crates/kglite-py/src/graph/pyapi/transaction.rs
@@ -281,11 +281,10 @@ impl Transaction {
         let current_version = Python::attach(|py| self.owner.borrow(py).inner.version);
         if current_version != base_version {
             return Err(crate::error_py::kg_to_pyerr(
-                crate::error::KgError::Argument(
-                    "Transaction conflict: graph was modified since begin(). \
-                     Retry the transaction."
-                        .to_string(),
-                ),
+                crate::error::KgError::TransactionConflict {
+                    base_version,
+                    current_version,
+                },
             ));
         }
 

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -284,15 +284,62 @@ fn from_bytes(py: Python<'_>, data: &[u8]) -> PyResult<KnowledgeGraph> {
 ///   keeps no log, which is measurably faster for write-heavy bulk loading (no
 ///   `fsync` per commit) and is the right choice when the graph is rebuildable
 ///   from source data.
+///
+/// `lock` (default `true`) takes the cross-process single-writer lease for the
+/// life of the returned graph. It is on by default because the alternative is
+/// silent data loss, not an error: two processes that open one path both build
+/// a complete snapshot and the last `save()` wins. `false` opts out for callers
+/// who coordinate writers themselves. Readers never take the lease — that is
+/// what `load` / `open_session` are for.
 #[pyfunction]
-#[pyo3(signature = (path, *, storage=None, durable=None))]
+#[pyo3(signature = (path, *, storage=None, durable=None, lock=true))]
 fn open(
     py: Python<'_>,
     path: String,
     storage: Option<&str>,
     durable: Option<bool>,
+    lock: bool,
 ) -> PyResult<KnowledgeGraph> {
     use kglite_core::api::GraphRead;
+
+    // Take write ownership *before* reading a byte. The window that loses a
+    // writer's work is open-to-save, not save itself: two processes that both
+    // load, both mutate, and both save produce two full snapshots, and the
+    // second one published wins outright. Locking at save time would be too
+    // late to notice.
+    //
+    // Fail-fast (`Duration::ZERO`) rather than waiting: `open()` is called on
+    // request paths and in worker startup, where a blocked-for-30s open is a
+    // worse failure than a clear error. A caller that genuinely wants to queue
+    // can retry around the error.
+    let writer_lease = if lock {
+        Some(
+            py.detach(|| {
+                kglite_core::api::io::GraphWriterLease::acquire(
+                    std::path::Path::new(&path),
+                    std::time::Duration::ZERO,
+                )
+            })
+            .map_err(|e| {
+                // The engine's message is binding-neutral by design, so the
+                // Python-specific way out is appended here rather than baked
+                // into core. Most callers who hit this wanted to *read* a
+                // graph someone else is writing, and naming the call that
+                // does that turns a refusal into an answer.
+                crate::error_py::kg_to_pyerr(crate::error::KgError::FileIo(std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "{e} To read this graph while another process writes it, use \
+                         kglite.load(path) or kglite.open_session(path), which take no \
+                         lease. Pass kglite.open(..., lock=False) only if you are \
+                         coordinating writers yourself.",
+                    ),
+                )))
+            })?,
+        )
+    } else {
+        None
+    };
 
     let mut kg = if std::path::Path::new(&path).exists() {
         py.detach(|| load_file(&path))
@@ -302,6 +349,7 @@ fn open(
         KnowledgeGraph::construct(storage, Some(&path))?
     };
     kg.lifecycle.source_path = Some(std::path::PathBuf::from(&path));
+    kg.lifecycle.writer_lease = writer_lease;
     // Resolved after the graph exists, because the mode of an *existing* path
     // comes from the file, not from the `storage` argument.
     let wanted = durable.unwrap_or(!kg.inner.graph.is_disk());

--- a/crates/kglite/src/error.rs
+++ b/crates/kglite/src/error.rs
@@ -85,6 +85,12 @@ pub enum KgErrorCode {
     ConstraintViolation,
     ConstraintCreationFailed,
 
+    // Optimistic concurrency control. Split from `InvalidArgument` because a
+    // conflict is the one error in the taxonomy whose correct handling is
+    // "retry the whole transaction" rather than "fix the call" — bindings and
+    // drivers route on that difference.
+    TransactionConflict,
+
     // Resource / access
     NodeNotFound,
     ConnectionNotFound,
@@ -118,6 +124,7 @@ impl KgErrorCode {
             KgErrorCode::Expr => "Expr",
             KgErrorCode::ConstraintViolation => "ConstraintViolation",
             KgErrorCode::ConstraintCreationFailed => "ConstraintCreationFailed",
+            KgErrorCode::TransactionConflict => "TransactionConflict",
             KgErrorCode::NodeNotFound => "NodeNotFound",
             KgErrorCode::ConnectionNotFound => "ConnectionNotFound",
             KgErrorCode::PropertyNotFound => "PropertyNotFound",
@@ -140,6 +147,7 @@ impl KgErrorCode {
     /// - `NodeNotFound`, `ConnectionNotFound`, `PropertyNotFound`,
     ///   `FileNotFound` → 404 Not Found
     /// - `CypherTimeout` → 408 Request Timeout
+    /// - `TransactionConflict` → 409 Conflict
     /// - `Schema`, `Validation`, `Expr` → 422 Unprocessable Entity
     /// - `CypherExecution`, `FileFormat`, `FileIo`, `Internal` →
     ///   500 Internal Server Error
@@ -163,6 +171,11 @@ impl KgErrorCode {
             | KgErrorCode::FileNotFound => 404,
 
             KgErrorCode::CypherTimeout => 408,
+
+            // 409 Conflict — the request was well-formed but lost an
+            // optimistic-concurrency race. Retriable as-is, unlike every
+            // other 4xx here.
+            KgErrorCode::TransactionConflict => 409,
 
             // 499 Client Closed Request (nginx convention) — the caller
             // interrupted the query before it finished.
@@ -205,6 +218,10 @@ impl KgErrorCode {
             KgErrorCode::ConstraintCreationFailed => {
                 "Neo.ClientError.Schema.ConstraintCreationFailed"
             }
+            // Matches the string `kglite-bolt-server` has published for OCC
+            // conflicts since the transaction work landed; the driver
+            // conformance suite pins it (tests/test_bolt_server_transactions.py).
+            KgErrorCode::TransactionConflict => "Neo.ClientError.Transaction.ConflictDetected",
             KgErrorCode::Validation | KgErrorCode::Expr => {
                 "Neo.ClientError.Statement.ArgumentError"
             }
@@ -320,6 +337,26 @@ pub enum KgError {
         message: String,
     },
 
+    // ── Concurrency ──────────────────────────────────────────────────
+    /// An optimistic-concurrency commit lost its race: the graph advanced
+    /// between `begin()` and `commit()`, so the transaction's working copy is
+    /// stale and applying it would silently discard the newer commit.
+    ///
+    /// The transaction is spent — the caller re-runs its work against a fresh
+    /// `begin()`. Both versions are carried so a binding can report the gap
+    /// (and a retry loop can log how far behind it was) without parsing
+    /// `message`.
+    ///
+    /// Note this is a *whole-graph* version check, not a read/write-set
+    /// intersection: commit publishes the transaction's working copy by
+    /// pointer swap, so any concurrent commit — even one touching entirely
+    /// different nodes — makes this transaction's copy stale. See
+    /// `docs/concepts/concurrency.md`.
+    TransactionConflict {
+        base_version: u64,
+        current_version: u64,
+    },
+
     /// Blueprint expression evaluation failure. Wraps the existing
     /// 7-variant [`ExprError`] enum verbatim.
     Expr(ExprError),
@@ -430,6 +467,7 @@ impl KgError {
             KgError::Validation(_) => KgErrorCode::Validation,
             KgError::ConstraintViolation { .. } => KgErrorCode::ConstraintViolation,
             KgError::ConstraintCreationFailed { .. } => KgErrorCode::ConstraintCreationFailed,
+            KgError::TransactionConflict { .. } => KgErrorCode::TransactionConflict,
             KgError::Expr(_) => KgErrorCode::Expr,
             KgError::NodeNotFound { .. } => KgErrorCode::NodeNotFound,
             KgError::ConnectionNotFound { .. } => KgErrorCode::ConnectionNotFound,
@@ -509,6 +547,18 @@ impl fmt::Display for KgError {
             // in a prefix that would bury the actionable part.
             KgError::ConstraintViolation { message, .. }
             | KgError::ConstraintCreationFailed { message, .. } => f.write_str(message),
+            KgError::TransactionConflict {
+                base_version,
+                current_version,
+            } => write!(
+                f,
+                "Transaction conflict: the graph was modified since begin() \
+                 (began at version {}, now at version {}), so this \
+                 transaction's changes are based on a stale snapshot and were \
+                 not applied. Retry the transaction — re-run the work against \
+                 a fresh begin().",
+                base_version, current_version
+            ),
             KgError::Expr(e) => write!(f, "Expression error: {}", e),
             KgError::NodeNotFound { node_type, id } => {
                 write!(f, "Node not found: {} with id {:?}", node_type, id)

--- a/crates/kglite/src/graph/dir_graph/constraints.rs
+++ b/crates/kglite/src/graph/dir_graph/constraints.rs
@@ -413,7 +413,27 @@ impl DirGraph {
     ///
     /// Empty on both sides when the type declares no unique constraint, which is
     /// the common case.
+    ///
+    /// A rejection is *also* parked on the graph by
+    /// [`DirGraph::record_constraint_violation`], so callers whose error channel
+    /// is a `String` (the Cypher `SET` / `REMOVE` tree) still surface a typed
+    /// `ConstraintViolationError`. Recording here rather than at each call site
+    /// keeps the violation attached to the code that produced it.
     pub(crate) fn plan_property_write(
+        &mut self,
+        node_type: &str,
+        node_idx: NodeIndex,
+        property: &str,
+        new_value: Option<&Value>,
+    ) -> Result<PropertyWritePlan, ConstraintViolation> {
+        let planned = self.plan_property_write_uncaught(node_type, node_idx, property, new_value);
+        if let Err(violation) = &planned {
+            self.record_constraint_violation(violation.clone());
+        }
+        planned
+    }
+
+    fn plan_property_write_uncaught(
         &mut self,
         node_type: &str,
         node_idx: NodeIndex,

--- a/crates/kglite/src/graph/dir_graph/independent_copy.rs
+++ b/crates/kglite/src/graph/dir_graph/independent_copy.rs
@@ -35,6 +35,7 @@ impl DirGraph {
         copy.active_write_scope = None;
         copy.active_git_sha = None;
         copy.active_modified_by = None;
+        copy.pending_constraint_violation = None;
         copy
     }
 }

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -274,6 +274,31 @@ pub struct DirGraph {
     pub(crate) active_git_sha: Option<String>,
     #[serde(skip, default)]
     pub(crate) active_modified_by: Option<String>,
+    /// Transient, **execution-scoped** carrier for the structured constraint
+    /// violation behind the write error currently unwinding.
+    ///
+    /// The Cypher mutation tree (`executor/write.rs`, `executor/schema_ddl.rs`)
+    /// and the bulk-loader gate (`mutation/maintain.rs`) both report failures
+    /// over a `Result<_, String>` channel, so a `ConstraintViolation` — which
+    /// already has an `impl From<ConstraintViolation> for KgError` — would
+    /// otherwise be flattened to prose and surface as a generic
+    /// `CypherExecutionError` / `ArgumentError`. Rather than retype ~535 call
+    /// sites across the executor, the violation is parked here by
+    /// [`Self::record_constraint_violation`] at the moment it is stringified
+    /// and drained by the adapter that builds the typed error.
+    ///
+    /// Stored **with the exact message it produced**, and the drain only
+    /// accepts it when the string that arrived is byte-identical: if any
+    /// intermediate frame wrapped or rewrote the message, the pair is
+    /// discarded and the caller falls back to the untyped error. That makes a
+    /// desync fail *safe* rather than fail *wrong*.
+    ///
+    /// Same lifecycle as `active_write_scope`: installed for one execution,
+    /// cleared unconditionally, never serialized, never copied (see
+    /// `independent_copy`).
+    #[serde(skip, default)]
+    pub(crate) pending_constraint_violation:
+        Option<Box<(String, crate::graph::constraints::ConstraintViolation)>>,
     /// Monotonically increasing version counter — incremented on every mutation.
     /// Used for optimistic concurrency control in transactions.
     #[serde(skip, default)]
@@ -418,6 +443,61 @@ impl DirGraph {
         self.version = self.version.wrapping_add(1);
     }
 
+    /// Stringify `violation` for the `Result<_, String>` error channel while
+    /// parking the structured value in
+    /// [`Self::pending_constraint_violation`], so the adapter that ultimately
+    /// builds the typed error can recover the constraint kind, node type,
+    /// properties, and descriptor instead of only the prose.
+    ///
+    /// Returns the message to hand to `Err(..)`; call it at every site that
+    /// would otherwise write `.map_err(|v| v.to_string())`.
+    pub(crate) fn record_constraint_violation(
+        &mut self,
+        violation: crate::graph::constraints::ConstraintViolation,
+    ) -> String {
+        let message = violation.to_string();
+        self.pending_constraint_violation = Some(Box::new((message.clone(), violation)));
+        message
+    }
+
+    /// Clear any parked violation. Called before an execution begins so a
+    /// violation left by an earlier run on the same working copy can never be
+    /// attributed to a later, unrelated error.
+    pub(crate) fn clear_pending_constraint_violation(&mut self) {
+        self.pending_constraint_violation = None;
+    }
+
+    /// Take the parked violation **only if** it is the one behind `message`.
+    ///
+    /// The identity check is what makes the side channel safe: the `String` is
+    /// still the control-flow channel, so if any intermediate frame wrapped or
+    /// replaced the message, the parked violation no longer describes the error
+    /// being reported and is dropped rather than mis-attributed. This is an
+    /// equality test against a string this graph itself produced — not a
+    /// pattern match on error prose.
+    pub(crate) fn take_constraint_violation_for(
+        &mut self,
+        message: &str,
+    ) -> Option<crate::graph::constraints::ConstraintViolation> {
+        let parked = self.pending_constraint_violation.take()?;
+        let (recorded, violation) = *parked;
+        (recorded == message).then_some(violation)
+    }
+
+    /// Typed [`KgError`] for a write that failed with `message`, when that
+    /// failure was a declared-constraint violation.
+    ///
+    /// Returns `None` when the error was something else, so each caller keeps
+    /// its own fallback: the Cypher path degrades to
+    /// [`KgError::CypherExecution`], the bulk-loader path to
+    /// [`KgError::Argument`]. Every binding that surfaces a write error over
+    /// the engine's `Result<_, String>` channel needs exactly this step, so it
+    /// lives here rather than being re-derived per binding.
+    pub fn take_constraint_error(&mut self, message: &str) -> Option<crate::error::KgError> {
+        self.take_constraint_violation_for(message)
+            .map(crate::error::KgError::from)
+    }
+
     pub fn new() -> Self {
         DirGraph {
             graph_id: next_graph_id(),
@@ -464,6 +544,7 @@ impl DirGraph {
             active_write_scope: None,
             active_git_sha: None,
             active_modified_by: None,
+            pending_constraint_violation: None,
             version: 0,
             interner: StringInterner::new(),
             type_schemas: HashMap::new(),
@@ -520,6 +601,7 @@ impl DirGraph {
             active_write_scope: None,
             active_git_sha: None,
             active_modified_by: None,
+            pending_constraint_violation: None,
             version: 0,
             interner: StringInterner::new(),
             type_schemas: HashMap::new(),

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -71,7 +71,7 @@ impl GraphWriterLease {
                     publish_owner_record(&writer_owner_path(graph_path));
                     return Ok(Self { file });
                 }
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                Err(error) if is_lock_contended(&error) => {
                     if started.elapsed() >= timeout {
                         return Err(io::Error::new(
                             io::ErrorKind::WouldBlock,
@@ -99,6 +99,27 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     let mut lock = graph_path.as_os_str().to_os_string();
     lock.push(".lock");
     lock.into()
+}
+
+/// Whether a failed `try_lock_*` means "someone else holds it" rather than a
+/// genuine I/O failure.
+///
+/// Deliberately **not** an `ErrorKind` comparison. `fs2` surfaces the
+/// platform's native lock errno — `EWOULDBLOCK` (35) on Unix,
+/// `ERROR_LOCK_VIOLATION` (33) on Windows — and only the Unix one maps to
+/// [`io::ErrorKind::WouldBlock`]; the Windows one is uncategorised. A `kind()`
+/// check therefore recognises contention on Unix and silently misses it on
+/// Windows, where two things then go wrong at once: the raw platform error
+/// escapes instead of a message naming the holder, *and* the retry loop below
+/// never runs, so a caller's timeout (the CLI and MCP server both pass 30s)
+/// returns instantly instead of waiting.
+///
+/// [`fs2::lock_contended_error`] exists precisely so callers can compare
+/// portably. The `WouldBlock` arm is kept as a belt-and-braces fallback for an
+/// error that carries the kind but no raw errno.
+fn is_lock_contended(error: &io::Error) -> bool {
+    error.raw_os_error() == fs2::lock_contended_error().raw_os_error()
+        || error.kind() == io::ErrorKind::WouldBlock
 }
 
 /// Sibling of the lock file holding the holder's identity. Never locked, so it
@@ -494,18 +515,74 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let graph = tmp.path().join("named.kgl");
         let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
-        let message = GraphWriterLease::acquire(&graph, Duration::ZERO)
+        let error = GraphWriterLease::acquire(&graph, Duration::ZERO)
             .err()
-            .expect("second acquire must be refused")
-            .to_string();
+            .expect("second acquire must be refused");
+        // Carry the raw platform error into the failure text. A refusal that
+        // still reads as the OS's own lock error means the contention check
+        // did not classify it, and naming the errno makes that diagnosable
+        // from a CI log alone instead of needing a local repro.
+        let diagnosis = format!(
+            "got {error:?} (raw OS error {:?}, kind {:?}). A raw platform lock \
+             error here means `is_lock_contended` failed to classify it — the \
+             errno differs per platform (EWOULDBLOCK on Unix, \
+             ERROR_LOCK_VIOLATION on Windows), so an `ErrorKind` comparison \
+             recognises only Unix.",
+            error.raw_os_error(),
+            error.kind()
+        );
+        let message = error.to_string();
         // Same-process contention is reported as such rather than as a
         // phantom "other process" carrying the caller's own pid.
         assert!(
             message.contains(&format!("pid {}", std::process::id())),
-            "{message}"
+            "the refusal must name the holding process; {diagnosis}"
         );
-        assert!(message.contains("named.kgl"), "{message}");
-        assert!(message.contains("does not release it"), "{message}");
+        assert!(message.contains("named.kgl"), "{diagnosis}");
+        assert!(message.contains("does not release it"), "{diagnosis}");
+    }
+
+    /// Pins the portable classification directly, so a regression is a one-line
+    /// failure rather than a confusing raw-errno leak somewhere downstream.
+    /// Un-gated on purpose: the whole point is that it must hold on the
+    /// platform whose errno is *not* the one `ErrorKind` understands.
+    #[test]
+    fn contention_is_classified_from_the_platform_lock_error() {
+        assert!(
+            is_lock_contended(&fs2::lock_contended_error()),
+            "the error fs2 returns for a contended lock must be recognised as \
+             contention on every platform"
+        );
+        assert!(is_lock_contended(&io::Error::from(
+            io::ErrorKind::WouldBlock
+        )));
+        // A real failure must still propagate rather than be retried as if
+        // someone else merely held the lock.
+        assert!(!is_lock_contended(&io::Error::from(
+            io::ErrorKind::PermissionDenied
+        )));
+    }
+
+    /// The misclassification also disabled waiting: an unrecognised error
+    /// returned immediately instead of entering the retry loop, so the CLI's
+    /// and MCP server's 30s lease timeouts silently became zero. Asserting the
+    /// call actually blocks catches that independently of the message.
+    #[test]
+    fn a_contended_acquire_waits_for_its_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("waiting.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let started = Instant::now();
+        let error = GraphWriterLease::acquire(&graph, Duration::from_millis(300))
+            .err()
+            .expect("a held lease must still be refused after the timeout");
+        assert!(
+            started.elapsed() >= Duration::from_millis(250),
+            "acquire returned after {:?}, so it never waited — contention was \
+             not recognised and the retry loop was skipped ({error})",
+            started.elapsed()
+        );
     }
 
     /// The property whose platform split broke this: the owner record must be

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -47,9 +47,19 @@ impl GraphWriterLease {
                 .open(&path)?;
             match file.try_lock_exclusive() {
                 Ok(()) => {
+                    // Truncate first, then publish in a single write. A
+                    // contender that reads mid-update must see either nothing
+                    // (reported as "another process") or the complete new
+                    // record — never the *previous*, now-dead holder's pid,
+                    // which would send someone chasing a process that exited.
+                    let record = format!(
+                        "pid={}\nsince={}\n",
+                        std::process::id(),
+                        chrono::Local::now().to_rfc3339()
+                    );
                     file.set_len(0)?;
                     file.rewind()?;
-                    writeln!(file, "pid={}", std::process::id())?;
+                    file.write_all(record.as_bytes())?;
                     file.sync_data()?;
                     return Ok(Self { file });
                 }
@@ -57,10 +67,7 @@ impl GraphWriterLease {
                     if started.elapsed() >= timeout {
                         return Err(io::Error::new(
                             io::ErrorKind::WouldBlock,
-                            format!(
-                                "timed out waiting for writer lease {}; another writer is active",
-                                path.display()
-                            ),
+                            contended_message(graph_path, &path),
                         ));
                     }
                     std::thread::sleep(Duration::from_millis(50));
@@ -84,6 +91,93 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     let mut lock = graph_path.as_os_str().to_os_string();
     lock.push(".lock");
     lock.into()
+}
+
+/// Ownership details the holder records in the sidecar lock file, read back
+/// only on the contention path. The bytes are advisory *documentation*: the
+/// lock itself is the OS file-descriptor lock, so a stale file with a dead
+/// pid in it locks nothing.
+#[derive(Debug, Default)]
+struct LeaseHolder {
+    pid: Option<u32>,
+    since: Option<String>,
+}
+
+impl LeaseHolder {
+    /// Best-effort parse. Every failure mode — unreadable file, truncated
+    /// mid-write by the holder, an older release's `pid`-only format —
+    /// degrades to a less specific description rather than masking the real
+    /// "another writer is active" error with a parse error.
+    ///
+    /// Retries briefly while the record is absent, because the holder takes
+    /// the lock *before* it publishes its identity: two processes racing at
+    /// startup (the exact case this guard exists for) otherwise reliably read
+    /// the empty window and report an unnamed "another process". The cost is
+    /// paid only on the error path, where a correct message beats promptness.
+    fn read(lock_path: &Path) -> Self {
+        const ATTEMPTS: u32 = 10;
+        for attempt in 0..ATTEMPTS {
+            let holder = Self::read_once(lock_path);
+            if holder.pid.is_some() {
+                return holder;
+            }
+            if attempt + 1 < ATTEMPTS {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+        Self::default()
+    }
+
+    fn read_once(lock_path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(lock_path) else {
+            return Self::default();
+        };
+        let mut holder = Self::default();
+        for line in text.lines() {
+            match line.split_once('=') {
+                Some(("pid", value)) => holder.pid = value.trim().parse().ok(),
+                Some(("since", value)) => holder.since = Some(value.trim().to_string()),
+                _ => {}
+            }
+        }
+        holder
+    }
+
+    fn describe(&self) -> String {
+        // A self-pid hit is not a deployment problem, it is an un-closed
+        // handle in the caller's own code, and saying "another process" for
+        // your own pid sends people hunting a process that does not exist.
+        if self.pid == Some(std::process::id()) {
+            return format!(
+                "this same process (pid {}), which has not closed an earlier open() of it",
+                std::process::id()
+            );
+        }
+        match (self.pid, self.since.as_deref()) {
+            (Some(pid), Some(since)) => format!("pid {pid} (since {since})"),
+            (Some(pid), None) => format!("pid {pid}"),
+            _ => "another process".to_string(),
+        }
+    }
+}
+
+/// The message a blocked writer sees. Names the holding process, because
+/// "another writer is active" leaves an operator with nothing to act on.
+///
+/// The closing sentence is deliberate support-burden prevention: the lock
+/// file is persistent and survives a `SIGKILL`, so the natural reflex on
+/// seeing one is to delete it. Deleting it does not release the lock (the OS
+/// already did that when the holder died) and only removes the record of who
+/// holds it, so the message says so before the reflex fires.
+fn contended_message(graph_path: &Path, lock_path: &Path) -> String {
+    format!(
+        "{} is open for writing by {}; only one process may write a graph at a time. \
+         The lock is released automatically when that process exits, even on a crash — \
+         deleting {} does not release it.",
+        graph_path.display(),
+        LeaseHolder::read(lock_path).describe(),
+        lock_path.display()
+    )
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -351,6 +445,52 @@ mod tests {
         let _lease = GraphWriterLease::acquire(&path, Duration::ZERO).unwrap();
         let opened = open_or_create_graph(&path, Some(StorageMode::Memory)).unwrap();
         assert_eq!(opened.disposition, OpenDisposition::Opened);
+    }
+
+    #[test]
+    fn contended_message_names_the_holding_process() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("named.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+        let message = GraphWriterLease::acquire(&graph, Duration::ZERO)
+            .err()
+            .expect("second acquire must be refused")
+            .to_string();
+        // Same-process contention is reported as such rather than as a
+        // phantom "other process" carrying the caller's own pid.
+        assert!(
+            message.contains(&format!("pid {}", std::process::id())),
+            "{message}"
+        );
+        assert!(message.contains("named.kgl"), "{message}");
+        assert!(message.contains("does not release it"), "{message}");
+    }
+
+    #[test]
+    fn lease_record_carries_pid_and_acquisition_time() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("record.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+        let holder = LeaseHolder::read(&writer_lease_path(&graph));
+        assert_eq!(holder.pid, Some(std::process::id()));
+        assert!(holder.since.is_some(), "acquisition time must be recorded");
+    }
+
+    #[test]
+    fn holder_description_degrades_without_a_readable_record() {
+        // A holder that has locked but not yet published its identity, and a
+        // lock file from a release that only wrote `pid=`, must both produce
+        // a usable message rather than a parse failure.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent.lock");
+        assert_eq!(
+            LeaseHolder::read_once(&missing).describe(),
+            "another process"
+        );
+
+        let legacy = tmp.path().join("legacy.lock");
+        std::fs::write(&legacy, b"pid=999999\n").unwrap();
+        assert_eq!(LeaseHolder::read_once(&legacy).describe(), "pid 999999");
     }
 
     #[test]

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -1,7 +1,7 @@
 //! Shared graph open-or-create lifecycle used by server-style bindings.
 
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -28,8 +28,29 @@ pub struct OpenGraphResult {
     pub identity: GraphFileIdentity,
 }
 
-/// Cross-process writer ownership for a graph path. The sibling lock file is
-/// persistent; OS advisory-lock teardown, not PID-file deletion, owns liveness.
+/// Cross-process writer ownership for a graph path. Both sidecars are
+/// persistent; OS lock teardown, not PID-file deletion, owns liveness.
+///
+/// Ownership is split across two files on purpose:
+///
+/// - `<path>.lock` is the lock token, and holds **no** data. It is what
+///   [`fs2`] locks, and it is deliberately still this exact path so that a
+///   binary from before the split still excludes, and is excluded by, this one.
+/// - `<path>.lock-owner` carries the human-readable `pid` / `since` record
+///   used to name the holder in an error message.
+///
+/// The record cannot live inside the lock file. `fs2` locks via `flock` on
+/// Unix, which is *advisory* — a contender can still read the bytes — but via
+/// `LockFileEx` on Windows, whose locks are **mandatory** over the whole range
+/// (`fs2` passes `(0, !0, !0)`). There, an exclusive lock makes the file
+/// unreadable to every other handle, including other handles in the holder's
+/// own process, and a contender's read fails with `ERROR_LOCK_VIOLATION` (33)
+/// rather than returning bytes. Keeping the record in an unlocked sibling is
+/// what lets the holder be *named* on every platform instead of degrading to
+/// an anonymous "another process" exactly where that matters most.
+///
+/// The same mandatory-lock mechanism is documented at the disk backend's
+/// `snapshot_files` helper, which skips `.kglite.lock` for this reason.
 pub struct GraphWriterLease {
     file: File,
 }
@@ -39,7 +60,7 @@ impl GraphWriterLease {
         let path = writer_lease_path(graph_path);
         let started = Instant::now();
         loop {
-            let mut file = OpenOptions::new()
+            let file = OpenOptions::new()
                 .read(true)
                 .write(true)
                 .create(true)
@@ -47,20 +68,7 @@ impl GraphWriterLease {
                 .open(&path)?;
             match file.try_lock_exclusive() {
                 Ok(()) => {
-                    // Truncate first, then publish in a single write. A
-                    // contender that reads mid-update must see either nothing
-                    // (reported as "another process") or the complete new
-                    // record — never the *previous*, now-dead holder's pid,
-                    // which would send someone chasing a process that exited.
-                    let record = format!(
-                        "pid={}\nsince={}\n",
-                        std::process::id(),
-                        chrono::Local::now().to_rfc3339()
-                    );
-                    file.set_len(0)?;
-                    file.rewind()?;
-                    file.write_all(record.as_bytes())?;
-                    file.sync_data()?;
+                    publish_owner_record(&writer_owner_path(graph_path));
                     return Ok(Self { file });
                 }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -93,10 +101,40 @@ fn writer_lease_path(graph_path: &Path) -> std::path::PathBuf {
     lock.into()
 }
 
-/// Ownership details the holder records in the sidecar lock file, read back
-/// only on the contention path. The bytes are advisory *documentation*: the
-/// lock itself is the OS file-descriptor lock, so a stale file with a dead
-/// pid in it locks nothing.
+/// Sibling of the lock file holding the holder's identity. Never locked, so it
+/// stays readable on Windows — see [`GraphWriterLease`].
+fn writer_owner_path(graph_path: &Path) -> std::path::PathBuf {
+    let mut owner = graph_path.as_os_str().to_os_string();
+    owner.push(".lock-owner");
+    owner.into()
+}
+
+/// Record who now holds the lease, for the benefit of whoever is refused next.
+///
+/// Truncate-then-write, so a contender reading mid-update sees either nothing
+/// (reported as "another process", and retried) or the complete new record —
+/// never the *previous*, now-released holder's pid, which would send someone
+/// chasing a process that has already exited.
+///
+/// Deliberately infallible: this is naming, not locking. The caller has
+/// already won the lock at this point, and failing an acquisition because a
+/// cosmetic sidecar could not be written would trade a working guard for a
+/// better error message. A failure here costs only the pid in a message that
+/// someone else may never see.
+fn publish_owner_record(owner_path: &Path) {
+    let record = format!(
+        "pid={}\nsince={}\n",
+        std::process::id(),
+        chrono::Local::now().to_rfc3339()
+    );
+    let _ = std::fs::write(owner_path, record);
+}
+
+/// Ownership details published to `<path>.lock-owner`, read back only on the
+/// contention path. The bytes are *documentation*: liveness is established by
+/// the failed lock acquisition that precedes every read, so a record left
+/// behind by a crashed process is never mistaken for a live holder — nothing
+/// reads it unless someone currently holds the lock.
 #[derive(Debug, Default)]
 struct LeaseHolder {
     pid: Option<u32>,
@@ -114,10 +152,10 @@ impl LeaseHolder {
     /// startup (the exact case this guard exists for) otherwise reliably read
     /// the empty window and report an unnamed "another process". The cost is
     /// paid only on the error path, where a correct message beats promptness.
-    fn read(lock_path: &Path) -> Self {
+    fn read(owner_path: &Path) -> Self {
         const ATTEMPTS: u32 = 10;
         for attempt in 0..ATTEMPTS {
-            let holder = Self::read_once(lock_path);
+            let holder = Self::read_once(owner_path);
             if holder.pid.is_some() {
                 return holder;
             }
@@ -128,8 +166,8 @@ impl LeaseHolder {
         Self::default()
     }
 
-    fn read_once(lock_path: &Path) -> Self {
-        let Ok(text) = std::fs::read_to_string(lock_path) else {
+    fn read_once(owner_path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(owner_path) else {
             return Self::default();
         };
         let mut holder = Self::default();
@@ -175,7 +213,7 @@ fn contended_message(graph_path: &Path, lock_path: &Path) -> String {
          The lock is released automatically when that process exits, even on a crash — \
          deleting {} does not release it.",
         graph_path.display(),
-        LeaseHolder::read(lock_path).describe(),
+        LeaseHolder::read(&writer_owner_path(graph_path)).describe(),
         lock_path.display()
     )
 }
@@ -447,6 +485,10 @@ mod tests {
         assert_eq!(opened.disposition, OpenDisposition::Opened);
     }
 
+    /// Deliberately **not** gated to Unix. Naming the holder is the feature,
+    /// and a `cfg`-gated test would let it silently degrade to "another
+    /// process" on Windows — the platform where a multi-process deployment
+    /// tripping this is arguably most likely — while CI stayed green.
     #[test]
     fn contended_message_names_the_holding_process() {
         let tmp = tempfile::tempdir().unwrap();
@@ -466,21 +508,89 @@ mod tests {
         assert!(message.contains("does not release it"), "{message}");
     }
 
+    /// The property whose platform split broke this: the owner record must be
+    /// readable *by someone other than the holder, while the lock is held*.
+    ///
+    /// It is asserted as a distinct test, with the raw OS error in the failure
+    /// message, because the two candidate causes look identical from the
+    /// outside. A record kept inside the locked file returns bytes on Unix
+    /// (`flock` is advisory) and fails with `ERROR_LOCK_VIOLATION` (33) on
+    /// Windows (`LockFileEx` is mandatory) — so this test distinguishes "the
+    /// read failed" from "the record was empty" instead of leaving the next
+    /// person to infer it from a `None`.
+    #[test]
+    fn owner_record_stays_readable_while_the_lease_is_held() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("readable.kgl");
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let owner = writer_owner_path(&graph);
+        let text = std::fs::read_to_string(&owner).unwrap_or_else(|error| {
+            panic!(
+                "the owner record must stay readable while the lease is held, but \
+                 reading {} failed: {error} (raw OS error {:?}). A mandatory-lock \
+                 platform reports ERROR_LOCK_VIOLATION (33) here the moment the \
+                 record is moved back inside the locked file.",
+                owner.display(),
+                error.raw_os_error()
+            )
+        });
+        assert!(
+            text.contains(&format!("pid={}", std::process::id())),
+            "{text}"
+        );
+
+        // And the lock token itself carries no data, so nothing can come to
+        // depend on reading it — which is the trap that caused this.
+        let lock = writer_lease_path(&graph);
+        assert_eq!(
+            std::fs::metadata(&lock).unwrap().len(),
+            0,
+            "the lock file must stay empty; its contents are unreadable to \
+             contenders on mandatory-lock platforms"
+        );
+    }
+
+    /// Also un-gated: the timestamp is half of what makes the message
+    /// actionable (a live writer versus one forgotten since Tuesday), so it
+    /// has to survive on every platform the guard ships to.
     #[test]
     fn lease_record_carries_pid_and_acquisition_time() {
         let tmp = tempfile::tempdir().unwrap();
         let graph = tmp.path().join("record.kgl");
         let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
-        let holder = LeaseHolder::read(&writer_lease_path(&graph));
+        let holder = LeaseHolder::read(&writer_owner_path(&graph));
         assert_eq!(holder.pid, Some(std::process::id()));
         assert!(holder.since.is_some(), "acquisition time must be recorded");
     }
 
+    /// A second holder must overwrite the first's record rather than leave a
+    /// dead pid to be reported as live. The record is only ever read after a
+    /// failed acquisition, so it must describe whoever holds the lock *now*.
+    #[test]
+    fn owner_record_is_replaced_by_each_new_holder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = tmp.path().join("succession.kgl");
+        let owner = writer_owner_path(&graph);
+
+        std::fs::write(&owner, b"pid=999999\nsince=long-ago\n").unwrap();
+        let _lease = GraphWriterLease::acquire(&graph, Duration::ZERO).unwrap();
+
+        let holder = LeaseHolder::read(&owner);
+        assert_eq!(
+            holder.pid,
+            Some(std::process::id()),
+            "a stale predecessor's pid must not survive a fresh acquisition"
+        );
+        assert_ne!(holder.since.as_deref(), Some("long-ago"));
+    }
+
     #[test]
     fn holder_description_degrades_without_a_readable_record() {
-        // A holder that has locked but not yet published its identity, and a
-        // lock file from a release that only wrote `pid=`, must both produce
-        // a usable message rather than a parse failure.
+        // Two cases must degrade to a usable message rather than a parse
+        // failure: no record at all — a holder that has locked but not yet
+        // published, or a holder running a build from before the record moved
+        // out of the lock file — and a record carrying only `pid=`.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("absent.lock");
         assert_eq!(

--- a/crates/kglite/src/graph/languages/cypher/executor/schema_ddl.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/schema_ddl.rs
@@ -722,10 +722,11 @@ fn install_constraint(
 
 fn declare_unique(graph: &mut DirGraph, label: &str, properties: &[String]) -> Result<(), String> {
     let refs: Vec<&str> = properties.iter().map(String::as_str).collect();
-    graph
-        .create_unique_constraint(label, &refs)
-        .map(|_| ())
-        .map_err(|violation| violation.to_string())
+    let declared = graph.create_unique_constraint(label, &refs);
+    match declared {
+        Ok(_) => Ok(()),
+        Err(violation) => Err(graph.record_constraint_violation(violation)),
+    }
 }
 
 /// Declare every property NOT NULL, recording which ones landed so a failed
@@ -741,9 +742,10 @@ fn declare_not_null<'p>(
     installed: &mut Vec<&'p String>,
 ) -> Result<(), String> {
     for property in properties {
-        graph
-            .create_not_null_constraint(label, property)
-            .map_err(|violation| violation.to_string())?;
+        let declared = graph.create_not_null_constraint(label, property);
+        if let Err(violation) = declared {
+            return Err(graph.record_constraint_violation(violation));
+        }
         installed.push(property);
     }
     Ok(())

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -948,13 +948,17 @@ fn create_node(
             },
         }
     };
-    graph
-        .check_required_fields(&label, constraint_read)
-        .map_err(|violation| violation.to_string())?;
+    // Bind before reporting: `record_constraint_violation` needs `&mut graph`,
+    // so the immutable borrow held by the check must end at the semicolon.
+    let required = graph.check_required_fields(&label, constraint_read);
+    if let Err(violation) = required {
+        return Err(graph.record_constraint_violation(violation));
+    }
     let unique_claims = graph.unique_claims(&label, constraint_read);
-    graph
-        .check_unique_claims(&unique_claims, None)
-        .map_err(|violation| violation.to_string())?;
+    let unique = graph.check_unique_claims(&unique_claims, None);
+    if let Err(violation) = unique {
+        return Err(graph.record_constraint_violation(violation));
+    }
 
     // Clone the id for incremental index maintenance below (it is moved into
     // insert_node_routed). The id-index is maintained incrementally whenever it

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1,6 +1,6 @@
 // src/graph/maintain.rs
 use crate::datatypes::{DataFrame, Value};
-use crate::graph::constraints::UniqueConstraintKey;
+use crate::graph::constraints::{ConstraintViolation, UniqueConstraintKey};
 use crate::graph::introspection::reporting::{ConnectionOperationReport, NodeOperationReport};
 use crate::graph::mutation::batch::{
     BatchProcessor, ConflictHandling, ConnectionBatchProcessor, NodeAction,
@@ -63,9 +63,32 @@ impl ConstraintColumns {
     /// reach storage. Returning `None` for an unconstrained type is what keeps
     /// the common path free — one `is_empty` and one `Option` check per call
     /// rather than per row.
-    fn for_batch(graph: &DirGraph, node_type: &str, df_data: &DataFrame) -> Option<Self> {
+    fn for_batch(graph: &mut DirGraph, node_type: &str, df_data: &DataFrame) -> Option<Self> {
+        // Batch entry point: no violation parked by an earlier load may be
+        // attributed to this one.
+        graph.clear_pending_constraint_violation();
         (graph.has_unique_constraints() || graph.has_required_fields(node_type))
             .then(|| Self::new(df_data))
+    }
+
+    /// [`Self::gate_row`] for callers on the `Result<_, String>` channel: parks
+    /// the structured violation so the binding raises
+    /// `ConstraintViolationError` instead of a generic argument error, and
+    /// returns the prose the caller would have produced itself.
+    fn gate_row_parked(
+        &self,
+        graph: &mut DirGraph,
+        node_type: &str,
+        row: GateRow<'_>,
+        existing_idx: Option<NodeIndex>,
+        batch_claims: &mut HashSet<(UniqueConstraintKey, CompositeValue)>,
+    ) -> Result<(), String> {
+        // Bound before reporting: recording needs a second mutable borrow.
+        let gated = self.gate_row(graph, node_type, row, existing_idx, batch_claims);
+        match gated {
+            Ok(()) => Ok(()),
+            Err(violation) => Err(graph.record_constraint_violation(violation)),
+        }
     }
 
     fn new(df_data: &DataFrame) -> Self {
@@ -101,7 +124,7 @@ impl ConstraintColumns {
         row: GateRow<'_>,
         existing_idx: Option<NodeIndex>,
         batch_claims: &mut HashSet<(UniqueConstraintKey, CompositeValue)>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ConstraintViolation> {
         // Both identity spellings are accepted, and identity wins over a
         // same-named ordinary column — matching `DirGraph::resolve_alias` on the
         // read side.
@@ -114,16 +137,15 @@ impl ConstraintColumns {
             }
             self.read(row.df_data, row.row_idx, property)
         };
-        graph
-            .check_required_fields(node_type, read)
-            .map_err(|violation| violation.to_string())?;
+        // Every failure this gate can report is a declared-constraint
+        // violation, so it returns the structured value and lets `add_nodes`
+        // decide how to render it.
+        graph.check_required_fields(node_type, read)?;
         let claims = graph.unique_claims(node_type, read);
-        graph
-            .check_unique_claims(&claims, existing_idx)
-            .map_err(|violation| violation.to_string())?;
+        graph.check_unique_claims(&claims, existing_idx)?;
         for claim in &claims {
             if !batch_claims.insert((claim.key.clone(), claim.value.clone())) {
-                return Err(graph.unique_batch_conflict(claim).to_string());
+                return Err(graph.unique_batch_conflict(claim));
             }
         }
         Ok(())
@@ -464,7 +486,7 @@ pub fn add_nodes(
         // rollback needed and no half-applied load.
         let existing_idx = type_lookup.check_uid(&id);
         if let Some(columns) = &constraint_columns {
-            columns.gate_row(
+            columns.gate_row_parked(
                 graph,
                 &node_type,
                 GateRow {

--- a/crates/kglite/src/graph/session/execute.rs
+++ b/crates/kglite/src/graph/session/execute.rs
@@ -177,11 +177,14 @@ impl<'a> ExecuteOptions<'a> {
 /// execution error. `cancel == None` (every server binding) always
 /// takes the `CypherExecution` branch, so behaviour is unchanged there.
 #[inline]
-fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
-    if opts
-        .cancel
+fn is_cancelled(opts: &ExecuteOptions<'_>) -> bool {
+    opts.cancel
         .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
-    {
+}
+
+#[inline]
+fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
+    if is_cancelled(opts) {
         KgError::Cancelled
     } else {
         KgError::CypherExecution {
@@ -189,6 +192,26 @@ fn exec_err(opts: &ExecuteOptions<'_>, message: String) -> KgError {
             position: None,
         }
     }
+}
+
+/// [`exec_err`] for the mutation path, which can additionally recover the
+/// structured constraint violation parked by
+/// [`DirGraph::record_constraint_violation`].
+///
+/// Cancellation keeps precedence: an interrupt is a user action and stays
+/// `KgError::Cancelled` regardless of what the aborted statement had parked.
+/// The park is drained on every path so nothing survives into a later run.
+fn mutation_err(graph: &mut DirGraph, opts: &ExecuteOptions<'_>, message: String) -> KgError {
+    if is_cancelled(opts) {
+        graph.clear_pending_constraint_violation();
+        return KgError::Cancelled;
+    }
+    graph
+        .take_constraint_error(&message)
+        .unwrap_or(KgError::CypherExecution {
+            message,
+            position: None,
+        })
 }
 
 /// Result of a successful execute. Wraps `CypherResult` with the
@@ -386,6 +409,9 @@ pub fn execute_mut(
         // mutation, then clear it unconditionally (even on error) so it never
         // leaks into a later execution on the same working copy.
         graph.active_write_scope = opts.write_scope.cloned();
+        // Same lifecycle as the write scope: no violation parked by an earlier
+        // execution on this working copy may be read by this one.
+        graph.clear_pending_constraint_violation();
         let r = graph.with_write_provenance(opts.git_sha, opts.modified_by, |graph| {
             cypher::executor::write::execute_mutable_with_csv(
                 graph,
@@ -400,8 +426,12 @@ pub fn execute_mut(
         let r = match r {
             Ok(result) => result,
             Err(message) => {
+                // Recover the structured violation *before* rolling back, so
+                // the typed error never depends on what a checkpoint restore
+                // does to the graph's transient fields.
+                let error = mutation_err(graph, opts, message);
                 checkpoint.rollback(graph);
-                return Err(exec_err(opts, message));
+                return Err(error);
             }
         };
         checkpoint.commit(graph);

--- a/crates/kglite/src/graph/storage/disk/generation.rs
+++ b/crates/kglite/src/graph/storage/disk/generation.rs
@@ -174,6 +174,13 @@ impl GraphDirectoryLock {
                 ),
             )
         })?;
+        // Written for a human reading the file directly, and deliberately
+        // never read back by this codebase. It cannot be: `fs2` locks via
+        // `LockFileEx` on Windows, whose locks are mandatory, so any other
+        // handle reading these bytes gets ERROR_LOCK_VIOLATION (33) rather
+        // than the pid. Code that needs to *name* a lock holder must publish
+        // the record to an unlocked sibling instead — see `GraphWriterLease`
+        // in `graph/io/open.rs`, which had exactly this bug.
         file.set_len(0)?;
         writeln!(file, "pid={}", std::process::id())?;
         file.sync_all()?;

--- a/docs/python/error-handling.md
+++ b/docs/python/error-handling.md
@@ -18,6 +18,10 @@ Exception
     ├── kglite.SchemaError
     ├── kglite.ValidationError
     ├── kglite.ExprError
+    ├── kglite.ConstraintError
+    │   ├── kglite.ConstraintViolationError
+    │   └── kglite.ConstraintCreationError
+    ├── kglite.TransactionConflictError
     ├── kglite.NodeNotFoundError
     ├── kglite.ConnectionNotFoundError
     ├── kglite.PropertyNotFoundError
@@ -33,6 +37,57 @@ Exception
 `CypherSyntaxError` always has `.line` and `.col` attributes (either may be
 `None`). `CypherExecutionError` has them when the executor can identify the
 source position. Timeout messages report the elapsed and configured limit.
+
+## Stable codes
+
+Every instance carries `.code`, a stable classifier string — branch on that
+rather than on message prose, which is free to improve between releases:
+
+```python
+try:
+    graph.cypher(query)
+except kglite.KgError as exc:
+    log.warning("kglite failed", extra={"kglite_code": exc.code})
+```
+
+`.code` is also readable on the concrete classes themselves
+(`kglite.ConstraintViolationError.code == "ConstraintViolation"`), so a
+dispatch table can be built up front. It is `None` on the three abstract bases
+— `KgError`, `CypherError`, `ConstraintError` — which each span several codes.
+The same strings appear as `KGLITE_STATUS_*` in the C ABI and drive the Bolt
+`Neo.*` status mapping, so one code means the same thing in every binding.
+
+## Constraint violations
+
+A write that breaks a declared UNIQUE / NOT NULL / NODE KEY constraint raises
+`ConstraintViolationError` — from **every** write path, `cypher()` and the bulk
+loaders alike. Declaring a constraint the stored data already violates is a
+different problem with a different fix, so it raises the sibling
+`ConstraintCreationError`; both subclass `ConstraintError`.
+
+```python
+try:
+    graph.cypher("CREATE (u:User {email: $email})", params={"email": email})
+except kglite.ConstraintViolationError:
+    raise Conflict("that email is already registered")
+```
+
+The message names the constraint, the property, and the offending value, so it
+is worth logging — but the type and `.code` are the contract.
+
+## Transaction conflicts
+
+`Transaction.commit()` raises `TransactionConflictError` when the graph moved
+since `begin()`. Nothing was applied, so the fix is to re-run the work against
+a fresh `begin()` — see {doc}`transactions` for `retry_on_conflict`, which is
+that loop.
+
+```python
+try:
+    tx.commit()
+except kglite.TransactionConflictError:
+    ...  # rebuild the transaction and try again
+```
 
 ## Catching errors
 

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -92,10 +92,33 @@ rather than silently truncated.
 snapshot; a `session()` serializes writers, begins each from the last committed
 state, and publishes with a pointer swap only on success — though note the
 durable-graph restriction on `Session` writes below. Explicit transactions
-are optimistically concurrent: independent work proceeds, and a commit against a
-state that moved underneath returns a conflict rather than winning silently.
-{doc}`/concepts/concurrency` is the full model, and worth reading before you rely
-on any of it.
+are optimistically concurrent: a commit against a state that moved underneath
+raises `TransactionConflictError` rather than winning silently.
+
+Be precise about how coarse that check is, because it is coarser than most
+databases you have used. It compares a **whole-graph version counter**, not the
+read/write sets of the two transactions — a commit publishes the transaction's
+working copy by pointer swap, so a transaction that began before *any* other
+commit is working from a stale snapshot regardless of which nodes it touched.
+Two transactions editing entirely unrelated nodes therefore conflict, and the
+second one loses. That is not over-caution: its working copy genuinely does not
+contain the first one's write, so applying it would silently revert that write.
+
+The practical consequence is that conflicts are ordinary rather than rare, and
+every concurrent writer needs a retry loop. Use `kglite.retry_on_conflict`
+rather than writing one:
+
+```python
+def signup(tx):
+    tx.cypher("CREATE (u:User {email: $email})", params={"email": email})
+
+kglite.retry_on_conflict(graph, signup)
+```
+
+If your workload has many short concurrent writers, prefer `session()` — it
+serializes writers and begins each from the last committed state, so they queue
+instead of colliding. {doc}`/concepts/concurrency` is the full model, and worth
+reading before you rely on any of it.
 
 **Failures are typed.** Errors arrive as a `KgError` hierarchy with stable
 codes, not as strings to match on — see {doc}`/python/error-handling`.
@@ -138,18 +161,26 @@ embedding-carry path. A graph filled through those can hold data that violates a
 declared constraint; `verify_unique_constraints()` exists to audit exactly that
 case.
 
-Two things about the error surface are worth knowing before you write `except`
-clauses. A declaration that cannot be installed raises `ConstraintCreationError`,
-and a violation from the bulk writers raises `ConstraintViolationError`; both
-subclass `ConstraintError`, so `except ConstraintError` catches either. Note that
-`define_schema` *can* now fail this way, because installing a schema installs the
+One thing about the error surface is worth knowing before you write `except`
+clauses. A violation raises `ConstraintViolationError` and a declaration that
+cannot be installed raises `ConstraintCreationError`; both subclass
+`ConstraintError`, so `except ConstraintError` catches either. This holds on
+every write path — `cypher()` and the bulk writers alike — so the duplicate-signup
+handler is a type check, not a substring match:
+
+```python
+try:
+    graph.cypher("CREATE (u:User {email: $email})", params={"email": email})
+except kglite.ConstraintViolationError:
+    raise Conflict("that email is already registered")
+```
+
+Each carries a stable `.code` (`"ConstraintViolation"` /
+`"ConstraintCreationFailed"`) for logging and cross-binding dispatch. Note that
+`define_schema` *can* fail this way, because installing a schema installs the
 constraints it declares — nothing is changed when it does, so you can fix the data
-and retry. A violation raised through **Cypher**, however, arrives as
-`CypherExecutionError` rather than the typed exception: the executor's internal
-error channel is a string, so the structured violation is rendered to text before
-any binding sees it. The message is stable and names the constraint, the property,
-and the offending value — match on that. Enforcement is identical either way; only
-the exception type differs.
+and retry. The message still names the constraint, the property, and the
+offending value, and is worth logging; the type and code are the contract.
 
 ## Defaults, and how to change them
 

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -166,10 +166,26 @@ cost in more detail.
 
 ## What KGLite does not do
 
-**One process writes.** There is no shared live multi-process transaction
-handle and no replication protocol. Disk mode publishes immutable generations
-behind a cross-process writer lease, which stops two processes from publishing
-at once — that is stable-reader/single-writer publication, not concurrent
+**One process writes — and this is now enforced, not just documented.**
+`kglite.open(path)` takes an exclusive cross-process writer lease for as long
+as the graph can write back to `path`, so a second process opening the same
+path fails immediately with the holder's pid rather than quietly overwriting
+its work at `save()`:
+
+```
+KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
+```
+
+Readers are unaffected: `load()` and `open_session()` take no lease, so any
+number of processes can read a graph while one writes. The lease is an OS-owned
+advisory lock, so a writer killed with `SIGKILL` releases it immediately — the
+leftover `<path>.lock` file is a record, not the lock itself, and deleting it
+achieves nothing. `open(..., lock=False)` opts out for callers that coordinate
+writers some other way.
+
+There is still no shared live multi-process transaction handle and no
+replication protocol. Disk mode publishes immutable generations behind the same
+kind of lease — that is stable-reader/single-writer publication, not concurrent
 multi-process write access. When several processes need to read and write one
 graph, the answer is to run `kglite-bolt-server` and let that one process own
 the graph while clients connect over the Bolt protocol. The official Python,

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -178,10 +178,11 @@ KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:0
 
 Readers are unaffected: `load()` and `open_session()` take no lease, so any
 number of processes can read a graph while one writes. The lease is an OS-owned
-advisory lock, so a writer killed with `SIGKILL` releases it immediately — the
-leftover `<path>.lock` file is a record, not the lock itself, and deleting it
-achieves nothing. `open(..., lock=False)` opts out for callers that coordinate
-writers some other way.
+lock, so a writer killed with `SIGKILL` releases it immediately — the leftover
+`<path>.lock` (the lock, always empty) and `<path>.lock-owner` (the pid and
+acquisition time, used to name a holder) are records, not the lock itself, and
+deleting them achieves nothing. `open(..., lock=False)` opts out for callers
+that coordinate writers some other way.
 
 There is still no shared live multi-process transaction handle and no
 replication protocol. Disk mode publishes immutable generations behind the same

--- a/kglite/__init__.py
+++ b/kglite/__init__.py
@@ -33,6 +33,7 @@ from .kglite import (  # explicit re-exports — names listed in __all__ below
     SchemaError,
     Session,
     Transaction,
+    TransactionConflictError,
     ValidationError,
     __version__,
     cypher_pass_names,
@@ -42,6 +43,7 @@ from .kglite import (  # explicit re-exports — names listed in __all__ below
     open,
     open_session,
 )
+from .retry import retry_on_conflict
 
 
 class Agg:
@@ -568,6 +570,8 @@ __all__ = [
     "ConstraintError",
     "ConstraintViolationError",
     "ConstraintCreationError",
+    "TransactionConflictError",
+    "retry_on_conflict",
     "NodeNotFoundError",
     "ConnectionNotFoundError",
     "PropertyNotFoundError",

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -725,8 +725,10 @@ def open(
 
         **A crash releases the lease.** The lock belongs to the operating
         system, not to the sidecar file, so a writer killed with ``SIGKILL``
-        (or lost to a power cut) frees it immediately. The ``.lock`` file is
-        left behind and is harmless — deleting it does *not* release a live
+        (or lost to a power cut) frees it immediately. Two small sidecars are
+        left behind and are harmless: ``<path>.lock`` (the lock itself, always
+        empty) and ``<path>.lock-owner`` (the pid/timestamp used to name a
+        holder in the error above). Deleting either does *not* release a live
         lock, and does nothing useful for a dead one.
 
     Note:

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -650,7 +650,13 @@ def graphgen(
     """
     ...
 
-def open(path: str, *, storage: str | None = None, durable: bool | None = None) -> KnowledgeGraph:
+def open(
+    path: str,
+    *,
+    storage: str | None = None,
+    durable: bool | None = None,
+    lock: bool = True,
+) -> KnowledgeGraph:
     """Open a graph at ``path`` — load it if it exists, create a fresh one if
     it doesn't (load-or-create). The embedded-database lifecycle entry point.
 
@@ -685,9 +691,43 @@ def open(path: str, *, storage: str | None = None, durable: bool | None = None) 
               rather than quietly returning a graph without the crash safety
               you asked for.
             - ``False`` — opt out. See the performance note below.
+        lock: Single-writer guard — **on by default**. Opening takes an
+            exclusive advisory lock on a ``<path>.lock`` sidecar and holds it
+            until ``close()`` / ``with``-block exit, so a second process that
+            opens the same path raises instead of silently overwriting your
+            work (see the note below). Pass ``False`` only when something else
+            already guarantees a single writer — an external supervisor, or a
+            process you have confined to reads. ``lock=False`` opts out of
+            *taking* the lease, not out of the consequences of ignoring one.
 
     Returns:
         A KnowledgeGraph bound to ``path``.
+
+    Raises:
+        KgError: If another process already holds the write lease for
+            ``path``. The message names the holding pid and when it acquired,
+            e.g. ``app.kgl is open for writing by pid 4711 (since ...)``.
+
+    Note:
+        **One process writes at a time.** ``save()`` republishes the whole
+        graph, so two processes that open the same path independently both
+        build a complete snapshot and the last one to save wins — silently
+        discarding everything the other did. That is the single most likely
+        accident when deploying an embedded database: a ``gunicorn`` worker
+        pool, a cron job overlapping a request, or a stale process left
+        running. The lease turns it into an error at ``open()`` rather than
+        data loss at ``save()``.
+
+        **Readers are never blocked.** :func:`load` and :func:`open_session`
+        take no lease, so any number of processes can read a graph while one
+        writes; they observe the last published snapshot. Only :func:`open` —
+        the write-back entry point — claims ownership.
+
+        **A crash releases the lease.** The lock belongs to the operating
+        system, not to the sidecar file, so a writer killed with ``SIGKILL``
+        (or lost to a power cut) frees it immediately. The ``.lock`` file is
+        left behind and is harmless — deleting it does *not* release a live
+        lock, and does nothing useful for a dead one.
 
     Note:
         **What durability costs.** Crash safety is bought with one ``fsync``

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -22,6 +22,20 @@ class KgError(Exception):
     Query, schema, graph-engine, transaction, and storage failures use this
     hierarchy. Python lookup, argument-shape, filesystem, and object-lifecycle
     protocols may instead raise their conventional built-in exceptions.
+
+    Every instance carries :attr:`code`, a stable classifier string, so an
+    application can branch on the failure kind without matching message prose.
+    """
+
+    code: str | None
+    """Stable error classifier — e.g. ``"ConstraintViolation"``,
+    ``"TransactionConflict"``, ``"CypherSyntax"``.
+
+    Set on every raised instance, and also readable on the concrete classes
+    themselves (``kglite.ConstraintViolationError.code``). It is ``None`` only
+    on the three abstract bases — ``KgError``, ``CypherError``,
+    ``ConstraintError`` — which span several codes. The same strings appear as
+    ``KGLITE_STATUS_*`` in the C ABI and drive the Bolt ``Neo.*`` mapping.
     """
 
 class CypherError(KgError):
@@ -115,6 +129,65 @@ class ConstraintCreationError(ConstraintError):
     ``unique`` tuple or ``primary_key`` that existing nodes already duplicate.
     Nothing is changed, so deduplicate the node type and call it again.
     """
+
+class TransactionConflictError(KgError):
+    """A transaction's commit lost an optimistic-concurrency race.
+
+    The graph advanced between :meth:`KnowledgeGraph.begin` and
+    :meth:`Transaction.commit`, so the transaction's working copy is stale and
+    **nothing was applied**. Re-run the work against a fresh ``begin()``;
+    :func:`retry_on_conflict` is that loop.
+
+    Note this is a whole-graph version check, not a read/write-set
+    intersection: a commit publishes the transaction's working copy by pointer
+    swap, so *any* concurrent commit conflicts — including one that touched
+    entirely different nodes. See :doc:`/concepts/concurrency`.
+    """
+
+def retry_on_conflict(
+    graph: KnowledgeGraph,
+    work: Callable[[Transaction], Any],
+    *,
+    attempts: int = 5,
+    base_delay: float = 0.005,
+    max_delay: float = 0.5,
+    jitter: bool = True,
+) -> Any:
+    """Run ``work`` in a transaction, retrying the whole unit on conflict.
+
+    ``work`` is called as ``work(tx)`` with a fresh :class:`Transaction` and is
+    re-invoked from the start on each attempt, so it must be safe to run more
+    than once — read what you need *inside* it rather than closing over values
+    read beforehand. The transaction commits when ``work`` returns and rolls
+    back if it raises.
+
+    Args:
+        graph: The graph to transact against.
+        work: Callable taking the transaction and returning the result.
+        attempts: Maximum tries, including the first.
+        base_delay: Seconds before the second attempt; doubles each further
+            attempt (exponential backoff).
+        max_delay: Upper bound on any single wait.
+        jitter: Spread each wait randomly over ``[0, delay]`` so competing
+            writers don't retry in lockstep. Disable only for deterministic
+            tests.
+
+    Returns:
+        Whatever ``work`` returned on the successful attempt.
+
+    Raises:
+        TransactionConflictError: Every attempt conflicted; the final error is
+            re-raised unchanged.
+        ValueError: ``attempts`` is less than 1.
+
+    Example:
+        >>> def signup(tx):
+        ...     tx.cypher("CREATE (u:User {email: $e})", params={"e": email})
+        ...     return "created"
+        >>> kglite.retry_on_conflict(graph, signup)
+        'created'
+    """
+    ...
 
 @runtime_checkable
 class EmbeddingModel(Protocol):

--- a/kglite/retry.py
+++ b/kglite/retry.py
@@ -1,0 +1,91 @@
+"""Optimistic-concurrency retry helper.
+
+KGLite commits a transaction by publishing its working copy with a pointer
+swap, so *any* commit that lands between ``begin()`` and ``commit()`` makes
+this transaction's snapshot stale — even one that touched entirely different
+nodes. Conflicts are therefore an ordinary outcome under concurrency rather
+than a rare edge case, and every correct writer needs a retry loop.
+
+The loop is short but easy to get subtly wrong: a conflicted transaction is
+already spent, so it must be *rebuilt* (not reused) on each attempt, the work
+must be re-run against the fresh snapshot rather than replayed from the stale
+one, and unbounded immediate retries livelock under contention.
+:func:`retry_on_conflict` is that loop, done once.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable, TypeVar
+
+from .kglite import TransactionConflictError
+
+__all__ = ["retry_on_conflict"]
+
+T = TypeVar("T")
+
+
+def retry_on_conflict(
+    graph: Any,
+    work: Callable[[Any], T],
+    *,
+    attempts: int = 5,
+    base_delay: float = 0.005,
+    max_delay: float = 0.5,
+    jitter: bool = True,
+) -> T:
+    """Run ``work`` in a transaction, retrying the whole unit on conflict.
+
+    ``work`` is called as ``work(tx)`` with a fresh :class:`Transaction` and is
+    re-invoked from the start on each attempt, so it must be safe to run more
+    than once — read what you need *inside* it rather than closing over values
+    read before the call. The transaction is committed when ``work`` returns
+    and rolled back if it raises.
+
+    Args:
+        graph: The :class:`KnowledgeGraph` to transact against.
+        work: Callable taking the transaction and returning the result.
+        attempts: Maximum number of tries, including the first.
+        base_delay: Seconds to wait before the second attempt. Doubles each
+            further attempt (exponential backoff).
+        max_delay: Upper bound on any single wait.
+        jitter: Spread the backoff randomly over ``[0, delay]`` (full jitter).
+            Keeps competing writers from retrying in lockstep; turn it off only
+            for deterministic tests.
+
+    Returns:
+        Whatever ``work`` returned on the successful attempt.
+
+    Raises:
+        TransactionConflictError: Every attempt conflicted. The final error is
+            re-raised unchanged, so ``.code`` and the version gap survive.
+        ValueError: ``attempts`` is less than 1.
+        Exception: Anything ``work`` raises is propagated immediately and the
+            transaction rolled back — only conflicts are retried.
+
+    Example:
+        >>> def signup(tx):
+        ...     tx.cypher("CREATE (u:User {email: $e})", params={"e": email})
+        ...     return "created"
+        >>> kglite.retry_on_conflict(graph, signup)
+        'created'
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            with graph.begin() as tx:
+                result = work(tx)
+            return result
+        except TransactionConflictError:
+            # The transaction is spent either way; the last attempt re-raises
+            # so the caller sees a real conflict rather than a silent failure.
+            if attempt == attempts:
+                raise
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+            time.sleep(random.uniform(0, delay) if jitter else delay)
+
+    # Unreachable: the final attempt either returns or re-raises.
+    raise AssertionError("retry_on_conflict exhausted its loop without returning")

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -1380,7 +1380,7 @@
     },
     "open": {
       "kind": "function",
-      "signature": "(path, *, storage=None, durable=None)"
+      "signature": "(path, *, storage=None, durable=None, lock=True)"
     },
     "open_session": {
       "kind": "function",

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -35,6 +35,8 @@
     "ConstraintError",
     "ConstraintViolationError",
     "ConstraintCreationError",
+    "TransactionConflictError",
+    "retry_on_conflict",
     "NodeNotFoundError",
     "ConnectionNotFoundError",
     "PropertyNotFoundError",
@@ -98,7 +100,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConnectionNotFoundError": {
@@ -108,7 +115,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintCreationError": {
@@ -118,7 +130,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintError": {
@@ -128,7 +145,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "ConstraintViolationError": {
@@ -138,7 +160,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "CypherError": {
@@ -148,7 +175,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "CypherExecutionError": {
@@ -159,6 +191,10 @@
       "constructor": null,
       "kind": "class",
       "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        },
         "col": {
           "kind": "attribute",
           "type": "NoneType"
@@ -178,6 +214,10 @@
       "constructor": null,
       "kind": "class",
       "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        },
         "col": {
           "kind": "attribute",
           "type": "NoneType"
@@ -196,7 +236,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "CypherTypeMismatchError": {
@@ -206,7 +251,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ExprError": {
@@ -216,7 +266,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileError": {
@@ -226,7 +281,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileFormatError": {
@@ -236,7 +296,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FileIoError": {
@@ -246,7 +311,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "FrozenGraph": {
@@ -279,7 +349,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "InternerCollisionError": {
@@ -289,7 +364,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "KgError": {
@@ -299,7 +379,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "NoneType"
+        }
+      },
       "module": "kglite"
     },
     "KnowledgeGraph": {
@@ -1100,7 +1185,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "NodeNotFoundError": {
@@ -1110,7 +1200,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "PropertyNotFoundError": {
@@ -1120,7 +1215,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "ResultIter": {
@@ -1220,7 +1320,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "Session": {
@@ -1328,6 +1433,21 @@
       },
       "module": "kglite"
     },
+    "TransactionConflictError": {
+      "bases": [
+        "KgError"
+      ],
+      "constructible": true,
+      "constructor": null,
+      "kind": "class",
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
+      "module": "kglite"
+    },
     "ValidationError": {
       "bases": [
         "KgError"
@@ -1335,7 +1455,12 @@
       "constructible": true,
       "constructor": null,
       "kind": "class",
-      "members": {},
+      "members": {
+        "code": {
+          "kind": "attribute",
+          "type": "str"
+        }
+      },
       "module": "kglite"
     },
     "__version__": {
@@ -1389,6 +1514,10 @@
     "outline": {
       "kind": "function",
       "signature": "(graph: 'KnowledgeGraph', root, edge: str, *, max_depth: int | None = None, body: str | None = None) -> str"
+    },
+    "retry_on_conflict": {
+      "kind": "function",
+      "signature": "(graph: 'Any', work: 'Callable[[Any], T]', *, attempts: 'int' = 5, base_delay: 'float' = 0.005, max_delay: 'float' = 0.5, jitter: 'bool' = True) -> 'T'"
     },
     "stamp_file_freshness": {
       "kind": "function",

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -1785,6 +1785,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1822,6 +1825,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2092,6 +2096,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3058,6 +3063,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3095,6 +3103,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3028,6 +3033,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3065,6 +3073,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3043,6 +3048,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3080,6 +3088,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -1770,6 +1770,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1807,6 +1810,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2077,6 +2081,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3028,6 +3033,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3065,6 +3073,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -1785,6 +1785,9 @@ pub kglite::api::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::api::KgError::Schema
 pub kglite::api::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::api::KgError::Schema::message: alloc::string::String
+pub kglite::api::KgError::TransactionConflict
+pub kglite::api::KgError::TransactionConflict::base_version: u64
+pub kglite::api::KgError::TransactionConflict::current_version: u64
 pub kglite::api::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -1822,6 +1825,7 @@ pub kglite::api::KgErrorCode::MissingArgument
 pub kglite::api::KgErrorCode::NodeNotFound
 pub kglite::api::KgErrorCode::PropertyNotFound
 pub kglite::api::KgErrorCode::Schema
+pub kglite::api::KgErrorCode::TransactionConflict
 pub kglite::api::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str
@@ -2092,6 +2096,7 @@ pub fn kglite::api::DirGraph::reindex(&mut self)
 pub fn kglite::api::DirGraph::resolve_alias<'a>(&'a self, node_type: &str, property: &'a str) -> &'a str
 pub fn kglite::api::DirGraph::set_type_connectivity(&self, triples: alloc::vec::Vec<kglite::graph::schema::ConnectivityTriple>)
 pub fn kglite::api::DirGraph::set_version(&mut self, v: u64)
+pub fn kglite::api::DirGraph::take_constraint_error(&mut self, message: &str) -> core::option::Option<kglite::error::KgError>
 pub fn kglite::api::DirGraph::upsert_connection_type_metadata(&mut self, conn_type: &str, source_type: &str, target_type: &str, prop_types: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::upsert_node_type_metadata(&mut self, node_type: &str, props: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
 pub fn kglite::api::DirGraph::vacuum(&mut self) -> std::collections::hash::map::HashMap<petgraph::graph_impl::NodeIndex, petgraph::graph_impl::NodeIndex>
@@ -3043,6 +3048,9 @@ pub kglite::error::KgError::PropertyNotFound::property: alloc::string::String
 pub kglite::error::KgError::Schema
 pub kglite::error::KgError::Schema::kind: kglite::error::SchemaErrorKindRepr
 pub kglite::error::KgError::Schema::message: alloc::string::String
+pub kglite::error::KgError::TransactionConflict
+pub kglite::error::KgError::TransactionConflict::base_version: u64
+pub kglite::error::KgError::TransactionConflict::current_version: u64
 pub kglite::error::KgError::Validation(kglite::api::ValidationError)
 impl kglite::error::KgError
 pub fn kglite::error::KgError::code(&self) -> kglite::error::KgErrorCode
@@ -3080,6 +3088,7 @@ pub kglite::error::KgErrorCode::MissingArgument
 pub kglite::error::KgErrorCode::NodeNotFound
 pub kglite::error::KgErrorCode::PropertyNotFound
 pub kglite::error::KgErrorCode::Schema
+pub kglite::error::KgErrorCode::TransactionConflict
 pub kglite::error::KgErrorCode::Validation
 impl kglite::error::KgErrorCode
 pub fn kglite::error::KgErrorCode::as_str(&self) -> &'static str

--- a/tests/test_decomposition_invariants.py
+++ b/tests/test_decomposition_invariants.py
@@ -146,8 +146,12 @@ def test_disk_copy_and_loaded_source_mutate_in_either_order(tmp_path, copy_first
     assert _count(copied) == 3
     source.save()
     copied.save(str(copy_path))
-    assert kglite.open(str(source_path)).cypher("MATCH (:Person {id: 20}) RETURN count(*) AS c").to_list() == [{"c": 0}]
-    assert kglite.open(str(copy_path)).cypher("MATCH (:Person {id: 10}) RETURN count(*) AS c").to_list() == [{"c": 0}]
+    # Read-back verification uses load(), not open(): `source` is still alive
+    # and still owns the write lease for source_path, and re-opening a path
+    # for writing merely to inspect it is what the single-writer guard exists
+    # to catch.
+    assert kglite.load(str(source_path)).cypher("MATCH (:Person {id: 20}) RETURN count(*) AS c").to_list() == [{"c": 0}]
+    assert kglite.load(str(copy_path)).cypher("MATCH (:Person {id: 10}) RETURN count(*) AS c").to_list() == [{"c": 0}]
 
 
 # ── Clone / derived views: preserve identity fields ──────────────────────────

--- a/tests/test_disk_sidecar_integrity.py
+++ b/tests/test_disk_sidecar_integrity.py
@@ -169,7 +169,10 @@ def test_durable_save_forces_fsync_with_warning(tmp_path):
     # The save is a real checkpoint: .kgl written, WAL truncated to header.
     assert os.path.exists(p)
     assert os.path.getsize(p + "-wal") == 5  # magic + version, no frames
-    # Data survives a reopen from the checkpoint alone.
+    # Data survives a reopen from the checkpoint alone. Release the first
+    # handle's writer lease first — reopening a path for writing while still
+    # holding it is refused by the single-writer guard.
+    del g
     g2 = kglite.open(p, durable=True)
     assert g2.cypher("MATCH (p:Person) RETURN count(*) AS c").scalar() == 1
 

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -13,6 +13,13 @@ Two child-death models, both real:
   on signal 9, which is what makes it a crash test rather than a shutdown
   test.
 
+A parent that seeds a checkpoint must ``del`` its handle before spawning the
+child. ``kglite.open`` holds a cross-process single-writer lease for the life
+of the graph, so a parent still holding one would block the child outright —
+and a parent that kept writing alongside the child would be the very
+lost-update bug the lease exists to prevent (see ``test_single_writer.py``).
+The ``del`` is the handover, not a formality.
+
 Every crash test runs for each storage mode that supports durability
 (:data:`DURABLE_STORAGE_MODES`). ``storage="disk"`` is deliberately excluded
 and its refusal is asserted in ``test_durable_rejects_disk_mode``.
@@ -196,6 +203,7 @@ def test_set_and_delete_survive_crash(tmp_path, storage):
     g.cypher("CREATE (:Person {id: 1, name: 'Alice', age: 30})")
     g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
     g.save()  # checkpoint
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,
@@ -219,6 +227,7 @@ def test_checkpoint_truncates_wal_then_recovers_post_checkpoint(tmp_path, storag
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()  # checkpoint: .kgl written, WAL truncated
     assert (tmp_path / "app.kgl").exists()
+    del g  # hand the write lease to the child; see the note at the top
 
     # Post-checkpoint mutation in a child that crashes.
     _crash_child(
@@ -299,6 +308,7 @@ def test_labels_survive_checkpoint_then_crash(tmp_path, storage):
     g = _open(tmp_path / "app.kgl", storage)
     g.cypher("CREATE (:Person:Employee {id: 1, name: 'Alice'})")
     g.save()  # labels go into the .kgl secondary_labels section; WAL truncated
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,
@@ -497,6 +507,7 @@ def test_durability_survives_an_auto_vacuum(tmp_path, storage):
         g.cypher(f"CREATE (:Doomed {{id: {i}}})")
     g.save()  # checkpoint, so recovery depends only on the WAL below
     g.set_auto_vacuum(0.3)
+    del g  # hand the write lease to the child; see the note at the top
 
     _crash_child(
         tmp_path,

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,309 @@
+"""The typed-error contract an application actually writes `except` clauses against.
+
+Two guarantees are under test, and both were broken before this suite existed:
+
+1. **A constraint violation is catchable by type, from every write path.**
+   `ConstraintViolationError` was previously unreachable — a violation raised
+   through Cypher arrived as `CypherExecutionError`, and one raised through the
+   bulk loader as `ArgumentError`, so the only handler an app could write was a
+   substring match on the message in its signup path.
+
+2. **A commit conflict is catchable by type and carries a stable code.**
+   It was previously `ArgumentError` ("Invalid argument: Transaction
+   conflict…"), with no `.code` anywhere on the surface.
+
+The message quality is asserted alongside the type on purpose: these messages
+name the constraint, the property, and the offending value, and adding a type
+must not be an excuse to regress them.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+
+# ─── A. Constraint violations are typed, on every write path ────────────────
+
+
+@pytest.fixture
+def users() -> kglite.KnowledgeGraph:
+    """A graph whose `User.email` is a NODE KEY (unique *and* present)."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"User": {"primary_key": "email", "required": ["email"]}}})
+    return kg
+
+
+def test_duplicate_signup_via_cypher_is_catchable_by_type(users):
+    """The signup case: `except kglite.ConstraintViolationError`, no substring match."""
+    users.cypher("CREATE (u:User {email: 'a@b.com', name: 'A'})")
+
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {email: 'a@b.com', name: 'B'})")
+
+    exc = excinfo.value
+    # Catchable at every level of the hierarchy an app might use.
+    assert isinstance(exc, kglite.ConstraintError)
+    assert isinstance(exc, kglite.KgError)
+    # ...and *not* as the generic execution error it used to be.
+    assert not isinstance(exc, kglite.CypherExecutionError)
+    assert exc.code == "ConstraintViolation"
+
+    # Message quality must survive the retyping: it still names the constraint,
+    # the property, the offending value, and the remedy.
+    message = str(exc)
+    assert "already exists" in message
+    assert "NODE KEY constraint on User.email" in message
+    assert "'a@b.com'" in message
+    assert "MERGE" in message
+
+
+def test_not_null_via_cypher_is_catchable_by_type(users):
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {name: 'no email'})")
+
+    message = str(excinfo.value)
+    assert "must have the property 'email'" in message
+    assert "NODE KEY constraint on User.email" in message
+    assert excinfo.value.code == "ConstraintViolation"
+
+
+def test_set_to_null_via_cypher_is_catchable_by_type(users):
+    users.cypher("CREATE (u:User {email: 'c@d.com'})")
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("MATCH (u:User) SET u.email = null")
+
+
+def test_remove_required_property_via_cypher_is_catchable_by_type(users):
+    users.cypher("CREATE (u:User {email: 'e@f.com'})")
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("MATCH (u:User) REMOVE u.email")
+
+
+def test_bulk_loader_violation_is_catchable_by_type():
+    """`add_nodes` is the funnel users trust most for volume; it raised
+    `ArgumentError` before, despite the docs promising the typed class."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"P": {"primary_key": "id", "required": ["email"]}}})
+
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        kg.add_nodes(pd.DataFrame([{"id": 1}]), "P", "id")
+
+    assert "NOT NULL constraint on P.email" in str(excinfo.value)
+    assert excinfo.value.code == "ConstraintViolation"
+
+
+def test_constraint_creation_failure_is_typed_and_distinct():
+    """Declaring a constraint the data already violates is a *different* fix
+    (deduplicate, then re-declare), so it stays a distinct sibling class."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:U {id: 1, email: 'd@d.com'})")
+    kg.cypher("CREATE (:U {id: 2, email: 'd@d.com'})")
+
+    with pytest.raises(kglite.ConstraintCreationError) as excinfo:
+        kg.define_schema({"nodes": {"U": {"unique": [["email"]]}}})
+
+    exc = excinfo.value
+    assert isinstance(exc, kglite.ConstraintError)
+    assert not isinstance(exc, kglite.ConstraintViolationError)
+    assert exc.code == "ConstraintCreationFailed"
+
+
+def test_cypher_create_constraint_ddl_violation_is_typed():
+    """The `CREATE CONSTRAINT` DDL path goes through its own raise sites."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:W {id: 1, email: 'x@x.com'})")
+    kg.cypher("CREATE (:W {id: 2, email: 'x@x.com'})")
+
+    with pytest.raises(kglite.ConstraintError) as excinfo:
+        kg.cypher("CREATE CONSTRAINT FOR (w:W) REQUIRE w.email IS UNIQUE")
+
+    assert excinfo.value.code in {"ConstraintViolation", "ConstraintCreationFailed"}
+
+
+def test_a_non_constraint_cypher_failure_is_still_a_cypher_error(users):
+    """The side channel must not mistype unrelated failures."""
+    users.cypher("CREATE (u:User {email: 'g@h.com'})")
+
+    with pytest.raises(kglite.CypherExecutionError) as excinfo:
+        users.cypher("MATCH (u:User) RETURN nonexistent_function(u)")
+
+    assert not isinstance(excinfo.value, kglite.ConstraintError)
+    assert excinfo.value.code == "CypherExecution"
+
+
+def test_a_successful_write_after_a_violation_is_unaffected(users):
+    """A parked violation must never leak into a later, successful execution."""
+    with pytest.raises(kglite.ConstraintViolationError):
+        users.cypher("CREATE (u:User {name: 'no email'})")
+
+    users.cypher("CREATE (u:User {email: 'ok@ok.com'})")
+    assert users.cypher("MATCH (u:User) RETURN count(u) AS n").to_list() == [{"n": 1}]
+
+    # ...and the *next* failure is still classified correctly, not stale.
+    with pytest.raises(kglite.ConstraintViolationError) as excinfo:
+        users.cypher("CREATE (u:User {email: 'ok@ok.com'})")
+    assert "already exists" in str(excinfo.value)
+
+
+# ─── B. Transaction conflicts are typed and carry a code ────────────────────
+
+
+def _two_node_graph() -> kglite.KnowledgeGraph:
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:N {id: 1, v: 0})")
+    kg.cypher("CREATE (:N {id: 2, v: 0})")
+    return kg
+
+
+def test_commit_conflict_raises_transaction_conflict_error():
+    kg = _two_node_graph()
+    t1 = kg.begin()
+    t2 = kg.begin()
+    t1.cypher("MATCH (n:N {id: 1}) SET n.v = 1")
+    t2.cypher("MATCH (n:N {id: 1}) SET n.v = 2")
+    t1.commit()
+
+    with pytest.raises(kglite.TransactionConflictError) as excinfo:
+        t2.commit()
+
+    exc = excinfo.value
+    assert isinstance(exc, kglite.KgError)
+    assert not isinstance(exc, kglite.ArgumentError)
+    assert exc.code == "TransactionConflict"
+    # The advice that was already good, plus the version gap.
+    message = str(exc)
+    assert "Retry the transaction" in message
+    assert "were not applied" in message
+
+
+def test_conflict_code_is_readable_without_an_instance():
+    """`.code` is a class constant too, so a dispatch table can be built up
+    front rather than inside an `except` block."""
+    assert kglite.TransactionConflictError.code == "TransactionConflict"
+    assert kglite.ConstraintViolationError.code == "ConstraintViolation"
+    assert kglite.CypherSyntaxError.code == "CypherSyntax"
+    # The abstract bases span several codes and so carry None.
+    assert kglite.KgError.code is None
+    assert kglite.ConstraintError.code is None
+
+
+def test_every_raised_error_carries_a_code():
+    """`.code` is a property of the surface, not of one lucky path."""
+    kg = kglite.KnowledgeGraph()
+    kg.cypher("CREATE (:U {id: 1})")
+
+    with pytest.raises(kglite.CypherSyntaxError) as syntax:
+        kg.cypher("MATCH (((")
+    assert syntax.value.code == "CypherSyntax"
+
+    with pytest.raises(kglite.KgError) as missing:
+        kg.cypher("MATCH (u:U) RETURN $undefined_param")
+    assert isinstance(missing.value.code, str) and missing.value.code
+
+
+def test_disjoint_transactions_still_conflict_by_design():
+    """Characterization test for a documented limitation.
+
+    OCC here is a whole-graph version check, not a read/write-set
+    intersection: a commit publishes the transaction's working copy by pointer
+    swap, so t2's copy does not contain t1's write and applying it would
+    silently revert t1. Rejecting is therefore *correct* for this commit model,
+    not a spurious failure — see docs/concepts/concurrency.md. If KGLite ever
+    gains a merging commit, this test is the one that should change.
+    """
+    kg = _two_node_graph()
+    t1 = kg.begin()
+    t2 = kg.begin()
+    t1.cypher("MATCH (n:N {id: 1}) SET n.v = 111")
+    t2.cypher("MATCH (n:N {id: 2}) SET n.v = 222")  # a different node
+    t1.commit()
+
+    # The lost update this rejection prevents: t2 still sees the pre-t1 value.
+    assert t2.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 0}]
+
+    with pytest.raises(kglite.TransactionConflictError):
+        t2.commit()
+
+    # t1's write survived precisely because t2 was refused.
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 111}]
+
+
+# ─── C. The retry loop, end to end ──────────────────────────────────────────
+
+
+def test_retry_on_conflict_succeeds_after_a_conflicting_commit():
+    """The loop every correct app needs: a writer that lost one race and won
+    on the retry, without the caller writing any retry code."""
+    kg = _two_node_graph()
+    attempts = []
+
+    def work(tx):
+        attempts.append(len(attempts) + 1)
+        # Interleave one competing commit, but only on the first attempt, so
+        # the first commit conflicts and the second succeeds.
+        if len(attempts) == 1:
+            kg.cypher("MATCH (n:N {id: 2}) SET n.v = 99")
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 42")
+        return "done"
+
+    result = kglite.retry_on_conflict(kg, work, base_delay=0, jitter=False)
+
+    assert result == "done"
+    assert len(attempts) == 2, "expected exactly one retry"
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 42}]
+
+
+def test_retry_on_conflict_commits_without_contention():
+    kg = _two_node_graph()
+    calls = []
+
+    def work(tx):
+        calls.append(1)
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 7")
+        return tx
+
+    kglite.retry_on_conflict(kg, work, base_delay=0, jitter=False)
+
+    assert len(calls) == 1, "no conflict means no retry"
+    assert kg.cypher("MATCH (n:N {id: 1}) RETURN n.v AS v").to_list() == [{"v": 7}]
+
+
+def test_retry_on_conflict_reraises_after_exhausting_attempts():
+    kg = _two_node_graph()
+
+    def work(tx):
+        # Guarantee a conflict on every single attempt.
+        kg.cypher("MATCH (n:N {id: 2}) SET n.v = 1")
+        tx.cypher("MATCH (n:N {id: 1}) SET n.v = 2")
+
+    with pytest.raises(kglite.TransactionConflictError) as excinfo:
+        kglite.retry_on_conflict(kg, work, attempts=3, base_delay=0, jitter=False)
+
+    # The real error survives the loop, codes and all.
+    assert excinfo.value.code == "TransactionConflict"
+
+
+def test_retry_on_conflict_does_not_retry_other_errors():
+    """Only conflicts are retried — a constraint violation is the caller's bug
+    and must surface immediately rather than being hammered `attempts` times."""
+    kg = kglite.KnowledgeGraph()
+    kg.define_schema({"nodes": {"User": {"primary_key": "email"}}})
+    kg.cypher("CREATE (u:User {email: 'dup@x.com'})")
+    calls = []
+
+    def work(tx):
+        calls.append(1)
+        tx.cypher("CREATE (u:User {email: 'dup@x.com'})")
+
+    with pytest.raises(kglite.ConstraintViolationError):
+        kglite.retry_on_conflict(kg, work, attempts=4, base_delay=0, jitter=False)
+
+    assert len(calls) == 1, "a non-conflict error must not be retried"
+
+
+def test_retry_on_conflict_rejects_a_nonsense_attempt_count():
+    kg = _two_node_graph()
+    with pytest.raises(ValueError, match="attempts must be >= 1"):
+        kglite.retry_on_conflict(kg, lambda tx: None, attempts=0)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -15,6 +15,7 @@ def test_open_creates_then_loads(tmp_path):
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()  # bare save uses the remembered path
     assert (tmp_path / "app.kgl").exists()
+    del g  # release the writer lease before reopening the same path
 
     g2 = kglite.open(p)  # exists -> load
     names = [r["n"] for r in g2.cypher("MATCH (p:Person) RETURN p.name AS n")]
@@ -26,10 +27,13 @@ def test_bare_save_round_trips(tmp_path):
     g = kglite.open(p)
     g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
     g.save()
+    del g  # each open() owns the path until released
     g = kglite.open(p)
     g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
     g.save()
-    assert kglite.open(p).cypher("MATCH (p) RETURN count(*) AS c").scalar() == 2
+    # Read-back uses load(): it takes no writer lease, so it works whether or
+    # not `g` is still holding one.
+    assert kglite.load(p).cypher("MATCH (p) RETURN count(*) AS c").scalar() == 2
 
 
 def test_save_as_updates_remembered_path(tmp_path):

--- a/tests/test_single_writer.py
+++ b/tests/test_single_writer.py
@@ -1,0 +1,322 @@
+"""Cross-process single-writer guard for ``kglite.open``.
+
+``open()`` is the write-back entry point — it remembers its path, logs to a
+WAL by default, and checkpoints on close — so two processes holding the same
+path both produce full snapshots at ``save()``, and whichever publishes last
+wins outright. Before the guard, both exited 0 and one writer's work vanished
+with no error, no warning, and nothing in the file to say it had happened.
+
+The guard is an advisory OS file lock on a ``<path>.lock`` sidecar, taken at
+``open()`` and held until ``close()`` / ``__exit__`` / drop. Three properties
+are load-bearing and each has a test here:
+
+- **It blocks a second writer, loudly**, naming the holding pid — an error a
+  reader of the traceback can act on without guessing.
+- **A crashed holder does not brick the graph.** The lock is owned by the OS,
+  not by the file's existence, so ``SIGKILL`` releases it even though the
+  sidecar stays on disk. If this ever regressed, users would learn to delete
+  lock files by reflex and the guard would be worth nothing.
+- **Readers are never blocked.** ``load()`` takes no lease, so read replicas
+  and analytics jobs keep working alongside a writer.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+import kglite
+
+PYBIN = sys.executable
+
+#: See ``tests/test_durability.py`` — ``SIGKILL`` is POSIX-only, and a crash
+#: test that silently degrades into a graceful-shutdown test on Windows is
+#: worse than one that does not run. The crashed-holder case is the whole
+#: reason this guard is safe to ship, so it must not be faked.
+requires_sigkill = pytest.mark.skipif(
+    not hasattr(signal, "SIGKILL"),
+    reason="SIGKILL is POSIX-only; this is a crash test and must not degrade into a graceful-shutdown test on Windows",
+)
+
+#: Long enough that the child is unambiguously still holding when the parent
+#: makes its assertions, short enough that a leaked child cannot outlive the
+#: suite's 120 s per-test ceiling.
+HOLD_SECONDS = 30
+
+
+def _seed(path: str) -> None:
+    """Create *path* as a real saved graph, releasing the lease afterwards."""
+    graph = kglite.open(path)
+    graph.cypher("CREATE (:Task {name: 'seed'})")
+    graph.save()
+    graph.close()
+
+
+def _write_script(directory: str, name: str, body: str) -> str:
+    script = os.path.join(directory, name)
+    with open(script, "w", encoding="utf-8") as handle:
+        handle.write(textwrap.dedent(body))
+    return script
+
+
+def _spawn_holder(directory: str, db: str) -> tuple[subprocess.Popen, str]:
+    """Start a child that opens *db* for writing and holds it.
+
+    Returns once the child has signalled that it owns the lease, so the
+    parent's assertions race nothing.
+    """
+    ready = os.path.join(directory, "ready")
+    script = _write_script(
+        directory,
+        "holder.py",
+        """
+        import sys, time, kglite
+        graph = kglite.open(sys.argv[1])
+        with open(sys.argv[2], "w") as handle:
+            handle.write("ready")
+        time.sleep(int(sys.argv[3]))
+        """,
+    )
+    child = subprocess.Popen([PYBIN, script, db, ready, str(HOLD_SECONDS)])
+    deadline = time.monotonic() + 30
+    while not os.path.exists(ready) and time.monotonic() < deadline:
+        if child.poll() is not None:
+            raise AssertionError(f"holder exited early with {child.returncode}")
+        time.sleep(0.02)
+    assert os.path.exists(ready), "holder never acquired the writer lease"
+    return child, ready
+
+
+def _reap(child: subprocess.Popen) -> None:
+    if child.poll() is None:
+        child.kill()
+    child.wait()
+
+
+def test_second_process_open_fails_instead_of_losing_writes(tmp_path):
+    """The audit's scenario: two processes, 20 writes each, 40 expected.
+
+    Before the guard both children exited 0 and the reopened graph held 20 —
+    one writer's work gone with no signal. The fix does not merge the two
+    writers; it makes the loser *fail loudly* instead of failing silently,
+    which is the difference between a bug report and silent data loss.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+
+    script = _write_script(
+        str(tmp_path),
+        "writer.py",
+        """
+        import sys, kglite
+        db, tag, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+        graph = kglite.open(db)
+        for index in range(count):
+            graph.cypher("CREATE (:Task {name: $nm})", params={"nm": f"{tag}-{index}"})
+        graph.save()
+        graph.close()
+        """,
+    )
+    first = subprocess.Popen([PYBIN, script, db, "A", "20"], stderr=subprocess.PIPE, text=True)
+    second = subprocess.Popen([PYBIN, script, db, "B", "20"], stderr=subprocess.PIPE, text=True)
+    _, first_err = first.communicate()
+    _, second_err = second.communicate()
+
+    codes = sorted([first.returncode, second.returncode])
+    assert codes == [0, 1], (
+        f"exactly one writer must win and the other must fail; got {codes} (this is the silent-loss regression)"
+    )
+    loser_err = first_err if first.returncode else second_err
+    assert "is open for writing by pid" in loser_err, loser_err
+
+    # The winner's 20 rows are intact and the loser wrote nothing — no
+    # partial interleaving, and no snapshot built on a stale read.
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 21, f"expected seed + one writer's 20 rows, got {total}"
+
+
+def test_blocked_open_names_the_holding_process(tmp_path):
+    """``KgError: app.kgl is open for writing by pid 4711`` — the message the
+    audit asked for. A pid the operator can look up is the whole difference
+    between an actionable error and a mystery."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db)
+        message = str(caught.value)
+        assert f"pid {child.pid}" in message, message
+        assert os.path.basename(db) in message, message
+        # A timestamp turns "some process has it" into "and it has had it
+        # since 09:15", which is what distinguishes a live writer from a
+        # forgotten one.
+        assert "since" in message, message
+    finally:
+        _reap(child)
+
+
+def test_reader_is_never_blocked_by_a_writer(tmp_path):
+    """``load()`` takes no lease.
+
+    The durability unit is ``save()``, which republishes the whole file, so a
+    reader either sees the previous consistent snapshot or the next one. Making
+    reads exclusive would break read-replica and analytics deployments to fix a
+    problem that only writers have.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        reader = kglite.load(db)
+        rows = reader.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()
+        assert rows[0]["c"] == 1
+        # A second concurrent reader is fine too — readers do not contend
+        # with each other any more than they contend with the writer.
+        assert kglite.load(db).cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()
+    finally:
+        _reap(child)
+
+
+@requires_sigkill
+def test_sigkill_holder_releases_the_lease(tmp_path):
+    """A crashed writer must not brick the graph.
+
+    ``SIGKILL`` is uncatchable, so no Rust ``Drop``, no ``atexit``, no
+    interpreter teardown runs — the sidecar lock file is left on disk exactly
+    as a crash leaves it. The lock is nevertheless released, because it is an
+    OS file-descriptor lock rather than a claim staked by the file's presence.
+    This is asserted, not assumed: if it regressed, the guard would turn every
+    crash into a permanent outage.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    lock_file = db + ".lock"
+
+    with pytest.raises(Exception):
+        kglite.open(db)
+
+    os.kill(child.pid, signal.SIGKILL)
+    assert child.wait() == -signal.SIGKILL, "child must have died on SIGKILL"
+
+    # The stale file survives the crash. That is expected and harmless, and
+    # is precisely why the error message tells users not to delete it.
+    assert os.path.exists(lock_file), "lock sidecar is persistent by design"
+
+    recovered = kglite.open(db)
+    recovered.cypher("CREATE (:Task {name: 'after-crash'})")
+    recovered.close()
+
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 2
+
+
+def test_close_releases_so_the_path_can_be_reopened(tmp_path):
+    """Two sequential ``with`` blocks over one path, in one process.
+
+    The graph object stays alive and bound after its ``with`` block, so if the
+    lease were held until garbage collection this everyday pattern would
+    deadlock against itself.
+    """
+    db = str(tmp_path / "app.kgl")
+    with kglite.open(db) as graph:
+        graph.cypher("CREATE (:Task {name: 'first'})")
+    with kglite.open(db) as graph:
+        graph.cypher("CREATE (:Task {name: 'second'})")
+
+    reopened = kglite.load(db)
+    total = reopened.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"]
+    assert total == 2
+
+
+def test_second_open_in_one_process_reports_itself(tmp_path):
+    """Overlapping opens inside one process are the same lost-update bug, and
+    are blocked the same way — but the message says so, rather than pointing at
+    a phantom "other process" with the caller's own pid."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    held = kglite.open(db)
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db)
+        assert "this same process" in str(caught.value), str(caught.value)
+        assert str(os.getpid()) in str(caught.value)
+    finally:
+        held.close()
+
+
+def test_lock_false_opts_out(tmp_path):
+    """The documented escape hatch, for callers coordinating externally.
+
+    Explicit and never the default — the point is that opting out of the guard
+    should be something a reviewer can see in the diff.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    first = kglite.open(db, lock=False)
+    second = kglite.open(db, lock=False)
+    assert first is not second
+    first.close()
+    second.close()
+
+
+def test_lock_false_neither_takes_nor_checks_the_lease(tmp_path):
+    """The escape hatch is a full opt-out, and is documented as one.
+
+    ``lock=False`` does not consult the lease either, so it will happily open
+    alongside a live holder — including one in another process. That is the
+    whole point (an external supervisor may be doing the coordinating), and it
+    is also exactly why it must stay explicit: a caller that reaches for it
+    without a coordination story has re-armed the original data-loss bug.
+    """
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    child, _ = _spawn_holder(str(tmp_path), db)
+    try:
+        # A guarded open is refused...
+        with pytest.raises(Exception):
+            kglite.open(db)
+        # ...and an explicitly unguarded one is not.
+        bypass = kglite.open(db, lock=False)
+        assert bypass.cypher("MATCH (t:Task) RETURN count(t) AS c").to_dicts()[0]["c"] == 1
+        bypass.close()
+    finally:
+        _reap(child)
+
+
+def test_lock_false_still_allows_a_guarded_writer(tmp_path):
+    """An unguarded opener must not leave a stale lease behind that blocks the
+    next honest writer."""
+    db = str(tmp_path / "app.kgl")
+    _seed(db)
+    unguarded = kglite.open(db, lock=False)
+    unguarded.close()
+    guarded = kglite.open(db)
+    guarded.close()
+
+
+def test_disk_mode_is_guarded_at_open(tmp_path):
+    """Disk graphs previously failed only at the first mutation, with a raw
+    ``Resource temporarily unavailable`` errno. They now fail at ``open()``
+    with the same named message as every other storage mode."""
+    db = str(tmp_path / "diskgraph")
+    seed = kglite.open(db, storage="disk")
+    seed.cypher("CREATE (:Task {name: 'seed'})")
+    seed.save()
+    seed.close()
+    del seed
+
+    held = kglite.open(db, storage="disk")
+    try:
+        with pytest.raises(Exception) as caught:
+            kglite.open(db, storage="disk")
+        assert "is open for writing by" in str(caught.value), str(caught.value)
+    finally:
+        held.close()


### PR DESCRIPTION
Integration branch merging two completed PRs so their combined tree gets one CI run.

- **#82 — single-writer guard.** Two processes opening one durable graph silently lost a writer's work. Adds a writer lease (`.lock` + `.lock-owner` sidecar), contention classified via `fs2::lock_contended_error()` on `raw_os_error()` so it is correct on both `flock` (Unix, EWOULDBLOCK) and `LockFileEx` (Windows, ERROR_LOCK_VIOLATION). Includes three Windows fixes, one of them a read-only-handle `sync_all` that could never have flushed on Windows.
- **#83 — typed constraint/conflict exceptions.** Replaces string-matched error handling with a real taxonomy, plus `kglite/retry.py`.

Both merged with no conflicts. The generated `tests/api-baselines/python-api.json` was textually merged and verified to carry both feature sets; CI's baseline check is authoritative.

No version bump — workspace stays 0.14.5, all entries under `[Unreleased]`.