### PR TITLE
fix: the undo-journal fast path now applies to saved and indexed graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The undo-journal fast path now applies to graphs that have been saved.**
+  Statement rollback uses a cheap O(changes) undo journal wherever it can, and
+  falls back to a whole-graph O(V+E) clone taken before *every* mutating
+  statement otherwise. The fast path previously excluded any graph holding
+  columnar property stores — which is every graph that has been through
+  `save()`, since saving enables columnar storage and nothing on a mutation
+  path turns it off again. A single `save()` therefore moved the process onto
+  the clone path permanently, and the cost of each subsequent write scaled
+  with the size of the whole graph rather than with what the write touched.
+
+  The exclusion was aimed at one real side channel — `SET` on a columnar
+  property writes the shared per-type store directly — which is now covered
+  instead of avoided: the master store is restored from the checkpoint's
+  schema copy, and the per-node handles come back through the journal. `CREATE`
+  and `DELETE` never touch a column store in memory mode at all.
+
+  Rollback behaviour is unchanged; this is a cost change only. The rollback
+  fidelity suite now runs every statement shape against a saved-graph fixture
+  as well as a fresh one.
+
 ### Fixed
 
 - **`kglite.open()` now enforces one writer per graph, instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fidelity suite now runs every statement shape against a saved-graph fixture
   as well as a fresh one.
 
+- **…and to graphs with user-created indexes.** The same fast path was
+  excluded for any graph holding a property, range, or composite index, for
+  the same reason and with the same permanence: one `create_index` moved every
+  later statement onto the whole-graph clone. That exclusion was the more
+  expensive of the two, and unlike columnar mode there was no way to
+  configure around it — dropping the index to buy back write speed turns the
+  lookup it served into a label scan.
+
+  Index maintenance is now journalled per bucket edit, with the position each
+  edit touched, so a failed statement restores bucket *order* and not merely
+  membership. Bucket order is the row order an indexed `MATCH` without
+  `ORDER BY` returns, so anything less would have made a rolled-back statement
+  observable. This uses the same `BucketAppended` / `BucketRemoved` entries
+  that already covered the built-in type and label indexes.
+
+  One behaviour change falls out of it: composite-index maintenance no longer
+  opportunistically drops buckets that were already empty before the write. It
+  only drops the ones the write itself emptied.
+
 ### Fixed
 
 - **`kglite.open()` now enforces one writer per graph, instead of silently

--- a/crates/kglite/src/graph/dir_graph/indexes.rs
+++ b/crates/kglite/src/graph/dir_graph/indexes.rs
@@ -16,6 +16,7 @@ use super::{DirGraph, IndexStats};
 use crate::datatypes::values::Value;
 use crate::graph::schema::{CompositeIndexKey, CompositeValue, IndexKey, InternedKey};
 use crate::graph::storage::backend::GraphBackend;
+use crate::graph::storage::undo::BucketId;
 use crate::graph::storage::GraphRead;
 use petgraph::graph::NodeIndex;
 
@@ -476,6 +477,164 @@ impl DirGraph {
     }
 
     // ========================================================================
+    // Statement-rollback capture for user indexes
+    // ========================================================================
+    //
+    // These helpers give the undo journal the *index* half of a statement's
+    // writes. Each records a bucket edit together with the position it
+    // touched, because bucket order is the row order an un-`ORDER BY`'d
+    // indexed `MATCH` returns (`lookup_by_index` hands the bucket `Vec`
+    // straight to the matcher) — restoring membership alone would leave a
+    // failed statement visible as a reordering.
+    //
+    // Each is one `Option` check when no checkpoint is capturing, which is
+    // every read and every statement outside a mutating one. They must be
+    // called *before* the edit they describe: an eviction needs the position
+    // while the node is still in the bucket, and an append needs to know
+    // whether the bucket existed beforehand.
+
+    /// Whether a statement checkpoint is currently capturing inverse ops.
+    #[inline]
+    fn capturing_undo(&mut self) -> bool {
+        self.graph.undo_journal_mut().is_some()
+    }
+
+    /// Journal `node_idx`'s position in a property-index bucket before it
+    /// leaves it.
+    fn note_property_eviction(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .property_indices
+            .get(key)
+            .and_then(|value_map| value_map.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::PropertyValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Range-index counterpart of [`note_property_eviction`](Self::note_property_eviction).
+    fn note_range_eviction(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .range_indices
+            .get(key)
+            .and_then(|btree| btree.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::RangeValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Composite-index counterpart of
+    /// [`note_property_eviction`](Self::note_property_eviction).
+    fn note_composite_eviction(
+        &mut self,
+        key: &CompositeIndexKey,
+        value: &CompositeValue,
+        node_idx: NodeIndex,
+    ) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .composite_indices
+            .get(key)
+            .and_then(|comp_map| comp_map.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::CompositeTuple {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Journal an append into a property-index bucket, recording whether the
+    /// bucket itself comes into existence with it.
+    fn note_property_append(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.property_indices.get(key) {
+            Some(value_map) => !value_map.contains_key(value),
+            // No such index: the caller's append will not happen either.
+            None => return,
+        };
+        let bucket = BucketId::PropertyValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    /// Range-index counterpart of [`note_property_append`](Self::note_property_append).
+    fn note_range_append(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.range_indices.get(key) {
+            Some(btree) => !btree.contains_key(value),
+            None => return,
+        };
+        let bucket = BucketId::RangeValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    /// Composite-index counterpart of
+    /// [`note_property_append`](Self::note_property_append).
+    fn note_composite_append(
+        &mut self,
+        key: &CompositeIndexKey,
+        value: &CompositeValue,
+        node_idx: NodeIndex,
+    ) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.composite_indices.get(key) {
+            Some(comp_map) => !comp_map.contains_key(value),
+            None => return,
+        };
+        let bucket = BucketId::CompositeTuple {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    // ========================================================================
     // Incremental Index Maintenance (called by Cypher mutations)
     // ========================================================================
 
@@ -503,9 +662,11 @@ impl DirGraph {
                 .collect()
         };
         for (key, value) in &prop_updates {
+            self.note_property_append(key, value, node_idx);
             if let Some(value_map) = self.property_indices.get_mut(key) {
                 value_map.entry(value.clone()).or_default().push(node_idx);
             }
+            self.note_range_append(key, value, node_idx);
             if let Some(btree) = self.range_indices.get_mut(key) {
                 btree.entry(value.clone()).or_default().push(node_idx);
             }
@@ -541,6 +702,7 @@ impl DirGraph {
                 .collect()
         };
         for (key, comp_val) in comp_updates {
+            self.note_composite_append(&key, &comp_val, node_idx);
             if let Some(comp_map) = self.composite_indices.get_mut(&key) {
                 comp_map.entry(comp_val).or_default().push(node_idx);
             }
@@ -558,9 +720,12 @@ impl DirGraph {
         new_value: &Value,
     ) {
         let key = (node_type.to_string(), property.to_string());
-        // Update hash index
-        if let Some(value_map) = self.property_indices.get_mut(&key) {
-            if let Some(old_val) = old_value {
+        // Update hash index. Vacating the old bucket and joining the new one
+        // are journalled separately, and each capture has to read the map as
+        // it stands just before its own edit — hence the split borrows.
+        if let Some(old_val) = old_value {
+            self.note_property_eviction(&key, old_val, node_idx);
+            if let Some(value_map) = self.property_indices.get_mut(&key) {
                 if let Some(indices) = value_map.get_mut(old_val) {
                     indices.retain(|&idx| idx != node_idx);
                     if indices.is_empty() {
@@ -568,14 +733,18 @@ impl DirGraph {
                     }
                 }
             }
+        }
+        self.note_property_append(&key, new_value, node_idx);
+        if let Some(value_map) = self.property_indices.get_mut(&key) {
             value_map
                 .entry(new_value.clone())
                 .or_default()
                 .push(node_idx);
         }
         // Update range index
-        if let Some(btree) = self.range_indices.get_mut(&key) {
-            if let Some(old_val) = old_value {
+        if let Some(old_val) = old_value {
+            self.note_range_eviction(&key, old_val, node_idx);
+            if let Some(btree) = self.range_indices.get_mut(&key) {
                 if let Some(indices) = btree.get_mut(old_val) {
                     indices.retain(|&idx| idx != node_idx);
                     if indices.is_empty() {
@@ -583,6 +752,9 @@ impl DirGraph {
                     }
                 }
             }
+        }
+        self.note_range_append(&key, new_value, node_idx);
+        if let Some(btree) = self.range_indices.get_mut(&key) {
             btree.entry(new_value.clone()).or_default().push(node_idx);
         }
 
@@ -599,6 +771,7 @@ impl DirGraph {
         old_value: &Value,
     ) {
         let key = (node_type.to_string(), property.to_string());
+        self.note_property_eviction(&key, old_value, node_idx);
         if let Some(value_map) = self.property_indices.get_mut(&key) {
             if let Some(indices) = value_map.get_mut(old_value) {
                 indices.retain(|&idx| idx != node_idx);
@@ -607,6 +780,7 @@ impl DirGraph {
                 }
             }
         }
+        self.note_range_eviction(&key, old_value, node_idx);
         if let Some(btree) = self.range_indices.get_mut(&key) {
             if let Some(indices) = btree.get_mut(old_value) {
                 indices.retain(|&idx| idx != node_idx);
@@ -651,25 +825,54 @@ impl DirGraph {
         };
 
         for key in comp_keys {
-            if let Some(comp_map) = self.composite_indices.get_mut(&key) {
-                // Remove node from all existing composite buckets
-                for indices in comp_map.values_mut() {
-                    indices.retain(|&idx| idx != node_idx);
-                }
-                // Remove empty buckets
-                comp_map.retain(|_, v| !v.is_empty());
-
-                // Build new composite value from current properties
-                let new_values: Vec<Value> = key
-                    .1
+            // The buckets this node currently sits in, read before vacating
+            // any of them so each position can be journalled.
+            let occupied: Vec<CompositeValue> = match self.composite_indices.get(&key) {
+                Some(comp_map) => comp_map
                     .iter()
-                    .map(|p| current_props.get(p).cloned().unwrap_or(Value::Null))
-                    .collect();
-                if new_values.iter().any(|v| !matches!(v, Value::Null)) {
-                    comp_map
-                        .entry(CompositeValue(new_values))
-                        .or_default()
-                        .push(node_idx);
+                    .filter(|(_, members)| members.contains(&node_idx))
+                    .map(|(value, _)| value.clone())
+                    .collect(),
+                None => continue,
+            };
+            for value in &occupied {
+                self.note_composite_eviction(&key, value, node_idx);
+            }
+            if let Some(comp_map) = self.composite_indices.get_mut(&key) {
+                // Vacate exactly the buckets this node was in, and drop only
+                // the ones this call emptied. The blanket
+                // `retain(|_, v| !v.is_empty())` this replaces also swept away
+                // buckets that were already empty before the call — harmless
+                // in itself, but it made the edit unrepresentable as an
+                // inverse, and "restore the pre-statement graph" includes the
+                // empty buckets it had.
+                for value in &occupied {
+                    let emptied = match comp_map.get_mut(value) {
+                        Some(members) => {
+                            members.retain(|&idx| idx != node_idx);
+                            members.is_empty()
+                        }
+                        None => false,
+                    };
+                    if emptied {
+                        comp_map.remove(value);
+                    }
+                }
+            }
+
+            // Build new composite value from current properties
+            let new_values: Vec<Value> = key
+                .1
+                .iter()
+                .map(|p| current_props.get(p).cloned().unwrap_or(Value::Null))
+                .collect();
+            if new_values.iter().any(|v| !matches!(v, Value::Null)) {
+                let value = CompositeValue(new_values);
+                // After the evictions, so `bucket_was_new` reflects the map
+                // the append actually lands in.
+                self.note_composite_append(&key, &value, node_idx);
+                if let Some(comp_map) = self.composite_indices.get_mut(&key) {
+                    comp_map.entry(value).or_default().push(node_idx);
                 }
             }
         }

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -106,6 +106,8 @@
 
 use std::collections::HashSet;
 
+use petgraph::graph::NodeIndex;
+
 use super::DirGraph;
 use crate::graph::storage::undo::{BucketId, UndoEntry, UndoJournal};
 use crate::graph::storage::{GraphRead, GraphWrite};
@@ -121,6 +123,14 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
     std::mem::swap(&mut a.graph, &mut b.graph);
     std::mem::swap(&mut a.type_indices, &mut b.type_indices);
     std::mem::swap(&mut a.id_indices, &mut b.id_indices);
+    // The three user-index families are journalled per *bucket edit* — the
+    // incremental maintenance a statement's writes drive. Whole-index DDL
+    // (`create_index` / `drop_index`, which replace a map wholesale) is not,
+    // so a `CREATE INDEX` that failed after installing its map would leave the
+    // map behind while the shell restored the `*_index_keys` list without it.
+    // That is unreachable rather than handled: on the journal-capable backend
+    // index DDL performs no fallible step after it mutates. A new fallible
+    // step there needs an undo entry for the whole index, or an explicit veto.
     std::mem::swap(&mut a.property_indices, &mut b.property_indices);
     std::mem::swap(&mut a.composite_indices, &mut b.composite_indices);
     std::mem::swap(&mut a.range_indices, &mut b.range_indices);
@@ -143,33 +153,48 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
     std::mem::swap(&mut a.unique_indices, &mut b.unique_indices);
 }
 
+/// Reverse one bucket append: drop the *last* copy of `idx`, which is the one
+/// the append pushed.
+///
+/// `retain`-style removal would be wrong here — it also drops an occurrence
+/// that pre-dated the statement, and a bucket can legitimately be appended to
+/// twice within one statement.
+fn undo_bucket_append(members: Option<&mut Vec<NodeIndex>>, idx: NodeIndex) {
+    if let Some(members) = members {
+        if let Some(pos) = members.iter().rposition(|member| *member == idx) {
+            members.remove(pos);
+        }
+    }
+}
+
 /// Whether the undo journal can reverse everything this graph's mutations can
 /// change. Conservative by construction — every `false` arm falls back to the
 /// clone checkpoint, so a shape that is merely *unproven* is still safe.
+///
+/// Only the backend is a gate now. Three graph-state vetoes that used to sit
+/// here are gone, and the reasoning for each is worth keeping, because
+/// re-adding one is cheap to type and expensive to run — a veto here is not a
+/// local slowdown but a permanent, whole-graph downgrade to an O(V+E) clone
+/// per statement, for every shape, for the rest of the session.
+///
+/// - **`column_stores`** guarded the columnar-`SET` master side channel, but
+///   fired on every graph that had ever been saved. Covered instead by the
+///   unparked shell restore plus journalled handle refresh; see the module
+///   doc.
+/// - **`property_indices` / `range_indices` / `composite_indices`** guarded
+///   the absence of position undo for user-index buckets. That undo now
+///   exists, recorded at the incremental-maintenance choke points in
+///   [`crate::graph::dir_graph::indexes`] and
+///   [`crate::graph::mutation::maintain`] with the same `BucketAppended` /
+///   `BucketRemoved` entries `type_indices` already used. Whole-index DDL is
+///   still not journalled — see the note on [`swap_data_scale`].
+/// - **`unique_indices`** was never gated: it reads as doctrine-consistent,
+///   but routing every constrained graph to `fork_transaction()` is strictly
+///   worse than the journal plus a per-touched-type unique rebuild, which is
+///   that field's undo story.
 fn journal_covers(graph: &DirGraph) -> bool {
     // Only the heap backend can express an inverse petgraph edit.
     graph.graph.supports_undo_journal()
-        // Deliberately *not* gated on `column_stores.is_empty()`. That read as
-        // a narrow guard on the columnar-`SET` master side channel, but it
-        // vetoed every statement shape on every saved graph — `save()` calls
-        // `enable_columnar`, and nothing on a mutation path ever empties the
-        // map again. The side channel is covered instead: the master store is
-        // restored verbatim from the unparked shell (`Arc::make_mut` cannot
-        // touch the shell's handle) and the per-node handles come back through
-        // the journal. See the module doc for the full argument.
-        //
-        // User-created indexes need per-bucket position undo on the delete
-        // path, which the journal does not record yet. Empty in the default
-        // graph — `create_index` opts in. Follow-up, tracked in the sprint
-        // report.
-        && graph.property_indices.is_empty()
-        && graph.composite_indices.is_empty()
-        && graph.range_indices.is_empty()
-    // Deliberately *not* gated on `unique_indices.is_empty()`. It reads as
-    // doctrine-consistent but is a pessimisation: it would route every
-    // constrained graph to `fork_transaction()`, an O(V+E) clone of everything,
-    // which is strictly worse than the journal plus a per-touched-type unique
-    // rebuild. The rebuild is that field's undo story.
 }
 
 /// An open rollback checkpoint for exactly one mutating statement.
@@ -409,6 +434,35 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
                     }
                 }
             }
+            // The three user-index families share one shape: undo the push,
+            // then drop the bucket only if this statement created it. An
+            // emptied-but-pre-existing bucket is left in place because the
+            // maintenance paths leave one there too, and restoring the
+            // pre-statement graph means restoring that as well.
+            BucketId::PropertyValue { key, value } => {
+                if let Some(value_map) = graph.property_indices.get_mut(&key) {
+                    undo_bucket_append(value_map.get_mut(&value), idx);
+                    if bucket_was_new {
+                        value_map.remove(&value);
+                    }
+                }
+            }
+            BucketId::RangeValue { key, value } => {
+                if let Some(btree) = graph.range_indices.get_mut(&key) {
+                    undo_bucket_append(btree.get_mut(&value), idx);
+                    if bucket_was_new {
+                        btree.remove(&value);
+                    }
+                }
+            }
+            BucketId::CompositeTuple { key, value } => {
+                if let Some(comp_map) = graph.composite_indices.get_mut(&key) {
+                    undo_bucket_append(comp_map.get_mut(&value), idx);
+                    if bucket_was_new {
+                        comp_map.remove(&value);
+                    }
+                }
+            }
         },
         UndoEntry::BucketRemoved { bucket, idx, pos } => match bucket {
             BucketId::NodeType(name) => {
@@ -420,6 +474,31 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
                 let members = graph.secondary_label_index.entry(label).or_default();
                 let pos = pos.min(members.len());
                 members.insert(pos, idx);
+            }
+            // A bucket the statement emptied was dropped from its map by the
+            // maintenance path, so re-inserting has to recreate it. If the
+            // index itself is gone the entry is skipped: nothing to restore
+            // into, and a rolled-back statement never removes an index.
+            BucketId::PropertyValue { key, value } => {
+                if let Some(value_map) = graph.property_indices.get_mut(&key) {
+                    let members = value_map.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
+            }
+            BucketId::RangeValue { key, value } => {
+                if let Some(btree) = graph.range_indices.get_mut(&key) {
+                    let members = btree.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
+            }
+            BucketId::CompositeTuple { key, value } => {
+                if let Some(comp_map) = graph.composite_indices.get_mut(&key) {
+                    let members = comp_map.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
             }
         },
         UndoEntry::TimeseriesRemoved { node, prior } => {
@@ -457,7 +536,6 @@ fn debug_assert_slot_reused(restored: usize, expected: usize, kind: &str) {
 mod tests {
     use super::*;
     use crate::datatypes::Value;
-    use petgraph::graph::NodeIndex;
     use petgraph::stable_graph::StableDiGraph;
     use std::collections::HashMap;
 
@@ -537,15 +615,33 @@ mod tests {
         assert_eq!(graph.type_indices.len(), 1);
     }
 
-    /// A graph with user-created property indexes must keep the clone
-    /// checkpoint until the journal learns to reverse them.
+    /// User-created indexes no longer veto the journal: their bucket edits are
+    /// journalled with positions, so an indexed graph keeps the cheap
+    /// checkpoint instead of paying a whole-graph clone per statement for the
+    /// rest of the session.
     #[test]
-    fn gate_rejects_user_property_indexes() {
+    fn gate_accepts_user_property_indexes() {
         let mut graph = DirGraph::new();
         assert!(journal_covers(&graph));
         graph
             .property_indices
             .insert(("Item".to_string(), "name".to_string()), HashMap::new());
-        assert!(!journal_covers(&graph));
+        graph
+            .range_indices
+            .insert(("Item".to_string(), "qty".to_string()), Default::default());
+        graph.composite_indices.insert(
+            ("Item".to_string(), vec!["name".to_string()]),
+            HashMap::new(),
+        );
+        assert!(journal_covers(&graph));
+    }
+
+    /// Undoing an append must remove the copy the append pushed, not every
+    /// copy — a bucket can hold a pre-statement occurrence of the same node.
+    #[test]
+    fn undoing_an_append_leaves_a_pre_existing_occurrence() {
+        let mut members = vec![NodeIndex::new(3), NodeIndex::new(7), NodeIndex::new(3)];
+        undo_bucket_append(Some(&mut members), NodeIndex::new(3));
+        assert_eq!(members, vec![NodeIndex::new(3), NodeIndex::new(7)]);
     }
 }

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -52,6 +52,39 @@
 //! explicit addition to [`swap_data_scale`] can introduce a correctness gap,
 //! and that is a change a reviewer is looking straight at.
 //!
+//! ## Columnar mode rides on the unparked half
+//!
+//! `column_stores` — the per-type master `Arc<ColumnStore>` map that `save()`
+//! installs via `enable_columnar` — is deliberately **not** parked, and that
+//! is the whole of its undo story. The shell clone captures one pre-statement
+//! `Arc` handle per type and `restore_schema_shell` reinstalls it verbatim.
+//! What makes that sufficient rather than merely hopeful:
+//!
+//! - `ColumnStore` has no interior mutability, and the only in-statement
+//!   writer of a master store is `execute_set`'s columnar fast path, which
+//!   goes through `Arc::make_mut`. The shell's handle keeps the refcount above
+//!   one for the whole statement, so `make_mut` provably copies-on-write and
+//!   the shell's store is never mutated in place.
+//! - Every node of a columnar type holds its own `Arc` clone of the store, so
+//!   the post-`make_mut` handle-refresh sweep re-points them all. That sweep
+//!   runs through `node_weight_mut_silent`, which is silent only towards the
+//!   WAL recorder — `MemoryGraph` does not override it, so each re-pointed
+//!   node's pre-statement `NodeData` (old handle and row id included) lands in
+//!   the journal as a `NodeWeight` entry.
+//! - `CREATE` and `DELETE` never reach a master store in memory mode: the
+//!   in-memory insert branch always builds a `Compact` node, and node removal
+//!   is a plain backend edit. Every other writer of `column_stores`
+//!   (`enable_columnar`, `disable_columnar`, `vacuum`, the spill and bulk-batch
+//!   paths, disk sync) runs outside the statement window.
+//!
+//! So a columnar graph is restored on both halves — master by verbatim shell
+//! restore, per-node handles by the journal — and needs no veto. The one cost
+//! to know about: because the refresh sweep touches every node of the type, a
+//! columnar `SET` journals one `NodeData` pre-image per node of that type
+//! rather than per row written. That is O(type), not O(changes) — still
+//! strictly cheaper than the O(V+E) fork it replaces, and it is the sweep's
+//! own cost that dominates either way.
+//!
 //! ## When the journal is not used
 //!
 //! [`journal_covers`] is the gate. It is conservative on purpose: any shape
@@ -116,11 +149,15 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
 fn journal_covers(graph: &DirGraph) -> bool {
     // Only the heap backend can express an inverse petgraph edit.
     graph.graph.supports_undo_journal()
-        // Columnar `SET` writes the shared per-type `Arc<ColumnStore>` through
-        // a side channel that bypasses `GraphWrite` entirely
-        // (`cypher::executor::write`'s columnar-master fast path), so the
-        // journal never sees the pre-image.
-        && graph.column_stores.is_empty()
+        // Deliberately *not* gated on `column_stores.is_empty()`. That read as
+        // a narrow guard on the columnar-`SET` master side channel, but it
+        // vetoed every statement shape on every saved graph — `save()` calls
+        // `enable_columnar`, and nothing on a mutation path ever empties the
+        // map again. The side channel is covered instead: the master store is
+        // restored verbatim from the unparked shell (`Arc::make_mut` cannot
+        // touch the shell's handle) and the per-node handles come back through
+        // the journal. See the module doc for the full argument.
+        //
         // User-created indexes need per-bucket position undo on the delete
         // path, which the journal does not record yet. Empty in the default
         // graph — `create_index` opts in. Follow-up, tracked in the sprint

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -16,9 +16,10 @@
 //!   while evaluating a later pattern's properties.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::datatypes::Value;
-use crate::graph::schema::DirGraph;
+use crate::graph::schema::{DirGraph, PropertyStorage};
 use crate::graph::session::execute::{execute_mut, ExecuteOptions};
 use crate::graph::storage::GraphRead;
 
@@ -38,6 +39,16 @@ type NodeFingerprint = (usize, String, String, String, PropPairs, Vec<String>);
 /// `(slot, src slot, tgt slot, conn type, sorted properties)`.
 type EdgeFingerprint = (usize, usize, usize, String, PropPairs);
 
+/// One master column store's rows: `(row id, id, title, sorted properties)`.
+///
+/// Read from `DirGraph::column_stores` — the *master* handle — not from a
+/// node's own `Arc` clone of it. The two can diverge (`Arc::make_mut` forks
+/// them on every columnar write), and only the node-side half shows up in
+/// `NodeFingerprint`. A rollback that restored the nodes but left the master
+/// carrying the failed statement's values would look clean node-side and then
+/// resurrect those values on the next `SET` or `save()`.
+type MasterRows = Vec<(u32, String, String, PropPairs)>;
+
 #[derive(Debug, PartialEq, Eq)]
 struct Fingerprint {
     version: u64,
@@ -56,6 +67,16 @@ struct Fingerprint {
     /// `(node_type, id)` → slot, read through the id index so a stale or
     /// unrebuilt index shows up as a mismatch.
     id_lookup: Vec<(String, String, usize)>,
+    /// Master column stores per node type. Empty on a non-columnar graph.
+    column_masters: Vec<(String, MasterRows)>,
+    /// Per columnar node slot: is its own `Arc<ColumnStore>` handle still the
+    /// same allocation as its type's master? `execute_set` writes the master
+    /// through `Arc::make_mut` — which forks it away from every node holding a
+    /// handle — and then re-points all of them at the fork. A rollback has to
+    /// put both halves back *together*: leaving the nodes on the pre-statement
+    /// store while the master keeps the fork (or the reverse) is the failure
+    /// mode this pins, and it is invisible to a values-only comparison.
+    columnar_handles: Vec<(usize, bool)>,
 }
 
 fn sorted_props(props: &HashMap<String, Value>) -> Vec<(String, String)> {
@@ -165,6 +186,53 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
     }
     id_lookup.sort();
 
+    let mut column_masters: Vec<(String, MasterRows)> = graph
+        .column_stores
+        .iter()
+        .map(|(node_type, store)| {
+            let rows: MasterRows = (0..store.row_count())
+                .map(|row| {
+                    let mut props: PropPairs = store
+                        .row_properties(row)
+                        .into_iter()
+                        .map(|(key, value)| {
+                            (
+                                graph.interner.resolve(key).to_string(),
+                                format!("{value:?}"),
+                            )
+                        })
+                        .collect();
+                    props.sort();
+                    (
+                        row,
+                        format!("{:?}", store.get_id(row)),
+                        format!("{:?}", store.get_title(row)),
+                        props,
+                    )
+                })
+                .collect();
+            (node_type.clone(), rows)
+        })
+        .collect();
+    column_masters.sort();
+
+    let mut columnar_handles: Vec<(usize, bool)> = Vec::new();
+    for idx in graph.graph.node_indices().collect::<Vec<_>>() {
+        let Some(node) = graph.graph.node_weight(idx) else {
+            continue;
+        };
+        let PropertyStorage::Columnar { store, .. } = &node.properties else {
+            continue;
+        };
+        let node_type = node.node_type_str(&graph.interner);
+        let matches_master = graph
+            .column_stores
+            .get(node_type)
+            .is_some_and(|master| Arc::ptr_eq(store, master));
+        columnar_handles.push((idx.index(), matches_master));
+    }
+    columnar_handles.sort();
+
     Fingerprint {
         version: graph.version,
         node_count: graph.graph.node_count(),
@@ -177,6 +245,8 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
         node_type_metadata,
         connection_type_metadata,
         id_lookup,
+        column_masters,
+        columnar_handles,
     }
 }
 
@@ -241,176 +311,160 @@ fn seeded() -> DirGraph {
     graph
 }
 
+/// `seeded()` after `enable_columnar()` — the shape every graph takes the
+/// moment it is saved, and keeps for the rest of its life. `save()` calls
+/// `enable_columnar` (`io/file.rs`), and only the explicit `disable_columnar`
+/// ever empties `column_stores` again, so "has been saved once" is a permanent
+/// property of a live graph and every mutation after it runs in this shape.
+///
+/// The preconditions are asserted, not assumed. If `enable_columnar` ever
+/// stopped installing master stores, or stopped re-pointing nodes at them, the
+/// columnar arms below would quietly become a second run of the plain fixture
+/// and prove nothing.
+fn seeded_columnar() -> DirGraph {
+    let mut graph = seeded();
+    graph.enable_columnar();
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the fixture must own master column stores, or the columnar arms are vacuous"
+    );
+    let columnar_nodes = graph
+        .graph
+        .node_indices()
+        .filter(|idx| {
+            matches!(
+                graph.graph.node_weight(*idx).map(|node| &node.properties),
+                Some(PropertyStorage::Columnar { .. })
+            )
+        })
+        .count();
+    assert_eq!(
+        columnar_nodes,
+        graph.graph.node_count(),
+        "every seeded node must read its properties through a column store"
+    );
+    graph
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Per-shape rollback fidelity
 // ─────────────────────────────────────────────────────────────────────
 
-#[test]
-fn create_nodes_roll_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
-        "CREATE (:Item {id: 100}), (:Item {id: 101, bad: duration({months: 2147483648})})",
-        None,
-    );
+/// Every mid-statement-failure shape, run against every graph configuration.
+///
+/// One entry generates one module holding one test per fixture, so a failure
+/// names both the shape and the configuration it failed in
+/// (`create_nodes::columnar`).
+///
+/// The extra arms exist because the plain fixture cannot detect the bug class
+/// this file is for. `seeded()` is never saved and never indexed, so it can
+/// never trip a `journal_covers` veto — it takes the journal path
+/// unconditionally, and is therefore structurally incapable of noticing a
+/// journal path that is wrong for a graph that *has* been saved or indexed.
+/// Every shape must hold in every configuration a real application graph can
+/// be in.
+macro_rules! rollback_shapes {
+    ($($(#[$doc:meta])* $name:ident: $query:expr, $scope:expr;)*) => {
+        $(
+            $(#[$doc])*
+            mod $name {
+                use super::*;
+
+                /// A fresh in-memory graph: no column stores, no user indexes.
+                #[test]
+                fn plain() {
+                    assert_rolls_back(&mut seeded(), $query, $scope);
+                }
+
+                /// The saved-graph shape — `enable_columnar` has installed
+                /// master column stores that no mutation path ever removes.
+                #[test]
+                fn columnar() {
+                    assert_rolls_back(&mut seeded_columnar(), $query, $scope);
+                }
+            }
+        )*
+    };
 }
 
-#[test]
-fn create_nodes_and_edges_roll_back() {
-    let mut graph = seeded();
-    // The first pattern (nodes + edge) commits, the second is rejected by the
-    // write whitelist — so the journal must reverse two nodes and an edge.
-    assert_rolls_back(
-        &mut graph,
+rollback_shapes! {
+    create_nodes:
+        "CREATE (:Item {id: 100}), (:Item {id: 101, bad: duration({months: 2147483648})})",
+        None;
+
+    /// The first pattern (nodes + edge) commits, the second is rejected by the
+    /// write whitelist — so the journal must reverse two nodes and an edge.
+    create_nodes_and_edges:
         "CREATE (x:Item {id: 200})-[:LINKS {weight: 1}]->(y:Item {id: 201}), \
                 (z:Blocked {id: 202})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn create_with_secondary_labels_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    create_with_secondary_labels:
         "CREATE (:Tag:Hot:Fresh {id: 300}), (:Blocked {id: 301})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn set_properties_roll_back() {
-    let mut graph = seeded();
-    // Every Item is updated, then the expression on the last SET item blows
-    // up — a multi-property SET across multiple rows.
-    assert_rolls_back(
-        &mut graph,
+    /// Every Item is updated, then the expression on the last SET item blows
+    /// up — a multi-property SET across multiple rows.
+    set_properties:
         "MATCH (n:Item) SET n.qty = n.qty + 1, n.name = 'touched', \
                              n.bad = duration({months: 2147483648})",
-        None,
-    );
-}
+        None;
 
-#[test]
-fn set_on_second_type_rolls_back_first() {
-    let mut graph = seeded();
-    // One SET clause writing two node types: the Item write commits, then the
-    // Tag write is rejected by the whitelist mid-clause.
-    assert_rolls_back(
-        &mut graph,
+    /// One SET clause writing two node types: the Item write commits, then the
+    /// Tag write is rejected by the whitelist mid-clause.
+    set_on_second_type:
         "MATCH (n:Item), (t:Tag) WHERE n.id = 1 AND t.id = 1 \
          SET n.marker = 'x', t.marker = 'y'",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn set_label_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    set_label:
         "MATCH (t:Tag {id: 2}) SET t:Hot, t.bad = duration({months: 2147483648})",
-        None,
-    );
-}
+        None;
 
-#[test]
-fn remove_property_and_label_roll_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    remove_property_and_label:
         "MATCH (t:Tag {id: 1}) REMOVE t.name, t:Hot \
          CREATE (:Blocked {id: 400})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn detach_delete_rolls_back_nodes_edges_and_bucket_order() {
-    let mut graph = seeded();
-    // Deletes the middle Item — so its slot is a hole in the middle of the
-    // type_indices bucket, and restoring it at the end instead of in place
-    // would fail the fingerprint.
-    assert_rolls_back(
-        &mut graph,
+    /// Deletes the middle Item — so its slot is a hole in the middle of the
+    /// type_indices bucket, and restoring it at the end instead of in place
+    /// would fail the fingerprint.
+    detach_delete_one:
         "MATCH (n:Item {id: 2}) DETACH DELETE n CREATE (:Blocked {id: 500})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn detach_delete_all_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    detach_delete_all:
         "MATCH (n) DETACH DELETE n CREATE (:Blocked {id: 501})",
-        Some(&["Item", "Tag"]),
-    );
-}
+        Some(&["Item", "Tag"]);
 
-#[test]
-fn delete_labelled_node_restores_its_labels() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    delete_labelled_node:
         "MATCH (t:Tag) DETACH DELETE t CREATE (:Blocked {id: 502})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn delete_edge_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    delete_edge:
         "MATCH ()-[r:LINKS]->() DELETE r CREATE (:Blocked {id: 600})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn merge_create_arm_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    merge_create_arm:
         "MERGE (n:Item {id: 700}) ON CREATE SET n.name = 'new' \
          CREATE (:Blocked {id: 701})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn merge_match_arm_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    merge_match_arm:
         "MERGE (n:Item {id: 1}) ON MATCH SET n.name = 'seen' \
          CREATE (:Blocked {id: 702})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn foreach_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    foreach:
         "FOREACH (i IN [1, 2, 3] | CREATE (:Item {id: 800 + i})) \
          CREATE (:Blocked {id: 804})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn multi_clause_create_then_set_then_delete_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    multi_clause_create_then_set_then_delete:
         "MATCH (n:Item {id: 3}) SET n.qty = 999 \
          CREATE (:Item {id: 900}) \
          CREATE (:Blocked {id: 901})",
-        Some(&["Item"]),
-    );
+        Some(&["Item"]);
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -615,6 +615,41 @@ fn a_second_statement_after_a_rollback_still_commits() {
     );
 }
 
+/// One statement of each mutating shape, run in an order where each leaves the
+/// graph as the next expects it.
+const ZERO_COPY_QUERIES: &[&str] = &[
+    "CREATE (:Item {id: 2000, name: 'x'})",
+    "MATCH (n:Item {id: 1}) SET n.qty = 11, n.name = 'renamed'",
+    "MATCH (n:Item {id: 2000}) SET n:Featured",
+    "MATCH (a:Item {id: 1}), (b:Item {id: 3}) CREATE (a)-[:LINKS {weight: 2}]->(b)",
+    "MATCH (n:Item {id: 2000}) DETACH DELETE n",
+    "MERGE (n:Item {id: 2001}) ON CREATE SET n.name = 'merged'",
+];
+
+/// Assert no statement copies a node, i.e. every one of them took the journal
+/// path rather than the clone checkpoint.
+///
+/// The counter is `BACKEND_CLONE_NODES`, bumped by `impl Clone for
+/// GraphBackend` by the number of nodes copied. That is what makes it a real
+/// oracle for *which path ran*: the clone checkpoint forks the whole graph and
+/// registers the fixture's node count, while the journal checkpoint clones a
+/// `DirGraph` whose backend was deliberately emptied first and registers zero.
+/// It counts nodes only — a `HashMap` clone bumps nothing — so it says nothing
+/// about how much *else* a statement copied.
+fn assert_statements_copy_zero_nodes(graph: &mut DirGraph, fixture: &str) {
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+
+    for &query in ZERO_COPY_QUERIES {
+        reset_backend_clone_count();
+        run(graph, query);
+        assert_eq!(
+            backend_clone_nodes(),
+            0,
+            "statement must not copy any node on the {fixture} fixture: {query}"
+        );
+    }
+}
+
 /// The point of the whole exercise: a mutating statement on the journal path
 /// must not copy a single node. This is the regression guard for the
 /// O(V+E)-per-write cost the sprint removed — a benchmark would only notice
@@ -625,41 +660,91 @@ fn a_second_statement_after_a_rollback_still_commits() {
 /// that O(1) clone is the design, not a regression.
 #[test]
 fn journalled_statements_copy_zero_nodes() {
-    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+    assert_statements_copy_zero_nodes(&mut seeded(), "plain");
+}
 
-    let mut graph = seeded();
-    for query in [
-        "CREATE (:Item {id: 2000, name: 'x'})",
-        "MATCH (n:Item {id: 1}) SET n.qty = 11, n.name = 'renamed'",
-        "MATCH (n:Item {id: 2000}) SET n:Featured",
-        "MATCH (a:Item {id: 1}), (b:Item {id: 3}) CREATE (a)-[:LINKS {weight: 2}]->(b)",
-        "MATCH (n:Item {id: 2000}) DETACH DELETE n",
-        "MERGE (n:Item {id: 2001}) ON CREATE SET n.name = 'merged'",
-    ] {
-        reset_backend_clone_count();
-        run(&mut graph, query);
-        assert_eq!(
-            backend_clone_nodes(),
-            0,
-            "statement must not copy any node: {query}"
-        );
-    }
+/// The same guard on a graph that has been saved.
+///
+/// This arm is the one that would have caught the columnar veto. A fresh
+/// `seeded()` graph has no column stores and no user indexes, so it cannot
+/// take the clone path no matter what the gate says — which made the guard
+/// above structurally blind to a gate that sends every *real* application
+/// graph down the expensive path.
+#[test]
+fn journalled_statements_copy_zero_nodes_on_a_saved_graph() {
+    assert_statements_copy_zero_nodes(&mut seeded_columnar(), "columnar");
+}
+
+/// The same guard on a graph with user-created indexes — the other half of
+/// the blind spot.
+#[test]
+fn journalled_statements_copy_zero_nodes_on_an_indexed_graph() {
+    assert_statements_copy_zero_nodes(&mut seeded_indexed(), "indexed");
 }
 
 /// Rollback is allowed to be the expensive direction, but it must still not
 /// reach for a whole-graph copy on the journal path.
-#[test]
-fn journalled_rollback_copies_zero_nodes() {
+fn assert_rollback_copies_zero_nodes(graph: &mut DirGraph, fixture: &str) {
     use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
 
-    let mut graph = seeded();
     reset_backend_clone_count();
     expect_failure(
-        &mut graph,
+        graph,
         "MATCH (n:Item) DETACH DELETE n CREATE (:Blocked {id: 1})",
         Some(&["Item"]),
     );
-    assert_eq!(backend_clone_nodes(), 0);
+    assert_eq!(
+        backend_clone_nodes(),
+        0,
+        "rollback must not copy any node on the {fixture} fixture"
+    );
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes() {
+    assert_rollback_copies_zero_nodes(&mut seeded(), "plain");
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes_on_a_saved_graph() {
+    assert_rollback_copies_zero_nodes(&mut seeded_columnar(), "columnar");
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes_on_an_indexed_graph() {
+    assert_rollback_copies_zero_nodes(&mut seeded_indexed(), "indexed");
+}
+
+/// Pins that the `columnar` arms exercise the master side channel rather than
+/// quietly falling through to the per-node setter.
+///
+/// `execute_set`'s columnar fast path only fires for an in-memory `Columnar`
+/// node writing a property that is neither `title` nor `name`. If that stopped
+/// holding for this fixture — a storage-mode change, a different fallthrough
+/// condition — every columnar rollback arm above would still pass, while
+/// testing the write path that was never at risk. The veto this file's change
+/// removed was aimed squarely at the master write, so "the master write
+/// happens here" is a precondition of the whole exercise, not a detail.
+#[test]
+fn the_columnar_fixture_writes_through_the_master_store() {
+    let mut graph = seeded_columnar();
+    let before = fingerprint(&mut graph);
+    run(&mut graph, "MATCH (n:Item {id: 1}) SET n.qty = 12345");
+    let after = fingerprint(&mut graph);
+
+    assert_ne!(
+        before.column_masters, after.column_masters,
+        "a successful columnar SET must land in the master store; if it does \
+         not, the columnar arms are exercising the per-node fallback"
+    );
+    assert!(
+        after
+            .columnar_handles
+            .iter()
+            .all(|(_, matches_master)| *matches_master),
+        "the post-write refresh sweep must leave every node's handle on the \
+         new master — that sweep is what the journal has to reverse"
+    );
 }
 
 /// An indexed graph rolls back through the journal, not through a whole-graph

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -77,6 +77,13 @@ struct Fingerprint {
     /// store while the master keeps the fork (or the reverse) is the failure
     /// mode this pins, and it is invisible to a values-only comparison.
     columnar_handles: Vec<(usize, bool)>,
+    /// Every user-index bucket as `(index, value, members in bucket order)`.
+    /// Order matters: `lookup_by_index` hands the bucket `Vec` straight to the
+    /// matcher, so bucket order is the row order an indexed `MATCH` without
+    /// `ORDER BY` returns. A rollback that restored membership but appended
+    /// the node instead of putting it back where it was would be a visible
+    /// reordering, and this is what catches it.
+    user_indexes: Vec<(String, String, Vec<usize>)>,
 }
 
 fn sorted_props(props: &HashMap<String, Value>) -> Vec<(String, String)> {
@@ -233,6 +240,36 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
     }
     columnar_handles.sort();
 
+    let mut user_indexes: Vec<(String, String, Vec<usize>)> = Vec::new();
+    for ((node_type, property), value_map) in &graph.property_indices {
+        for (value, members) in value_map {
+            user_indexes.push((
+                format!("property {node_type}.{property}"),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    for ((node_type, property), btree) in &graph.range_indices {
+        for (value, members) in btree {
+            user_indexes.push((
+                format!("range {node_type}.{property}"),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    for ((node_type, properties), comp_map) in &graph.composite_indices {
+        for (value, members) in comp_map {
+            user_indexes.push((
+                format!("composite {node_type}.{}", properties.join("+")),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    user_indexes.sort();
+
     Fingerprint {
         version: graph.version,
         node_count: graph.graph.node_count(),
@@ -247,6 +284,7 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
         id_lookup,
         column_masters,
         columnar_handles,
+        user_indexes,
     }
 }
 
@@ -346,6 +384,38 @@ fn seeded_columnar() -> DirGraph {
     graph
 }
 
+/// `seeded()` plus one index of each user-created family over `Item`.
+///
+/// The indexed shape is not exotic: an application indexes the property it
+/// looks rows up by, and cannot opt out to get a faster write — dropping the
+/// index turns the lookup into a label scan. So this is the configuration a
+/// primary store actually runs in, and every shape has to hold in it.
+///
+/// `qty` is indexed twice on purpose (equality *and* range), because
+/// `CREATE RANGE INDEX` in Cypher installs both and the two are maintained by
+/// separate code.
+fn seeded_indexed() -> DirGraph {
+    let mut graph = seeded();
+    graph.create_index("Item", "name");
+    graph.create_index("Item", "qty");
+    graph.create_range_index("Item", "qty");
+    graph.create_composite_index("Item", &["name", "qty"]);
+    assert!(
+        !graph.property_indices.is_empty()
+            && !graph.range_indices.is_empty()
+            && !graph.composite_indices.is_empty(),
+        "all three index families must be live, or the indexed arms are vacuous"
+    );
+    assert!(
+        graph
+            .property_indices
+            .values()
+            .any(|value_map| value_map.values().any(|members| !members.is_empty())),
+        "the indexes must have been populated from the seeded nodes"
+    );
+    graph
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Per-shape rollback fidelity
 // ─────────────────────────────────────────────────────────────────────
@@ -381,6 +451,13 @@ macro_rules! rollback_shapes {
                 #[test]
                 fn columnar() {
                     assert_rolls_back(&mut seeded_columnar(), $query, $scope);
+                }
+
+                /// The indexed shape — one user index of each family, whose
+                /// buckets the statement's writes maintain incrementally.
+                #[test]
+                fn indexed() {
+                    assert_rolls_back(&mut seeded_indexed(), $query, $scope);
                 }
             }
         )*
@@ -585,19 +662,71 @@ fn journalled_rollback_copies_zero_nodes() {
     assert_eq!(backend_clone_nodes(), 0);
 }
 
-/// A graph with a user-created property index falls back to the clone
-/// checkpoint. The observable contract is the same, and this test exists so
-/// the fallback stays exercised rather than becoming dead code.
+/// An indexed graph rolls back through the journal, not through a whole-graph
+/// clone. The fidelity half is covered by the `indexed` arm of every shape
+/// above; what this pins is the *cost* half — that a user index no longer
+/// downgrades the checkpoint for the rest of the session.
 #[test]
-fn indexed_graph_still_rolls_back_via_the_clone_path() {
-    let mut graph = seeded();
-    graph.create_index("Item", "name");
-    assert!(!graph.property_indices.is_empty(), "index must be live");
+fn indexed_graph_rolls_back_without_copying_the_graph() {
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+
+    let mut graph = seeded_indexed();
+    reset_backend_clone_count();
     assert_rolls_back(
         &mut graph,
         "MATCH (n:Item) SET n.name = 'touched', n.bad = duration({months: 2147483648})",
         None,
     );
+    assert_eq!(
+        backend_clone_nodes(),
+        0,
+        "an indexed graph must take the journal path, not the clone checkpoint"
+    );
+}
+
+/// The bucket-order case the position journal exists for.
+///
+/// `Item` 1 and 3 share a `qty` after the setup write, so that bucket holds
+/// two members in a known order. A statement that moves the *first* member out
+/// and then fails must put it back at the front — a rollback that merely
+/// restored membership would append it, silently reordering the rows an
+/// indexed `MATCH` returns.
+#[test]
+fn rollback_restores_index_bucket_order_not_just_membership() {
+    let mut graph = seeded_indexed();
+    run(&mut graph, "MATCH (n:Item {id: 3}) SET n.qty = 10");
+    let bucket_before = index_bucket(&graph, "qty", Value::Int64(10));
+    assert_eq!(
+        bucket_before.len(),
+        2,
+        "the fixture needs a bucket with two members to have an order at all"
+    );
+
+    let before = fingerprint(&mut graph);
+    let error = expect_failure(
+        &mut graph,
+        "MATCH (n:Item {id: 1}) SET n.qty = 999 \
+         WITH n MATCH (m:Item {id: 2}) SET m.bad = duration({months: 2147483648})",
+        None,
+    );
+    let after = fingerprint(&mut graph);
+
+    assert_eq!(before, after, "statement must roll back.\nerror: {error}");
+    assert_eq!(
+        index_bucket(&graph, "qty", Value::Int64(10)),
+        bucket_before,
+        "the evicted member must come back at its original position"
+    );
+}
+
+/// One `Item` property-index bucket's members, in bucket order.
+fn index_bucket(graph: &DirGraph, property: &str, value: Value) -> Vec<usize> {
+    graph
+        .property_indices
+        .get(&("Item".to_string(), property.to_string()))
+        .and_then(|value_map| value_map.get(&value))
+        .map(|members| members.iter().map(|idx| idx.index()).collect())
+        .unwrap_or_default()
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1011,6 +1011,91 @@ fn vivify_stubs(graph: &mut DirGraph, node_type: &str, ids: &[Value]) -> Result<
     Ok(report.nodes_created)
 }
 
+/// Journal every inverted-index eviction this delete is about to perform,
+/// with the *position* each doomed member occupies.
+///
+/// Position and not merely membership, because bucket order is the scan order
+/// an un-`ORDER BY`'d `MATCH` returns: `type_indices` drives a label scan and
+/// the user-index buckets are handed straight to the matcher. Must be called
+/// while the doomed indices are still in their buckets. One `Option` check
+/// when no checkpoint is open, which is every non-mutating call.
+fn journal_bucket_evictions(
+    graph: &mut DirGraph,
+    affected_types: &HashSet<String>,
+    nodes_to_delete: &HashSet<NodeIndex>,
+) {
+    if graph.graph.undo_journal_mut().is_none() {
+        return;
+    }
+    let mut evictions: Vec<(BucketId, Vec<NodeIndex>)> = Vec::new();
+    for node_type in affected_types {
+        if let Some(members) = graph.type_indices.get(node_type) {
+            evictions.push((BucketId::NodeType(node_type.clone()), members.to_vec()));
+        }
+        // User-created indexes, same treatment. Only buckets that actually
+        // hold a doomed node are captured, so the cost tracks the deletion
+        // rather than the size of the index.
+        for (key, value_map) in &graph.property_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in value_map {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::PropertyValue {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+        for (key, btree) in &graph.range_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in btree {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::RangeValue {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+        for (key, comp_map) in &graph.composite_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in comp_map {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::CompositeTuple {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+    }
+    if graph.has_secondary_labels {
+        for (label, members) in &graph.secondary_label_index {
+            evictions.push((BucketId::SecondaryLabel(*label), members.clone()));
+        }
+    }
+    if let Some(journal) = graph.graph.undo_journal_mut() {
+        for (bucket, members) in &evictions {
+            journal.note_bucket_retain(bucket, members.iter().copied(), nodes_to_delete);
+        }
+    }
+}
+
 /// DETACH-delete a set of nodes: remove every incident edge, then the
 /// nodes, then clean the type / id / property / composite / secondary-label
 /// indexes. Shared by the Cypher DETACH DELETE executor and
@@ -1085,29 +1170,9 @@ pub(crate) fn detach_delete_nodes(
         }
     }
 
-    // Statement-rollback capture: record every inverted-index eviction with
-    // its *position*, so a failed statement restores bucket order and not
-    // merely membership — bucket order is the scan order an un-`ORDER BY`'d
-    // `MATCH` returns. Read before the `retain` sweeps below, while the doomed
-    // indices are still present. One `Option` check when no checkpoint is open.
-    if graph.graph.undo_journal_mut().is_some() {
-        let mut evictions: Vec<(BucketId, Vec<NodeIndex>)> = Vec::new();
-        for node_type in &affected_types {
-            if let Some(members) = graph.type_indices.get(node_type) {
-                evictions.push((BucketId::NodeType(node_type.clone()), members.to_vec()));
-            }
-        }
-        if graph.has_secondary_labels {
-            for (label, members) in &graph.secondary_label_index {
-                evictions.push((BucketId::SecondaryLabel(*label), members.clone()));
-            }
-        }
-        if let Some(journal) = graph.graph.undo_journal_mut() {
-            for (bucket, members) in &evictions {
-                journal.note_bucket_retain(bucket, members.iter().copied(), nodes_to_delete);
-            }
-        }
-    }
+    // Statement-rollback capture, before the `retain` sweeps below strip the
+    // doomed members out of the buckets.
+    journal_bucket_evictions(graph, &affected_types, nodes_to_delete);
 
     // Index cleanup — StableDiGraph keeps surviving indices stable.
     for node_type in &affected_types {

--- a/crates/kglite/src/graph/storage/undo.rs
+++ b/crates/kglite/src/graph/storage/undo.rs
@@ -26,9 +26,10 @@
 //!   [`crate::graph::storage::recording::RecordingGraph`] hooks, and the one
 //!   every Cypher write path funnels through;
 //! - **`DirGraph`'s inverted indexes** (`type_indices`,
-//!   `secondary_label_index`) and `timeseries_store`, captured at their
-//!   documented choke-point APIs, because those structures sit *above*
-//!   storage and a backend cannot see them.
+//!   `secondary_label_index`, and the user-created `property_indices` /
+//!   `range_indices` / `composite_indices`) and `timeseries_store`, captured
+//!   at their documented choke-point APIs, because those structures sit
+//!   *above* storage and a backend cannot see them.
 //!
 //! Everything else a statement can touch is O(schema)-sized and is restored
 //! verbatim from a cheap shell clone — see
@@ -58,8 +59,11 @@ use std::collections::HashSet;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
 
+use crate::datatypes::Value;
 use crate::graph::features::timeseries::NodeTimeseries;
-use crate::graph::schema::{EdgeData, InternedKey, NodeData};
+use crate::graph::schema::{
+    CompositeIndexKey, CompositeValue, EdgeData, IndexKey, InternedKey, NodeData,
+};
 
 /// A `Vec<NodeIndex>` bucket in one of `DirGraph`'s inverted indexes.
 /// Bucket edits are journalled with a *position* so a rollback restores the
@@ -72,6 +76,20 @@ pub enum BucketId {
     NodeType(String),
     /// `DirGraph::secondary_label_index`, keyed by interned label.
     SecondaryLabel(InternedKey),
+    /// One value bucket of a user-created single-property index
+    /// (`DirGraph::property_indices`).
+    PropertyValue { key: IndexKey, value: Value },
+    /// One value bucket of a user-created range index
+    /// (`DirGraph::range_indices`). Same key shape as
+    /// [`PropertyValue`](Self::PropertyValue); the bucket lives in a B-tree,
+    /// which orders the *values* but not the node indices inside a bucket.
+    RangeValue { key: IndexKey, value: Value },
+    /// One tuple bucket of a user-created composite index
+    /// (`DirGraph::composite_indices`).
+    CompositeTuple {
+        key: CompositeIndexKey,
+        value: CompositeValue,
+    },
 }
 
 /// One reversible edit. See the module docs for the replay contract.


### PR DESCRIPTION
`journal_covers` gates whether a mutating statement uses the O(changes) undo journal or falls back to `fork_transaction()` — a full O(V+E) deep clone, **per statement**. Both of its veto terms were tripped by ordinary user actions, so the fast path applied to almost no real graph.

**Not a regression.** `journal_covers` is days old; the code it replaced cloned unconditionally. This is a new optimisation that silently failed to apply — released 0.14.5 is slow on writes in every configuration.

**Measured impact** (100k, matched F_FULLFSYNC durability, from the competitive benchmark):
- with two secondary indexes: insert 21–38 ms
- without: **3.668 ms**, against SQLite's **3.666 ms** — parity
- `save()` alone, no index: writes 0.0062 → 3.06 ms **permanently**, min ≈ mean

The bind that made this worth fixing rather than documenting: you cannot avoid it by not indexing — dropping the index costs **52×** on `lookup_by_email` as it degrades to a label scan.

## The two terms

**`column_stores`** (tripped by `save()` → `enable_columnar()`): term removed. Discharged by running all 15 statement shapes against a saved/columnar fixture, each one a failed-statement rollback comparing an over-specified before/after fingerprint. **Plus a test proving the fixture is not vacuous** — a columnar arm would look identical if `execute_set`'s master fast path never fired, which is the only path at risk, so `the_columnar_fixture_writes_through_the_master_store` asserts a successful columnar `SET` actually mutates the master and that the refresh sweep leaves every handle on the new master.

The stickiness of `column_stores` is deliberate and is preserved — `enable_columnar`'s fast path depends on it, which is what makes a second `save()` cheap.

**`property_indices` / `range_indices` / `composite_indices`**: narrowed by adding real **position-preserving bucket undo**, not a shape guess. Discriminating test: two members share a bucket, the first is moved out, the statement fails, and it must return at **position 0** — a membership-only restore would append it.

## The blind spot that let this ship

`journalled_statements_copy_zero_nodes` ran against `seeded()` — a graph never saved and never indexed — so it was structurally incapable of observing either veto. It now has `seeded_columnar()` and `seeded_indexed()` arms.

Whole-index DDL remains unjournalled, documented in-tree as a load-bearing invariant (safe only because no fallible step follows index-map installation on the journal-capable backend). Not expanded into scope here.

Local: `cargo test -p kglite` 1294/1294 (exit code verified, not inferred from piped output); clippy `--all-targets -D warnings` clean; `cargo fmt --check` clean **on each commit individually**, not just the tip; source-quality, api-chokepoint, docs-facts, ruff all clean. No version bump; `[Unreleased]`.