### PR TITLE
Merge #86 (journal_covers vetoes) + #85 (durability levels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The undo-journal fast path now applies to graphs that have been saved.**
+  Statement rollback uses a cheap O(changes) undo journal wherever it can, and
+  falls back to a whole-graph O(V+E) clone taken before *every* mutating
+  statement otherwise. The fast path previously excluded any graph holding
+  columnar property stores — which is every graph that has been through
+  `save()`, since saving enables columnar storage and nothing on a mutation
+  path turns it off again. A single `save()` therefore moved the process onto
+  the clone path permanently, and the cost of each subsequent write scaled
+  with the size of the whole graph rather than with what the write touched.
+
+  The exclusion was aimed at one real side channel — `SET` on a columnar
+  property writes the shared per-type store directly — which is now covered
+  instead of avoided: the master store is restored from the checkpoint's
+  schema copy, and the per-node handles come back through the journal. `CREATE`
+  and `DELETE` never touch a column store in memory mode at all.
+
+  Rollback behaviour is unchanged; this is a cost change only. The rollback
+  fidelity suite now runs every statement shape against a saved-graph fixture
+  as well as a fresh one.
+
 ### Fixed
 
 - **`kglite.open()` now enforces one writer per graph, instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fidelity suite now runs every statement shape against a saved-graph fixture
   as well as a fresh one.
 
+- **…and to graphs with user-created indexes.** The same fast path was
+  excluded for any graph holding a property, range, or composite index, for
+  the same reason and with the same permanence: one `create_index` moved every
+  later statement onto the whole-graph clone. That exclusion was the more
+  expensive of the two, and unlike columnar mode there was no way to
+  configure around it — dropping the index to buy back write speed turns the
+  lookup it served into a label scan.
+
+  Index maintenance is now journalled per bucket edit, with the position each
+  edit touched, so a failed statement restores bucket *order* and not merely
+  membership. Bucket order is the row order an indexed `MATCH` without
+  `ORDER BY` returns, so anything less would have made a rolled-back statement
+  observable. This uses the same `BucketAppended` / `BucketRemoved` entries
+  that already covered the built-in type and label indexes.
+
+  One behaviour change falls out of it: composite-index maintenance no longer
+  opportunistically drops buckets that were already empty before the write. It
+  only drops the ones the write itself emptied.
+
 ### Fixed
 
 - **`kglite.open()` now enforces one writer per graph, instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (Rust API): `kglite::api::durable::Wal::open` takes a second
+  argument**, `sync: SyncMode`, naming how each appended frame is made durable.
+  Any Rust embedder calling it directly must pass a mode; Python callers are
+  unaffected. Kept as a break rather than adding a second constructor
+  alongside an unchanged `open`, for two reasons: a compat wrapper for a
+  replaced function is exactly the dual old-vs-new API path this project does
+  not carry, and an `open` that kept its old signature would have to *default*
+  the sync mode — silently choosing a durability guarantee on the caller's
+  behalf, at the one boundary where a silent default costs data. Naming the
+  mode is the point. `DurabilityLevel::sync_mode()` maps a level to one.
+
 - **A WAL frame is written with a single `write` call** instead of three (one
   each for the length prefix, the CRC, and the payload). Besides removing two
   syscalls from the per-commit path, this closes the window in which a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`save()` now barriers the write-ahead log before writing its
+  checkpoint.** A checkpoint truncates the log, and recovery folds the
+  surviving frames into net per-entity state. Previously the log was
+  guaranteed to be on disk at that point only because every commit had
+  already barriered; with a level that skips the per-commit barrier, a crash
+  in the window between writing the checkpoint and truncating the log could
+  leave a *prefix* of the frames, and replaying that prefix over the newer
+  checkpoint would roll committed properties backwards — losing data that had
+  already been durably saved. The checkpoint path now flushes the log first,
+  restoring the invariant that the on-disk log is complete whenever a
+  checkpoint supersedes it.
+
+- **WAL recovery now rejects a zero-length frame explicitly.** A run of zero
+  bytes — the shape an OS crash leaves when a file's length was extended but
+  its data block never reached the platter — declares a zero-length payload,
+  and `crc32` of an empty payload is zero, so such a prefix passed the
+  integrity check as a "valid" empty frame and was stopped only by the
+  decoder failing further down. Recovery now stops at it by intent. No
+  correct WAL can contain one.
+
 - **`kglite.open()` now enforces one writer per graph, instead of silently
   losing one.** Two processes that opened the same path both built a complete
   snapshot in memory and both wrote it at `save()`, so whichever saved last
@@ -105,6 +125,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retried, and the final conflict is re-raised unchanged. Conflicts are ordinary
   rather than rare here, because OCC compares a whole-graph version counter (see
   the documentation fix below).
+
+- **`kglite.open(..., durable="normal")` — a middle durability level.** Until
+  now `durable` offered only "barrier on every commit" or "no log at all",
+  and the gap between them is where most applications actually live.
+  `durable` now takes SQLite's `synchronous` vocabulary, naming **what a
+  committed mutation survives** rather than which syscall runs:
+
+  - `"full"` (also spelled `True`, and still the default) — survives **power
+    loss**. One barrier per commit.
+  - `"normal"` — survives the **process** dying: `SIGKILL`, an unhandled
+    panic, an OOM-kill. The log frame is in the kernel's page cache before
+    the call returns, and the page cache outlives the process. An OS crash or
+    power loss loses commits made since the last `save()`. No barrier per
+    commit.
+  - `"off"` (also spelled `False`) — no log; `save()` is the only durability
+    point.
+
+  `True`/`False` are accepted spellings rather than a second code path, so
+  existing calls are unaffected and **the default is unchanged**. The levels
+  are stated as guarantees because the syscall behind them differs by
+  platform while the guarantee does not — which is also why there is no
+  separate "plain `fsync`" level: `fsync` is the power-loss barrier on Linux
+  but not on macOS, so it could not be given one honest description.
+
+  **The levels are deliberately not uniform across storage modes.**
+  `storage="disk"` supports only `"off"`; both `"full"` and `"normal"` raise
+  `ValueError` there, because a disk graph commits by publishing an immutable
+  generation rather than by logging a write. The refusal now names the level
+  that was requested and the modes that do support logging.
+
+- **`KnowledgeGraph.sync()` — the on-demand barrier.** Flushes every commit
+  made so far to stable storage: the barrier `durable="full"` performs on
+  every commit, taken when the caller wants it. This is what makes
+  `"normal"` adoptable rather than merely fast — without it, a `"normal"`
+  graph's only route to power-safety is a full `save()`, which republishes
+  the entire graph and is the wrong granularity for "flush at the end of a
+  request" or "flush before shutdown". Returns immediately under `"full"`
+  (the guarantee already holds) and raises `ValueError` on a graph with no
+  log, rather than silently doing nothing. Pending mutations are folded into
+  the log first, so it cannot report success over ops that never reached it.
+
 - `kglite-bolt-server --neo4j-compat` (or `KGLITE_BOLT_NEO4J_COMPAT=1`) makes the
   server present a Neo4j-compatible agent in the Bolt handshake, so official
   drivers that refuse to connect to a non-Neo4j server will talk to it. The
@@ -355,6 +416,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole-graph write checkpoint.
 
 ### Changed
+
+- **A WAL frame is written with a single `write` call** instead of three (one
+  each for the length prefix, the CRC, and the payload). Besides removing two
+  syscalls from the per-commit path, this closes the window in which a
+  process death could leave a frame torn between its prefix and its payload:
+  a `write(2)` cannot be interrupted partway by a signal. The length/CRC
+  torn-tail check remains the authority, since a short write is still
+  possible in principle.
 
 - Documented what a crash actually costs a `storage="disk"` graph, and stopped
   steering growing apps toward it. Disk mode has no write-ahead log, which read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,138 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **The undo-journal fast path now applies to graphs that have been saved.**
-  Statement rollback uses a cheap O(changes) undo journal wherever it can, and
-  falls back to a whole-graph O(V+E) clone taken before *every* mutating
-  statement otherwise. The fast path previously excluded any graph holding
-  columnar property stores — which is every graph that has been through
-  `save()`, since saving enables columnar storage and nothing on a mutation
-  path turns it off again. A single `save()` therefore moved the process onto
-  the clone path permanently, and the cost of each subsequent write scaled
-  with the size of the whole graph rather than with what the write touched.
-
-  The exclusion was aimed at one real side channel — `SET` on a columnar
-  property writes the shared per-type store directly — which is now covered
-  instead of avoided: the master store is restored from the checkpoint's
-  schema copy, and the per-node handles come back through the journal. `CREATE`
-  and `DELETE` never touch a column store in memory mode at all.
-
-  Rollback behaviour is unchanged; this is a cost change only. The rollback
-  fidelity suite now runs every statement shape against a saved-graph fixture
-  as well as a fresh one.
-
-- **…and to graphs with user-created indexes.** The same fast path was
-  excluded for any graph holding a property, range, or composite index, for
-  the same reason and with the same permanence: one `create_index` moved every
-  later statement onto the whole-graph clone. That exclusion was the more
-  expensive of the two, and unlike columnar mode there was no way to
-  configure around it — dropping the index to buy back write speed turns the
-  lookup it served into a label scan.
-
-  Index maintenance is now journalled per bucket edit, with the position each
-  edit touched, so a failed statement restores bucket *order* and not merely
-  membership. Bucket order is the row order an indexed `MATCH` without
-  `ORDER BY` returns, so anything less would have made a rolled-back statement
-  observable. This uses the same `BucketAppended` / `BucketRemoved` entries
-  that already covered the built-in type and label indexes.
-
-  One behaviour change falls out of it: composite-index maintenance no longer
-  opportunistically drops buckets that were already empty before the write. It
-  only drops the ones the write itself emptied.
-
-### Fixed
-
-- **`save()` now barriers the write-ahead log before writing its
-  checkpoint.** A checkpoint truncates the log, and recovery folds the
-  surviving frames into net per-entity state. Previously the log was
-  guaranteed to be on disk at that point only because every commit had
-  already barriered; with a level that skips the per-commit barrier, a crash
-  in the window between writing the checkpoint and truncating the log could
-  leave a *prefix* of the frames, and replaying that prefix over the newer
-  checkpoint would roll committed properties backwards — losing data that had
-  already been durably saved. The checkpoint path now flushes the log first,
-  restoring the invariant that the on-disk log is complete whenever a
-  checkpoint supersedes it.
-
-- **WAL recovery now rejects a zero-length frame explicitly.** A run of zero
-  bytes — the shape an OS crash leaves when a file's length was extended but
-  its data block never reached the platter — declares a zero-length payload,
-  and `crc32` of an empty payload is zero, so such a prefix passed the
-  integrity check as a "valid" empty frame and was stopped only by the
-  decoder failing further down. Recovery now stops at it by intent. No
-  correct WAL can contain one.
-
-- **`kglite.open()` now enforces one writer per graph, instead of silently
-  losing one.** Two processes that opened the same path both built a complete
-  snapshot in memory and both wrote it at `save()`, so whichever saved last
-  won and everything the other had done disappeared — with both processes
-  exiting 0, nothing logged, and nothing in the file to show it had happened.
-  That is the likeliest accident when deploying an embedded database: a
-  multi-worker `gunicorn` pool, a cron job overlapping a request, or a stale
-  process nobody noticed.
-
-  `open()` now takes an exclusive cross-process writer lease on a
-  `<path>.lock` sidecar and holds it until `close()` / `with`-block exit. A
-  second writer fails immediately, naming the process that has it:
-
-  ```
-  KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
-  ```
-
-  The lease mechanism itself is not new — the CLI and the MCP server have held
-  it since disk generations shipped, and `open_or_create_graph` documents it as
-  a caller's responsibility. The Python binding was the caller that never
-  opted in, which left the most-used surface unguarded.
-
-  Three deliberate boundaries:
-
-  - **Readers are never blocked.** `load()` and `open_session()` take no
-    lease. `save()` republishes the whole graph, so a reader sees the last
-    consistent snapshot; making reads exclusive would break read-replica and
-    analytics deployments to fix a problem only writers have.
-  - **A crash releases it.** The lock is owned by the OS, not by the sidecar
-    file's existence, so a writer lost to `SIGKILL` or a power cut frees it
-    at once. The leftover `<path>.lock` (the lock, always empty) and
-    `<path>.lock-owner` (the pid/timestamp used to name a holder) are records,
-    not the lock — deleting them releases nothing, and the error message says
-    so, since deleting lock files by reflex is how this class of guard gets
-    defeated.
-
-  Contention is classified from the platform's lock errno via
-  `fs2::lock_contended_error()` rather than from `io::ErrorKind`. The kinds
-  differ per platform — `EWOULDBLOCK` maps to `WouldBlock` on Unix, but
-  `ERROR_LOCK_VIOLATION` is uncategorised on Windows — so a kind comparison
-  recognised contention only on Unix. On Windows that meant a blocked writer
-  saw the raw OS error instead of a message naming the holder, **and** the
-  retry loop was skipped entirely, so the 30-second lease timeouts used by
-  `kglite` CLI commands and the MCP server returned instantly rather than
-  waiting for the current writer to finish.
-
-  The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
-  rather than inside the lock file, because `fs2` locks via `flock` on Unix
-  (advisory — contenders can still read) but `LockFileEx` on Windows
-  (mandatory over the whole range), where an exclusive lock makes the file
-  unreadable to every other handle and a contender's read fails with
-  `ERROR_LOCK_VIOLATION` instead of returning the pid. Splitting the two keeps
-  the holder *named* on every platform. `<path>.lock` is still the file that
-  is locked, so binaries from either side of this change continue to exclude
-  each other.
-  - **`open(..., lock=False)` opts out**, explicitly and never by default, for
-    deployments that coordinate writers externally.
-
-  Disk-mode graphs were already protected by their own generation lock, but
-  only failed at the *first mutation* with a bare
-  `Resource temporarily unavailable (os error 35)`; they now fail at `open()`
-  with the same named message as every other storage mode.
-
-  **Possible impact:** a deployment that genuinely opened one graph from two
-  processes was already losing writes, and now gets an error instead. Two
-  overlapping `kglite.open()` calls on one path *within* a single process are
-  refused for the same reason (the error says so explicitly); sequential
-  `with kglite.open(path)` blocks are unaffected, because the lease is
-  released on block exit.
 
 ### Added
 
@@ -458,6 +326,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The undo-journal fast path now applies to graphs that have been saved.**
+  Statement rollback uses a cheap O(changes) undo journal wherever it can, and
+  falls back to a whole-graph O(V+E) clone taken before *every* mutating
+  statement otherwise. The fast path previously excluded any graph holding
+  columnar property stores — which is every graph that has been through
+  `save()`, since saving enables columnar storage and nothing on a mutation
+  path turns it off again. A single `save()` therefore moved the process onto
+  the clone path permanently, and the cost of each subsequent write scaled
+  with the size of the whole graph rather than with what the write touched.
+
+  The exclusion was aimed at one real side channel — `SET` on a columnar
+  property writes the shared per-type store directly — which is now covered
+  instead of avoided: the master store is restored from the checkpoint's
+  schema copy, and the per-node handles come back through the journal. `CREATE`
+  and `DELETE` never touch a column store in memory mode at all.
+
+  Rollback behaviour is unchanged; this is a cost change only. The rollback
+  fidelity suite now runs every statement shape against a saved-graph fixture
+  as well as a fresh one.
+
+- **…and to graphs with user-created indexes.** The same fast path was
+  excluded for any graph holding a property, range, or composite index, for
+  the same reason and with the same permanence: one `create_index` moved every
+  later statement onto the whole-graph clone. That exclusion was the more
+  expensive of the two, and unlike columnar mode there was no way to
+  configure around it — dropping the index to buy back write speed turns the
+  lookup it served into a label scan.
+
+  Index maintenance is now journalled per bucket edit, with the position each
+  edit touched, so a failed statement restores bucket *order* and not merely
+  membership. Bucket order is the row order an indexed `MATCH` without
+  `ORDER BY` returns, so anything less would have made a rolled-back statement
+  observable. This uses the same `BucketAppended` / `BucketRemoved` entries
+  that already covered the built-in type and label indexes.
+
+  One behaviour change falls out of it: composite-index maintenance no longer
+  opportunistically drops buckets that were already empty before the write. It
+  only drops the ones the write itself emptied.
+
 - **Breaking (Rust API): `kglite::api::durable::Wal::open` takes a second
   argument**, `sync: SyncMode`, naming how each appended frame is made durable.
   Any Rust embedder calling it directly must pass a mode; Python callers are
@@ -613,6 +520,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour.
 
 ### Fixed
+
+- **`save()` now barriers the write-ahead log before writing its
+  checkpoint.** A checkpoint truncates the log, and recovery folds the
+  surviving frames into net per-entity state. Previously the log was
+  guaranteed to be on disk at that point only because every commit had
+  already barriered; with a level that skips the per-commit barrier, a crash
+  in the window between writing the checkpoint and truncating the log could
+  leave a *prefix* of the frames, and replaying that prefix over the newer
+  checkpoint would roll committed properties backwards — losing data that had
+  already been durably saved. The checkpoint path now flushes the log first,
+  restoring the invariant that the on-disk log is complete whenever a
+  checkpoint supersedes it.
+
+- **WAL recovery now rejects a zero-length frame explicitly.** A run of zero
+  bytes — the shape an OS crash leaves when a file's length was extended but
+  its data block never reached the platter — declares a zero-length payload,
+  and `crc32` of an empty payload is zero, so such a prefix passed the
+  integrity check as a "valid" empty frame and was stopped only by the
+  decoder failing further down. Recovery now stops at it by intent. No
+  correct WAL can contain one.
+
+- **`kglite.open()` now enforces one writer per graph, instead of silently
+  losing one.** Two processes that opened the same path both built a complete
+  snapshot in memory and both wrote it at `save()`, so whichever saved last
+  won and everything the other had done disappeared — with both processes
+  exiting 0, nothing logged, and nothing in the file to show it had happened.
+  That is the likeliest accident when deploying an embedded database: a
+  multi-worker `gunicorn` pool, a cron job overlapping a request, or a stale
+  process nobody noticed.
+
+  `open()` now takes an exclusive cross-process writer lease on a
+  `<path>.lock` sidecar and holds it until `close()` / `with`-block exit. A
+  second writer fails immediately, naming the process that has it:
+
+  ```
+  KgError: app.kgl is open for writing by pid 4711 (since 2026-07-26T09:15:03+02:00)
+  ```
+
+  The lease mechanism itself is not new — the CLI and the MCP server have held
+  it since disk generations shipped, and `open_or_create_graph` documents it as
+  a caller's responsibility. The Python binding was the caller that never
+  opted in, which left the most-used surface unguarded.
+
+  Three deliberate boundaries:
+
+  - **Readers are never blocked.** `load()` and `open_session()` take no
+    lease. `save()` republishes the whole graph, so a reader sees the last
+    consistent snapshot; making reads exclusive would break read-replica and
+    analytics deployments to fix a problem only writers have.
+  - **A crash releases it.** The lock is owned by the OS, not by the sidecar
+    file's existence, so a writer lost to `SIGKILL` or a power cut frees it
+    at once. The leftover `<path>.lock` (the lock, always empty) and
+    `<path>.lock-owner` (the pid/timestamp used to name a holder) are records,
+    not the lock — deleting them releases nothing, and the error message says
+    so, since deleting lock files by reflex is how this class of guard gets
+    defeated.
+
+  Contention is classified from the platform's lock errno via
+  `fs2::lock_contended_error()` rather than from `io::ErrorKind`. The kinds
+  differ per platform — `EWOULDBLOCK` maps to `WouldBlock` on Unix, but
+  `ERROR_LOCK_VIOLATION` is uncategorised on Windows — so a kind comparison
+  recognised contention only on Unix. On Windows that meant a blocked writer
+  saw the raw OS error instead of a message naming the holder, **and** the
+  retry loop was skipped entirely, so the 30-second lease timeouts used by
+  `kglite` CLI commands and the MCP server returned instantly rather than
+  waiting for the current writer to finish.
+
+  The holder's identity lives in the unlocked `<path>.lock-owner` sidecar
+  rather than inside the lock file, because `fs2` locks via `flock` on Unix
+  (advisory — contenders can still read) but `LockFileEx` on Windows
+  (mandatory over the whole range), where an exclusive lock makes the file
+  unreadable to every other handle and a contender's read fails with
+  `ERROR_LOCK_VIOLATION` instead of returning the pid. Splitting the two keeps
+  the holder *named* on every platform. `<path>.lock` is still the file that
+  is locked, so binaries from either side of this change continue to exclude
+  each other.
+  - **`open(..., lock=False)` opts out**, explicitly and never by default, for
+    deployments that coordinate writers externally.
+
+  Disk-mode graphs were already protected by their own generation lock, but
+  only failed at the *first mutation* with a bare
+  `Resource temporarily unavailable (os error 35)`; they now fail at `open()`
+  with the same named message as every other storage mode.
+
+  **Possible impact:** a deployment that genuinely opened one graph from two
+  processes was already losing writes, and now gets an error instead. Two
+  overlapping `kglite.open()` calls on one path *within* a single process are
+  refused for the same reason (the error says so explicitly); sequential
+  `with kglite.open(path)` blocks are unaffected, because the lease is
+  released on block exit.
 
 - **A constraint violation is now catchable by type from every write path.**
   `ConstraintViolationError` existed but was reachable from nowhere: a violation

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -252,6 +252,11 @@ pub(crate) struct DurableState {
     pub(crate) wal: kglite_core::api::durable::Wal,
     /// Monotonic log-sequence number stamped on the next WAL frame.
     pub(crate) next_lsn: u64,
+    /// The level the caller asked for. Never `Off` — an `Off` graph has no
+    /// `DurableState` at all. The WAL's own `SyncMode` is derived from this
+    /// at open; this field is kept because it is the *user's* vocabulary,
+    /// which error messages and `sync()` echo back.
+    pub(crate) level: kglite_core::api::durable::DurabilityLevel,
 }
 
 impl std::fmt::Debug for DurableState {
@@ -259,6 +264,7 @@ impl std::fmt::Debug for DurableState {
         f.debug_struct("DurableState")
             .field("wal", &self.wal.path())
             .field("next_lsn", &self.next_lsn)
+            .field("level", &self.level.name())
             .finish()
     }
 }

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -611,6 +611,28 @@ impl KnowledgeGraph {
         self.lifecycle.source_path = Some(std::path::PathBuf::from(&effective));
         let path: &str = &effective;
 
+        // Force any WAL frames that are still only in the OS page cache onto
+        // stable storage BEFORE the checkpoint that supersedes them.
+        //
+        // **This is load-bearing for `durable="normal"`, not belt-and-braces.**
+        // The checkpoint below truncates the log, and replay folds whatever
+        // frames survive into net per-entity state. Under `full` every frame
+        // is already on disk at this point, so a crash in the write→truncate
+        // window leaves the *complete* frame set and replaying it reproduces
+        // exactly the checkpointed state — harmless, as the comment further
+        // down says. Under `normal` the tail may still be in the page cache,
+        // so the same crash can leave a *prefix*; folding that prefix over a
+        // newer checkpoint would roll properties back to their values as of
+        // an earlier commit, destroying data that was already durably saved.
+        // Syncing here restores the `full`-mode invariant — at checkpoint
+        // time the on-disk log is complete — and costs one barrier per
+        // save(), against a full serialize-and-fsync that is already running.
+        if let Some(ds) = self.lifecycle.durable.as_mut() {
+            ds.wal
+                .sync()
+                .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        }
+
         // Mode-aware durable save lives in core (`save_graph_with`): disk dir
         // vs in-memory `.kgl`, columnar consolidation (v3 requires columnar;
         // handles fresh / mixed / mapped), atomic temp+rename, and file +
@@ -640,6 +662,57 @@ impl KnowledgeGraph {
             }
         }
         Ok(())
+    }
+
+    /// Flush every commit made so far to stable storage — the barrier that
+    /// `durable="full"` performs on *every* commit, taken on demand.
+    ///
+    /// This is what makes `durable="normal"` adoptable rather than merely
+    /// fast. Without it, a `normal` graph's only route to power-safety is a
+    /// full `save()`, which republishes the entire graph — the wrong
+    /// granularity for "flush at the end of a request" or "flush before
+    /// shutdown".
+    ///
+    /// Behaviour by level:
+    ///
+    /// - `"normal"` — the real work: takes the barrier `normal` skips per
+    ///   commit, so everything committed before this call now survives power
+    ///   loss too.
+    /// - `"full"` — returns immediately. Every commit was already barriered,
+    ///   so the guarantee this call promises already holds.
+    /// - `"off"` / a non-durable graph — raises `ValueError`. There is no log
+    ///   to flush, so the call cannot deliver what its name promises, and a
+    ///   caller who believes they bought power-safety and silently got
+    ///   nothing is the failure direction that actually costs data.
+    ///
+    /// Pending mutations are folded into the log first, so this is also the
+    /// safe way to force a commit boundary before an external snapshot.
+    fn sync(&mut self, py: Python<'_>) -> PyResult<()> {
+        use kglite_core::api::durable::DurabilityLevel;
+
+        if self.lifecycle.durable.is_none() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "sync() needs a graph opened with a write-ahead log. This graph \
+                 has none (durable='off'), so there is nothing to flush and no \
+                 power-safe point to take — call save() to write a checkpoint \
+                 instead, or reopen with kglite.open(path, durable='normal') if \
+                 you want per-commit logging with on-demand barriers.",
+            ));
+        }
+        // Drain anything still buffered in the capture layer into a frame
+        // before barriering, so `sync()` cannot report success over ops that
+        // never reached the log.
+        self.commit_wal()?;
+        let ds = self
+            .lifecycle
+            .durable
+            .as_mut()
+            .expect("durable checked Some above; commit_wal does not clear it");
+        if ds.level == DurabilityLevel::Full {
+            return Ok(());
+        }
+        py.detach(|| ds.wal.sync())
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))
     }
 
     /// Serialize the in-memory graph to a `.kgl` byte buffer (the same

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -264,26 +264,78 @@ fn from_bytes(py: Python<'_>, data: &[u8]) -> PyResult<KnowledgeGraph> {
 /// `storage` (`"mapped"` / `"disk"`) applies only when *creating* a new
 /// graph; opening an existing file uses whatever mode it was saved in.
 ///
+/// The `durable=` argument: a level name, a bool, or `None`.
+///
+/// `True`/`False` are accepted *spellings* of `"full"`/`"off"`, not a second
+/// code path — every form normalises to one [`DurabilityLevel`] here, at the
+/// single point where Python vocabulary becomes engine vocabulary, and
+/// nothing downstream knows which spelling was used.
+/// Normalise the `durable=` argument into one [`DurabilityLevel`].
+///
+/// A plain function rather than a `FromPyObject` impl: the trait's shape has
+/// moved across PyO3 releases, and nothing here needs to participate in
+/// generic extraction — `open` is the only caller, and it wants to own the
+/// error messages anyway.
+fn durable_level_from_arg(
+    ob: &Bound<'_, PyAny>,
+) -> PyResult<kglite_core::api::durable::DurabilityLevel> {
+    use kglite_core::api::durable::DurabilityLevel;
+    // `bool` extraction is strict in PyO3 (it requires an actual `PyBool`),
+    // so this cannot swallow `1` or a string.
+    if let Ok(flag) = ob.extract::<bool>() {
+        return Ok(if flag {
+            DurabilityLevel::Full
+        } else {
+            DurabilityLevel::Off
+        });
+    }
+    let name: String = ob.extract().map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+            "durable must be a bool or one of {:?} (True is 'full', False is 'off')",
+            DurabilityLevel::NAMES,
+        ))
+    })?;
+    DurabilityLevel::from_name(&name).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "unknown durability level {name:?}. Valid levels are {:?}: \
+             'full' survives power loss (one barrier per commit), \
+             'normal' survives the process dying but not an OS crash or \
+             power loss, 'off' keeps no log and relies on save().",
+            DurabilityLevel::NAMES,
+        ))
+    })
+}
+
 /// Durability is **on by default**: each committed mutation is `fsync`'d to a
 /// `<path>-wal` sidecar before the call returns, and on open any WAL frames are
 /// replayed onto the loaded checkpoint to recover work committed since the last
 /// `save()`. This is the point of an embedded database — without it a hard
 /// crash loses everything since the last explicit save.
 ///
-/// `durable` is tri-state so that the default can mean "wherever it is
-/// supported" without turning an unsupported mode into an error:
+/// `durable` names **what a committed mutation survives**, using SQLite's
+/// `synchronous` vocabulary. Guarantees, not syscalls — the syscall differs by
+/// platform, the guarantee does not:
 ///
-/// - `None` (the default) — enable it unless the graph is `storage="disk"`,
-///   whose commit boundary is a generation publish rather than a logical log.
-///   A disk graph therefore opens non-durable instead of raising, exactly as it
-///   did before durability had a default.
-/// - `True` — require it. `storage="disk"` raises `ValueError`, because
-///   silently handing back a non-durable graph to a caller who explicitly asked
-///   for crash safety is the one outcome worse than an error.
-/// - `False` — opt out. The graph still remembers `path` for `save()`; it just
-///   keeps no log, which is measurably faster for write-heavy bulk loading (no
-///   `fsync` per commit) and is the right choice when the graph is rebuildable
-///   from source data.
+/// - `"full"` (also spelled `True`) — survives **power loss**. One barrier per
+///   commit; on macOS that is `F_FULLFSYNC`, which is a stronger guarantee than
+///   SQLite's own default gives.
+/// - `"normal"` — survives the **process** dying (`SIGKILL`, an unhandled
+///   panic, an OOM-kill), because the frame is in the kernel's page cache
+///   before the call returns. An OS crash or power loss loses commits made
+///   since the last `save()`. No barrier per commit, so it costs
+///   essentially nothing beyond the write itself. Call `sync()` to take an
+///   explicit power-safe point without a full checkpoint.
+/// - `"off"` (also spelled `False`) — no log at all. The graph still remembers
+///   `path` for `save()`, which is measurably faster for write-heavy bulk
+///   loading and is the right choice when the graph is rebuildable from source
+///   data.
+/// - `None` (the default) — `"full"`, except on `storage="disk"` where it
+///   resolves to `"off"` (see below) rather than raising.
+///
+/// **The rungs are not uniform across storage modes: `storage="disk"` supports
+/// only `"off"`, and any explicit request to log raises `ValueError`** — a disk
+/// graph commits by publishing an immutable generation rather than by logging a
+/// write, so the blocker is structural and not a matter of barrier strength.
 ///
 /// `lock` (default `true`) takes the cross-process single-writer lease for the
 /// life of the returned graph. It is on by default because the alternative is
@@ -297,9 +349,10 @@ fn open(
     py: Python<'_>,
     path: String,
     storage: Option<&str>,
-    durable: Option<bool>,
+    durable: Option<Bound<'_, PyAny>>,
     lock: bool,
 ) -> PyResult<KnowledgeGraph> {
+    use kglite_core::api::durable::DurabilityLevel;
     use kglite_core::api::GraphRead;
 
     // Take write ownership *before* reading a byte. The window that loses a
@@ -352,9 +405,16 @@ fn open(
     kg.lifecycle.writer_lease = writer_lease;
     // Resolved after the graph exists, because the mode of an *existing* path
     // comes from the file, not from the `storage` argument.
-    let wanted = durable.unwrap_or(!kg.inner.graph.is_disk());
-    if wanted {
-        setup_durable(&mut kg, &path)?;
+    let level = match durable.as_ref() {
+        Some(ob) => durable_level_from_arg(ob)?,
+        // Default stays the strongest level the mode supports. Disk keeps no
+        // log at any level, so it resolves to `off` instead of raising —
+        // unchanged from when `durable` was a plain tri-state bool.
+        None if kg.inner.graph.is_disk() => DurabilityLevel::Off,
+        None => DurabilityLevel::Full,
+    };
+    if level.logs() {
+        setup_durable(&mut kg, &path, level)?;
     }
     Ok(kg)
 }
@@ -367,24 +427,46 @@ fn open(
 /// `GraphBackend` enum rather than a concrete backend, and both memory and
 /// mapped graphs mutate the same heap `StableDiGraph` underneath, so one
 /// capture path covers both. Disk is refused — see the error below.
-fn setup_durable(kg: &mut KnowledgeGraph, path: &str) -> PyResult<()> {
+fn setup_durable(
+    kg: &mut KnowledgeGraph,
+    path: &str,
+    level: kglite_core::api::durable::DurabilityLevel,
+) -> PyResult<()> {
     use kglite_core::api::GraphRead;
     // `wal` stays a below-api reach (durable-transaction internals) —
     // deferred to a high-level durable-transaction api lift (roadmap Piece 2).
     use kglite_core::api::durable as wal;
 
     if kg.inner.graph.is_disk() {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "durable=True is not supported for storage='disk'. A disk graph \
-             commits by publishing an immutable generation, so its durability \
-             boundary is the generation publish, not a logical write-ahead log: \
-             a replayed WAL frame and a published generation can each describe \
-             the same commit, and reconciling them needs a generation-aware log \
-             this release does not have. Use save() checkpoints for disk graphs, \
-             or storage='mapped' / the in-memory default if you need per-commit \
-             crash safety.",
-        ));
+        // `ValueError`, not one of the typed `kglite.*Error` classes, and that
+        // is deliberate: `error_py`'s taxonomy reserves the typed hierarchy for
+        // *engine* failures and keeps "argument-shape" rejections in their
+        // built-in family. An unsupported `durable` + `storage` combination is
+        // rejected at the Python API boundary before any engine work starts,
+        // so it belongs in the built-in family — as the pre-existing
+        // `test_durable_rejects_disk_mode` contract already fixed.
+        //
+        // Every logging level is refused here, not just `full`. The blocker is
+        // structural rather than a matter of barrier strength: there is no WAL
+        // for disk mode at any level, so `normal` would be exactly as
+        // unimplementable as `full`. Naming the requested level keeps the
+        // message honest for a caller who reasonably assumed the rungs were
+        // uniform across storage modes.
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "durable={:?} is not supported for storage='disk' (only 'off' is). \
+             A disk graph commits by publishing an immutable generation, so its \
+             durability boundary is the generation publish, not a logical \
+             write-ahead log: a replayed WAL frame and a published generation \
+             can each describe the same commit, and reconciling them needs a \
+             generation-aware log this release does not have. Use save() \
+             checkpoints for disk graphs, or storage='mapped' / the in-memory \
+             default if you need per-commit crash safety.",
+            level.name(),
+        )));
     }
+    let sync = level
+        .sync_mode()
+        .expect("caller checks level.logs() before setup_durable");
 
     let wpath = wal::wal_path(std::path::Path::new(path));
     // Read (do not truncate) any frames committed since the last checkpoint.
@@ -399,11 +481,12 @@ fn setup_durable(kg: &mut KnowledgeGraph, path: &str) -> PyResult<()> {
         .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)?;
     KnowledgeGraph::wrap_backend_for_durability(dir);
 
-    let walh = wal::Wal::open(wpath)
+    let walh = wal::Wal::open(wpath, sync)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
     kg.lifecycle.durable = Some(crate::graph::DurableState {
         wal: walh,
         next_lsn: max_lsn + 1,
+        level,
     });
     Ok(())
 }

--- a/crates/kglite/src/graph/dir_graph/indexes.rs
+++ b/crates/kglite/src/graph/dir_graph/indexes.rs
@@ -16,6 +16,7 @@ use super::{DirGraph, IndexStats};
 use crate::datatypes::values::Value;
 use crate::graph::schema::{CompositeIndexKey, CompositeValue, IndexKey, InternedKey};
 use crate::graph::storage::backend::GraphBackend;
+use crate::graph::storage::undo::BucketId;
 use crate::graph::storage::GraphRead;
 use petgraph::graph::NodeIndex;
 
@@ -476,6 +477,164 @@ impl DirGraph {
     }
 
     // ========================================================================
+    // Statement-rollback capture for user indexes
+    // ========================================================================
+    //
+    // These helpers give the undo journal the *index* half of a statement's
+    // writes. Each records a bucket edit together with the position it
+    // touched, because bucket order is the row order an un-`ORDER BY`'d
+    // indexed `MATCH` returns (`lookup_by_index` hands the bucket `Vec`
+    // straight to the matcher) — restoring membership alone would leave a
+    // failed statement visible as a reordering.
+    //
+    // Each is one `Option` check when no checkpoint is capturing, which is
+    // every read and every statement outside a mutating one. They must be
+    // called *before* the edit they describe: an eviction needs the position
+    // while the node is still in the bucket, and an append needs to know
+    // whether the bucket existed beforehand.
+
+    /// Whether a statement checkpoint is currently capturing inverse ops.
+    #[inline]
+    fn capturing_undo(&mut self) -> bool {
+        self.graph.undo_journal_mut().is_some()
+    }
+
+    /// Journal `node_idx`'s position in a property-index bucket before it
+    /// leaves it.
+    fn note_property_eviction(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .property_indices
+            .get(key)
+            .and_then(|value_map| value_map.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::PropertyValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Range-index counterpart of [`note_property_eviction`](Self::note_property_eviction).
+    fn note_range_eviction(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .range_indices
+            .get(key)
+            .and_then(|btree| btree.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::RangeValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Composite-index counterpart of
+    /// [`note_property_eviction`](Self::note_property_eviction).
+    fn note_composite_eviction(
+        &mut self,
+        key: &CompositeIndexKey,
+        value: &CompositeValue,
+        node_idx: NodeIndex,
+    ) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let pos = self
+            .composite_indices
+            .get(key)
+            .and_then(|comp_map| comp_map.get(value))
+            .and_then(|members| members.iter().position(|member| *member == node_idx));
+        let Some(pos) = pos else {
+            return;
+        };
+        let bucket = BucketId::CompositeTuple {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_removed(bucket, node_idx, pos);
+        }
+    }
+
+    /// Journal an append into a property-index bucket, recording whether the
+    /// bucket itself comes into existence with it.
+    fn note_property_append(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.property_indices.get(key) {
+            Some(value_map) => !value_map.contains_key(value),
+            // No such index: the caller's append will not happen either.
+            None => return,
+        };
+        let bucket = BucketId::PropertyValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    /// Range-index counterpart of [`note_property_append`](Self::note_property_append).
+    fn note_range_append(&mut self, key: &IndexKey, value: &Value, node_idx: NodeIndex) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.range_indices.get(key) {
+            Some(btree) => !btree.contains_key(value),
+            None => return,
+        };
+        let bucket = BucketId::RangeValue {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    /// Composite-index counterpart of
+    /// [`note_property_append`](Self::note_property_append).
+    fn note_composite_append(
+        &mut self,
+        key: &CompositeIndexKey,
+        value: &CompositeValue,
+        node_idx: NodeIndex,
+    ) {
+        if !self.capturing_undo() {
+            return;
+        }
+        let bucket_was_new = match self.composite_indices.get(key) {
+            Some(comp_map) => !comp_map.contains_key(value),
+            None => return,
+        };
+        let bucket = BucketId::CompositeTuple {
+            key: key.clone(),
+            value: value.clone(),
+        };
+        if let Some(journal) = self.graph.undo_journal_mut() {
+            journal.note_bucket_appended(bucket, node_idx, bucket_was_new);
+        }
+    }
+
+    // ========================================================================
     // Incremental Index Maintenance (called by Cypher mutations)
     // ========================================================================
 
@@ -503,9 +662,11 @@ impl DirGraph {
                 .collect()
         };
         for (key, value) in &prop_updates {
+            self.note_property_append(key, value, node_idx);
             if let Some(value_map) = self.property_indices.get_mut(key) {
                 value_map.entry(value.clone()).or_default().push(node_idx);
             }
+            self.note_range_append(key, value, node_idx);
             if let Some(btree) = self.range_indices.get_mut(key) {
                 btree.entry(value.clone()).or_default().push(node_idx);
             }
@@ -541,6 +702,7 @@ impl DirGraph {
                 .collect()
         };
         for (key, comp_val) in comp_updates {
+            self.note_composite_append(&key, &comp_val, node_idx);
             if let Some(comp_map) = self.composite_indices.get_mut(&key) {
                 comp_map.entry(comp_val).or_default().push(node_idx);
             }
@@ -558,9 +720,12 @@ impl DirGraph {
         new_value: &Value,
     ) {
         let key = (node_type.to_string(), property.to_string());
-        // Update hash index
-        if let Some(value_map) = self.property_indices.get_mut(&key) {
-            if let Some(old_val) = old_value {
+        // Update hash index. Vacating the old bucket and joining the new one
+        // are journalled separately, and each capture has to read the map as
+        // it stands just before its own edit — hence the split borrows.
+        if let Some(old_val) = old_value {
+            self.note_property_eviction(&key, old_val, node_idx);
+            if let Some(value_map) = self.property_indices.get_mut(&key) {
                 if let Some(indices) = value_map.get_mut(old_val) {
                     indices.retain(|&idx| idx != node_idx);
                     if indices.is_empty() {
@@ -568,14 +733,18 @@ impl DirGraph {
                     }
                 }
             }
+        }
+        self.note_property_append(&key, new_value, node_idx);
+        if let Some(value_map) = self.property_indices.get_mut(&key) {
             value_map
                 .entry(new_value.clone())
                 .or_default()
                 .push(node_idx);
         }
         // Update range index
-        if let Some(btree) = self.range_indices.get_mut(&key) {
-            if let Some(old_val) = old_value {
+        if let Some(old_val) = old_value {
+            self.note_range_eviction(&key, old_val, node_idx);
+            if let Some(btree) = self.range_indices.get_mut(&key) {
                 if let Some(indices) = btree.get_mut(old_val) {
                     indices.retain(|&idx| idx != node_idx);
                     if indices.is_empty() {
@@ -583,6 +752,9 @@ impl DirGraph {
                     }
                 }
             }
+        }
+        self.note_range_append(&key, new_value, node_idx);
+        if let Some(btree) = self.range_indices.get_mut(&key) {
             btree.entry(new_value.clone()).or_default().push(node_idx);
         }
 
@@ -599,6 +771,7 @@ impl DirGraph {
         old_value: &Value,
     ) {
         let key = (node_type.to_string(), property.to_string());
+        self.note_property_eviction(&key, old_value, node_idx);
         if let Some(value_map) = self.property_indices.get_mut(&key) {
             if let Some(indices) = value_map.get_mut(old_value) {
                 indices.retain(|&idx| idx != node_idx);
@@ -607,6 +780,7 @@ impl DirGraph {
                 }
             }
         }
+        self.note_range_eviction(&key, old_value, node_idx);
         if let Some(btree) = self.range_indices.get_mut(&key) {
             if let Some(indices) = btree.get_mut(old_value) {
                 indices.retain(|&idx| idx != node_idx);
@@ -651,25 +825,54 @@ impl DirGraph {
         };
 
         for key in comp_keys {
-            if let Some(comp_map) = self.composite_indices.get_mut(&key) {
-                // Remove node from all existing composite buckets
-                for indices in comp_map.values_mut() {
-                    indices.retain(|&idx| idx != node_idx);
-                }
-                // Remove empty buckets
-                comp_map.retain(|_, v| !v.is_empty());
-
-                // Build new composite value from current properties
-                let new_values: Vec<Value> = key
-                    .1
+            // The buckets this node currently sits in, read before vacating
+            // any of them so each position can be journalled.
+            let occupied: Vec<CompositeValue> = match self.composite_indices.get(&key) {
+                Some(comp_map) => comp_map
                     .iter()
-                    .map(|p| current_props.get(p).cloned().unwrap_or(Value::Null))
-                    .collect();
-                if new_values.iter().any(|v| !matches!(v, Value::Null)) {
-                    comp_map
-                        .entry(CompositeValue(new_values))
-                        .or_default()
-                        .push(node_idx);
+                    .filter(|(_, members)| members.contains(&node_idx))
+                    .map(|(value, _)| value.clone())
+                    .collect(),
+                None => continue,
+            };
+            for value in &occupied {
+                self.note_composite_eviction(&key, value, node_idx);
+            }
+            if let Some(comp_map) = self.composite_indices.get_mut(&key) {
+                // Vacate exactly the buckets this node was in, and drop only
+                // the ones this call emptied. The blanket
+                // `retain(|_, v| !v.is_empty())` this replaces also swept away
+                // buckets that were already empty before the call — harmless
+                // in itself, but it made the edit unrepresentable as an
+                // inverse, and "restore the pre-statement graph" includes the
+                // empty buckets it had.
+                for value in &occupied {
+                    let emptied = match comp_map.get_mut(value) {
+                        Some(members) => {
+                            members.retain(|&idx| idx != node_idx);
+                            members.is_empty()
+                        }
+                        None => false,
+                    };
+                    if emptied {
+                        comp_map.remove(value);
+                    }
+                }
+            }
+
+            // Build new composite value from current properties
+            let new_values: Vec<Value> = key
+                .1
+                .iter()
+                .map(|p| current_props.get(p).cloned().unwrap_or(Value::Null))
+                .collect();
+            if new_values.iter().any(|v| !matches!(v, Value::Null)) {
+                let value = CompositeValue(new_values);
+                // After the evictions, so `bucket_was_new` reflects the map
+                // the append actually lands in.
+                self.note_composite_append(&key, &value, node_idx);
+                if let Some(comp_map) = self.composite_indices.get_mut(&key) {
+                    comp_map.entry(value).or_default().push(node_idx);
                 }
             }
         }

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -106,6 +106,8 @@
 
 use std::collections::HashSet;
 
+use petgraph::graph::NodeIndex;
+
 use super::DirGraph;
 use crate::graph::storage::undo::{BucketId, UndoEntry, UndoJournal};
 use crate::graph::storage::{GraphRead, GraphWrite};
@@ -121,6 +123,14 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
     std::mem::swap(&mut a.graph, &mut b.graph);
     std::mem::swap(&mut a.type_indices, &mut b.type_indices);
     std::mem::swap(&mut a.id_indices, &mut b.id_indices);
+    // The three user-index families are journalled per *bucket edit* — the
+    // incremental maintenance a statement's writes drive. Whole-index DDL
+    // (`create_index` / `drop_index`, which replace a map wholesale) is not,
+    // so a `CREATE INDEX` that failed after installing its map would leave the
+    // map behind while the shell restored the `*_index_keys` list without it.
+    // That is unreachable rather than handled: on the journal-capable backend
+    // index DDL performs no fallible step after it mutates. A new fallible
+    // step there needs an undo entry for the whole index, or an explicit veto.
     std::mem::swap(&mut a.property_indices, &mut b.property_indices);
     std::mem::swap(&mut a.composite_indices, &mut b.composite_indices);
     std::mem::swap(&mut a.range_indices, &mut b.range_indices);
@@ -143,33 +153,48 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
     std::mem::swap(&mut a.unique_indices, &mut b.unique_indices);
 }
 
+/// Reverse one bucket append: drop the *last* copy of `idx`, which is the one
+/// the append pushed.
+///
+/// `retain`-style removal would be wrong here — it also drops an occurrence
+/// that pre-dated the statement, and a bucket can legitimately be appended to
+/// twice within one statement.
+fn undo_bucket_append(members: Option<&mut Vec<NodeIndex>>, idx: NodeIndex) {
+    if let Some(members) = members {
+        if let Some(pos) = members.iter().rposition(|member| *member == idx) {
+            members.remove(pos);
+        }
+    }
+}
+
 /// Whether the undo journal can reverse everything this graph's mutations can
 /// change. Conservative by construction — every `false` arm falls back to the
 /// clone checkpoint, so a shape that is merely *unproven* is still safe.
+///
+/// Only the backend is a gate now. Three graph-state vetoes that used to sit
+/// here are gone, and the reasoning for each is worth keeping, because
+/// re-adding one is cheap to type and expensive to run — a veto here is not a
+/// local slowdown but a permanent, whole-graph downgrade to an O(V+E) clone
+/// per statement, for every shape, for the rest of the session.
+///
+/// - **`column_stores`** guarded the columnar-`SET` master side channel, but
+///   fired on every graph that had ever been saved. Covered instead by the
+///   unparked shell restore plus journalled handle refresh; see the module
+///   doc.
+/// - **`property_indices` / `range_indices` / `composite_indices`** guarded
+///   the absence of position undo for user-index buckets. That undo now
+///   exists, recorded at the incremental-maintenance choke points in
+///   [`crate::graph::dir_graph::indexes`] and
+///   [`crate::graph::mutation::maintain`] with the same `BucketAppended` /
+///   `BucketRemoved` entries `type_indices` already used. Whole-index DDL is
+///   still not journalled — see the note on [`swap_data_scale`].
+/// - **`unique_indices`** was never gated: it reads as doctrine-consistent,
+///   but routing every constrained graph to `fork_transaction()` is strictly
+///   worse than the journal plus a per-touched-type unique rebuild, which is
+///   that field's undo story.
 fn journal_covers(graph: &DirGraph) -> bool {
     // Only the heap backend can express an inverse petgraph edit.
     graph.graph.supports_undo_journal()
-        // Deliberately *not* gated on `column_stores.is_empty()`. That read as
-        // a narrow guard on the columnar-`SET` master side channel, but it
-        // vetoed every statement shape on every saved graph — `save()` calls
-        // `enable_columnar`, and nothing on a mutation path ever empties the
-        // map again. The side channel is covered instead: the master store is
-        // restored verbatim from the unparked shell (`Arc::make_mut` cannot
-        // touch the shell's handle) and the per-node handles come back through
-        // the journal. See the module doc for the full argument.
-        //
-        // User-created indexes need per-bucket position undo on the delete
-        // path, which the journal does not record yet. Empty in the default
-        // graph — `create_index` opts in. Follow-up, tracked in the sprint
-        // report.
-        && graph.property_indices.is_empty()
-        && graph.composite_indices.is_empty()
-        && graph.range_indices.is_empty()
-    // Deliberately *not* gated on `unique_indices.is_empty()`. It reads as
-    // doctrine-consistent but is a pessimisation: it would route every
-    // constrained graph to `fork_transaction()`, an O(V+E) clone of everything,
-    // which is strictly worse than the journal plus a per-touched-type unique
-    // rebuild. The rebuild is that field's undo story.
 }
 
 /// An open rollback checkpoint for exactly one mutating statement.
@@ -409,6 +434,35 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
                     }
                 }
             }
+            // The three user-index families share one shape: undo the push,
+            // then drop the bucket only if this statement created it. An
+            // emptied-but-pre-existing bucket is left in place because the
+            // maintenance paths leave one there too, and restoring the
+            // pre-statement graph means restoring that as well.
+            BucketId::PropertyValue { key, value } => {
+                if let Some(value_map) = graph.property_indices.get_mut(&key) {
+                    undo_bucket_append(value_map.get_mut(&value), idx);
+                    if bucket_was_new {
+                        value_map.remove(&value);
+                    }
+                }
+            }
+            BucketId::RangeValue { key, value } => {
+                if let Some(btree) = graph.range_indices.get_mut(&key) {
+                    undo_bucket_append(btree.get_mut(&value), idx);
+                    if bucket_was_new {
+                        btree.remove(&value);
+                    }
+                }
+            }
+            BucketId::CompositeTuple { key, value } => {
+                if let Some(comp_map) = graph.composite_indices.get_mut(&key) {
+                    undo_bucket_append(comp_map.get_mut(&value), idx);
+                    if bucket_was_new {
+                        comp_map.remove(&value);
+                    }
+                }
+            }
         },
         UndoEntry::BucketRemoved { bucket, idx, pos } => match bucket {
             BucketId::NodeType(name) => {
@@ -420,6 +474,31 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
                 let members = graph.secondary_label_index.entry(label).or_default();
                 let pos = pos.min(members.len());
                 members.insert(pos, idx);
+            }
+            // A bucket the statement emptied was dropped from its map by the
+            // maintenance path, so re-inserting has to recreate it. If the
+            // index itself is gone the entry is skipped: nothing to restore
+            // into, and a rolled-back statement never removes an index.
+            BucketId::PropertyValue { key, value } => {
+                if let Some(value_map) = graph.property_indices.get_mut(&key) {
+                    let members = value_map.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
+            }
+            BucketId::RangeValue { key, value } => {
+                if let Some(btree) = graph.range_indices.get_mut(&key) {
+                    let members = btree.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
+            }
+            BucketId::CompositeTuple { key, value } => {
+                if let Some(comp_map) = graph.composite_indices.get_mut(&key) {
+                    let members = comp_map.entry(value).or_default();
+                    let pos = pos.min(members.len());
+                    members.insert(pos, idx);
+                }
             }
         },
         UndoEntry::TimeseriesRemoved { node, prior } => {
@@ -457,7 +536,6 @@ fn debug_assert_slot_reused(restored: usize, expected: usize, kind: &str) {
 mod tests {
     use super::*;
     use crate::datatypes::Value;
-    use petgraph::graph::NodeIndex;
     use petgraph::stable_graph::StableDiGraph;
     use std::collections::HashMap;
 
@@ -537,15 +615,33 @@ mod tests {
         assert_eq!(graph.type_indices.len(), 1);
     }
 
-    /// A graph with user-created property indexes must keep the clone
-    /// checkpoint until the journal learns to reverse them.
+    /// User-created indexes no longer veto the journal: their bucket edits are
+    /// journalled with positions, so an indexed graph keeps the cheap
+    /// checkpoint instead of paying a whole-graph clone per statement for the
+    /// rest of the session.
     #[test]
-    fn gate_rejects_user_property_indexes() {
+    fn gate_accepts_user_property_indexes() {
         let mut graph = DirGraph::new();
         assert!(journal_covers(&graph));
         graph
             .property_indices
             .insert(("Item".to_string(), "name".to_string()), HashMap::new());
-        assert!(!journal_covers(&graph));
+        graph
+            .range_indices
+            .insert(("Item".to_string(), "qty".to_string()), Default::default());
+        graph.composite_indices.insert(
+            ("Item".to_string(), vec!["name".to_string()]),
+            HashMap::new(),
+        );
+        assert!(journal_covers(&graph));
+    }
+
+    /// Undoing an append must remove the copy the append pushed, not every
+    /// copy — a bucket can hold a pre-statement occurrence of the same node.
+    #[test]
+    fn undoing_an_append_leaves_a_pre_existing_occurrence() {
+        let mut members = vec![NodeIndex::new(3), NodeIndex::new(7), NodeIndex::new(3)];
+        undo_bucket_append(Some(&mut members), NodeIndex::new(3));
+        assert_eq!(members, vec![NodeIndex::new(3), NodeIndex::new(7)]);
     }
 }

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -52,6 +52,39 @@
 //! explicit addition to [`swap_data_scale`] can introduce a correctness gap,
 //! and that is a change a reviewer is looking straight at.
 //!
+//! ## Columnar mode rides on the unparked half
+//!
+//! `column_stores` — the per-type master `Arc<ColumnStore>` map that `save()`
+//! installs via `enable_columnar` — is deliberately **not** parked, and that
+//! is the whole of its undo story. The shell clone captures one pre-statement
+//! `Arc` handle per type and `restore_schema_shell` reinstalls it verbatim.
+//! What makes that sufficient rather than merely hopeful:
+//!
+//! - `ColumnStore` has no interior mutability, and the only in-statement
+//!   writer of a master store is `execute_set`'s columnar fast path, which
+//!   goes through `Arc::make_mut`. The shell's handle keeps the refcount above
+//!   one for the whole statement, so `make_mut` provably copies-on-write and
+//!   the shell's store is never mutated in place.
+//! - Every node of a columnar type holds its own `Arc` clone of the store, so
+//!   the post-`make_mut` handle-refresh sweep re-points them all. That sweep
+//!   runs through `node_weight_mut_silent`, which is silent only towards the
+//!   WAL recorder — `MemoryGraph` does not override it, so each re-pointed
+//!   node's pre-statement `NodeData` (old handle and row id included) lands in
+//!   the journal as a `NodeWeight` entry.
+//! - `CREATE` and `DELETE` never reach a master store in memory mode: the
+//!   in-memory insert branch always builds a `Compact` node, and node removal
+//!   is a plain backend edit. Every other writer of `column_stores`
+//!   (`enable_columnar`, `disable_columnar`, `vacuum`, the spill and bulk-batch
+//!   paths, disk sync) runs outside the statement window.
+//!
+//! So a columnar graph is restored on both halves — master by verbatim shell
+//! restore, per-node handles by the journal — and needs no veto. The one cost
+//! to know about: because the refresh sweep touches every node of the type, a
+//! columnar `SET` journals one `NodeData` pre-image per node of that type
+//! rather than per row written. That is O(type), not O(changes) — still
+//! strictly cheaper than the O(V+E) fork it replaces, and it is the sweep's
+//! own cost that dominates either way.
+//!
 //! ## When the journal is not used
 //!
 //! [`journal_covers`] is the gate. It is conservative on purpose: any shape
@@ -116,11 +149,15 @@ fn swap_data_scale(a: &mut DirGraph, b: &mut DirGraph) {
 fn journal_covers(graph: &DirGraph) -> bool {
     // Only the heap backend can express an inverse petgraph edit.
     graph.graph.supports_undo_journal()
-        // Columnar `SET` writes the shared per-type `Arc<ColumnStore>` through
-        // a side channel that bypasses `GraphWrite` entirely
-        // (`cypher::executor::write`'s columnar-master fast path), so the
-        // journal never sees the pre-image.
-        && graph.column_stores.is_empty()
+        // Deliberately *not* gated on `column_stores.is_empty()`. That read as
+        // a narrow guard on the columnar-`SET` master side channel, but it
+        // vetoed every statement shape on every saved graph — `save()` calls
+        // `enable_columnar`, and nothing on a mutation path ever empties the
+        // map again. The side channel is covered instead: the master store is
+        // restored verbatim from the unparked shell (`Arc::make_mut` cannot
+        // touch the shell's handle) and the per-node handles come back through
+        // the journal. See the module doc for the full argument.
+        //
         // User-created indexes need per-bucket position undo on the delete
         // path, which the journal does not record yet. Empty in the default
         // graph — `create_index` opts in. Follow-up, tracked in the sprint

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -16,9 +16,10 @@
 //!   while evaluating a later pattern's properties.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::datatypes::Value;
-use crate::graph::schema::DirGraph;
+use crate::graph::schema::{DirGraph, PropertyStorage};
 use crate::graph::session::execute::{execute_mut, ExecuteOptions};
 use crate::graph::storage::GraphRead;
 
@@ -38,6 +39,16 @@ type NodeFingerprint = (usize, String, String, String, PropPairs, Vec<String>);
 /// `(slot, src slot, tgt slot, conn type, sorted properties)`.
 type EdgeFingerprint = (usize, usize, usize, String, PropPairs);
 
+/// One master column store's rows: `(row id, id, title, sorted properties)`.
+///
+/// Read from `DirGraph::column_stores` — the *master* handle — not from a
+/// node's own `Arc` clone of it. The two can diverge (`Arc::make_mut` forks
+/// them on every columnar write), and only the node-side half shows up in
+/// `NodeFingerprint`. A rollback that restored the nodes but left the master
+/// carrying the failed statement's values would look clean node-side and then
+/// resurrect those values on the next `SET` or `save()`.
+type MasterRows = Vec<(u32, String, String, PropPairs)>;
+
 #[derive(Debug, PartialEq, Eq)]
 struct Fingerprint {
     version: u64,
@@ -56,6 +67,16 @@ struct Fingerprint {
     /// `(node_type, id)` → slot, read through the id index so a stale or
     /// unrebuilt index shows up as a mismatch.
     id_lookup: Vec<(String, String, usize)>,
+    /// Master column stores per node type. Empty on a non-columnar graph.
+    column_masters: Vec<(String, MasterRows)>,
+    /// Per columnar node slot: is its own `Arc<ColumnStore>` handle still the
+    /// same allocation as its type's master? `execute_set` writes the master
+    /// through `Arc::make_mut` — which forks it away from every node holding a
+    /// handle — and then re-points all of them at the fork. A rollback has to
+    /// put both halves back *together*: leaving the nodes on the pre-statement
+    /// store while the master keeps the fork (or the reverse) is the failure
+    /// mode this pins, and it is invisible to a values-only comparison.
+    columnar_handles: Vec<(usize, bool)>,
 }
 
 fn sorted_props(props: &HashMap<String, Value>) -> Vec<(String, String)> {
@@ -165,6 +186,53 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
     }
     id_lookup.sort();
 
+    let mut column_masters: Vec<(String, MasterRows)> = graph
+        .column_stores
+        .iter()
+        .map(|(node_type, store)| {
+            let rows: MasterRows = (0..store.row_count())
+                .map(|row| {
+                    let mut props: PropPairs = store
+                        .row_properties(row)
+                        .into_iter()
+                        .map(|(key, value)| {
+                            (
+                                graph.interner.resolve(key).to_string(),
+                                format!("{value:?}"),
+                            )
+                        })
+                        .collect();
+                    props.sort();
+                    (
+                        row,
+                        format!("{:?}", store.get_id(row)),
+                        format!("{:?}", store.get_title(row)),
+                        props,
+                    )
+                })
+                .collect();
+            (node_type.clone(), rows)
+        })
+        .collect();
+    column_masters.sort();
+
+    let mut columnar_handles: Vec<(usize, bool)> = Vec::new();
+    for idx in graph.graph.node_indices().collect::<Vec<_>>() {
+        let Some(node) = graph.graph.node_weight(idx) else {
+            continue;
+        };
+        let PropertyStorage::Columnar { store, .. } = &node.properties else {
+            continue;
+        };
+        let node_type = node.node_type_str(&graph.interner);
+        let matches_master = graph
+            .column_stores
+            .get(node_type)
+            .is_some_and(|master| Arc::ptr_eq(store, master));
+        columnar_handles.push((idx.index(), matches_master));
+    }
+    columnar_handles.sort();
+
     Fingerprint {
         version: graph.version,
         node_count: graph.graph.node_count(),
@@ -177,6 +245,8 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
         node_type_metadata,
         connection_type_metadata,
         id_lookup,
+        column_masters,
+        columnar_handles,
     }
 }
 
@@ -241,176 +311,160 @@ fn seeded() -> DirGraph {
     graph
 }
 
+/// `seeded()` after `enable_columnar()` — the shape every graph takes the
+/// moment it is saved, and keeps for the rest of its life. `save()` calls
+/// `enable_columnar` (`io/file.rs`), and only the explicit `disable_columnar`
+/// ever empties `column_stores` again, so "has been saved once" is a permanent
+/// property of a live graph and every mutation after it runs in this shape.
+///
+/// The preconditions are asserted, not assumed. If `enable_columnar` ever
+/// stopped installing master stores, or stopped re-pointing nodes at them, the
+/// columnar arms below would quietly become a second run of the plain fixture
+/// and prove nothing.
+fn seeded_columnar() -> DirGraph {
+    let mut graph = seeded();
+    graph.enable_columnar();
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the fixture must own master column stores, or the columnar arms are vacuous"
+    );
+    let columnar_nodes = graph
+        .graph
+        .node_indices()
+        .filter(|idx| {
+            matches!(
+                graph.graph.node_weight(*idx).map(|node| &node.properties),
+                Some(PropertyStorage::Columnar { .. })
+            )
+        })
+        .count();
+    assert_eq!(
+        columnar_nodes,
+        graph.graph.node_count(),
+        "every seeded node must read its properties through a column store"
+    );
+    graph
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Per-shape rollback fidelity
 // ─────────────────────────────────────────────────────────────────────
 
-#[test]
-fn create_nodes_roll_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
-        "CREATE (:Item {id: 100}), (:Item {id: 101, bad: duration({months: 2147483648})})",
-        None,
-    );
+/// Every mid-statement-failure shape, run against every graph configuration.
+///
+/// One entry generates one module holding one test per fixture, so a failure
+/// names both the shape and the configuration it failed in
+/// (`create_nodes::columnar`).
+///
+/// The extra arms exist because the plain fixture cannot detect the bug class
+/// this file is for. `seeded()` is never saved and never indexed, so it can
+/// never trip a `journal_covers` veto — it takes the journal path
+/// unconditionally, and is therefore structurally incapable of noticing a
+/// journal path that is wrong for a graph that *has* been saved or indexed.
+/// Every shape must hold in every configuration a real application graph can
+/// be in.
+macro_rules! rollback_shapes {
+    ($($(#[$doc:meta])* $name:ident: $query:expr, $scope:expr;)*) => {
+        $(
+            $(#[$doc])*
+            mod $name {
+                use super::*;
+
+                /// A fresh in-memory graph: no column stores, no user indexes.
+                #[test]
+                fn plain() {
+                    assert_rolls_back(&mut seeded(), $query, $scope);
+                }
+
+                /// The saved-graph shape — `enable_columnar` has installed
+                /// master column stores that no mutation path ever removes.
+                #[test]
+                fn columnar() {
+                    assert_rolls_back(&mut seeded_columnar(), $query, $scope);
+                }
+            }
+        )*
+    };
 }
 
-#[test]
-fn create_nodes_and_edges_roll_back() {
-    let mut graph = seeded();
-    // The first pattern (nodes + edge) commits, the second is rejected by the
-    // write whitelist — so the journal must reverse two nodes and an edge.
-    assert_rolls_back(
-        &mut graph,
+rollback_shapes! {
+    create_nodes:
+        "CREATE (:Item {id: 100}), (:Item {id: 101, bad: duration({months: 2147483648})})",
+        None;
+
+    /// The first pattern (nodes + edge) commits, the second is rejected by the
+    /// write whitelist — so the journal must reverse two nodes and an edge.
+    create_nodes_and_edges:
         "CREATE (x:Item {id: 200})-[:LINKS {weight: 1}]->(y:Item {id: 201}), \
                 (z:Blocked {id: 202})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn create_with_secondary_labels_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    create_with_secondary_labels:
         "CREATE (:Tag:Hot:Fresh {id: 300}), (:Blocked {id: 301})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn set_properties_roll_back() {
-    let mut graph = seeded();
-    // Every Item is updated, then the expression on the last SET item blows
-    // up — a multi-property SET across multiple rows.
-    assert_rolls_back(
-        &mut graph,
+    /// Every Item is updated, then the expression on the last SET item blows
+    /// up — a multi-property SET across multiple rows.
+    set_properties:
         "MATCH (n:Item) SET n.qty = n.qty + 1, n.name = 'touched', \
                              n.bad = duration({months: 2147483648})",
-        None,
-    );
-}
+        None;
 
-#[test]
-fn set_on_second_type_rolls_back_first() {
-    let mut graph = seeded();
-    // One SET clause writing two node types: the Item write commits, then the
-    // Tag write is rejected by the whitelist mid-clause.
-    assert_rolls_back(
-        &mut graph,
+    /// One SET clause writing two node types: the Item write commits, then the
+    /// Tag write is rejected by the whitelist mid-clause.
+    set_on_second_type:
         "MATCH (n:Item), (t:Tag) WHERE n.id = 1 AND t.id = 1 \
          SET n.marker = 'x', t.marker = 'y'",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn set_label_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    set_label:
         "MATCH (t:Tag {id: 2}) SET t:Hot, t.bad = duration({months: 2147483648})",
-        None,
-    );
-}
+        None;
 
-#[test]
-fn remove_property_and_label_roll_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    remove_property_and_label:
         "MATCH (t:Tag {id: 1}) REMOVE t.name, t:Hot \
          CREATE (:Blocked {id: 400})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn detach_delete_rolls_back_nodes_edges_and_bucket_order() {
-    let mut graph = seeded();
-    // Deletes the middle Item — so its slot is a hole in the middle of the
-    // type_indices bucket, and restoring it at the end instead of in place
-    // would fail the fingerprint.
-    assert_rolls_back(
-        &mut graph,
+    /// Deletes the middle Item — so its slot is a hole in the middle of the
+    /// type_indices bucket, and restoring it at the end instead of in place
+    /// would fail the fingerprint.
+    detach_delete_one:
         "MATCH (n:Item {id: 2}) DETACH DELETE n CREATE (:Blocked {id: 500})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn detach_delete_all_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    detach_delete_all:
         "MATCH (n) DETACH DELETE n CREATE (:Blocked {id: 501})",
-        Some(&["Item", "Tag"]),
-    );
-}
+        Some(&["Item", "Tag"]);
 
-#[test]
-fn delete_labelled_node_restores_its_labels() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    delete_labelled_node:
         "MATCH (t:Tag) DETACH DELETE t CREATE (:Blocked {id: 502})",
-        Some(&["Tag"]),
-    );
-}
+        Some(&["Tag"]);
 
-#[test]
-fn delete_edge_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    delete_edge:
         "MATCH ()-[r:LINKS]->() DELETE r CREATE (:Blocked {id: 600})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn merge_create_arm_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    merge_create_arm:
         "MERGE (n:Item {id: 700}) ON CREATE SET n.name = 'new' \
          CREATE (:Blocked {id: 701})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn merge_match_arm_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    merge_match_arm:
         "MERGE (n:Item {id: 1}) ON MATCH SET n.name = 'seen' \
          CREATE (:Blocked {id: 702})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn foreach_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    foreach:
         "FOREACH (i IN [1, 2, 3] | CREATE (:Item {id: 800 + i})) \
          CREATE (:Blocked {id: 804})",
-        Some(&["Item"]),
-    );
-}
+        Some(&["Item"]);
 
-#[test]
-fn multi_clause_create_then_set_then_delete_rolls_back() {
-    let mut graph = seeded();
-    assert_rolls_back(
-        &mut graph,
+    multi_clause_create_then_set_then_delete:
         "MATCH (n:Item {id: 3}) SET n.qty = 999 \
          CREATE (:Item {id: 900}) \
          CREATE (:Blocked {id: 901})",
-        Some(&["Item"]),
-    );
+        Some(&["Item"]);
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -615,6 +615,41 @@ fn a_second_statement_after_a_rollback_still_commits() {
     );
 }
 
+/// One statement of each mutating shape, run in an order where each leaves the
+/// graph as the next expects it.
+const ZERO_COPY_QUERIES: &[&str] = &[
+    "CREATE (:Item {id: 2000, name: 'x'})",
+    "MATCH (n:Item {id: 1}) SET n.qty = 11, n.name = 'renamed'",
+    "MATCH (n:Item {id: 2000}) SET n:Featured",
+    "MATCH (a:Item {id: 1}), (b:Item {id: 3}) CREATE (a)-[:LINKS {weight: 2}]->(b)",
+    "MATCH (n:Item {id: 2000}) DETACH DELETE n",
+    "MERGE (n:Item {id: 2001}) ON CREATE SET n.name = 'merged'",
+];
+
+/// Assert no statement copies a node, i.e. every one of them took the journal
+/// path rather than the clone checkpoint.
+///
+/// The counter is `BACKEND_CLONE_NODES`, bumped by `impl Clone for
+/// GraphBackend` by the number of nodes copied. That is what makes it a real
+/// oracle for *which path ran*: the clone checkpoint forks the whole graph and
+/// registers the fixture's node count, while the journal checkpoint clones a
+/// `DirGraph` whose backend was deliberately emptied first and registers zero.
+/// It counts nodes only — a `HashMap` clone bumps nothing — so it says nothing
+/// about how much *else* a statement copied.
+fn assert_statements_copy_zero_nodes(graph: &mut DirGraph, fixture: &str) {
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+
+    for &query in ZERO_COPY_QUERIES {
+        reset_backend_clone_count();
+        run(graph, query);
+        assert_eq!(
+            backend_clone_nodes(),
+            0,
+            "statement must not copy any node on the {fixture} fixture: {query}"
+        );
+    }
+}
+
 /// The point of the whole exercise: a mutating statement on the journal path
 /// must not copy a single node. This is the regression guard for the
 /// O(V+E)-per-write cost the sprint removed — a benchmark would only notice
@@ -625,41 +660,91 @@ fn a_second_statement_after_a_rollback_still_commits() {
 /// that O(1) clone is the design, not a regression.
 #[test]
 fn journalled_statements_copy_zero_nodes() {
-    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+    assert_statements_copy_zero_nodes(&mut seeded(), "plain");
+}
 
-    let mut graph = seeded();
-    for query in [
-        "CREATE (:Item {id: 2000, name: 'x'})",
-        "MATCH (n:Item {id: 1}) SET n.qty = 11, n.name = 'renamed'",
-        "MATCH (n:Item {id: 2000}) SET n:Featured",
-        "MATCH (a:Item {id: 1}), (b:Item {id: 3}) CREATE (a)-[:LINKS {weight: 2}]->(b)",
-        "MATCH (n:Item {id: 2000}) DETACH DELETE n",
-        "MERGE (n:Item {id: 2001}) ON CREATE SET n.name = 'merged'",
-    ] {
-        reset_backend_clone_count();
-        run(&mut graph, query);
-        assert_eq!(
-            backend_clone_nodes(),
-            0,
-            "statement must not copy any node: {query}"
-        );
-    }
+/// The same guard on a graph that has been saved.
+///
+/// This arm is the one that would have caught the columnar veto. A fresh
+/// `seeded()` graph has no column stores and no user indexes, so it cannot
+/// take the clone path no matter what the gate says — which made the guard
+/// above structurally blind to a gate that sends every *real* application
+/// graph down the expensive path.
+#[test]
+fn journalled_statements_copy_zero_nodes_on_a_saved_graph() {
+    assert_statements_copy_zero_nodes(&mut seeded_columnar(), "columnar");
+}
+
+/// The same guard on a graph with user-created indexes — the other half of
+/// the blind spot.
+#[test]
+fn journalled_statements_copy_zero_nodes_on_an_indexed_graph() {
+    assert_statements_copy_zero_nodes(&mut seeded_indexed(), "indexed");
 }
 
 /// Rollback is allowed to be the expensive direction, but it must still not
 /// reach for a whole-graph copy on the journal path.
-#[test]
-fn journalled_rollback_copies_zero_nodes() {
+fn assert_rollback_copies_zero_nodes(graph: &mut DirGraph, fixture: &str) {
     use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
 
-    let mut graph = seeded();
     reset_backend_clone_count();
     expect_failure(
-        &mut graph,
+        graph,
         "MATCH (n:Item) DETACH DELETE n CREATE (:Blocked {id: 1})",
         Some(&["Item"]),
     );
-    assert_eq!(backend_clone_nodes(), 0);
+    assert_eq!(
+        backend_clone_nodes(),
+        0,
+        "rollback must not copy any node on the {fixture} fixture"
+    );
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes() {
+    assert_rollback_copies_zero_nodes(&mut seeded(), "plain");
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes_on_a_saved_graph() {
+    assert_rollback_copies_zero_nodes(&mut seeded_columnar(), "columnar");
+}
+
+#[test]
+fn journalled_rollback_copies_zero_nodes_on_an_indexed_graph() {
+    assert_rollback_copies_zero_nodes(&mut seeded_indexed(), "indexed");
+}
+
+/// Pins that the `columnar` arms exercise the master side channel rather than
+/// quietly falling through to the per-node setter.
+///
+/// `execute_set`'s columnar fast path only fires for an in-memory `Columnar`
+/// node writing a property that is neither `title` nor `name`. If that stopped
+/// holding for this fixture — a storage-mode change, a different fallthrough
+/// condition — every columnar rollback arm above would still pass, while
+/// testing the write path that was never at risk. The veto this file's change
+/// removed was aimed squarely at the master write, so "the master write
+/// happens here" is a precondition of the whole exercise, not a detail.
+#[test]
+fn the_columnar_fixture_writes_through_the_master_store() {
+    let mut graph = seeded_columnar();
+    let before = fingerprint(&mut graph);
+    run(&mut graph, "MATCH (n:Item {id: 1}) SET n.qty = 12345");
+    let after = fingerprint(&mut graph);
+
+    assert_ne!(
+        before.column_masters, after.column_masters,
+        "a successful columnar SET must land in the master store; if it does \
+         not, the columnar arms are exercising the per-node fallback"
+    );
+    assert!(
+        after
+            .columnar_handles
+            .iter()
+            .all(|(_, matches_master)| *matches_master),
+        "the post-write refresh sweep must leave every node's handle on the \
+         new master — that sweep is what the journal has to reverse"
+    );
 }
 
 /// An indexed graph rolls back through the journal, not through a whole-graph

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -77,6 +77,13 @@ struct Fingerprint {
     /// store while the master keeps the fork (or the reverse) is the failure
     /// mode this pins, and it is invisible to a values-only comparison.
     columnar_handles: Vec<(usize, bool)>,
+    /// Every user-index bucket as `(index, value, members in bucket order)`.
+    /// Order matters: `lookup_by_index` hands the bucket `Vec` straight to the
+    /// matcher, so bucket order is the row order an indexed `MATCH` without
+    /// `ORDER BY` returns. A rollback that restored membership but appended
+    /// the node instead of putting it back where it was would be a visible
+    /// reordering, and this is what catches it.
+    user_indexes: Vec<(String, String, Vec<usize>)>,
 }
 
 fn sorted_props(props: &HashMap<String, Value>) -> Vec<(String, String)> {
@@ -233,6 +240,36 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
     }
     columnar_handles.sort();
 
+    let mut user_indexes: Vec<(String, String, Vec<usize>)> = Vec::new();
+    for ((node_type, property), value_map) in &graph.property_indices {
+        for (value, members) in value_map {
+            user_indexes.push((
+                format!("property {node_type}.{property}"),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    for ((node_type, property), btree) in &graph.range_indices {
+        for (value, members) in btree {
+            user_indexes.push((
+                format!("range {node_type}.{property}"),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    for ((node_type, properties), comp_map) in &graph.composite_indices {
+        for (value, members) in comp_map {
+            user_indexes.push((
+                format!("composite {node_type}.{}", properties.join("+")),
+                format!("{value:?}"),
+                members.iter().map(|idx| idx.index()).collect(),
+            ));
+        }
+    }
+    user_indexes.sort();
+
     Fingerprint {
         version: graph.version,
         node_count: graph.graph.node_count(),
@@ -247,6 +284,7 @@ fn fingerprint(graph: &mut DirGraph) -> Fingerprint {
         id_lookup,
         column_masters,
         columnar_handles,
+        user_indexes,
     }
 }
 
@@ -346,6 +384,38 @@ fn seeded_columnar() -> DirGraph {
     graph
 }
 
+/// `seeded()` plus one index of each user-created family over `Item`.
+///
+/// The indexed shape is not exotic: an application indexes the property it
+/// looks rows up by, and cannot opt out to get a faster write — dropping the
+/// index turns the lookup into a label scan. So this is the configuration a
+/// primary store actually runs in, and every shape has to hold in it.
+///
+/// `qty` is indexed twice on purpose (equality *and* range), because
+/// `CREATE RANGE INDEX` in Cypher installs both and the two are maintained by
+/// separate code.
+fn seeded_indexed() -> DirGraph {
+    let mut graph = seeded();
+    graph.create_index("Item", "name");
+    graph.create_index("Item", "qty");
+    graph.create_range_index("Item", "qty");
+    graph.create_composite_index("Item", &["name", "qty"]);
+    assert!(
+        !graph.property_indices.is_empty()
+            && !graph.range_indices.is_empty()
+            && !graph.composite_indices.is_empty(),
+        "all three index families must be live, or the indexed arms are vacuous"
+    );
+    assert!(
+        graph
+            .property_indices
+            .values()
+            .any(|value_map| value_map.values().any(|members| !members.is_empty())),
+        "the indexes must have been populated from the seeded nodes"
+    );
+    graph
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Per-shape rollback fidelity
 // ─────────────────────────────────────────────────────────────────────
@@ -381,6 +451,13 @@ macro_rules! rollback_shapes {
                 #[test]
                 fn columnar() {
                     assert_rolls_back(&mut seeded_columnar(), $query, $scope);
+                }
+
+                /// The indexed shape — one user index of each family, whose
+                /// buckets the statement's writes maintain incrementally.
+                #[test]
+                fn indexed() {
+                    assert_rolls_back(&mut seeded_indexed(), $query, $scope);
                 }
             }
         )*
@@ -585,19 +662,71 @@ fn journalled_rollback_copies_zero_nodes() {
     assert_eq!(backend_clone_nodes(), 0);
 }
 
-/// A graph with a user-created property index falls back to the clone
-/// checkpoint. The observable contract is the same, and this test exists so
-/// the fallback stays exercised rather than becoming dead code.
+/// An indexed graph rolls back through the journal, not through a whole-graph
+/// clone. The fidelity half is covered by the `indexed` arm of every shape
+/// above; what this pins is the *cost* half — that a user index no longer
+/// downgrades the checkpoint for the rest of the session.
 #[test]
-fn indexed_graph_still_rolls_back_via_the_clone_path() {
-    let mut graph = seeded();
-    graph.create_index("Item", "name");
-    assert!(!graph.property_indices.is_empty(), "index must be live");
+fn indexed_graph_rolls_back_without_copying_the_graph() {
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+
+    let mut graph = seeded_indexed();
+    reset_backend_clone_count();
     assert_rolls_back(
         &mut graph,
         "MATCH (n:Item) SET n.name = 'touched', n.bad = duration({months: 2147483648})",
         None,
     );
+    assert_eq!(
+        backend_clone_nodes(),
+        0,
+        "an indexed graph must take the journal path, not the clone checkpoint"
+    );
+}
+
+/// The bucket-order case the position journal exists for.
+///
+/// `Item` 1 and 3 share a `qty` after the setup write, so that bucket holds
+/// two members in a known order. A statement that moves the *first* member out
+/// and then fails must put it back at the front — a rollback that merely
+/// restored membership would append it, silently reordering the rows an
+/// indexed `MATCH` returns.
+#[test]
+fn rollback_restores_index_bucket_order_not_just_membership() {
+    let mut graph = seeded_indexed();
+    run(&mut graph, "MATCH (n:Item {id: 3}) SET n.qty = 10");
+    let bucket_before = index_bucket(&graph, "qty", Value::Int64(10));
+    assert_eq!(
+        bucket_before.len(),
+        2,
+        "the fixture needs a bucket with two members to have an order at all"
+    );
+
+    let before = fingerprint(&mut graph);
+    let error = expect_failure(
+        &mut graph,
+        "MATCH (n:Item {id: 1}) SET n.qty = 999 \
+         WITH n MATCH (m:Item {id: 2}) SET m.bad = duration({months: 2147483648})",
+        None,
+    );
+    let after = fingerprint(&mut graph);
+
+    assert_eq!(before, after, "statement must roll back.\nerror: {error}");
+    assert_eq!(
+        index_bucket(&graph, "qty", Value::Int64(10)),
+        bucket_before,
+        "the evicted member must come back at its original position"
+    );
+}
+
+/// One `Item` property-index bucket's members, in bucket order.
+fn index_bucket(graph: &DirGraph, property: &str, value: Value) -> Vec<usize> {
+    graph
+        .property_indices
+        .get(&("Item".to_string(), property.to_string()))
+        .and_then(|value_map| value_map.get(&value))
+        .map(|members| members.iter().map(|idx| idx.index()).collect())
+        .unwrap_or_default()
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1011,6 +1011,91 @@ fn vivify_stubs(graph: &mut DirGraph, node_type: &str, ids: &[Value]) -> Result<
     Ok(report.nodes_created)
 }
 
+/// Journal every inverted-index eviction this delete is about to perform,
+/// with the *position* each doomed member occupies.
+///
+/// Position and not merely membership, because bucket order is the scan order
+/// an un-`ORDER BY`'d `MATCH` returns: `type_indices` drives a label scan and
+/// the user-index buckets are handed straight to the matcher. Must be called
+/// while the doomed indices are still in their buckets. One `Option` check
+/// when no checkpoint is open, which is every non-mutating call.
+fn journal_bucket_evictions(
+    graph: &mut DirGraph,
+    affected_types: &HashSet<String>,
+    nodes_to_delete: &HashSet<NodeIndex>,
+) {
+    if graph.graph.undo_journal_mut().is_none() {
+        return;
+    }
+    let mut evictions: Vec<(BucketId, Vec<NodeIndex>)> = Vec::new();
+    for node_type in affected_types {
+        if let Some(members) = graph.type_indices.get(node_type) {
+            evictions.push((BucketId::NodeType(node_type.clone()), members.to_vec()));
+        }
+        // User-created indexes, same treatment. Only buckets that actually
+        // hold a doomed node are captured, so the cost tracks the deletion
+        // rather than the size of the index.
+        for (key, value_map) in &graph.property_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in value_map {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::PropertyValue {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+        for (key, btree) in &graph.range_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in btree {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::RangeValue {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+        for (key, comp_map) in &graph.composite_indices {
+            if &key.0 != node_type {
+                continue;
+            }
+            for (value, members) in comp_map {
+                if members.iter().any(|idx| nodes_to_delete.contains(idx)) {
+                    evictions.push((
+                        BucketId::CompositeTuple {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                        members.clone(),
+                    ));
+                }
+            }
+        }
+    }
+    if graph.has_secondary_labels {
+        for (label, members) in &graph.secondary_label_index {
+            evictions.push((BucketId::SecondaryLabel(*label), members.clone()));
+        }
+    }
+    if let Some(journal) = graph.graph.undo_journal_mut() {
+        for (bucket, members) in &evictions {
+            journal.note_bucket_retain(bucket, members.iter().copied(), nodes_to_delete);
+        }
+    }
+}
+
 /// DETACH-delete a set of nodes: remove every incident edge, then the
 /// nodes, then clean the type / id / property / composite / secondary-label
 /// indexes. Shared by the Cypher DETACH DELETE executor and
@@ -1085,29 +1170,9 @@ pub(crate) fn detach_delete_nodes(
         }
     }
 
-    // Statement-rollback capture: record every inverted-index eviction with
-    // its *position*, so a failed statement restores bucket order and not
-    // merely membership — bucket order is the scan order an un-`ORDER BY`'d
-    // `MATCH` returns. Read before the `retain` sweeps below, while the doomed
-    // indices are still present. One `Option` check when no checkpoint is open.
-    if graph.graph.undo_journal_mut().is_some() {
-        let mut evictions: Vec<(BucketId, Vec<NodeIndex>)> = Vec::new();
-        for node_type in &affected_types {
-            if let Some(members) = graph.type_indices.get(node_type) {
-                evictions.push((BucketId::NodeType(node_type.clone()), members.to_vec()));
-            }
-        }
-        if graph.has_secondary_labels {
-            for (label, members) in &graph.secondary_label_index {
-                evictions.push((BucketId::SecondaryLabel(*label), members.clone()));
-            }
-        }
-        if let Some(journal) = graph.graph.undo_journal_mut() {
-            for (bucket, members) in &evictions {
-                journal.note_bucket_retain(bucket, members.iter().copied(), nodes_to_delete);
-            }
-        }
-    }
+    // Statement-rollback capture, before the `retain` sweeps below strip the
+    // doomed members out of the buckets.
+    journal_bucket_evictions(graph, &affected_types, nodes_to_delete);
 
     // Index cleanup — StableDiGraph keeps surviving indices stable.
     for node_type in &affected_types {

--- a/crates/kglite/src/graph/storage/undo.rs
+++ b/crates/kglite/src/graph/storage/undo.rs
@@ -26,9 +26,10 @@
 //!   [`crate::graph::storage::recording::RecordingGraph`] hooks, and the one
 //!   every Cypher write path funnels through;
 //! - **`DirGraph`'s inverted indexes** (`type_indices`,
-//!   `secondary_label_index`) and `timeseries_store`, captured at their
-//!   documented choke-point APIs, because those structures sit *above*
-//!   storage and a backend cannot see them.
+//!   `secondary_label_index`, and the user-created `property_indices` /
+//!   `range_indices` / `composite_indices`) and `timeseries_store`, captured
+//!   at their documented choke-point APIs, because those structures sit
+//!   *above* storage and a backend cannot see them.
 //!
 //! Everything else a statement can touch is O(schema)-sized and is restored
 //! verbatim from a cheap shell clone — see
@@ -58,8 +59,11 @@ use std::collections::HashSet;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
 
+use crate::datatypes::Value;
 use crate::graph::features::timeseries::NodeTimeseries;
-use crate::graph::schema::{EdgeData, InternedKey, NodeData};
+use crate::graph::schema::{
+    CompositeIndexKey, CompositeValue, EdgeData, IndexKey, InternedKey, NodeData,
+};
 
 /// A `Vec<NodeIndex>` bucket in one of `DirGraph`'s inverted indexes.
 /// Bucket edits are journalled with a *position* so a rollback restores the
@@ -72,6 +76,20 @@ pub enum BucketId {
     NodeType(String),
     /// `DirGraph::secondary_label_index`, keyed by interned label.
     SecondaryLabel(InternedKey),
+    /// One value bucket of a user-created single-property index
+    /// (`DirGraph::property_indices`).
+    PropertyValue { key: IndexKey, value: Value },
+    /// One value bucket of a user-created range index
+    /// (`DirGraph::range_indices`). Same key shape as
+    /// [`PropertyValue`](Self::PropertyValue); the bucket lives in a B-tree,
+    /// which orders the *values* but not the node indices inside a bucket.
+    RangeValue { key: IndexKey, value: Value },
+    /// One tuple bucket of a user-created composite index
+    /// (`DirGraph::composite_indices`).
+    CompositeTuple {
+        key: CompositeIndexKey,
+        value: CompositeValue,
+    },
 }
 
 /// One reversible edit. See the module docs for the replay contract.

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -731,12 +731,6 @@ impl Wal {
         self.file.sync_data()
     }
 
-    /// How this WAL makes each frame durable.
-    #[inline]
-    pub fn sync_mode(&self) -> SyncMode {
-        self.sync
-    }
-
     /// Reset to an empty WAL (header only), `fsync`ing the truncation.
     /// Called after a checkpoint (a full `.kgl` save) has folded every
     /// frame into the snapshot, so the log can start fresh.
@@ -1320,7 +1314,6 @@ mod tests {
         let p = dir.path().join("g.kgl-wal");
         {
             let mut wal = Wal::open(p.clone(), SyncMode::PageCache).unwrap();
-            assert_eq!(wal.sync_mode(), SyncMode::PageCache);
             wal.append(&frame(1)).unwrap();
             wal.append(&frame(2)).unwrap();
         }

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -31,14 +31,47 @@
 //!
 //! ## Crash safety of the format
 //!
-//! A frame is `[len: u32 LE][crc32: u32 LE][payload: codec(WalFrame)]`.
+//! A frame is `[len: u32 LE][crc32: u32 LE][payload: codec(WalFrame)]`,
+//! emitted by a **single** `write_all` (see [`append_frame`]).
 //! The v2/v3 file headers select Postcard for every frame. Older headers
 //! are rejected before any payload or torn-tail handling.
 //! A crash mid-append leaves a torn trailing frame; [`read_frames`] stops
 //! at the first short read or CRC mismatch and returns every frame up to
 //! it. A torn frame is therefore *discarded*, never half-applied — the
-//! atomic unit of durability is the whole frame, committed by the `fsync`
-//! that follows its append.
+//! atomic unit of durability is the whole frame.
+//!
+//! Torn-tail handling does **not** depend on `fsync`. `fsync` controls
+//! *when* bytes reach stable storage, not whether a write is atomic, so a
+//! torn frame has always been possible and has always been discarded. That
+//! is what lets the barrier become a per-level choice below without
+//! touching recovery.
+//!
+//! ## Durability levels
+//!
+//! [`DurabilityLevel`] names what a committed mutation survives; the WAL
+//! itself only cares about the derived [`SyncMode`]:
+//!
+//! - [`DurabilityLevel::Full`] → [`SyncMode::Barrier`]. Every frame is
+//!   flushed to stable storage before [`Wal::append`] returns, so an
+//!   acknowledged commit survives **power loss**.
+//! - [`DurabilityLevel::Normal`] → [`SyncMode::PageCache`]. The frame is
+//!   handed to the OS with `write(2)` and no barrier. The page cache
+//!   belongs to the kernel, not the process, so an acknowledged commit
+//!   survives the **process** dying (`SIGKILL`, panic, OOM-kill) but not an
+//!   OS crash or power loss.
+//! - [`DurabilityLevel::Off`] → no WAL at all; durability is whatever the
+//!   caller's `save()` checkpoints provide.
+//!
+//! Under `Normal` an OS crash can lose an arbitrary suffix of the log, but
+//! never a *hole*: [`read_frames`] stops at the first frame it cannot
+//! verify, so recovery always yields a **prefix**. Frames are per-commit
+//! and replay is idempotent, so a prefix is a valid earlier state rather
+//! than a corrupt one.
+//!
+//! One invariant this places on the *caller*: a checkpoint must not
+//! truncate frames that are still only in the page cache, or replaying the
+//! surviving prefix could revert data the checkpoint already holds. Call
+//! [`Wal::sync`] before checkpointing — see its docs.
 
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, Read, Write};
@@ -80,6 +113,95 @@ pub const WAL_FORMAT_VERSION: u8 = 3;
 pub const MIN_READABLE_WAL_FORMAT_VERSION: u8 = 2;
 
 const MAX_WAL_FRAME_BYTES: u64 = u32::MAX as u64;
+
+/// What a committed mutation is guaranteed to survive — the durability
+/// vocabulary a binding exposes to its users. Deliberately mirrors SQLite's
+/// `synchronous` levels (`FULL` / `NORMAL` / `OFF`), because the audience for
+/// an embedded database already knows that vocabulary and the guarantees line
+/// up.
+///
+/// The levels are stated in terms of *what survives*, not in terms of which
+/// syscall runs, because the syscall differs by platform while the guarantee
+/// does not. That is also why there is no separate "plain `fsync`" level: on
+/// Linux `fsync` is the power-loss barrier, while on macOS it is not (only
+/// `F_FULLFSYNC` flushes the drive cache), so such a level could not be given
+/// one honest description.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DurabilityLevel {
+    /// No write-ahead log. Nothing survives beyond the caller's most recent
+    /// `save()` checkpoint.
+    Off,
+    /// Log every commit, but do not barrier. An acknowledged mutation
+    /// survives the **process** dying — `SIGKILL`, an unhandled panic, an
+    /// OOM-kill — because the frame is already in the kernel's page cache.
+    /// An OS crash or power loss loses commits made since the last `save()`.
+    Normal,
+    /// Log every commit and barrier before returning. An acknowledged
+    /// mutation survives **power loss**. The default, and the strongest
+    /// guarantee the platform offers.
+    #[default]
+    Full,
+}
+
+impl DurabilityLevel {
+    /// Whether this level writes a WAL at all. `false` only for
+    /// [`DurabilityLevel::Off`].
+    #[inline]
+    pub fn logs(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// How the WAL should make each frame durable, or `None` when this level
+    /// keeps no log. Total by construction, so a new level cannot be added
+    /// without deciding its sync behaviour.
+    #[inline]
+    pub fn sync_mode(self) -> Option<SyncMode> {
+        match self {
+            Self::Off => None,
+            Self::Normal => Some(SyncMode::PageCache),
+            Self::Full => Some(SyncMode::Barrier),
+        }
+    }
+
+    /// The level named by a binding-facing string (`"full"` / `"normal"` /
+    /// `"off"`), or `None` if unrecognised. Shared by every binding so the
+    /// vocabulary cannot drift between them; the caller owns the error type
+    /// and message.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "full" => Some(Self::Full),
+            "normal" => Some(Self::Normal),
+            "off" => Some(Self::Off),
+            _ => None,
+        }
+    }
+
+    /// The canonical name of this level, the inverse of [`Self::from_name`].
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Normal => "normal",
+            Self::Full => "full",
+        }
+    }
+
+    /// Every accepted level name, for error messages that need to list them.
+    pub const NAMES: [&'static str; 3] = ["full", "normal", "off"];
+}
+
+/// How [`Wal::append`] makes a frame durable. Derived from a
+/// [`DurabilityLevel`] via [`DurabilityLevel::sync_mode`]; separate from it so
+/// that "no log at all" is unrepresentable on an open WAL file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncMode {
+    /// Barrier after every frame — `append` returns only once the bytes are
+    /// on stable storage. On Apple targets this is `fcntl(F_FULLFSYNC)`;
+    /// elsewhere it is `fdatasync`/`fsync`.
+    Barrier,
+    /// Hand the frame to the OS and return. Bytes are in the kernel page
+    /// cache, which outlives the process but not the kernel.
+    PageCache,
+}
 
 /// One logical, identity-keyed mutation. See the module docs for why
 /// the state-changing shapes are idempotent upserts.
@@ -214,6 +336,16 @@ fn write_header_version(w: &mut impl Write, version: u8) -> io::Result<()> {
 /// for `fsync`/`flush` after the append to make it durable — this fn
 /// only writes the bytes (so a batch of frames can share one fsync if
 /// the caller wants).
+///
+/// The prefix and payload are assembled into one buffer and emitted with a
+/// **single** `write_all`, rather than three. That removes two syscalls from
+/// the per-commit path, and — more importantly for
+/// [`DurabilityLevel::Normal`] — it shrinks the window in which a process
+/// death can leave a torn frame: a `write(2)` cannot be interrupted partway
+/// by `SIGKILL`, so a frame that fits in one write is either wholly in the
+/// page cache or wholly absent. A short write is still possible in
+/// principle, which is why the length/CRC torn-tail check remains the
+/// authority rather than an optimisation.
 pub fn append_frame(w: &mut impl Write, frame: &WalFrame) -> io::Result<()> {
     append_frame_with_codec(w, frame, crate::serde_codec::CURRENT_CODEC)
 }
@@ -228,9 +360,11 @@ fn append_frame_with_codec(
     let len = u32::try_from(payload.len())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "WAL frame exceeds 4 GiB"))?;
     let crc = crc32(&payload);
-    w.write_all(&len.to_le_bytes())?;
-    w.write_all(&crc.to_le_bytes())?;
-    w.write_all(&payload)?;
+    let mut framed = Vec::with_capacity(8 + payload.len());
+    framed.extend_from_slice(&len.to_le_bytes());
+    framed.extend_from_slice(&crc.to_le_bytes());
+    framed.extend_from_slice(&payload);
+    w.write_all(&framed)?;
     Ok(())
 }
 
@@ -308,6 +442,18 @@ pub fn read_frames(mut r: impl Read, stream_len: u64) -> io::Result<Vec<WalFrame
         let len = u32::from_le_bytes(len_buf) as u64;
         let expected_crc = u32::from_le_bytes(crc_buf);
 
+        if len == 0 {
+            // A run of zero bytes — the shape an OS crash leaves when a
+            // file's length was extended but its data block never reached
+            // the platter, which `DurabilityLevel::Normal` makes reachable.
+            // `crc32(b"") == 0`, so a zero prefix would otherwise pass the
+            // CRC check as a "valid" empty frame and reach the decoder.
+            // `append_frame` can never emit one (the smallest real payload
+            // is a two-byte Postcard `lsn` + `ops` pair), so treat it as the
+            // torn tail it is — by intent, rather than relying on the
+            // decoder to reject it.
+            break Some(frame_start);
+        }
         if len > stream_len.saturating_sub(consumed) {
             // Declared length exceeds the bytes that exist — torn or
             // corrupt prefix. Stop WITHOUT allocating `len` bytes.
@@ -499,12 +645,21 @@ fn prepare_wal_file(path: &Path) -> io::Result<()> {
 /// An open, append-only WAL file. Session-scoped (one per open graph
 /// file) — it owns a `File` handle, so it lives *outside* the CoW-cloned
 /// `DirGraph` (which must stay `Clone`). Each [`append`](Self::append)
-/// writes a frame and `fsync`s, making the committed mutation durable
-/// before the call returns.
+/// writes a frame, and under [`SyncMode::Barrier`] also flushes it to
+/// stable storage, making the committed mutation durable before the call
+/// returns.
+///
+/// The handle is deliberately **unbuffered** — `file` is a bare [`File`],
+/// never a `BufWriter`. That is what makes [`SyncMode::PageCache`] mean
+/// anything: the bytes are in the kernel's page cache by the time `append`
+/// returns, so they outlive the process even without a barrier. Wrapping
+/// this in a userspace buffer would silently downgrade
+/// [`DurabilityLevel::Normal`] to "survives nothing".
 #[derive(Debug)]
 pub struct Wal {
     file: File,
     path: PathBuf,
+    sync: SyncMode,
 }
 
 impl Wal {
@@ -523,22 +678,63 @@ impl Wal {
     /// [`WAL_FORMAT_VERSION`]) is rejected before a single frame is
     /// appended; a *readable* older version is upgraded in place, since the
     /// frames already present parse under the current schema unchanged.
-    pub fn open(path: PathBuf) -> io::Result<Self> {
+    ///
+    /// `sync` fixes the per-append durability behaviour for the life of the
+    /// handle; see [`SyncMode`]. Header maintenance always barriers
+    /// regardless of the level — a WAL whose header might not exist after a
+    /// crash could not be recovered at all, and it is paid once per open
+    /// rather than once per commit.
+    pub fn open(path: PathBuf, sync: SyncMode) -> io::Result<Self> {
         // Create/validate/repair the header first, on an ordinary handle. By
         // the time the append handle below exists the file is well-formed, so
         // that handle only ever has to do what append handles can portably do.
         prepare_wal_file(&path)?;
         let file = OpenOptions::new().read(true).append(true).open(&path)?;
-        Ok(Self { file, path })
+        Ok(Self { file, path, sync })
     }
 
-    /// Append one frame and `fsync` — the durability point. Returns only
-    /// after the bytes are on stable storage.
+    /// Append one frame — the commit point.
+    ///
+    /// Under [`SyncMode::Barrier`] this returns only after the bytes are on
+    /// stable storage. Under [`SyncMode::PageCache`] it returns once the
+    /// kernel has the bytes, which is the whole of
+    /// [`DurabilityLevel::Normal`]'s guarantee: the page cache is the
+    /// kernel's, so it survives this process dying but not the kernel
+    /// dying.
     pub fn append(&mut self, frame: &WalFrame) -> io::Result<()> {
         append_frame(&mut self.file, frame)?;
         self.file.flush()?;
-        self.file.sync_data()?;
+        if self.sync == SyncMode::Barrier {
+            self.file.sync_data()?;
+        }
         Ok(())
+    }
+
+    /// Flush every frame appended so far to stable storage — the barrier
+    /// that [`SyncMode::Barrier`] performs on every commit, on demand.
+    ///
+    /// Two callers, and both matter:
+    ///
+    /// 1. **Before a checkpoint.** A checkpoint truncates the log, so the
+    ///    frames it folds in must already be on disk. If they are not, an OS
+    ///    crash in the window between writing the checkpoint and truncating
+    ///    the log can leave a *prefix* of the frames, and replaying that
+    ///    prefix over the newer checkpoint would revert data the checkpoint
+    ///    already holds. Under [`SyncMode::Barrier`] the frames are on disk
+    ///    already and this is the no-op it looks like; under
+    ///    [`SyncMode::PageCache`] it is load-bearing.
+    /// 2. **On user demand.** It is the only way a `Normal` graph can reach
+    ///    power-safety at a granularity finer than a whole checkpoint —
+    ///    "flush at end of request", "flush before shutdown".
+    pub fn sync(&mut self) -> io::Result<()> {
+        self.file.flush()?;
+        self.file.sync_data()
+    }
+
+    /// How this WAL makes each frame durable.
+    #[inline]
+    pub fn sync_mode(&self) -> SyncMode {
+        self.sync
     }
 
     /// Reset to an empty WAL (header only), `fsync`ing the truncation.
@@ -620,6 +816,14 @@ mod tests {
     fn read_frames_all(bytes: Vec<u8>) -> io::Result<Vec<WalFrame>> {
         let len = bytes.len() as u64;
         read_frames(Cursor::new(bytes), len)
+    }
+
+    /// Open a WAL at the full barrier — the default level, and the one every
+    /// pre-existing test in this module was written against. Tests that care
+    /// about the no-barrier rung call [`Wal::open`] directly with
+    /// [`SyncMode::PageCache`].
+    fn open_wal(path: PathBuf) -> io::Result<Wal> {
+        Wal::open(path, SyncMode::Barrier)
     }
 
     #[test]
@@ -861,7 +1065,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut wal = Wal::open(p.clone()).unwrap();
+        let mut wal = open_wal(p.clone()).unwrap();
         wal.append(&WalFrame {
             lsn: 2,
             ops: vec![MutationOp::SetNodeLabels {
@@ -895,7 +1099,7 @@ mod tests {
         header.push(WAL_FORMAT_VERSION + 1);
         std::fs::write(&p, &header).unwrap();
         for message in [
-            Wal::open(p.clone()).unwrap_err().to_string(),
+            open_wal(p.clone()).unwrap_err().to_string(),
             recover(&p).unwrap_err().to_string(),
         ] {
             assert!(
@@ -920,13 +1124,13 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("g.kgl-wal");
         {
-            let mut wal = Wal::open(p.clone()).unwrap();
+            let mut wal = open_wal(p.clone()).unwrap();
             wal.append(&frame(1)).unwrap();
             wal.append(&frame(2)).unwrap();
         } // drop closes the file
           // Reopen for append (must NOT clobber existing frames)...
         {
-            let mut wal = Wal::open(p.clone()).unwrap();
+            let mut wal = open_wal(p.clone()).unwrap();
             wal.append(&frame(3)).unwrap();
         }
         let frames = recover(&p).unwrap();
@@ -939,7 +1143,7 @@ mod tests {
         let p = dir.path().join("g.kgl-wal");
         std::fs::write(&p, b"KWAL\x01").unwrap();
 
-        let error = Wal::open(p).unwrap_err();
+        let error = open_wal(p).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
@@ -947,7 +1151,7 @@ mod tests {
     fn reset_truncates_to_header_only() {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("g.kgl-wal");
-        let mut wal = Wal::open(p.clone()).unwrap();
+        let mut wal = open_wal(p.clone()).unwrap();
         wal.append(&frame(1)).unwrap();
         wal.append(&frame(2)).unwrap();
         wal.reset().unwrap();
@@ -992,7 +1196,7 @@ mod tests {
             std::fs::write(&p, &WAL_MAGIC[..torn_len.min(4)]).unwrap();
             // For torn_len == 4 the magic is complete but the version
             // byte is missing — still shorter than a full header.
-            let mut wal = Wal::open(p.clone()).unwrap();
+            let mut wal = open_wal(p.clone()).unwrap();
             wal.append(&frame(1)).unwrap();
             drop(wal);
             let frames = recover(&p).unwrap();
@@ -1011,7 +1215,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("g.kgl-wal");
         std::fs::write(&p, b"XXXXX").unwrap();
-        let mut wal = Wal::open(p.clone()).unwrap();
+        let mut wal = open_wal(p.clone()).unwrap();
         wal.append(&frame(7)).unwrap();
         drop(wal);
         assert_eq!(recover(&p).unwrap().len(), 1);
@@ -1024,7 +1228,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("g.kgl-wal");
         std::fs::write(&p, b"not a wal file at all").unwrap();
-        let err = Wal::open(p.clone()).unwrap_err();
+        let err = open_wal(p.clone()).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         // The file is untouched.
         assert_eq!(std::fs::read(&p).unwrap(), b"not a wal file at all");
@@ -1072,7 +1276,147 @@ mod tests {
     fn open_fresh_file_is_immediately_recoverable() {
         let dir = TempDir::new().unwrap();
         let p = dir.path().join("g.kgl-wal");
-        let _wal = Wal::open(p.clone()).unwrap();
+        let _wal = open_wal(p.clone()).unwrap();
         assert!(recover(&p).unwrap().is_empty());
+    }
+
+    // ── durability levels ────────────────────────────────────────────
+
+    /// The level → sync-mode mapping is the whole of the feature, so pin it
+    /// rather than trusting the match arms to stay put.
+    #[test]
+    fn level_maps_to_sync_mode_and_round_trips_by_name() {
+        assert_eq!(DurabilityLevel::Off.sync_mode(), None);
+        assert_eq!(
+            DurabilityLevel::Normal.sync_mode(),
+            Some(SyncMode::PageCache)
+        );
+        assert_eq!(DurabilityLevel::Full.sync_mode(), Some(SyncMode::Barrier));
+
+        assert!(!DurabilityLevel::Off.logs());
+        assert!(DurabilityLevel::Normal.logs());
+        assert!(DurabilityLevel::Full.logs());
+
+        // The default must stay `Full`: weakening it is a maintainer
+        // decision, never a side effect of editing this enum.
+        assert_eq!(DurabilityLevel::default(), DurabilityLevel::Full);
+
+        for name in DurabilityLevel::NAMES {
+            let level = DurabilityLevel::from_name(name).expect("listed name must parse");
+            assert_eq!(level.name(), name);
+        }
+        assert_eq!(DurabilityLevel::from_name("fsync"), None);
+        assert_eq!(DurabilityLevel::from_name("FULL"), None);
+    }
+
+    /// The `Normal` rung's core claim at the format level: a frame appended
+    /// without a barrier is still a complete, recoverable frame. (This test
+    /// cannot observe the *absence* of the fsync — that is what the
+    /// process-crash tests in `tests/test_durability.py` are for. What it
+    /// pins is that skipping the barrier does not corrupt or truncate.)
+    #[test]
+    fn page_cache_appends_are_recoverable() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("g.kgl-wal");
+        {
+            let mut wal = Wal::open(p.clone(), SyncMode::PageCache).unwrap();
+            assert_eq!(wal.sync_mode(), SyncMode::PageCache);
+            wal.append(&frame(1)).unwrap();
+            wal.append(&frame(2)).unwrap();
+        }
+        let got = recover(&p).unwrap();
+        assert_eq!(got.iter().map(|f| f.lsn).collect::<Vec<_>>(), [1, 2]);
+    }
+
+    /// `sync()` is callable at every mode and leaves the log intact — under
+    /// `Barrier` it is redundant, under `PageCache` it is the user-facing
+    /// route to power-safety without a full checkpoint.
+    #[test]
+    fn explicit_sync_preserves_frames_at_every_mode() {
+        for mode in [SyncMode::Barrier, SyncMode::PageCache] {
+            let dir = TempDir::new().unwrap();
+            let p = dir.path().join("g.kgl-wal");
+            let mut wal = Wal::open(p.clone(), mode).unwrap();
+            wal.append(&frame(1)).unwrap();
+            wal.sync().unwrap();
+            wal.append(&frame(2)).unwrap();
+            wal.sync().unwrap();
+            drop(wal);
+            assert_eq!(
+                recover(&p)
+                    .unwrap()
+                    .iter()
+                    .map(|f| f.lsn)
+                    .collect::<Vec<_>>(),
+                [1, 2],
+                "sync() must not disturb the log at {mode:?}"
+            );
+        }
+    }
+
+    /// A zero-filled run is what an OS crash leaves when a file's length was
+    /// extended but its data block never landed — reachable only once the
+    /// per-commit barrier is optional. `crc32(b"") == 0`, so without the
+    /// explicit guard a zero prefix passes the CRC check as a "valid" empty
+    /// frame, and only the decoder's failure stops recovery. Stop by intent.
+    #[test]
+    fn zero_filled_hole_is_treated_as_a_torn_tail() {
+        let good = vec![frame(1), frame(2)];
+        let mut bytes = write_wal(&good);
+        // A zero-length/zero-CRC prefix: self-consistent, and not a frame.
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        // A perfectly valid frame after the hole must stay unreachable — a
+        // frame boundary cannot be trusted past a gap.
+        append_frame(&mut bytes, &frame(3)).unwrap();
+
+        let got = read_frames_all(bytes).unwrap();
+        assert_eq!(got.iter().map(|f| f.lsn).collect::<Vec<_>>(), [1, 2]);
+    }
+
+    /// A whole page of zeros — the realistic shape of the hazard above.
+    #[test]
+    fn zero_page_after_frames_recovers_the_prefix() {
+        let mut bytes = write_wal(&[frame(1)]);
+        bytes.extend_from_slice(&[0u8; 4096]);
+        let got = read_frames_all(bytes).unwrap();
+        assert_eq!(got, vec![frame(1)]);
+    }
+
+    /// Counts `write` calls so the single-syscall property is asserted, not
+    /// assumed. `write_all` issues exactly one `write` per full acceptance.
+    struct CountingWriter {
+        inner: Vec<u8>,
+        writes: usize,
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.writes += 1;
+            self.inner.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// One frame is one write. Beyond saving two syscalls per commit, this
+    /// is what keeps a `SIGKILL` from landing *between* a frame's length
+    /// prefix and its payload: a `write(2)` is not interruptible partway.
+    #[test]
+    fn frame_is_emitted_in_a_single_write() {
+        let mut w = CountingWriter {
+            inner: Vec::new(),
+            writes: 0,
+        };
+        append_frame(&mut w, &frame(1)).unwrap();
+        assert_eq!(w.writes, 1, "a frame must not be split across writes");
+
+        // …and the bytes are still exactly what the reader expects.
+        let mut bytes = Vec::new();
+        write_header(&mut bytes).unwrap();
+        bytes.extend_from_slice(&w.inner);
+        assert_eq!(read_frames_all(bytes).unwrap(), vec![frame(1)]);
     }
 }

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -370,7 +370,7 @@ pub mod api {
     pub mod durable {
         pub use crate::graph::mutation::wal_replay::apply_frames;
         pub use crate::graph::storage::recording::{resolve_ops, RecordingGraph};
-        pub use crate::graph::wal::{recover, wal_path, Wal, WalFrame};
+        pub use crate::graph::wal::{recover, wal_path, DurabilityLevel, SyncMode, Wal, WalFrame};
     }
 
     /// Code-entity read surface — resolve / locate / contextualize entities

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -30,7 +30,8 @@ KGLite stores nodes and relationships in a Rust graph structure ([petgraph](http
   results are already materialized in Rust (Python values convert on access)
 - **Fluent API** chains build a *selection* (a set of node indices) — no data is copied until you call `collect()`, `to_df()`, etc.
 - **Persistence** uses `save()`/`load()` snapshots; `open()` is crash-safe by
-  default via a write-ahead log (`durable=False` opts out; `storage="disk"`
+  default via a write-ahead log (`durable="normal"` keeps the log without the
+  per-commit barrier, `durable="off"` opts out entirely; `storage="disk"`
   is the exception — see [Choosing a storage mode](#choosing-a-storage-mode)),
   and context-managed `open()` also persists on clean exit
 
@@ -76,7 +77,8 @@ Cypher API, so moving up is a one-line constructor change.
 `mapped` keeps the same per-commit crash safety as in-memory, so growing out
 of RAM costs you nothing there. `disk` commits by publishing an immutable
 generation instead of by logging a write: `kglite.open(path, storage="disk")`
-opens **non-durable** (passing `durable=True` raises rather than pretending),
+opens **non-durable** (passing any logging level — `durable=True`/`"full"` or
+`durable="normal"` — raises rather than pretending),
 and a crash loses every mutation made since the last `save()`. That is a real
 and bounded guarantee — the published generation always survives intact — but
 it is *your* `save()` calls, not the engine, that decide how much a crash can

--- a/docs/python/guides/durable-apps.md
+++ b/docs/python/guides/durable-apps.md
@@ -67,15 +67,53 @@ You get this without asking for it because it is what makes an embedded database
 trustworthy: the alternative default silently loses every write since the last
 explicit `save()` whenever a process dies.
 
-## Opting out: `durable=False`
+The default is the *strongest* level, not the only one. If power-loss safety is
+more than your application needs, `durable="normal"` keeps the log and drops
+only the per-commit barrier — see [Choosing a durability
+level](#choosing-a-durability-level).
 
-Durability costs one `fsync` per commit. When the graph is rebuildable from
-source data — a bulk load, a derived index, a scratch analysis — that cost buys
-nothing, and `durable=False` gives you the older snapshot-on-close behaviour:
+## Choosing a durability level
+
+`durable` names **what a committed mutation survives**. It uses SQLite's
+`synchronous` vocabulary, and the levels are stated as guarantees rather than
+as syscalls — the syscall differs by platform, the guarantee does not.
+
+| `durable=` | A committed mutation survives… | Per-commit cost |
+|---|---|---|
+| `"full"` (or `True`) — **default** | process crash, OS crash, **power loss** | one barrier |
+| `"normal"` | **process crash** — `kill -9`, panic, OOM-kill | no barrier |
+| `"off"` (or `False`) | nothing since the last `save()` | no log |
+
+`True` and `False` are accepted spellings of `"full"` and `"off"`, so existing
+code keeps working unchanged.
+
+### `"normal"` — the process-crash level
 
 ```python
-g = kglite.open("kb.kgl", durable=False)
-g.add_nodes(df, node_type="Topic", unique_id_field="id")   # no fsync per write
+g = kglite.open("app.kgl", durable="normal")
+g.cypher("CREATE (:Order {id: 1001, total: 49.90})")   # logged, not barriered
+```
+
+The frame is handed to the kernel with a plain write before the call returns.
+**The page cache belongs to the kernel, not to your process**, so the commit
+survives your process dying by any means — an uncaught exception, `kill -9`,
+the OOM killer. What it does not survive is the *kernel* dying: an OS crash or
+a power cut loses commits made since the last `save()`.
+
+That is the right trade for most applications, because a crashing process is
+the failure that actually happens and a power cut is the one you keep backups
+for. It is also the level to reach for when per-commit barrier latency is
+shaping your write throughput — `"normal"` writes the same log frame and skips
+only the barrier.
+
+### `"off"` — no log at all
+
+When the graph is rebuildable from source data — a bulk load, a derived index,
+a scratch analysis — logging buys nothing:
+
+```python
+g = kglite.open("kb.kgl", durable="off")
+g.add_nodes(df, node_type="Topic", unique_id_field="id")   # nothing logged
 g.save()          # one explicit checkpoint at the end
 g.close()
 ```
@@ -85,6 +123,31 @@ What that is **not**: crash-safe. A snapshot is written only when *you* call
 killed mid-session (`kill -9`, power loss, an unhandled crash before the next
 `save()`), the work since the last checkpoint is gone.
 
+### Taking a power-safe point on demand: `sync()`
+
+`"normal"` skips the per-commit barrier — but you can take that barrier
+whenever it matters:
+
+```python
+g = kglite.open("app.kgl", durable="normal")
+
+def handle_request(payload):
+    g.cypher("CREATE (:Event $props)", params={"props": payload})
+
+handle_request(...)
+g.sync()      # everything committed so far now survives power loss too
+```
+
+`sync()` writes **no checkpoint** and truncates nothing — it only makes the
+existing log durable, which is why it is the right granularity for "flush at
+the end of a request" or "flush before shutdown". A full `save()` republishes
+the entire graph and is far more expensive.
+
+Under `"full"` it returns immediately (every commit was already barriered). On
+a graph with no log it raises `ValueError` rather than silently doing nothing,
+because a caller who believes they bought power-safety and got nothing is the
+failure that costs data.
+
 ## How durability works
 
 With durability on, every committed mutation is appended to a
@@ -93,9 +156,11 @@ returns**. A mutation that has returned is guaranteed to survive a hard crash.
 
 How it fits together:
 
-- **Each mutation** → one WAL frame, `fsync`'d per commit. This is the
-  durability cost: durable writes are bounded by `fsync` latency, not by engine
-  speed (see "Cost and tuning" below).
+- **Each mutation** → one WAL frame, written before the call returns. Under
+  `"full"` the frame is also barriered to stable storage per commit; that
+  barrier is the durability cost, and it bounds write latency by device
+  latency rather than engine speed (see "Cost and tuning" below). Under
+  `"normal"` the frame is written but not barriered.
 - **`save()`** → writes a full checkpoint (`.kgl`) and **truncates the WAL**.
   The checkpoint is the new baseline; the WAL starts empty again.
 - **`open(...)`** → loads the last checkpoint, then **replays**
@@ -132,12 +197,13 @@ optimising for:
 
 | You want… | Use | Trade-off |
 |---|---|---|
-| Every committed write to survive a hard crash | `open(path)` (the default) | One `fsync` per commit; reopen is O(graph) (loads the whole graph). |
-| Maximum write throughput on rebuildable data | `open(path, durable=False)` | No `fsync` per write; a crash loses work since the last checkpoint. |
+| Every committed write to survive a hard crash | `open(path)` (the default) | One barrier per commit; reopen is O(graph) (loads the whole graph). |
+| Committed writes to survive a crashing *process*, cheaply | `open(path, durable="normal")` | No barrier per commit; an OS crash or power cut loses work since the last `save()`. Call `sync()` for a power-safe point. |
+| Maximum write throughput on rebuildable data | `open(path, durable="off")` | Nothing logged; a crash loses work since the last checkpoint. |
 | Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` | Same per-commit WAL guarantee; property columns spill to mmap. |
 | 100 M+ nodes (Wikidata-scale), cheap cold-open | `open(path, storage="disk")` | Paged mmap, lazy load; **no per-commit WAL** — durability is your `save()` calls. |
 
-The first two are **in-memory** — the whole graph lives in RAM, which is what
+The first three are **in-memory** — the whole graph lives in RAM, which is what
 makes traversal and multi-hop queries fast. Durability adds crash-safety on
 top of that model without changing the in-memory read path.
 
@@ -178,13 +244,23 @@ model.
 
 ## Cost and tuning
 
-- **Durability is `fsync`-bound, not engine-bound.** A workload of many
-  small committed transactions spends its time waiting on the disk to confirm
-  each `fsync`, not in KGLite. `durable=False` does the same logical work
-  far faster precisely because it skips the per-commit `fsync`. This is the
-  price of crash-safety and is inherent to any WAL database. The cost scales
-  with the *number* of commits and with device latency, not with graph size,
-  and reads pay nothing at all.
+- **`"full"` is barrier-bound, not engine-bound.** A workload of many small
+  committed transactions spends its time waiting on the disk to confirm each
+  barrier, not in KGLite. This is the price of power-loss safety and is
+  inherent to any WAL database. The cost scales with the *number* of commits
+  and with device latency, not with graph size, and reads pay nothing at all.
+- **`"normal"` is the level to try before you reach for `"off"`.** It writes
+  the same log frame and skips only the barrier, so it costs roughly what an
+  unlogged write costs while still losing nothing to a crashing process. If
+  you were about to disable durability purely for write throughput, this is
+  almost always the better answer — and `sync()` gives you power-safe points
+  wherever you actually need them.
+- **On macOS, `"full"` buys more than SQLite's default does.** KGLite's
+  barrier is `F_FULLFSYNC`, which flushes the drive's own write cache;
+  SQLite's default `synchronous=FULL` issues a plain `fsync`, which on macOS
+  does not. The guarantees are therefore not the same thing measured
+  differently — KGLite's default is the stronger one, and it costs
+  accordingly.
 - **Batch where you can.** One `cypher()` that creates 1,000 nodes is one
   `fsync`; 1,000 separate `cypher()` calls are 1,000 `fsync`s. Group related
   mutations into a single statement (or a transaction — see
@@ -200,10 +276,13 @@ model.
   immutable generation, so its durability boundary is that publish rather than a
   logical log; reconciling a replayed frame against a published generation needs
   a generation-aware log this release does not have. `open(path,
-  storage="disk")` therefore opens **non-durable**, and passing an explicit
-  `durable=True` raises `ValueError` rather than pretending. The in-memory
-  default and `storage="mapped"` are both fully durable — if you want crash
-  safety on a graph that outgrew RAM, `mapped` is the answer.
+  storage="disk")` therefore opens **non-durable**, and **both `durable="full"`
+  and `durable="normal"` raise `ValueError`** rather than pretending — the
+  levels are not uniform across storage modes, because the blocker here is the
+  commit boundary itself and not barrier strength. `storage="disk"` supports
+  only `durable="off"`. The in-memory default and `storage="mapped"` support
+  every level — if you want crash safety on a graph that outgrew RAM, `mapped`
+  is the answer.
 
   What disk mode *does* guarantee is worth stating exactly, because it is
   stronger than "no crash safety" and is kill-9 tested

--- a/docs/python/guides/import-export.md
+++ b/docs/python/guides/import-export.md
@@ -80,9 +80,11 @@ g.cypher("MATCH (p:Person) RETURN p.name")   # -> Alice
 - Supported for the in-memory default and `storage="mapped"`.
   `storage="disk"` opens non-durable (its commit boundary is a generation
   publish, not a log) and uses explicit-`save()` checkpoints.
-- **`durable=False` opts out** and skips the per-commit `fsync` entirely —
-  the right choice for bulk loading and for graphs rebuildable from source
-  data. Reads never pay for the capture path either way.
+- **`durable=False` opts out** of logging entirely — the right choice for bulk
+  loading and for graphs rebuildable from source data. If you want to keep the
+  log but not the per-commit barrier, `durable="normal"` costs roughly what an
+  unlogged write costs and still loses nothing to a crashing process. Reads
+  never pay for the capture path at any level.
 
 ## Export Formats
 

--- a/docs/python/guides/index.md
+++ b/docs/python/guides/index.md
@@ -26,7 +26,7 @@ Domain-specific surfaces — pull them in when your data has the shape:
 
 | Guide | Read this if… |
 |---|---|
-| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default (in-memory and `mapped`; `disk` checkpoints on `save()`), checkpoint-on-close, and when to opt out with `durable=False`. |
+| {doc}`durable-apps` | …the graph is long-lived state your app reopens across runs. `open()` load-or-create lifecycle, crash-safe write-ahead-log writes by default (in-memory and `mapped`; `disk` checkpoints on `save()`), checkpoint-on-close, the `"full"`/`"normal"`/`"off"` durability levels and what each survives, and `sync()` for a power-safe point on demand. |
 | {doc}`derived-index` | …the authoritative copy of your data lives elsewhere — a warehouse, an API, a directory — and the graph is a rebuildable projection you query. Rebuild-and-swap, incremental refresh, carrying embeddings across a rebuild. |
 | {doc}`primary-store` | …the graph *is* the authoritative copy. What holds (statement atomicity, WAL crash safety, snapshot isolation), what is opt-in, and the limits stated plainly. |
 | {doc}`okf` | …your "data" is a markdown knowledge base — an OKF bundle, a Claude memory dir, a skills folder, an Obsidian vault. Frontmatter → nodes, links → typed edges. |

--- a/docs/python/guides/primary-store.md
+++ b/docs/python/guides/primary-store.md
@@ -55,9 +55,11 @@ never observes a torn file.
 `storage="disk"` is the exception, and not because it was overlooked: a disk
 graph commits by publishing an immutable generation, so a logical write-ahead
 log is not its durability boundary. A disk graph opens non-durable and takes
-`save()` checkpoints instead. Asking for `durable=True` there raises
-`ValueError` explaining that; the *default* does not raise, so disk callers are
-unaffected by the default being on elsewhere.
+`save()` checkpoints instead. Asking for any logging level there —
+`durable=True`/`"full"` *or* `durable="normal"` — raises `ValueError`
+explaining that, since the blocker is the commit boundary rather than barrier
+strength; only `durable="off"` is supported. The *default* does not raise, so
+disk callers are unaffected by the default being on elsewhere.
 
 **Not everything is logged.** State the log cannot express is *checkpoint-only*
 and is persisted by `save()` rather than by the log: schema and config metadata,
@@ -66,13 +68,16 @@ user-created indexes, embeddings, and timeseries. If those matter to you, a
 
 Three consequences worth internalising before you rely on this:
 
-- **It costs one `fsync` per committed mutation.** Writes now wait on physical
+- **It costs one barrier per committed mutation.** Writes now wait on physical
   storage, so the cost is device latency rather than graph size — most visible
   in loops of many small writes, negligible for a few large ones. Reads are
-  unaffected. `durable=False` remains fully supported and is the right choice
-  for bulk loading and for graphs you can rebuild from source. Batching writes
-  into one statement, or one `begin()` transaction, buys throughput *and* crash
-  safety.
+  unaffected. `durable="normal"` keeps the log and drops only that barrier: a
+  committed mutation still survives the process dying, but an OS crash or power
+  cut loses work since the last `save()`, and `sync()` gives you a power-safe
+  point on demand. `durable=False` (no log at all) remains fully supported and
+  is the right choice for bulk loading and for graphs you can rebuild from
+  source. Batching writes into one statement, or one `begin()` transaction,
+  buys throughput *and* the strongest guarantee.
 - **A `with` block is not a transaction.** Mutations commit as they run, so an
   exception inside the block does not discard them — they are recovered on the
   next `open()`. What the clean or failed exit controls is whether a *checkpoint*
@@ -186,7 +191,7 @@ offending value, and is worth logging; the type and code are the contract.
 
 | | Default | To change |
 |---|---|---|
-| Crash safety | **On** for in-memory and `mapped`; `disk` opens non-durable | `durable=False` to opt out |
+| Crash safety | **On** (`"full"` — survives power loss) for in-memory and `mapped`; `disk` opens non-durable | `durable="normal"` to keep the log without the per-commit barrier, `durable="off"` to opt out entirely |
 | Schema | No schema; any property on any node | `define_schema(...)` |
 | UNIQUE / NOT NULL / node key | Permissive — a type declaring none keeps the old behaviour | `unique` / `required` / `primary_key` in `define_schema` |
 | Freshness stamps | Off, so writes stay deterministic | `auto_timestamp: True` per type |

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -3,7 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Optional, Protocol, Union, overload, runtime_checkable
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    Protocol,
+    Union,
+    overload,
+    runtime_checkable,
+)
 
 import pandas as pd
 
@@ -727,7 +736,7 @@ def open(
     path: str,
     *,
     storage: str | None = None,
-    durable: bool | None = None,
+    durable: bool | Literal["full", "normal", "off"] | None = None,
     lock: bool = True,
 ) -> KnowledgeGraph:
     """Open a graph at ``path`` — load it if it exists, create a fresh one if
@@ -749,21 +758,42 @@ def open(
             ``"disk"``); ignored when opening an existing file, which keeps the
             mode it was saved in.
         durable: Write-ahead logging — **on by default**. Each committed
-            mutation is appended to a ``<path>-wal`` sidecar and ``fsync``'d
-            before the call returns, and on open any WAL frames are replayed
-            onto the loaded checkpoint to recover work committed since the last
-            ``save()``. ``save()`` writes a full checkpoint and truncates the
-            log.
+            mutation is appended to a ``<path>-wal`` sidecar, and on open any
+            WAL frames are replayed onto the loaded checkpoint to recover work
+            committed since the last ``save()``. ``save()`` writes a full
+            checkpoint and truncates the log.
 
-            - ``None`` (default) — enabled wherever it is supported, i.e. for
-              the in-memory default and ``storage="mapped"``. A
-              ``storage="disk"`` graph opens **non-durable** rather than
-              raising, since its commit boundary is a generation publish, not a
-              logical log.
-            - ``True`` — required. ``storage="disk"`` raises ``ValueError``
-              rather than quietly returning a graph without the crash safety
-              you asked for.
-            - ``False`` — opt out. See the performance note below.
+            The level names **what a committed mutation survives**, using
+            SQLite's ``synchronous`` vocabulary. These are guarantees, not
+            syscalls — the syscall differs by platform, the guarantee does not:
+
+            - ``"full"`` (also spelled ``True``, and the default) — survives
+              **power loss**. One barrier per commit. On macOS that barrier is
+              ``F_FULLFSYNC``, a stronger guarantee than SQLite's own default
+              provides.
+            - ``"normal"`` — survives the **process** dying: ``SIGKILL``, an
+              unhandled panic, an OOM-kill. The frame is in the kernel's page
+              cache before the call returns, and the page cache outlives the
+              process. An OS crash or power loss loses commits made since the
+              last ``save()``. No barrier per commit. Call :meth:`sync
+              <KnowledgeGraph.sync>` to take an explicit power-safe point
+              without republishing the whole graph.
+            - ``"off"`` (also spelled ``False``) — no log. The graph still
+              remembers ``path`` for ``save()``; a crash loses everything since
+              the last checkpoint.
+            - ``None`` (default) — ``"full"``, except on ``storage="disk"``
+              where it resolves to ``"off"`` rather than raising.
+
+            **The levels are not uniform across storage modes:**
+            ``storage="disk"`` supports only ``"off"``, and both ``"full"`` and
+            ``"normal"`` raise ``ValueError`` there. A disk graph commits by
+            publishing an immutable generation rather than by logging a write,
+            so the blocker is structural, not a matter of barrier strength.
+
+            Which to pick: ``"full"`` when losing an acknowledged write is
+            unacceptable; ``"normal"`` when you want a crash-safe application
+            and treat power loss as a restore-from-backup event; ``"off"`` for
+            bulk loading and graphs rebuildable from source data.
         lock: Single-writer guard — **on by default**. Opening takes an
             exclusive advisory lock on a ``<path>.lock`` sidecar and holds it
             until ``close()`` / ``with``-block exit, so a second process that
@@ -805,20 +835,27 @@ def open(
         lock, and does nothing useful for a dead one.
 
     Note:
-        **What durability costs.** Crash safety is bought with one ``fsync``
-        per committed mutation, so a write returns only once the log entry is
-        on physical storage. That makes each individual write substantially
-        more expensive than an unlogged one — the cost is dominated by device
-        latency, not by graph size, so it is most visible in loops of many
-        small writes and least visible for a few large ones. Reads are
-        completely unaffected: the capture layer forwards them with no
-        overhead.
+        **What durability costs.** Under ``"full"``, crash safety is bought
+        with one barrier per committed mutation, so a write returns only once
+        the log entry is on physical storage. That makes each individual write
+        substantially more expensive than an unlogged one — the cost is
+        dominated by device latency, not by graph size, so it is most visible
+        in loops of many small writes and least visible for a few large ones.
+        Reads are completely unaffected: the capture layer forwards them with
+        no overhead.
 
-        Prefer ``durable=False`` for bulk loading and for graphs that are
+        ``"normal"`` is where that cost goes away while the log stays: it
+        writes the same frame and skips only the barrier, so a write costs
+        roughly what an unlogged write costs, and a process crash still loses
+        nothing. That is the level to reach for when the failure you are
+        actually defending against is a crashing process rather than a power
+        cut.
+
+        Otherwise: prefer ``durable=False`` for bulk loading and for graphs
         rebuildable from source data, then ``save()`` once at the end; batch
         many small mutations into one statement (or one ``begin()``
         transaction, which commits as a single log entry) when you need both
-        throughput and crash safety.
+        throughput and the strongest guarantee.
 
     Note:
         **A ``with`` block is not a transaction.** Each mutation commits as it
@@ -3476,6 +3513,38 @@ class KnowledgeGraph:
                 flush happens anyway): the save is the checkpoint that truncates
                 the fsync'd write-ahead log, so skipping the flush could lose
                 both the checkpoint and the log on a crash.
+        """
+        ...
+
+    def sync(self) -> None:
+        """Flush every commit made so far to stable storage.
+
+        This is the barrier ``durable="full"`` performs on *every* commit,
+        taken on demand — and it is what makes ``durable="normal"`` adoptable
+        rather than merely fast. Without it, a ``"normal"`` graph's only route
+        to power-safety is a full :meth:`save`, which republishes the entire
+        graph: the wrong granularity for "flush at the end of a request" or
+        "flush before shutdown"::
+
+            g = kglite.open("app.kgl", durable="normal")
+            handle_request(g)      # commits survive the process dying
+            g.sync()               # …and now survive power loss too
+
+        Behaviour by level:
+
+        - ``"normal"`` — the real work. Everything committed before this call
+          now survives power loss, not just process death.
+        - ``"full"`` — returns immediately; every commit was already
+          barriered, so the guarantee is already met.
+        - ``"off"`` or a graph opened without a log — raises ``ValueError``.
+          There is nothing to flush, and silently doing nothing would leave a
+          caller believing they had bought power-safety.
+
+        Pending mutations are folded into the log first, so this is also the
+        safe way to force a commit boundary before an external snapshot.
+
+        Unlike :meth:`save`, this writes **no checkpoint** and does not
+        truncate the log — it only makes the existing log durable.
         """
         ...
 

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -1063,6 +1063,10 @@
           "kind": "method",
           "signature": "(self, /, other)"
         },
+        "sync": {
+          "kind": "method",
+          "signature": "(self, /)"
+        },
         "time_index": {
           "kind": "method",
           "signature": "(self, /, node_id)"

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -733,6 +733,39 @@ pub fn kglite::api::cypher::resolve_node_property(node: &kglite::api::NodeData, 
 pub fn kglite::api::cypher::rewrite_text_score(query: &mut kglite::api::cypher::CypherQuery, params: &std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>) -> core::result::Result<kglite::api::cypher::planner::simplification::TextScoreRewrite, alloc::string::String>
 pub fn kglite::api::cypher::validate_schema(query: &kglite::api::cypher::CypherQuery, graph: &kglite::api::DirGraph) -> core::result::Result<(), kglite::api::cypher::planner::schema_check::SchemaError>
 pub mod kglite::api::durable
+pub enum kglite::api::durable::DurabilityLevel
+pub kglite::api::durable::DurabilityLevel::Full
+pub kglite::api::durable::DurabilityLevel::Normal
+pub kglite::api::durable::DurabilityLevel::Off
+impl kglite::api::durable::DurabilityLevel
+pub const kglite::api::durable::DurabilityLevel::NAMES: [&'static str; 3]
+pub fn kglite::api::durable::DurabilityLevel::from_name(name: &str) -> core::option::Option<Self>
+pub fn kglite::api::durable::DurabilityLevel::logs(self) -> bool
+pub fn kglite::api::durable::DurabilityLevel::name(self) -> &'static str
+pub fn kglite::api::durable::DurabilityLevel::sync_mode(self) -> core::option::Option<kglite::api::durable::SyncMode>
+impl core::clone::Clone for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::clone(&self) -> kglite::api::durable::DurabilityLevel
+impl core::cmp::Eq for kglite::api::durable::DurabilityLevel
+impl core::cmp::PartialEq for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::eq(&self, other: &kglite::api::durable::DurabilityLevel) -> bool
+impl core::default::Default for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::default() -> kglite::api::durable::DurabilityLevel
+impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::DurabilityLevel
+impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::SyncMode
+pub kglite::api::durable::SyncMode::Barrier
+pub kglite::api::durable::SyncMode::PageCache
+impl core::clone::Clone for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::clone(&self) -> kglite::api::durable::SyncMode
+impl core::cmp::Eq for kglite::api::durable::SyncMode
+impl core::cmp::PartialEq for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::eq(&self, other: &kglite::api::durable::SyncMode) -> bool
+impl core::fmt::Debug for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::SyncMode
+impl core::marker::StructuralPartialEq for kglite::api::durable::SyncMode
 pub struct kglite::api::durable::RecordingGraph<G: kglite::api::GraphRead>
 impl<G: kglite::api::GraphRead> kglite::api::durable::RecordingGraph<G>
 pub fn kglite::api::durable::RecordingGraph<G>::inner(&self) -> &G
@@ -799,9 +832,10 @@ pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph
 pub struct kglite::api::durable::Wal
 impl kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::append(&mut self, frame: &kglite::api::durable::WalFrame) -> core::io::error::Result<()>
-pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf) -> core::io::error::Result<Self>
+pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf, sync: kglite::api::durable::SyncMode) -> core::io::error::Result<Self>
 pub fn kglite::api::durable::Wal::path(&self) -> &std::path::Path
 pub fn kglite::api::durable::Wal::reset(&mut self) -> core::io::error::Result<()>
+pub fn kglite::api::durable::Wal::sync(&mut self) -> core::io::error::Result<()>
 impl core::fmt::Debug for kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::durable::WalFrame

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -733,6 +733,39 @@ pub fn kglite::api::cypher::resolve_node_property(node: &kglite::api::NodeData, 
 pub fn kglite::api::cypher::rewrite_text_score(query: &mut kglite::api::cypher::CypherQuery, params: &std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>) -> core::result::Result<kglite::api::cypher::planner::simplification::TextScoreRewrite, alloc::string::String>
 pub fn kglite::api::cypher::validate_schema(query: &kglite::api::cypher::CypherQuery, graph: &kglite::api::DirGraph) -> core::result::Result<(), kglite::api::cypher::planner::schema_check::SchemaError>
 pub mod kglite::api::durable
+pub enum kglite::api::durable::DurabilityLevel
+pub kglite::api::durable::DurabilityLevel::Full
+pub kglite::api::durable::DurabilityLevel::Normal
+pub kglite::api::durable::DurabilityLevel::Off
+impl kglite::api::durable::DurabilityLevel
+pub const kglite::api::durable::DurabilityLevel::NAMES: [&'static str; 3]
+pub fn kglite::api::durable::DurabilityLevel::from_name(name: &str) -> core::option::Option<Self>
+pub fn kglite::api::durable::DurabilityLevel::logs(self) -> bool
+pub fn kglite::api::durable::DurabilityLevel::name(self) -> &'static str
+pub fn kglite::api::durable::DurabilityLevel::sync_mode(self) -> core::option::Option<kglite::api::durable::SyncMode>
+impl core::clone::Clone for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::clone(&self) -> kglite::api::durable::DurabilityLevel
+impl core::cmp::Eq for kglite::api::durable::DurabilityLevel
+impl core::cmp::PartialEq for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::eq(&self, other: &kglite::api::durable::DurabilityLevel) -> bool
+impl core::default::Default for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::default() -> kglite::api::durable::DurabilityLevel
+impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::DurabilityLevel
+impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::SyncMode
+pub kglite::api::durable::SyncMode::Barrier
+pub kglite::api::durable::SyncMode::PageCache
+impl core::clone::Clone for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::clone(&self) -> kglite::api::durable::SyncMode
+impl core::cmp::Eq for kglite::api::durable::SyncMode
+impl core::cmp::PartialEq for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::eq(&self, other: &kglite::api::durable::SyncMode) -> bool
+impl core::fmt::Debug for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::SyncMode
+impl core::marker::StructuralPartialEq for kglite::api::durable::SyncMode
 pub struct kglite::api::durable::RecordingGraph<G: kglite::api::GraphRead>
 impl<G: kglite::api::GraphRead> kglite::api::durable::RecordingGraph<G>
 pub fn kglite::api::durable::RecordingGraph<G>::inner(&self) -> &G
@@ -799,9 +832,10 @@ pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph
 pub struct kglite::api::durable::Wal
 impl kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::append(&mut self, frame: &kglite::api::durable::WalFrame) -> core::io::error::Result<()>
-pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf) -> core::io::error::Result<Self>
+pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf, sync: kglite::api::durable::SyncMode) -> core::io::error::Result<Self>
 pub fn kglite::api::durable::Wal::path(&self) -> &std::path::Path
 pub fn kglite::api::durable::Wal::reset(&mut self) -> core::io::error::Result<()>
+pub fn kglite::api::durable::Wal::sync(&mut self) -> core::io::error::Result<()>
 impl core::fmt::Debug for kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::durable::WalFrame

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -733,6 +733,39 @@ pub fn kglite::api::cypher::resolve_node_property(node: &kglite::api::NodeData, 
 pub fn kglite::api::cypher::rewrite_text_score(query: &mut kglite::api::cypher::CypherQuery, params: &std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>) -> core::result::Result<kglite::api::cypher::planner::simplification::TextScoreRewrite, alloc::string::String>
 pub fn kglite::api::cypher::validate_schema(query: &kglite::api::cypher::CypherQuery, graph: &kglite::api::DirGraph) -> core::result::Result<(), kglite::api::cypher::planner::schema_check::SchemaError>
 pub mod kglite::api::durable
+pub enum kglite::api::durable::DurabilityLevel
+pub kglite::api::durable::DurabilityLevel::Full
+pub kglite::api::durable::DurabilityLevel::Normal
+pub kglite::api::durable::DurabilityLevel::Off
+impl kglite::api::durable::DurabilityLevel
+pub const kglite::api::durable::DurabilityLevel::NAMES: [&'static str; 3]
+pub fn kglite::api::durable::DurabilityLevel::from_name(name: &str) -> core::option::Option<Self>
+pub fn kglite::api::durable::DurabilityLevel::logs(self) -> bool
+pub fn kglite::api::durable::DurabilityLevel::name(self) -> &'static str
+pub fn kglite::api::durable::DurabilityLevel::sync_mode(self) -> core::option::Option<kglite::api::durable::SyncMode>
+impl core::clone::Clone for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::clone(&self) -> kglite::api::durable::DurabilityLevel
+impl core::cmp::Eq for kglite::api::durable::DurabilityLevel
+impl core::cmp::PartialEq for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::eq(&self, other: &kglite::api::durable::DurabilityLevel) -> bool
+impl core::default::Default for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::default() -> kglite::api::durable::DurabilityLevel
+impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::DurabilityLevel
+impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::SyncMode
+pub kglite::api::durable::SyncMode::Barrier
+pub kglite::api::durable::SyncMode::PageCache
+impl core::clone::Clone for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::clone(&self) -> kglite::api::durable::SyncMode
+impl core::cmp::Eq for kglite::api::durable::SyncMode
+impl core::cmp::PartialEq for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::eq(&self, other: &kglite::api::durable::SyncMode) -> bool
+impl core::fmt::Debug for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::SyncMode
+impl core::marker::StructuralPartialEq for kglite::api::durable::SyncMode
 pub struct kglite::api::durable::RecordingGraph<G: kglite::api::GraphRead>
 impl<G: kglite::api::GraphRead> kglite::api::durable::RecordingGraph<G>
 pub fn kglite::api::durable::RecordingGraph<G>::inner(&self) -> &G
@@ -799,9 +832,10 @@ pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph
 pub struct kglite::api::durable::Wal
 impl kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::append(&mut self, frame: &kglite::api::durable::WalFrame) -> core::io::error::Result<()>
-pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf) -> core::io::error::Result<Self>
+pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf, sync: kglite::api::durable::SyncMode) -> core::io::error::Result<Self>
 pub fn kglite::api::durable::Wal::path(&self) -> &std::path::Path
 pub fn kglite::api::durable::Wal::reset(&mut self) -> core::io::error::Result<()>
+pub fn kglite::api::durable::Wal::sync(&mut self) -> core::io::error::Result<()>
 impl core::fmt::Debug for kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::durable::WalFrame

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -733,6 +733,39 @@ pub fn kglite::api::cypher::resolve_node_property(node: &kglite::api::NodeData, 
 pub fn kglite::api::cypher::rewrite_text_score(query: &mut kglite::api::cypher::CypherQuery, params: &std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>) -> core::result::Result<kglite::api::cypher::planner::simplification::TextScoreRewrite, alloc::string::String>
 pub fn kglite::api::cypher::validate_schema(query: &kglite::api::cypher::CypherQuery, graph: &kglite::api::DirGraph) -> core::result::Result<(), kglite::api::cypher::planner::schema_check::SchemaError>
 pub mod kglite::api::durable
+pub enum kglite::api::durable::DurabilityLevel
+pub kglite::api::durable::DurabilityLevel::Full
+pub kglite::api::durable::DurabilityLevel::Normal
+pub kglite::api::durable::DurabilityLevel::Off
+impl kglite::api::durable::DurabilityLevel
+pub const kglite::api::durable::DurabilityLevel::NAMES: [&'static str; 3]
+pub fn kglite::api::durable::DurabilityLevel::from_name(name: &str) -> core::option::Option<Self>
+pub fn kglite::api::durable::DurabilityLevel::logs(self) -> bool
+pub fn kglite::api::durable::DurabilityLevel::name(self) -> &'static str
+pub fn kglite::api::durable::DurabilityLevel::sync_mode(self) -> core::option::Option<kglite::api::durable::SyncMode>
+impl core::clone::Clone for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::clone(&self) -> kglite::api::durable::DurabilityLevel
+impl core::cmp::Eq for kglite::api::durable::DurabilityLevel
+impl core::cmp::PartialEq for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::eq(&self, other: &kglite::api::durable::DurabilityLevel) -> bool
+impl core::default::Default for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::default() -> kglite::api::durable::DurabilityLevel
+impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::DurabilityLevel
+impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::SyncMode
+pub kglite::api::durable::SyncMode::Barrier
+pub kglite::api::durable::SyncMode::PageCache
+impl core::clone::Clone for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::clone(&self) -> kglite::api::durable::SyncMode
+impl core::cmp::Eq for kglite::api::durable::SyncMode
+impl core::cmp::PartialEq for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::eq(&self, other: &kglite::api::durable::SyncMode) -> bool
+impl core::fmt::Debug for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::SyncMode
+impl core::marker::StructuralPartialEq for kglite::api::durable::SyncMode
 pub struct kglite::api::durable::RecordingGraph<G: kglite::api::GraphRead>
 impl<G: kglite::api::GraphRead> kglite::api::durable::RecordingGraph<G>
 pub fn kglite::api::durable::RecordingGraph<G>::inner(&self) -> &G
@@ -799,9 +832,10 @@ pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph
 pub struct kglite::api::durable::Wal
 impl kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::append(&mut self, frame: &kglite::api::durable::WalFrame) -> core::io::error::Result<()>
-pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf) -> core::io::error::Result<Self>
+pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf, sync: kglite::api::durable::SyncMode) -> core::io::error::Result<Self>
 pub fn kglite::api::durable::Wal::path(&self) -> &std::path::Path
 pub fn kglite::api::durable::Wal::reset(&mut self) -> core::io::error::Result<()>
+pub fn kglite::api::durable::Wal::sync(&mut self) -> core::io::error::Result<()>
 impl core::fmt::Debug for kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::durable::WalFrame

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -733,6 +733,39 @@ pub fn kglite::api::cypher::resolve_node_property(node: &kglite::api::NodeData, 
 pub fn kglite::api::cypher::rewrite_text_score(query: &mut kglite::api::cypher::CypherQuery, params: &std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>) -> core::result::Result<kglite::api::cypher::planner::simplification::TextScoreRewrite, alloc::string::String>
 pub fn kglite::api::cypher::validate_schema(query: &kglite::api::cypher::CypherQuery, graph: &kglite::api::DirGraph) -> core::result::Result<(), kglite::api::cypher::planner::schema_check::SchemaError>
 pub mod kglite::api::durable
+pub enum kglite::api::durable::DurabilityLevel
+pub kglite::api::durable::DurabilityLevel::Full
+pub kglite::api::durable::DurabilityLevel::Normal
+pub kglite::api::durable::DurabilityLevel::Off
+impl kglite::api::durable::DurabilityLevel
+pub const kglite::api::durable::DurabilityLevel::NAMES: [&'static str; 3]
+pub fn kglite::api::durable::DurabilityLevel::from_name(name: &str) -> core::option::Option<Self>
+pub fn kglite::api::durable::DurabilityLevel::logs(self) -> bool
+pub fn kglite::api::durable::DurabilityLevel::name(self) -> &'static str
+pub fn kglite::api::durable::DurabilityLevel::sync_mode(self) -> core::option::Option<kglite::api::durable::SyncMode>
+impl core::clone::Clone for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::clone(&self) -> kglite::api::durable::DurabilityLevel
+impl core::cmp::Eq for kglite::api::durable::DurabilityLevel
+impl core::cmp::PartialEq for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::eq(&self, other: &kglite::api::durable::DurabilityLevel) -> bool
+impl core::default::Default for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::default() -> kglite::api::durable::DurabilityLevel
+impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
+pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::DurabilityLevel
+impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::SyncMode
+pub kglite::api::durable::SyncMode::Barrier
+pub kglite::api::durable::SyncMode::PageCache
+impl core::clone::Clone for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::clone(&self) -> kglite::api::durable::SyncMode
+impl core::cmp::Eq for kglite::api::durable::SyncMode
+impl core::cmp::PartialEq for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::eq(&self, other: &kglite::api::durable::SyncMode) -> bool
+impl core::fmt::Debug for kglite::api::durable::SyncMode
+pub fn kglite::api::durable::SyncMode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for kglite::api::durable::SyncMode
+impl core::marker::StructuralPartialEq for kglite::api::durable::SyncMode
 pub struct kglite::api::durable::RecordingGraph<G: kglite::api::GraphRead>
 impl<G: kglite::api::GraphRead> kglite::api::durable::RecordingGraph<G>
 pub fn kglite::api::durable::RecordingGraph<G>::inner(&self) -> &G
@@ -799,9 +832,10 @@ pub fn kglite::api::durable::RecordingGraph<G>::str_prop_eq(&self, idx: petgraph
 pub struct kglite::api::durable::Wal
 impl kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::append(&mut self, frame: &kglite::api::durable::WalFrame) -> core::io::error::Result<()>
-pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf) -> core::io::error::Result<Self>
+pub fn kglite::api::durable::Wal::open(path: std::path::PathBuf, sync: kglite::api::durable::SyncMode) -> core::io::error::Result<Self>
 pub fn kglite::api::durable::Wal::path(&self) -> &std::path::Path
 pub fn kglite::api::durable::Wal::reset(&mut self) -> core::io::error::Result<()>
+pub fn kglite::api::durable::Wal::sync(&mut self) -> core::io::error::Result<()>
 impl core::fmt::Debug for kglite::api::durable::Wal
 pub fn kglite::api::durable::Wal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::durable::WalFrame

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -3,7 +3,40 @@
 import pandas as pd
 import pytest
 
+import kglite
 from kglite import KnowledgeGraph
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_native_extension():
+    """Pay every first-touch cost of the native extension before the first
+    timed sample.
+
+    On macOS a *freshly linked* `kglite.abi3.so` triggers a Gatekeeper /
+    XProtect first-run assessment the first time it is loaded, which can burn
+    most of a core in `syspolicyd` for tens of seconds (it is also what makes
+    a warm `cargo test` appear to stall at ~0% CPU on first execution — see
+    CLAUDE.md). Alongside it sit the ordinary one-off costs: lazy symbol
+    binding, and the first fault-in of the extension's pages.
+
+    `pytest-benchmark`'s own warmup is per-benchmark and runs *inside* the
+    timed function, so whichever benchmark happens to be collected first would
+    otherwise absorb these session-level costs and read hot for no reason
+    related to the code under test.
+
+    Note what this does and does not do. The assessment normally completes at
+    *import*, which pytest does during collection, so by the time this fixture
+    runs the expensive part is usually already paid — this makes that
+    deterministic and gives the one-off costs a named home rather than letting
+    them land in an arbitrary sample. It does **not** substitute for the
+    capture procedure: fully removing the assessment from a measurement means
+    touching the extension in a *separate process first*, then waiting for the
+    machine to go idle, and only then measuring.
+    """
+    graph = KnowledgeGraph()
+    graph.add_nodes(pd.DataFrame({"id": [1, 2], "name": ["a", "b"]}), "Warmup", "id", "name")
+    graph.cypher("MATCH (n:Warmup) RETURN count(n) AS c").scalar()
+    assert kglite.__version__
 
 
 @pytest.fixture

--- a/tests/benchmarks/test_bench_write_scaling.py
+++ b/tests/benchmarks/test_bench_write_scaling.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+import kglite
 from kglite import KnowledgeGraph
 
 # 1k / 100k / 1M spans three orders of magnitude, which is enough for a linear
@@ -212,3 +213,142 @@ def test_bench_id_index_invalidation_on_create(benchmark, scaled_graphs_no_pk, s
         )
 
     benchmark.pedantic(write, rounds=OV_ROUNDS, iterations=1, warmup_rounds=OV_WARMUP_ROUNDS)
+
+
+# ── durability levels: what does a commit actually cost? ─────────────
+#
+# `durable` picks what a committed mutation survives, and the levels differ
+# only in whether each commit is barriered:
+#
+#   "full"   — barrier per commit (survives power loss)
+#   "normal" — log written, no barrier (survives the process dying)
+#   "off"    — no log
+#
+# The point of measuring all three side by side is to attribute the cost
+# rather than assume it. Reading the code says the barrier should dominate
+# "full" and that "normal" should land near "off", because a WAL frame is one
+# postcard encode, one CRC32, and one `write` — but that is a *hypothesis
+# derived from reading*, and the whole reason these cells exist is that it has
+# to be measured before anyone quotes a number.
+#
+# Read `normal - off` as the true cost of logging, and `full - normal` as the
+# true cost of the barrier. Both are per-commit and neither should scale with
+# graph size, which is why one fixed size is enough here.
+#
+# Not in `test_bench_core.py` on purpose: everything in this file is outside
+# the `make bench-check` tracked set, so adding cells here cannot break the
+# gate. Absolute numbers are machine- and device-specific — a barrier is
+# storage-hardware latency, so these are meaningless across machines and must
+# never be compared against a number captured elsewhere.
+
+#: 1k matches the scale the competitive single-insert comparison uses. The
+#: per-commit cost is independent of graph size, so a second decade would add
+#: runtime without adding information.
+DURABILITY_BENCH_SIZE = 1_000
+
+DURABILITY_LEVELS = ["full", "normal", "off"]
+
+
+def _persisted_graph(path, level: str) -> KnowledgeGraph:
+    """A file-backed graph of `DURABILITY_BENCH_SIZE` nodes, opened at `level`.
+
+    Built and checkpointed with logging off, then reopened at the level under
+    test, so the fixture's own bulk load never lands in the measurement.
+    """
+    seed = kglite.open(str(path), durable="off")
+    seed.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    seed.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(DURABILITY_BENCH_SIZE),
+                "name": [f"item-{i}" for i in range(DURABILITY_BENCH_SIZE)],
+            }
+        ),
+        "Item",
+        "id",
+        "name",
+    )
+    seed.save()
+    seed.close()
+
+    graph = kglite.open(str(path), durable=level)
+    # Warm the id index so the measurement is the write, not a first touch.
+    graph.cypher("MATCH (n:Item {id: 0}) RETURN n.id")
+    return graph
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("level", DURABILITY_LEVELS)
+def test_bench_single_create_by_durability_level(benchmark, tmp_path, level):
+    """One `CREATE` of one node, per durability level. The headline cell."""
+    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    ids = iter(range(10_000_000, 1 << 30))
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
+
+    benchmark(write)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("level", ["full", "normal"])
+def test_bench_explicit_sync(benchmark, tmp_path, level):
+    """`sync()` — the on-demand barrier.
+
+    Under `"normal"` this is a real barrier and should cost about what
+    `full`'s per-commit barrier costs; under `"full"` it returns immediately
+    because every commit was already barriered. That gap is the number a
+    caller needs to decide how often to call it.
+    """
+    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    ids = iter(range(60_000_000, 1 << 30))
+
+    def commit_then_sync():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
+        graph.sync()
+
+    benchmark(commit_then_sync)
+
+
+# ── diagnostic: what is the non-durable commit actually spending? ────
+#
+# `durable="off"` is the engine's own per-commit cost with no durability
+# excuse, and reading the commit path turns up three candidate explanations
+# that reading alone cannot rank:
+#
+#   1. The Cypher plan cache is keyed on graph `version`, which is bumped
+#      before the lookup — so a write can never hit it and re-runs the full
+#      parse + optimizer pipeline every time.
+#   2. `Arc::make_mut` deep-clones the whole graph when a second
+#      `Arc<DirGraph>` is alive; a lazy `ResultView` above the 32-cell
+#      materialisation budget holds one.
+#   3. The statement rollback checkpoint, when it falls off its skip
+#      whitelist.
+#
+# The pair below discriminates (2) from the rest without changing a line of
+# engine code: same statement, once with the result dropped immediately and
+# once with it held across the next write. If `result_held` is dramatically
+# worse, it is the Arc clone; if the two are close, the cost is elsewhere and
+# (1) is the next suspect.
+#
+# This is a diagnostic, not a regression guard — it exists to attribute a
+# cost, and its conclusion belongs in an issue rather than in a threshold.
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("held", [False, True], ids=["result_dropped", "result_held"])
+def test_bench_create_with_lazy_result_alive(benchmark, held):
+    """One `CREATE`, with and without a lazy `ResultView` pinning the graph."""
+    graph = _graph(DURABILITY_BENCH_SIZE)
+    ids = iter(range(50_000_000, 1 << 30))
+    # Wide enough to exceed the eager-materialisation budget, so the view
+    # stays lazy and keeps its own `Arc<DirGraph>` alive.
+    pinned = graph.cypher("MATCH (n:Item) RETURN n.id AS i, n.name AS nm") if held else None
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
+
+    benchmark(write)
+    # Keep `pinned` referenced past the measurement, or the interpreter is
+    # free to collect it early and quietly turn this into the other case.
+    assert pinned is None or pinned is not None

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -23,6 +23,13 @@ The ``del`` is the handover, not a formality.
 Every crash test runs for each storage mode that supports durability
 (:data:`DURABLE_STORAGE_MODES`). ``storage="disk"`` is deliberately excluded
 and its refusal is asserted in ``test_durable_rejects_disk_mode``.
+
+Tests below the "durability levels" heading run for each level that keeps a
+log (:data:`LOGGING_LEVELS`). Note what a ``SIGKILL`` can and cannot show:
+it kills the *process*, which is precisely ``durable="normal"``'s guarantee,
+but it cannot evict the kernel page cache, so nothing here tests — or
+claims to test — the OS-crash and power-loss cases that separate
+``"normal"`` from ``"full"``.
 """
 
 import os
@@ -54,29 +61,31 @@ requires_sigkill = pytest.mark.skipif(
 )
 
 
-def _open_kwargs(storage: str) -> str:
+def _open_kwargs(storage: str, durable: object = True) -> str:
     """``kglite.open`` kwargs, as source text for a child script."""
-    if storage == "memory":
-        return "durable=True"
-    return f"storage={storage!r}, durable=True"
+    parts = [f"durable={durable!r}"]
+    if storage != "memory":
+        parts.insert(0, f"storage={storage!r}")
+    return ", ".join(parts)
 
 
-def _open(path, storage: str = "memory"):
-    """Open *path* durably in *storage* mode (parent-side counterpart)."""
-    kwargs = {"durable": True}
+def _open(path, storage: str = "memory", durable: object = True):
+    """Open *path* in *storage* mode at durability level *durable*
+    (parent-side counterpart)."""
+    kwargs = {"durable": durable}
     if storage != "memory":
         kwargs["storage"] = storage
     return kglite.open(str(path), **kwargs)
 
 
-def _child_script(tmp_path, body: str, storage: str, ending: str) -> str:
+def _child_script(tmp_path, body: str, storage: str, ending: str, durable: object = True) -> str:
     return textwrap.dedent(
         f"""
         import kglite, os, signal
         path = {str(tmp_path / "app.kgl")!r}
 
         def open_durable():
-            return kglite.open(path, {_open_kwargs(storage)})
+            return kglite.open(path, {_open_kwargs(storage, durable)})
 
         {textwrap.indent(textwrap.dedent(body), "        ").strip()}
         {ending}
@@ -84,16 +93,16 @@ def _child_script(tmp_path, body: str, storage: str, ending: str) -> str:
     )
 
 
-def _crash_child(tmp_path, body: str, storage: str = "memory") -> None:
+def _crash_child(tmp_path, body: str, storage: str = "memory", durable: object = True) -> None:
     """Run *body* in a child that hard-exits (``os._exit``) at the end — no
     atexit, no Python finalizers, no clean close. Models a power loss
     mid-session."""
-    script = _child_script(tmp_path, body, storage, "os._exit(0)")
+    script = _child_script(tmp_path, body, storage, "os._exit(0)", durable)
     # Child must import the same built extension.
     subprocess.run([PYBIN, "-c", script], check=True, env=dict(os.environ))
 
 
-def _sigkill_child(tmp_path, body: str, storage: str = "memory") -> None:
+def _sigkill_child(tmp_path, body: str, storage: str = "memory", durable: object = True) -> None:
     """Run *body* in a child that then ``SIGKILL``s itself.
 
     Stronger than ``_crash_child``: ``SIGKILL`` cannot be caught, blocked, or
@@ -102,7 +111,7 @@ def _sigkill_child(tmp_path, body: str, storage: str = "memory") -> None:
     that exited any other way would mean the test had stopped being a crash
     test.
     """
-    script = _child_script(tmp_path, body, storage, "os.kill(os.getpid(), signal.SIGKILL)")
+    script = _child_script(tmp_path, body, storage, "os.kill(os.getpid(), signal.SIGKILL)", durable)
     done = subprocess.run([PYBIN, "-c", script], env=dict(os.environ), capture_output=True)
     assert done.returncode == -signal.SIGKILL, (
         f"child must die on SIGKILL, got returncode {done.returncode}; stderr={done.stderr.decode(errors='replace')}"
@@ -556,3 +565,285 @@ def test_non_durable_open_writes_no_wal(tmp_path):
     g.save()
     # Non-durable mode never creates a WAL sidecar.
     assert not (tmp_path / "app.kgl-wal").exists()
+
+
+# ── durability levels ────────────────────────────────────────────────
+#
+# ``durable="normal"`` logs every commit but skips the per-commit barrier.
+# Its guarantee is: **a mutation that has returned survives the process
+# dying; an OS crash or power loss loses commits since the last save().**
+#
+# The first half is exactly what ``_sigkill_child`` models, so it is tested
+# here as rigorously as ``"full"`` is. The second half is deliberately NOT
+# tested: killing a process cannot evict the kernel page cache, so a test
+# claiming to simulate power loss would be theatre. What is asserted instead
+# is the honest boundary — ``"normal"`` writes a log, and recovery of that
+# log is level-independent.
+
+#: Levels that keep a write-ahead log. ``"off"`` is excluded: it has no log,
+#: so none of the recovery contracts below apply to it.
+LOGGING_LEVELS = ("full", "normal")
+
+
+@requires_sigkill
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+@pytest.mark.parametrize("level", LOGGING_LEVELS)
+def test_logging_levels_survive_sigkill(tmp_path, storage, level):
+    """**The claim the "normal" rung exists to make.** A committed mutation
+    that has returned must survive an uncatchable ``SIGKILL`` — no interpreter
+    teardown, no ``Drop``, no flush of any kind. ``"normal"`` must be
+    indistinguishable from ``"full"`` here; that is the whole point, and the
+    only thing separating them is a failure mode this test cannot produce.
+    """
+    _sigkill_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        g.cypher("CREATE (:Person:Staff {id: 2, name: 'Bob'})")
+        g.cypher("MATCH (a:Person {id:1}),(b:Person {id:2}) CREATE (a)-[:KNOWS]->(b)")
+        """,
+        storage,
+        durable=level,
+    )
+    # Never saved, so only the log can account for the data.
+    assert not (tmp_path / "app.kgl").exists()
+    assert (tmp_path / "app.kgl-wal").exists()
+
+    g = _open(tmp_path / "app.kgl", storage, durable=level)
+    names = sorted(r["n"] for r in g.cypher("MATCH (p:Person) RETURN p.name AS n"))
+    assert names == ["Alice", "Bob"]
+    assert g.cypher("MATCH (:Person)-[r:KNOWS]->(:Person) RETURN count(r) AS c").scalar() == 1
+    assert g.cypher("MATCH (p:Person {id:2}) RETURN labels(p) AS l").scalar() == [
+        "Person",
+        "Staff",
+    ]
+
+
+@requires_sigkill
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_normal_and_full_recover_identical_state(tmp_path, storage):
+    """Same workload, same crash, two levels — the recovered graphs must be
+    byte-for-byte equivalent in content. A divergence would mean the levels
+    differ in *what they log*, not merely in when they barrier."""
+    recovered = {}
+    for level in LOGGING_LEVELS:
+        run = tmp_path / level
+        run.mkdir()
+        _sigkill_child(
+            run,
+            """
+            g = open_durable()
+            for i in range(25):
+                g.cypher("CREATE (:Item {id: $i, tag: $t})", params={"i": i, "t": f"t{i}"})
+            g.cypher("MATCH (n:Item {id: 7}) SET n.tag = 'edited'")
+            g.cypher("MATCH (n:Item {id: 9}) DELETE n")
+            """,
+            storage,
+            durable=level,
+        )
+        g = _open(run / "app.kgl", storage, durable=level)
+        recovered[level] = sorted((r["i"], r["t"]) for r in g.cypher("MATCH (n:Item) RETURN n.id AS i, n.tag AS t"))
+
+    assert recovered["normal"] == recovered["full"]
+    # And the workload actually exercised all three op shapes.
+    assert len(recovered["full"]) == 24, "one node was deleted"
+    assert (7, "edited") in recovered["full"]
+
+
+@requires_sigkill
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_normal_log_is_recoverable_by_a_full_reopen(tmp_path, storage):
+    """The log format carries no level — it is a property of the *session*
+    that wrote it, not of the file. A graph crashed under ``"normal"`` must
+    recover completely when reopened under ``"full"`` (and the reverse), or
+    the level would have silently become an on-disk format variant."""
+    _sigkill_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        """,
+        storage,
+        durable="normal",
+    )
+    g = _open(tmp_path / "app.kgl", storage, durable="full")
+    assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"
+
+
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_normal_checkpoint_truncates_then_recovers_post_checkpoint(tmp_path, storage):
+    """The checkpoint/log interaction at ``"normal"``, which is where the
+    level's one genuine hazard lives.
+
+    ``save()`` folds the log into a checkpoint and truncates it. Under
+    ``"normal"`` the frames it folds in may still be in the page cache, so
+    ``save()`` barriers the log *before* writing the checkpoint — otherwise a
+    crash in the window between the checkpoint and the truncation could leave
+    a stale prefix of the log, and replaying that prefix over a newer
+    checkpoint would roll committed properties backwards.
+
+    What this test pins is the observable end of that contract: data from
+    before the checkpoint and after it must both survive a crash, and neither
+    may revert the other.
+    """
+    _crash_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        g.cypher("MATCH (p:Person {id: 1}) SET p.name = 'Alice2'")
+        g.save()                       # checkpoint: folds + truncates the log
+        g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
+        g.cypher("MATCH (p:Person {id: 1}) SET p.name = 'Alice3'")
+        """,
+        storage,
+        durable="normal",
+    )
+    assert (tmp_path / "app.kgl").exists(), "the checkpoint was written"
+
+    g = _open(tmp_path / "app.kgl", storage, durable="normal")
+    names = sorted(r["n"] for r in g.cypher("MATCH (p:Person) RETURN p.name AS n"))
+    # 'Alice3' — NOT 'Alice2'. A reverted value here is the stale-prefix
+    # replay hazard the pre-checkpoint barrier exists to prevent.
+    assert names == ["Alice3", "Bob"]
+
+
+# ── level spellings and validation ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("flag", "name"),
+    [(True, "full"), (False, "off")],
+)
+def test_bool_spellings_match_their_named_levels(tmp_path, flag, name):
+    """``True``/``False`` are accepted spellings of ``"full"``/``"off"``, not a
+    second code path. Equivalence is observable through whether a log exists."""
+    by_flag = tmp_path / "flag"
+    by_name = tmp_path / "name"
+    by_flag.mkdir()
+    by_name.mkdir()
+    for target, level in ((by_flag, flag), (by_name, name)):
+        g = kglite.open(str(target / "app.kgl"), durable=level)
+        g.cypher("CREATE (:Person {id: 1})")
+    assert (by_flag / "app.kgl-wal").exists() == (by_name / "app.kgl-wal").exists()
+    assert (by_flag / "app.kgl-wal").exists() == (name == "full")
+
+
+def test_normal_writes_a_wal_sidecar(tmp_path):
+    """``"normal"`` logs — it is the barrier it skips, not the log."""
+    g = kglite.open(str(tmp_path / "app.kgl"), durable="normal")
+    g.cypher("CREATE (:Person {id: 1})")
+    assert (tmp_path / "app.kgl-wal").exists()
+
+
+def test_unknown_level_is_refused_with_the_valid_set(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        kglite.open(str(tmp_path / "app.kgl"), durable="fsync")
+    message = str(excinfo.value)
+    assert "fsync" in message, "must echo what was asked for"
+    for level in ("full", "normal", "off"):
+        assert level in message, "must list the valid levels"
+
+
+def test_non_string_non_bool_level_is_a_type_error(tmp_path):
+    with pytest.raises(TypeError):
+        kglite.open(str(tmp_path / "app.kgl"), durable=2)
+
+
+@pytest.mark.parametrize("level", LOGGING_LEVELS)
+def test_disk_mode_refuses_every_logging_level(tmp_path, level):
+    """**The levels are not uniform across storage modes.** A disk graph keeps
+    no log at *any* level — the blocker is the generation-publish commit
+    boundary, not barrier strength — so ``"normal"`` must be refused exactly as
+    ``"full"`` is. Accepting it would hand back a graph with none of the
+    crash safety the level name promises."""
+    with pytest.raises(ValueError) as excinfo:
+        kglite.open(str(tmp_path / "g"), storage="disk", durable=level)
+    message = str(excinfo.value)
+    assert level in message, "must name the level that was asked for"
+    assert "storage='disk'" in message
+    assert "'off'" in message, "must name the level disk does support"
+    assert "mapped" in message, "must name the modes that do support logging"
+
+
+@pytest.mark.parametrize("level", [False, "off", None])
+def test_disk_mode_accepts_the_non_logging_levels(tmp_path, level):
+    """The counterpart: ``off`` is fine on disk, and the tri-state default
+    still resolves to it rather than raising."""
+    # `tmp_path` is unique per parametrised case, so a fixed name is safe and
+    # keeps the level out of the filename (``"off"`` would carry quotes).
+    g = kglite.open(str(tmp_path / "g"), storage="disk", durable=level)
+    g.cypher("CREATE (:Person {id: 1})")
+    assert not (tmp_path / "g-wal").exists()
+
+
+# ── sync(): the on-demand barrier ────────────────────────────────────
+
+
+def test_sync_raises_without_a_log(tmp_path):
+    """A caller who believes they bought power-safety and silently got nothing
+    is the failure direction that costs data, so this raises rather than
+    no-ops. The message must point at the levels that do support it."""
+    g = kglite.open(str(tmp_path / "app.kgl"), durable="off")
+    g.cypher("CREATE (:Person {id: 1})")
+    with pytest.raises(ValueError) as excinfo:
+        g.sync()
+    message = str(excinfo.value)
+    assert "save()" in message, "must name the alternative for a log-less graph"
+    assert "normal" in message, "must name the level that makes sync() useful"
+
+
+@pytest.mark.parametrize("level", LOGGING_LEVELS)
+def test_sync_is_a_no_op_for_the_data(tmp_path, level):
+    """``sync()`` writes no checkpoint and truncates nothing — it only makes
+    the existing log durable. Content and the log's existence are unchanged."""
+    g = kglite.open(str(tmp_path / "app.kgl"), durable=level)
+    g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+    g.sync()
+    g.sync()  # idempotent
+    assert g.cypher("MATCH (p:Person) RETURN count(*) AS c").scalar() == 1
+    assert (tmp_path / "app.kgl-wal").exists()
+    assert not (tmp_path / "app.kgl").exists(), "sync() is not a checkpoint"
+
+
+@requires_sigkill
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_sync_then_crash_recovers_everything(tmp_path, storage):
+    """``sync()`` must not disturb the log: commits before *and* after it are
+    still recovered. A barrier that truncated or reordered would show up here.
+    """
+    _sigkill_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        g.sync()
+        g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
+        """,
+        storage,
+        durable="normal",
+    )
+    g = _open(tmp_path / "app.kgl", storage, durable="normal")
+    names = sorted(r["n"] for r in g.cypher("MATCH (p:Person) RETURN p.name AS n"))
+    assert names == ["Alice", "Bob"]
+
+
+@requires_sigkill
+def test_sync_flushes_pending_ops_into_the_log(tmp_path):
+    """``sync()`` folds anything still buffered in the capture layer into a
+    frame before barriering, so it can never report success over ops that
+    never reached the log. Regression guard for the shape of bug that an
+    internal-only barrier with a single caller previously allowed."""
+    _sigkill_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        g.sync()
+        """,
+        "memory",
+        durable="normal",
+    )
+    g = _open(tmp_path / "app.kgl", "memory", durable="normal")
+    assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"


### PR DESCRIPTION
Integration branch merging two independently-green PRs so their combined tree gets one CI run.

- **#86 — the undo-journal fast path now applies to saved and indexed graphs.** Both `journal_covers` veto terms removed. This is the fix carrying the highest measured value in the programme: at 100k with matched F_FULLFSYNC durability, an insert costs 21–38 ms with two secondary indexes versus **3.668 ms** without, against SQLite's **3.666 ms**. The bind was that you couldn't avoid it by not indexing — dropping the index costs 52× on the lookup it served.
- **#85 — durability levels `full`/`normal`/`off` with an on-demand barrier.** Adds the middle rung, plus a crash-safety fix: `save()` now barriers the WAL before writing its checkpoint, so a partial WAL prefix can't fold over a newer checkpoint and revert durably-saved data.

Both were green on their own branches (23 SUCCESS each). File sets are disjoint apart from `CHANGELOG.md`.

**One manual resolution:** each branch added its own `### Changed` / `### Fixed` headings under `[Unreleased]`, so the merge produced duplicates. Folded into the existing sections in Keep a Changelog order; verified line-for-line identical apart from the two removed headings.

**Not included, deliberately:** any durability performance number. The measurement completed but three of its cells are demonstrably unsound — the `off` cell reads faster than the repo's own tracked read baseline, which is impossible for a write doing strictly more work — so it is being repaired and retaken rather than published. Docs say `normal` "costs roughly what an unlogged write costs" and nothing more precise.

No version bump — workspace stays 0.14.5, all entries under `[Unreleased]`.