### PR TITLE
perf: journal the columnar handle refresh once per type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `SET` on a saved graph no longer costs one node copy per node of the
+  type.** Writing a single property to a type with N nodes journalled N
+  `NodeData` pre-images rather than one, making a one-row `SET` on a saved
+  100k-node graph measurably *slower* (~1.8×) than the whole-graph clone the
+  undo journal replaced. The cause is the end-of-statement sweep that
+  re-points every node's shared column-store handle after a columnar write
+  forks the master: that sweep is bookkeeping rather than a logical mutation,
+  but it ran through the recorded write path and so captured an undo pre-image
+  for each node it touched. The sweep's inverse is now journalled once per
+  node type — the pre-statement master handle, no store copy — so the cost of
+  a `SET` again scales with the number of rows it changes. `CREATE` and
+  indexed-write throughput are unaffected, and rollback fidelity is unchanged:
+  a failed statement still restores the master store, every node's handle, and
+  any unique claims the write moved.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -52,38 +52,45 @@
 //! explicit addition to [`swap_data_scale`] can introduce a correctness gap,
 //! and that is a change a reviewer is looking straight at.
 //!
-//! ## Columnar mode rides on the unparked half
+//! ## Columnar mode: master from the shell, node handles from the journal
 //!
 //! `column_stores` — the per-type master `Arc<ColumnStore>` map that `save()`
-//! installs via `enable_columnar` — is deliberately **not** parked, and that
-//! is the whole of its undo story. The shell clone captures one pre-statement
-//! `Arc` handle per type and `restore_schema_shell` reinstalls it verbatim.
-//! What makes that sufficient rather than merely hopeful:
+//! installs via `enable_columnar` — is deliberately **not** parked, so the
+//! shell clone captures one pre-statement `Arc` handle per type and
+//! `restore_schema_shell` reinstalls it verbatim. That covers the master.
+//! The other half is per-node: every node of a columnar type holds its own
+//! `Arc` clone of the store, and `execute_set`'s fast path re-points all of
+//! them at the fork its write created. That sweep is journalled as a single
+//! [`UndoEntry::ColumnarHandles`] per type, whose replay re-points them back.
+//!
+//! What makes the pair sufficient rather than merely hopeful:
 //!
 //! - `ColumnStore` has no interior mutability, and the only in-statement
-//!   writer of a master store is `execute_set`'s columnar fast path, which
-//!   goes through `Arc::make_mut`. The shell's handle keeps the refcount above
-//!   one for the whole statement, so `make_mut` provably copies-on-write and
-//!   the shell's store is never mutated in place.
-//! - Every node of a columnar type holds its own `Arc` clone of the store, so
-//!   the post-`make_mut` handle-refresh sweep re-points them all. That sweep
-//!   runs through `node_weight_mut_silent`, which is silent only towards the
-//!   WAL recorder — `MemoryGraph` does not override it, so each re-pointed
-//!   node's pre-statement `NodeData` (old handle and row id included) lands in
-//!   the journal as a `NodeWeight` entry.
+//!   writer of a master store is that fast path, which goes through
+//!   `Arc::make_mut`. The refcount is above one before any checkpoint exists —
+//!   every node of the type holds a handle — so `make_mut` copies on write and
+//!   the pre-statement store is never mutated in place. **The shell's handle
+//!   is not what forces that copy**, so dropping it would buy nothing; see
+//!   `every_node_shares_the_master_column_store_handle` in `rollback_tests`.
 //! - `CREATE` and `DELETE` never reach a master store in memory mode: the
 //!   in-memory insert branch always builds a `Compact` node, and node removal
 //!   is a plain backend edit. Every other writer of `column_stores`
 //!   (`enable_columnar`, `disable_columnar`, `vacuum`, the spill and bulk-batch
 //!   paths, disk sync) runs outside the statement window.
 //!
-//! So a columnar graph is restored on both halves — master by verbatim shell
-//! restore, per-node handles by the journal — and needs no veto. The one cost
-//! to know about: because the refresh sweep touches every node of the type, a
-//! columnar `SET` journals one `NodeData` pre-image per node of that type
-//! rather than per row written. That is O(type), not O(changes) — still
-//! strictly cheaper than the O(V+E) fork it replaces, and it is the sweep's
-//! own cost that dominates either way.
+//! The per-type entry is load-bearing for *cost*, not just tidiness. The sweep
+//! touches every node of the type, so routing it through the ordinary weight
+//! seam made a one-row `SET` clone a `NodeData` per node of the type — O(type)
+//! per write, and measured at ~1.8× the whole-graph clone it was supposed to
+//! replace on a 100k-node graph. `MemoryGraph::node_weight_mut_silent`
+//! therefore skips undo capture as well as WAL capture, and
+//! `a_columnar_set_journals_one_pre_image_per_changed_node` pins it.
+//!
+//! One consequence to keep in view when touching this path: a columnar `SET`
+//! writes into the master, never into a node's weight, so it produces **no**
+//! `NodeWeight` entry for the node it changed. `ColumnarHandles` is the only
+//! entry that knows the type was written at all, which is why its replay is
+//! what reports the type into `stale_unique_indices`.
 //!
 //! ## When the journal is not used
 //!
@@ -105,6 +112,7 @@
 //! next insert reuses the slot.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::NodeIndex;
 
@@ -503,6 +511,44 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
         },
         UndoEntry::TimeseriesRemoved { node, prior } => {
             graph.timeseries_store.insert(node, *prior);
+        }
+        UndoEntry::ColumnarHandles { node_type, prior } => {
+            // The master half of the restore belongs to the shell —
+            // `column_stores` is not parked, so `restore_schema_shell` puts
+            // the pre-statement `Arc` back into the map. What the shell
+            // cannot reach is the copy of that handle each node of the type
+            // holds; the refresh sweep moved every one of them to the fork.
+            //
+            // Reading the membership from `type_indices` is correct because
+            // this entry was captured at the statement's *first* columnar
+            // write, so it replays near the end — after the bucket entries
+            // have already restored `type_indices` to its pre-statement
+            // contents. Nodes the statement created are gone by now, and
+            // nodes it deleted are back holding their own pre-image handles;
+            // re-pointing those again is a no-op.
+            let members: Vec<NodeIndex> = graph
+                .type_indices
+                .get(&node_type)
+                .map(|members| members.iter().collect())
+                .unwrap_or_default();
+            for idx in members {
+                if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
+                    if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
+                        &mut node.properties
+                    {
+                        *store = Arc::clone(&prior);
+                    }
+                }
+            }
+            // A columnar `SET` lands in the master store, not in any node's
+            // weight, so it produces no `NodeWeight` entry for the node it
+            // changed — this entry is the only signal that a value under a
+            // declared unique constraint may have moved. Without it a failed
+            // columnar `SET` would leave the claim it took behind (a phantom
+            // occupant) or the claim it released free (a real duplicate
+            // admitted), which is exactly the failure mode `swap_data_scale`
+            // warns about for the parked `unique_indices`.
+            fallout.stale_unique_indices.insert(node_type);
         }
     }
 }

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -747,6 +747,134 @@ fn the_columnar_fixture_writes_through_the_master_store() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Columnar SET cost: O(changes), not O(type)
+// ─────────────────────────────────────────────────────────────────────
+
+/// How many `Item` nodes [`wide_columnar`] seeds.
+///
+/// Large enough that an O(type) capture is unmistakable next to the single
+/// node a one-row `SET` actually changes, small enough to stay a unit test.
+const WIDE_ITEMS: usize = 200;
+
+/// A saved graph with many nodes of one type — the shape that separates
+/// "captures per node changed" from "captures per node of the type".
+///
+/// The narrow fixtures cannot do this: `seeded_columnar()` holds three
+/// `Item`s, so a per-node sweep and a per-change capture differ by two
+/// entries and any threshold that catches the difference is indistinguishable
+/// from noise.
+fn wide_columnar() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let rows: Vec<String> = (0..WIDE_ITEMS)
+        .map(|i| format!("(:Item {{id: {i}, name: 'n{i}', qty: {i}}})"))
+        .collect();
+    run(&mut graph, &format!("CREATE {}", rows.join(", ")));
+    graph.enable_columnar();
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the fixture must own a master column store, or this test is vacuous"
+    );
+    graph
+}
+
+/// A one-row columnar `SET` must journal a pre-image for the node it changed,
+/// not for every node of the type.
+///
+/// This is the guard for the cost regression the post-merge benchmark caught:
+/// `MATCH (i:Item {id: …}) SET i.priority = …` on a saved 100k-node graph ran
+/// ~1.8× slower than the whole-graph clone it replaced. The mechanism is the
+/// end-of-batch handle-refresh sweep in `execute_set`, which re-points every
+/// node's `Arc<ColumnStore>` at the forked master. That sweep goes through
+/// `node_weight_mut_silent` — silent towards the WAL recorder, but until this
+/// guard existed it fell through to the *recorded* `node_weight_mut` on
+/// `MemoryGraph`, so a single-property write cloned a `NodeData` per node of
+/// the type into the journal.
+///
+/// Why the existing guards cannot see it: `journalled_statements_copy_zero_nodes`
+/// reads `BACKEND_CLONE_NODES`, which counts backend clones only — the journal
+/// path deliberately clones no backend, so the counter reads zero whether the
+/// journal captured one pre-image or two hundred. The cost lives entirely
+/// inside the journal, so the counter has to as well.
+#[test]
+fn a_columnar_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row columnar SET captured {captured} node pre-images across \
+         {WIDE_ITEMS} nodes of the type; it must be O(nodes changed), not \
+         O(nodes of the type) — the handle-refresh sweep is being journalled"
+    );
+}
+
+/// The same statement on a *plain* (never-saved) graph, as the control.
+///
+/// Pins that the bound above is a property of the columnar path rather than of
+/// this fixture's size: if the plain path ever started capturing per type, the
+/// columnar assertion alone would not say which layer regressed.
+#[test]
+fn a_plain_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    graph.disable_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row SET on a non-columnar graph captured {captured} node \
+         pre-images across {WIDE_ITEMS} nodes"
+    );
+}
+
+/// Why the checkpoint's second `Arc` on the master is *not* what makes the
+/// columnar fast path fork the store.
+///
+/// The natural reading of `Arc::make_mut(master)` forking is that something
+/// else holds a handle, and the statement checkpoint's schema shell does hold
+/// one. It is not the cause and removing it would not help: `enable_columnar`
+/// points every node of the type at the master, so its strong count is
+/// `1 + nodes-of-type` before any checkpoint is opened, and the first write of
+/// every statement forks regardless. Pinned here because "drop the shell's
+/// handle to stop the fork" is a plausible-sounding fix that would trade the
+/// rollback guarantee for nothing.
+#[test]
+fn every_node_shares_the_master_column_store_handle() {
+    let graph = wide_columnar();
+    let master = graph
+        .column_stores
+        .get("Item")
+        .expect("the fixture installs a master store for Item");
+
+    assert!(
+        Arc::strong_count(master) > 1,
+        "the master must be shared with the per-node handles; if it were not, \
+         the columnar fast path would mutate in place and need no refresh sweep"
+    );
+    let sharing = graph
+        .graph
+        .node_indices()
+        .filter(
+            |idx| match graph.graph.node_weight(*idx).map(|n| &n.properties) {
+                Some(PropertyStorage::Columnar { store, .. }) => Arc::ptr_eq(store, master),
+                _ => false,
+            },
+        )
+        .count();
+    assert_eq!(
+        sharing, WIDE_ITEMS,
+        "every node of the type must hold its own handle on the master"
+    );
+}
+
 /// An indexed graph rolls back through the journal, not through a whole-graph
 /// clone. The fidelity half is covered by the `indexed` arm of every shape
 /// above; what this pins is the *cost* half — that a user index no longer
@@ -885,6 +1013,71 @@ fn seeded_with_unique_name() -> DirGraph {
          would exercise the clone checkpoint instead of the journal"
     );
     graph
+}
+
+/// `seeded()` with a UNIQUE constraint over `Item.qty`, then saved.
+///
+/// `qty` rather than `name` because the columnar fast path deliberately skips
+/// `name`/`title` (they fall through to the inline node setter), so a
+/// constraint over `name` would exercise the ordinary journalled write and
+/// prove nothing about the master side channel. The seeded `qty` values are
+/// distinct, so the constraint is satisfiable.
+fn seeded_columnar_with_unique_qty() -> DirGraph {
+    let mut graph = seeded();
+    run(
+        &mut graph,
+        "CREATE CONSTRAINT FOR (i:Item) REQUIRE i.qty IS UNIQUE",
+    );
+    graph.enable_columnar();
+    assert_eq!(
+        graph.unique_indices.len(),
+        1,
+        "the constraint must be declared and enforcing"
+    );
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the graph must be saved, or this is the plain unique fixture again"
+    );
+    graph
+}
+
+/// A unique claim moved by a *columnar* `SET` must come back.
+///
+/// This is the shape with no `NodeWeight` entry behind it: the value goes into
+/// the master column store, so the node's weight never changes and the journal
+/// sees only the per-type `ColumnarHandles` entry. Until that entry started
+/// reporting the type as stale, the rebuild was reached only by accident —
+/// the handle-refresh sweep captured a pre-image for every node of the type,
+/// and each of those marked the type stale on the way past. Removing that
+/// per-node capture is what made the report explicit, and this test is what
+/// says so: without it a failed columnar `SET` leaves the claim it took behind
+/// and the claim it released free.
+#[test]
+fn rollback_restores_claims_moved_by_a_columnar_property_overwrite() {
+    let mut graph = seeded_columnar_with_unique_qty();
+    let before = unique_fingerprint(&graph);
+    assert!(
+        !before.is_empty() && !before[0].2.is_empty(),
+        "the constraint must hold claims, or this test is vacuous"
+    );
+
+    let error = expect_failure(
+        &mut graph,
+        "MATCH (i:Item {id: 1}) SET i.qty = 999 \
+         WITH i MATCH (j:Item {id: 2}) SET j.bad = duration({months: 2147483648})",
+        None,
+    );
+
+    assert_eq!(
+        unique_fingerprint(&graph),
+        before,
+        "a claim moved through the master column store must move back.\
+         \nerror: {error}"
+    );
+    // The observable half: 10 is claimed again (no lost claim) and 999 is free
+    // (no phantom occupant).
+    expect_failure(&mut graph, "CREATE (:Item {id: 40, qty: 10})", None);
+    run(&mut graph, "CREATE (:Item {id: 41, qty: 999})");
 }
 
 /// A statement that claims a new value and *then* fails must not leave the

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1145,6 +1145,93 @@ fn is_null_write_target(row: &ResultRow, variable: &str) -> bool {
         && matches!(row.projected.get(variable), None | Some(Value::Null))
 }
 
+/// One property write aimed at a node type's master column store.
+///
+/// `row_id` is `None` for a node whose properties are not `Columnar`, which is
+/// one of the fallthrough conditions rather than a caller error — carrying the
+/// `Option` here keeps the whole "can this go through the master?" decision in
+/// one place.
+struct ColumnMasterWrite<'a> {
+    node_idx: NodeIndex,
+    node_type: &'a str,
+    property: &'a str,
+    value: &'a Value,
+    row_id: Option<u32>,
+}
+
+/// Write one property through the in-memory columnar master store, reporting
+/// whether it landed there.
+///
+/// The fast path for `Columnar` storage: route the write through the per-type
+/// master `Arc<ColumnStore>` once, instead of through each node's own handle.
+/// Every node of the type points at the same allocation, so `Arc::make_mut` on
+/// a *node's* handle would clone the whole store on every write — O(N²) for a
+/// batch `SET`. Going through the master forks once; the per-node handles are
+/// re-pointed in a single sweep at the end of the clause.
+///
+/// Returns `false` — leaving the caller to fall through to the per-node setter
+/// — for disk-backed graphs (which have their own write path), for non-
+/// `Columnar` nodes, for a `Columnar` node whose type is absent from
+/// `column_stores`, and for `title`/`name`.
+///
+/// `title`/`name` are excluded deliberately: the fallthrough sets the inline
+/// `node.title`, and `enable_columnar` detects that inline override on save
+/// (it differs from the stale `__title__` column) and rebuilds, consolidating
+/// the fresh title. That single save-side chokepoint covers every title-write
+/// path — Cypher `SET`, `add_nodes` update/replace, connection titles —
+/// without per-path master writes (petekSuite bug 2).
+///
+/// The property name is interned into the graph's `StringInterner` *before*
+/// `column_stores` is borrowed. The per-node path gets this free via
+/// `node.set_property(…, &mut graph.interner)`; the master path once used
+/// `InternedKey::from_str()`, which only hashes, leaving `save()` unable to
+/// resolve the key back to a string at serialize time. Symptom: every
+/// Cypher-`SET` property on a 0.8.39 in-memory Sodir-scale graph survived
+/// in-memory but vanished after save+load, with
+/// `BUG: InternedKey N not found in StringInterner`.
+///
+/// Both journals are handled here, and they pull in opposite directions:
+///
+/// - **WAL**: the write bypasses the recorded `GraphWrite` path, so the one
+///   mutated node is captured explicitly. The end-of-clause refresh sweep must
+///   *not* be, or a single `SET` would log every node of the type.
+/// - **Undo**: the pre-statement master is captured once per type, as
+///   [`UndoEntry::ColumnarHandles`], which is what lets the refresh sweep skip
+///   per-node capture entirely. The store itself is never copied — the fork
+///   already left the pre-statement one pristine, so holding its handle is the
+///   whole pre-image. `touched_columnar_types` keeps this to one attempt per
+///   type per clause; the journal's own first-touch rule covers a later clause
+///   writing the same type again.
+fn set_via_column_master(
+    graph: &mut DirGraph,
+    write: ColumnMasterWrite<'_>,
+    touched_columnar_types: &mut std::collections::HashSet<String>,
+) -> bool {
+    // Disk-backed graphs use a separate write path; the master `column_stores`
+    // Arc is for the in-memory Columnar mode only.
+    let Some(row_id) = write.row_id else {
+        return false;
+    };
+    if graph.graph.is_disk() || write.property == "title" || write.property == "name" {
+        return false;
+    }
+    let key = graph.interner.get_or_intern(write.property);
+    if !touched_columnar_types.contains(write.node_type) {
+        if let Some(prior) = graph.column_stores.get(write.node_type).map(Arc::clone) {
+            if let Some(journal) = graph.graph.undo_journal_mut() {
+                journal.note_columnar_fork(write.node_type, || Some(prior));
+            }
+        }
+    }
+    let Some(master) = graph.column_stores.get_mut(write.node_type) else {
+        return false;
+    };
+    Arc::make_mut(master).set(row_id, key, write.value, None);
+    touched_columnar_types.insert(write.node_type.to_string());
+    graph.graph.note_recorded_node_upsert(write.node_idx);
+    true
+}
+
 /// Execute a SET clause, modifying node properties in the graph.
 /// A single-property node `SET` that has already landed in storage, as the
 /// post-write bookkeeping needs to see it.
@@ -1399,47 +1486,19 @@ fn execute_set(
                             _ => None,
                         }
                     };
-                    let mut wrote_via_master = false;
-                    // Disk-backed graphs use a separate write path; the
-                    // master `column_stores` Arc is for the in-memory
-                    // Columnar mode only.
-                    let is_in_memory = !graph.graph.is_disk();
-                    // NB: title/name are intentionally NOT routed through the
-                    // master store here — the fallthrough sets the inline
-                    // `node.title`, and `enable_columnar` detects that inline
-                    // override on save (it differs from the stale `__title__`
-                    // column) and rebuilds, consolidating the fresh title. That
-                    // single save-side chokepoint covers every title-write path
-                    // (Cypher SET, add_nodes update/replace, connection titles)
-                    // without per-path master writes (petekSuite bug 2).
-                    if is_in_memory && property != "title" && property != "name" {
-                        if let Some(row_id) = columnar_row_id {
-                            // Register the property name in the graph's
-                            // StringInterner BEFORE borrowing column_stores.
-                            // The non-master path does this via
-                            // `node.set_property(..., &mut graph.interner)`;
-                            // the master path used `InternedKey::from_str()`
-                            // which only hashes — leaving `save()` unable
-                            // to resolve the key back to a string at
-                            // serialize time. Symptom: every Cypher-SET
-                            // property on a 0.8.39 in-memory Sodir-scale
-                            // graph survived in-memory but vanished after
-                            // save+load, accompanied by
-                            // `BUG: InternedKey N not found in StringInterner`.
-                            let key = graph.interner.get_or_intern(property);
-                            if let Some(master) = graph.column_stores.get_mut(&node_type_str) {
-                                Arc::make_mut(master).set(row_id, key, &value, None);
-                                touched_columnar_types.insert(node_type_str.clone());
-                                stats.properties_set += 1;
-                                wrote_via_master = true;
-                                // This master-store write bypasses the recorded
-                                // GraphWrite path, so explicitly capture the one
-                                // mutated node for the WAL. (The silent refresh
-                                // sweep below must NOT be captured — else a
-                                // single SET would log every node of the type.)
-                                graph.graph.note_recorded_node_upsert(*node_idx);
-                            }
-                        }
+                    let wrote_via_master = set_via_column_master(
+                        graph,
+                        ColumnMasterWrite {
+                            node_idx: *node_idx,
+                            node_type: &node_type_str,
+                            property,
+                            value: &value,
+                            row_id: columnar_row_id,
+                        },
+                        &mut touched_columnar_types,
+                    );
+                    if wrote_via_master {
+                        stats.properties_set += 1;
                     }
                     if !wrote_via_master {
                         // Compact / Map storage, or title/name, or a Columnar
@@ -1639,7 +1698,6 @@ fn execute_set(
     // equality-index update — provenance is range-queried, not equality-matched.
     if !nodes_to_stamp.is_empty() {
         let prov = graph.provenance_props();
-        let is_in_memory = !graph.graph.is_disk();
         for (node_idx, node_type) in &nodes_to_stamp {
             // Arena guard: node_weight materializes on the disk backend
             // (protocol in disk/graph.rs); scoped so the borrow ends before
@@ -1660,17 +1718,17 @@ fn execute_set(
                         Arc::make_mut(schema_arc).add_key(key);
                     }
                 }
-                let mut wrote = false;
-                if is_in_memory {
-                    if let Some(row_id) = columnar_row_id {
-                        if let Some(master) = graph.column_stores.get_mut(node_type) {
-                            Arc::make_mut(master).set(row_id, key, pval, None);
-                            touched_columnar_types.insert(node_type.clone());
-                            graph.graph.note_recorded_node_upsert(*node_idx);
-                            wrote = true;
-                        }
-                    }
-                }
+                let wrote = set_via_column_master(
+                    graph,
+                    ColumnMasterWrite {
+                        node_idx: *node_idx,
+                        node_type,
+                        property: pname,
+                        value: pval,
+                        row_id: columnar_row_id,
+                    },
+                    &mut touched_columnar_types,
+                );
                 if !wrote {
                     if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, *node_idx) {
                         node.set_property(pname, pval.clone(), &mut graph.interner);

--- a/crates/kglite/src/graph/storage/impls.rs
+++ b/crates/kglite/src/graph/storage/impls.rs
@@ -347,6 +347,23 @@ impl GraphWrite for MemoryGraph {
         self.inner.node_weight_mut(idx)
     }
 
+    /// Bypasses the undo journal as well as the WAL recorder.
+    ///
+    /// The one caller is the columnar handle-refresh sweep, which re-points
+    /// every node of a type at a forked master store. Capturing a `NodeData`
+    /// pre-image for each of them would make a one-row `SET` cost one clone
+    /// per node *of the type* — the O(V+E)-per-write cost this journal exists
+    /// to remove, reintroduced at a smaller constant. The sweep's inverse is
+    /// journalled once per type instead, as
+    /// [`UndoEntry::ColumnarHandles`](crate::graph::storage::undo::UndoEntry::ColumnarHandles).
+    ///
+    /// Nothing else may use this method to skip capture: a caller that
+    /// changes a node's *content* silently is unrecoverable on rollback.
+    #[inline]
+    fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
+        self.inner.node_weight_mut(idx)
+    }
+
     #[inline]
     fn edge_weight_mut(&mut self, idx: EdgeIndex) -> Option<&mut EdgeData> {
         self.invalidate_peer_counts();

--- a/crates/kglite/src/graph/storage/recording.rs
+++ b/crates/kglite/src/graph/storage/recording.rs
@@ -581,8 +581,11 @@ impl<G: GraphWrite> GraphWrite for RecordingGraph<G> {
     #[inline]
     fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
         // Bypass recording — internal bookkeeping (columnar handle refresh),
-        // not a logical mutation. See the trait method docs.
-        self.inner.node_weight_mut(idx)
+        // not a logical mutation. See the trait method docs. Delegated to the
+        // inner backend's *silent* method rather than its recorded one so the
+        // silence composes: `MemoryGraph` also skips undo-journal capture
+        // here, and wrapping it must not put that capture back.
+        self.inner.node_weight_mut_silent(idx)
     }
 
     #[inline]

--- a/crates/kglite/src/graph/storage/undo.rs
+++ b/crates/kglite/src/graph/storage/undo.rs
@@ -56,6 +56,7 @@
 //!   `NodeData` clone, not five.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
 
@@ -64,6 +65,33 @@ use crate::graph::features::timeseries::NodeTimeseries;
 use crate::graph::schema::{
     CompositeIndexKey, CompositeValue, EdgeData, IndexKey, InternedKey, NodeData,
 };
+use crate::graph::storage::column_store::ColumnStore;
+
+#[cfg(test)]
+thread_local! {
+    /// Node pre-images actually cloned into an undo journal since the last
+    /// reset.
+    ///
+    /// The complement of `BACKEND_CLONE_NODES` (`storage/backend.rs`), which
+    /// counts nodes copied by a *backend* clone and is therefore blind to the
+    /// journal path by construction: the whole point of the journal checkpoint
+    /// is that it clones no backend. A statement that captures a pre-image per
+    /// node of a type rather than per node it changed is O(type)-per-write,
+    /// which is the cost class the journal exists to remove, and this is the
+    /// only counter that can see it.
+    static JOURNAL_NODE_PRE_IMAGES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_journal_node_pre_images() {
+    JOURNAL_NODE_PRE_IMAGES.set(0);
+}
+
+/// Node pre-images cloned into an undo journal since the last reset.
+#[cfg(test)]
+pub(crate) fn journal_node_pre_images() -> usize {
+    JOURNAL_NODE_PRE_IMAGES.get()
+}
 
 /// A `Vec<NodeIndex>` bucket in one of `DirGraph`'s inverted indexes.
 /// Bucket edits are journalled with a *position* so a rollback restores the
@@ -141,6 +169,22 @@ pub enum UndoEntry {
         node: usize,
         prior: Box<NodeTimeseries>,
     },
+    /// `execute_set`'s columnar fast path wrote through the master
+    /// `Arc<ColumnStore>` for `node_type`, forking it, and then re-pointed
+    /// every node of that type at the fork. `prior` is the master as it stood
+    /// before the statement's first such write; undo re-points them all back.
+    ///
+    /// **One entry per type per statement, not per node.** That is the whole
+    /// reason this variant exists: the refresh sweep touches every node of the
+    /// type, so journalling it through the ordinary weight-capture seam would
+    /// cost a `NodeData` clone per node of the type on every single-row `SET`.
+    /// The store itself needs no copy — `ColumnStore` has no interior
+    /// mutability and the fork already left `prior` pristine, so holding the
+    /// handle is the entire pre-image.
+    ColumnarHandles {
+        node_type: String,
+        prior: Arc<ColumnStore>,
+    },
 }
 
 /// Buffer of inverse operations for exactly one statement.
@@ -157,6 +201,11 @@ pub struct UndoJournal {
     weighed_nodes: HashSet<NodeIndex>,
     /// Edge counterpart of `weighed_nodes`.
     weighed_edges: HashSet<EdgeIndex>,
+    /// Node types whose pre-statement master column store is already captured.
+    /// First touch wins, exactly like `weighed_nodes`: a statement can write
+    /// through the same master in several clauses, and only the first one saw
+    /// the pre-statement store.
+    forked_columnar_types: HashSet<String>,
 }
 
 impl UndoJournal {
@@ -189,6 +238,8 @@ impl UndoJournal {
     pub fn note_node_weight(&mut self, idx: NodeIndex, prior: impl FnOnce() -> Option<NodeData>) {
         if self.weighed_nodes.insert(idx) {
             if let Some(prior) = prior() {
+                #[cfg(test)]
+                JOURNAL_NODE_PRE_IMAGES.set(JOURNAL_NODE_PRE_IMAGES.get() + 1);
                 self.entries.push(UndoEntry::NodeWeight { idx, prior });
             }
         }
@@ -275,6 +326,31 @@ impl UndoJournal {
         for (pos, idx) in hits {
             self.note_bucket_removed(bucket.clone(), idx, pos);
         }
+    }
+
+    /// The master column store for `node_type` is about to be forked by a
+    /// columnar write. `prior` is only taken on the statement's first fork of
+    /// that type, so the captured handle is the pre-statement one.
+    ///
+    /// Returns whether the capture happened, so the caller can skip the
+    /// `Arc::clone` on later writes of the same statement.
+    #[inline]
+    pub fn note_columnar_fork(
+        &mut self,
+        node_type: &str,
+        prior: impl FnOnce() -> Option<Arc<ColumnStore>>,
+    ) -> bool {
+        if !self.forked_columnar_types.contains(node_type) {
+            self.forked_columnar_types.insert(node_type.to_string());
+            if let Some(prior) = prior() {
+                self.entries.push(UndoEntry::ColumnarHandles {
+                    node_type: node_type.to_string(),
+                    prior,
+                });
+                return true;
+            }
+        }
+        false
     }
 
     /// A node's timeseries was dropped.

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 536,
-      "branches": 75,
+      "lines": 507,
+      "branches": 70,
       "nesting": 8
     },
     {


### PR DESCRIPTION
Fixes a regression a post-merge benchmark caught in PR #86, and lands well past the pre-#86 baseline.

**Measured** (release, same probe/schema/machine, two takes, `min ≈ mean`, takes agreeing within 1%) — post-`save()` `SET` at 100k:

| build | min |
|---|---|
| pre-#86 (`680cb492`) | 3.0736 / 3.0546 ms |
| `main` (`425cea12`) | 5.5120 / 5.4674 ms |
| **this branch** | **1.0828 / 1.0733 ms** |

5.1× better than `main`, 2.8× better than pre-#86. No other cell moved — all six remaining cells sit at ratio 0.97–1.02× across 1k→100k, index veto still gone.

**The inferred cause was refuted.** The hypothesis was that `schema_shell()` held a second `Arc` on the master store, making `Arc::make_mut` fork. It does not: `PropertyStorage::Columnar` gives *every node* its own `Arc<ColumnStore>` handle, so the strong count is `1 + nodes-of-type` before any checkpoint exists. `make_mut` forks on the first write of every statement, pre- and post-#86 identically.

**The actual cause:** the end-of-statement handle-refresh sweep calls `node_weight_mut_silent`, which was silent only towards the *WAL* — `MemoryGraph` never overrode it, so it fell through to `capture_node_weight`. Measured: a one-row `SET` on a 200-node type journalled **200 node pre-images**. Pre-#86 that was free because the veto meant no journal existed; removing the veto turned a no-op into a per-node clone on every write. The `rollback.rs` module doc claimed this path was "still strictly cheaper than the O(V+E) fork it replaces" — that sentence is what the measurement refuted, and it has been rewritten.

**A correctness obligation the accidental capture was discharging.** A columnar `SET` never touches a node's weight, so it emits no `NodeWeight` entry — those per-node pre-images were the *only* thing reporting the type into `stale_unique_indices`, which drives the post-rollback unique rebuild. Silencing the sweep naively would have silently broken unique-constraint rollback. Now recorded explicitly as `UndoEntry::ColumnarHandles`.

Each test confirmed non-vacuous by removing its half of the fix. Deliberately **no** column-store clone counter was added — the store clone was never the regression, and `BACKEND_CLONE_NODES` is structurally blind here.

**Surfaced, not fixed:** columnar `SET` remains O(N_type) in wall clock — measured floor 1.08 ms at 100k, ratio 70× from 1k. The fork and the N-node re-point sweep both survive; only the journal allocations are gone. That predates #86 and needs an architectural change (nodes resolving the store through `DirGraph` rather than holding handles), not a patch.

Local: `cargo test -p kglite` 1309 green, workspace clippy `-D warnings` clean, gate/source-quality/fmt clean per-commit. No version bump.