### PR TITLE
Merge #88 (columnar SET fix) + #89 (blind-spot benchmarks) + encoding-gate fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `SET` on a saved graph no longer costs one node copy per node of the
+  type.** Writing a single property to a type with N nodes journalled N
+  `NodeData` pre-images rather than one, making a one-row `SET` on a saved
+  100k-node graph measurably *slower* (~1.8×) than the whole-graph clone the
+  undo journal replaced. The cause is the end-of-statement sweep that
+  re-points every node's shared column-store handle after a columnar write
+  forks the master: that sweep is bookkeeping rather than a logical mutation,
+  but it ran through the recorded write path and so captured an undo pre-image
+  for each node it touched. The sweep's inverse is now journalled once per
+  node type — the pre-statement master handle, no store copy — so the cost of
+  a `SET` again scales with the number of rows it changes. `CREATE` and
+  indexed-write throughput are unaffected, and rollback fidelity is unchanged:
+  a failed statement still restores the master store, every node's handle, and
+  any unique claims the write moved.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -52,38 +52,45 @@
 //! explicit addition to [`swap_data_scale`] can introduce a correctness gap,
 //! and that is a change a reviewer is looking straight at.
 //!
-//! ## Columnar mode rides on the unparked half
+//! ## Columnar mode: master from the shell, node handles from the journal
 //!
 //! `column_stores` — the per-type master `Arc<ColumnStore>` map that `save()`
-//! installs via `enable_columnar` — is deliberately **not** parked, and that
-//! is the whole of its undo story. The shell clone captures one pre-statement
-//! `Arc` handle per type and `restore_schema_shell` reinstalls it verbatim.
-//! What makes that sufficient rather than merely hopeful:
+//! installs via `enable_columnar` — is deliberately **not** parked, so the
+//! shell clone captures one pre-statement `Arc` handle per type and
+//! `restore_schema_shell` reinstalls it verbatim. That covers the master.
+//! The other half is per-node: every node of a columnar type holds its own
+//! `Arc` clone of the store, and `execute_set`'s fast path re-points all of
+//! them at the fork its write created. That sweep is journalled as a single
+//! [`UndoEntry::ColumnarHandles`] per type, whose replay re-points them back.
+//!
+//! What makes the pair sufficient rather than merely hopeful:
 //!
 //! - `ColumnStore` has no interior mutability, and the only in-statement
-//!   writer of a master store is `execute_set`'s columnar fast path, which
-//!   goes through `Arc::make_mut`. The shell's handle keeps the refcount above
-//!   one for the whole statement, so `make_mut` provably copies-on-write and
-//!   the shell's store is never mutated in place.
-//! - Every node of a columnar type holds its own `Arc` clone of the store, so
-//!   the post-`make_mut` handle-refresh sweep re-points them all. That sweep
-//!   runs through `node_weight_mut_silent`, which is silent only towards the
-//!   WAL recorder — `MemoryGraph` does not override it, so each re-pointed
-//!   node's pre-statement `NodeData` (old handle and row id included) lands in
-//!   the journal as a `NodeWeight` entry.
+//!   writer of a master store is that fast path, which goes through
+//!   `Arc::make_mut`. The refcount is above one before any checkpoint exists —
+//!   every node of the type holds a handle — so `make_mut` copies on write and
+//!   the pre-statement store is never mutated in place. **The shell's handle
+//!   is not what forces that copy**, so dropping it would buy nothing; see
+//!   `every_node_shares_the_master_column_store_handle` in `rollback_tests`.
 //! - `CREATE` and `DELETE` never reach a master store in memory mode: the
 //!   in-memory insert branch always builds a `Compact` node, and node removal
 //!   is a plain backend edit. Every other writer of `column_stores`
 //!   (`enable_columnar`, `disable_columnar`, `vacuum`, the spill and bulk-batch
 //!   paths, disk sync) runs outside the statement window.
 //!
-//! So a columnar graph is restored on both halves — master by verbatim shell
-//! restore, per-node handles by the journal — and needs no veto. The one cost
-//! to know about: because the refresh sweep touches every node of the type, a
-//! columnar `SET` journals one `NodeData` pre-image per node of that type
-//! rather than per row written. That is O(type), not O(changes) — still
-//! strictly cheaper than the O(V+E) fork it replaces, and it is the sweep's
-//! own cost that dominates either way.
+//! The per-type entry is load-bearing for *cost*, not just tidiness. The sweep
+//! touches every node of the type, so routing it through the ordinary weight
+//! seam made a one-row `SET` clone a `NodeData` per node of the type — O(type)
+//! per write, and measured at ~1.8× the whole-graph clone it was supposed to
+//! replace on a 100k-node graph. `MemoryGraph::node_weight_mut_silent`
+//! therefore skips undo capture as well as WAL capture, and
+//! `a_columnar_set_journals_one_pre_image_per_changed_node` pins it.
+//!
+//! One consequence to keep in view when touching this path: a columnar `SET`
+//! writes into the master, never into a node's weight, so it produces **no**
+//! `NodeWeight` entry for the node it changed. `ColumnarHandles` is the only
+//! entry that knows the type was written at all, which is why its replay is
+//! what reports the type into `stale_unique_indices`.
 //!
 //! ## When the journal is not used
 //!
@@ -105,6 +112,7 @@
 //! next insert reuses the slot.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::NodeIndex;
 
@@ -503,6 +511,44 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
         },
         UndoEntry::TimeseriesRemoved { node, prior } => {
             graph.timeseries_store.insert(node, *prior);
+        }
+        UndoEntry::ColumnarHandles { node_type, prior } => {
+            // The master half of the restore belongs to the shell —
+            // `column_stores` is not parked, so `restore_schema_shell` puts
+            // the pre-statement `Arc` back into the map. What the shell
+            // cannot reach is the copy of that handle each node of the type
+            // holds; the refresh sweep moved every one of them to the fork.
+            //
+            // Reading the membership from `type_indices` is correct because
+            // this entry was captured at the statement's *first* columnar
+            // write, so it replays near the end — after the bucket entries
+            // have already restored `type_indices` to its pre-statement
+            // contents. Nodes the statement created are gone by now, and
+            // nodes it deleted are back holding their own pre-image handles;
+            // re-pointing those again is a no-op.
+            let members: Vec<NodeIndex> = graph
+                .type_indices
+                .get(&node_type)
+                .map(|members| members.iter().collect())
+                .unwrap_or_default();
+            for idx in members {
+                if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
+                    if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
+                        &mut node.properties
+                    {
+                        *store = Arc::clone(&prior);
+                    }
+                }
+            }
+            // A columnar `SET` lands in the master store, not in any node's
+            // weight, so it produces no `NodeWeight` entry for the node it
+            // changed — this entry is the only signal that a value under a
+            // declared unique constraint may have moved. Without it a failed
+            // columnar `SET` would leave the claim it took behind (a phantom
+            // occupant) or the claim it released free (a real duplicate
+            // admitted), which is exactly the failure mode `swap_data_scale`
+            // warns about for the parked `unique_indices`.
+            fallout.stale_unique_indices.insert(node_type);
         }
     }
 }

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -747,6 +747,134 @@ fn the_columnar_fixture_writes_through_the_master_store() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Columnar SET cost: O(changes), not O(type)
+// ─────────────────────────────────────────────────────────────────────
+
+/// How many `Item` nodes [`wide_columnar`] seeds.
+///
+/// Large enough that an O(type) capture is unmistakable next to the single
+/// node a one-row `SET` actually changes, small enough to stay a unit test.
+const WIDE_ITEMS: usize = 200;
+
+/// A saved graph with many nodes of one type — the shape that separates
+/// "captures per node changed" from "captures per node of the type".
+///
+/// The narrow fixtures cannot do this: `seeded_columnar()` holds three
+/// `Item`s, so a per-node sweep and a per-change capture differ by two
+/// entries and any threshold that catches the difference is indistinguishable
+/// from noise.
+fn wide_columnar() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let rows: Vec<String> = (0..WIDE_ITEMS)
+        .map(|i| format!("(:Item {{id: {i}, name: 'n{i}', qty: {i}}})"))
+        .collect();
+    run(&mut graph, &format!("CREATE {}", rows.join(", ")));
+    graph.enable_columnar();
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the fixture must own a master column store, or this test is vacuous"
+    );
+    graph
+}
+
+/// A one-row columnar `SET` must journal a pre-image for the node it changed,
+/// not for every node of the type.
+///
+/// This is the guard for the cost regression the post-merge benchmark caught:
+/// `MATCH (i:Item {id: …}) SET i.priority = …` on a saved 100k-node graph ran
+/// ~1.8× slower than the whole-graph clone it replaced. The mechanism is the
+/// end-of-batch handle-refresh sweep in `execute_set`, which re-points every
+/// node's `Arc<ColumnStore>` at the forked master. That sweep goes through
+/// `node_weight_mut_silent` — silent towards the WAL recorder, but until this
+/// guard existed it fell through to the *recorded* `node_weight_mut` on
+/// `MemoryGraph`, so a single-property write cloned a `NodeData` per node of
+/// the type into the journal.
+///
+/// Why the existing guards cannot see it: `journalled_statements_copy_zero_nodes`
+/// reads `BACKEND_CLONE_NODES`, which counts backend clones only — the journal
+/// path deliberately clones no backend, so the counter reads zero whether the
+/// journal captured one pre-image or two hundred. The cost lives entirely
+/// inside the journal, so the counter has to as well.
+#[test]
+fn a_columnar_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row columnar SET captured {captured} node pre-images across \
+         {WIDE_ITEMS} nodes of the type; it must be O(nodes changed), not \
+         O(nodes of the type) — the handle-refresh sweep is being journalled"
+    );
+}
+
+/// The same statement on a *plain* (never-saved) graph, as the control.
+///
+/// Pins that the bound above is a property of the columnar path rather than of
+/// this fixture's size: if the plain path ever started capturing per type, the
+/// columnar assertion alone would not say which layer regressed.
+#[test]
+fn a_plain_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    graph.disable_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row SET on a non-columnar graph captured {captured} node \
+         pre-images across {WIDE_ITEMS} nodes"
+    );
+}
+
+/// Why the checkpoint's second `Arc` on the master is *not* what makes the
+/// columnar fast path fork the store.
+///
+/// The natural reading of `Arc::make_mut(master)` forking is that something
+/// else holds a handle, and the statement checkpoint's schema shell does hold
+/// one. It is not the cause and removing it would not help: `enable_columnar`
+/// points every node of the type at the master, so its strong count is
+/// `1 + nodes-of-type` before any checkpoint is opened, and the first write of
+/// every statement forks regardless. Pinned here because "drop the shell's
+/// handle to stop the fork" is a plausible-sounding fix that would trade the
+/// rollback guarantee for nothing.
+#[test]
+fn every_node_shares_the_master_column_store_handle() {
+    let graph = wide_columnar();
+    let master = graph
+        .column_stores
+        .get("Item")
+        .expect("the fixture installs a master store for Item");
+
+    assert!(
+        Arc::strong_count(master) > 1,
+        "the master must be shared with the per-node handles; if it were not, \
+         the columnar fast path would mutate in place and need no refresh sweep"
+    );
+    let sharing = graph
+        .graph
+        .node_indices()
+        .filter(
+            |idx| match graph.graph.node_weight(*idx).map(|n| &n.properties) {
+                Some(PropertyStorage::Columnar { store, .. }) => Arc::ptr_eq(store, master),
+                _ => false,
+            },
+        )
+        .count();
+    assert_eq!(
+        sharing, WIDE_ITEMS,
+        "every node of the type must hold its own handle on the master"
+    );
+}
+
 /// An indexed graph rolls back through the journal, not through a whole-graph
 /// clone. The fidelity half is covered by the `indexed` arm of every shape
 /// above; what this pins is the *cost* half — that a user index no longer
@@ -885,6 +1013,71 @@ fn seeded_with_unique_name() -> DirGraph {
          would exercise the clone checkpoint instead of the journal"
     );
     graph
+}
+
+/// `seeded()` with a UNIQUE constraint over `Item.qty`, then saved.
+///
+/// `qty` rather than `name` because the columnar fast path deliberately skips
+/// `name`/`title` (they fall through to the inline node setter), so a
+/// constraint over `name` would exercise the ordinary journalled write and
+/// prove nothing about the master side channel. The seeded `qty` values are
+/// distinct, so the constraint is satisfiable.
+fn seeded_columnar_with_unique_qty() -> DirGraph {
+    let mut graph = seeded();
+    run(
+        &mut graph,
+        "CREATE CONSTRAINT FOR (i:Item) REQUIRE i.qty IS UNIQUE",
+    );
+    graph.enable_columnar();
+    assert_eq!(
+        graph.unique_indices.len(),
+        1,
+        "the constraint must be declared and enforcing"
+    );
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the graph must be saved, or this is the plain unique fixture again"
+    );
+    graph
+}
+
+/// A unique claim moved by a *columnar* `SET` must come back.
+///
+/// This is the shape with no `NodeWeight` entry behind it: the value goes into
+/// the master column store, so the node's weight never changes and the journal
+/// sees only the per-type `ColumnarHandles` entry. Until that entry started
+/// reporting the type as stale, the rebuild was reached only by accident —
+/// the handle-refresh sweep captured a pre-image for every node of the type,
+/// and each of those marked the type stale on the way past. Removing that
+/// per-node capture is what made the report explicit, and this test is what
+/// says so: without it a failed columnar `SET` leaves the claim it took behind
+/// and the claim it released free.
+#[test]
+fn rollback_restores_claims_moved_by_a_columnar_property_overwrite() {
+    let mut graph = seeded_columnar_with_unique_qty();
+    let before = unique_fingerprint(&graph);
+    assert!(
+        !before.is_empty() && !before[0].2.is_empty(),
+        "the constraint must hold claims, or this test is vacuous"
+    );
+
+    let error = expect_failure(
+        &mut graph,
+        "MATCH (i:Item {id: 1}) SET i.qty = 999 \
+         WITH i MATCH (j:Item {id: 2}) SET j.bad = duration({months: 2147483648})",
+        None,
+    );
+
+    assert_eq!(
+        unique_fingerprint(&graph),
+        before,
+        "a claim moved through the master column store must move back.\
+         \nerror: {error}"
+    );
+    // The observable half: 10 is claimed again (no lost claim) and 999 is free
+    // (no phantom occupant).
+    expect_failure(&mut graph, "CREATE (:Item {id: 40, qty: 10})", None);
+    run(&mut graph, "CREATE (:Item {id: 41, qty: 999})");
 }
 
 /// A statement that claims a new value and *then* fails must not leave the

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1145,6 +1145,93 @@ fn is_null_write_target(row: &ResultRow, variable: &str) -> bool {
         && matches!(row.projected.get(variable), None | Some(Value::Null))
 }
 
+/// One property write aimed at a node type's master column store.
+///
+/// `row_id` is `None` for a node whose properties are not `Columnar`, which is
+/// one of the fallthrough conditions rather than a caller error — carrying the
+/// `Option` here keeps the whole "can this go through the master?" decision in
+/// one place.
+struct ColumnMasterWrite<'a> {
+    node_idx: NodeIndex,
+    node_type: &'a str,
+    property: &'a str,
+    value: &'a Value,
+    row_id: Option<u32>,
+}
+
+/// Write one property through the in-memory columnar master store, reporting
+/// whether it landed there.
+///
+/// The fast path for `Columnar` storage: route the write through the per-type
+/// master `Arc<ColumnStore>` once, instead of through each node's own handle.
+/// Every node of the type points at the same allocation, so `Arc::make_mut` on
+/// a *node's* handle would clone the whole store on every write — O(N²) for a
+/// batch `SET`. Going through the master forks once; the per-node handles are
+/// re-pointed in a single sweep at the end of the clause.
+///
+/// Returns `false` — leaving the caller to fall through to the per-node setter
+/// — for disk-backed graphs (which have their own write path), for non-
+/// `Columnar` nodes, for a `Columnar` node whose type is absent from
+/// `column_stores`, and for `title`/`name`.
+///
+/// `title`/`name` are excluded deliberately: the fallthrough sets the inline
+/// `node.title`, and `enable_columnar` detects that inline override on save
+/// (it differs from the stale `__title__` column) and rebuilds, consolidating
+/// the fresh title. That single save-side chokepoint covers every title-write
+/// path — Cypher `SET`, `add_nodes` update/replace, connection titles —
+/// without per-path master writes (petekSuite bug 2).
+///
+/// The property name is interned into the graph's `StringInterner` *before*
+/// `column_stores` is borrowed. The per-node path gets this free via
+/// `node.set_property(…, &mut graph.interner)`; the master path once used
+/// `InternedKey::from_str()`, which only hashes, leaving `save()` unable to
+/// resolve the key back to a string at serialize time. Symptom: every
+/// Cypher-`SET` property on a 0.8.39 in-memory Sodir-scale graph survived
+/// in-memory but vanished after save+load, with
+/// `BUG: InternedKey N not found in StringInterner`.
+///
+/// Both journals are handled here, and they pull in opposite directions:
+///
+/// - **WAL**: the write bypasses the recorded `GraphWrite` path, so the one
+///   mutated node is captured explicitly. The end-of-clause refresh sweep must
+///   *not* be, or a single `SET` would log every node of the type.
+/// - **Undo**: the pre-statement master is captured once per type, as
+///   [`UndoEntry::ColumnarHandles`], which is what lets the refresh sweep skip
+///   per-node capture entirely. The store itself is never copied — the fork
+///   already left the pre-statement one pristine, so holding its handle is the
+///   whole pre-image. `touched_columnar_types` keeps this to one attempt per
+///   type per clause; the journal's own first-touch rule covers a later clause
+///   writing the same type again.
+fn set_via_column_master(
+    graph: &mut DirGraph,
+    write: ColumnMasterWrite<'_>,
+    touched_columnar_types: &mut std::collections::HashSet<String>,
+) -> bool {
+    // Disk-backed graphs use a separate write path; the master `column_stores`
+    // Arc is for the in-memory Columnar mode only.
+    let Some(row_id) = write.row_id else {
+        return false;
+    };
+    if graph.graph.is_disk() || write.property == "title" || write.property == "name" {
+        return false;
+    }
+    let key = graph.interner.get_or_intern(write.property);
+    if !touched_columnar_types.contains(write.node_type) {
+        if let Some(prior) = graph.column_stores.get(write.node_type).map(Arc::clone) {
+            if let Some(journal) = graph.graph.undo_journal_mut() {
+                journal.note_columnar_fork(write.node_type, || Some(prior));
+            }
+        }
+    }
+    let Some(master) = graph.column_stores.get_mut(write.node_type) else {
+        return false;
+    };
+    Arc::make_mut(master).set(row_id, key, write.value, None);
+    touched_columnar_types.insert(write.node_type.to_string());
+    graph.graph.note_recorded_node_upsert(write.node_idx);
+    true
+}
+
 /// Execute a SET clause, modifying node properties in the graph.
 /// A single-property node `SET` that has already landed in storage, as the
 /// post-write bookkeeping needs to see it.
@@ -1399,47 +1486,19 @@ fn execute_set(
                             _ => None,
                         }
                     };
-                    let mut wrote_via_master = false;
-                    // Disk-backed graphs use a separate write path; the
-                    // master `column_stores` Arc is for the in-memory
-                    // Columnar mode only.
-                    let is_in_memory = !graph.graph.is_disk();
-                    // NB: title/name are intentionally NOT routed through the
-                    // master store here — the fallthrough sets the inline
-                    // `node.title`, and `enable_columnar` detects that inline
-                    // override on save (it differs from the stale `__title__`
-                    // column) and rebuilds, consolidating the fresh title. That
-                    // single save-side chokepoint covers every title-write path
-                    // (Cypher SET, add_nodes update/replace, connection titles)
-                    // without per-path master writes (petekSuite bug 2).
-                    if is_in_memory && property != "title" && property != "name" {
-                        if let Some(row_id) = columnar_row_id {
-                            // Register the property name in the graph's
-                            // StringInterner BEFORE borrowing column_stores.
-                            // The non-master path does this via
-                            // `node.set_property(..., &mut graph.interner)`;
-                            // the master path used `InternedKey::from_str()`
-                            // which only hashes — leaving `save()` unable
-                            // to resolve the key back to a string at
-                            // serialize time. Symptom: every Cypher-SET
-                            // property on a 0.8.39 in-memory Sodir-scale
-                            // graph survived in-memory but vanished after
-                            // save+load, accompanied by
-                            // `BUG: InternedKey N not found in StringInterner`.
-                            let key = graph.interner.get_or_intern(property);
-                            if let Some(master) = graph.column_stores.get_mut(&node_type_str) {
-                                Arc::make_mut(master).set(row_id, key, &value, None);
-                                touched_columnar_types.insert(node_type_str.clone());
-                                stats.properties_set += 1;
-                                wrote_via_master = true;
-                                // This master-store write bypasses the recorded
-                                // GraphWrite path, so explicitly capture the one
-                                // mutated node for the WAL. (The silent refresh
-                                // sweep below must NOT be captured — else a
-                                // single SET would log every node of the type.)
-                                graph.graph.note_recorded_node_upsert(*node_idx);
-                            }
-                        }
+                    let wrote_via_master = set_via_column_master(
+                        graph,
+                        ColumnMasterWrite {
+                            node_idx: *node_idx,
+                            node_type: &node_type_str,
+                            property,
+                            value: &value,
+                            row_id: columnar_row_id,
+                        },
+                        &mut touched_columnar_types,
+                    );
+                    if wrote_via_master {
+                        stats.properties_set += 1;
                     }
                     if !wrote_via_master {
                         // Compact / Map storage, or title/name, or a Columnar
@@ -1639,7 +1698,6 @@ fn execute_set(
     // equality-index update — provenance is range-queried, not equality-matched.
     if !nodes_to_stamp.is_empty() {
         let prov = graph.provenance_props();
-        let is_in_memory = !graph.graph.is_disk();
         for (node_idx, node_type) in &nodes_to_stamp {
             // Arena guard: node_weight materializes on the disk backend
             // (protocol in disk/graph.rs); scoped so the borrow ends before
@@ -1660,17 +1718,17 @@ fn execute_set(
                         Arc::make_mut(schema_arc).add_key(key);
                     }
                 }
-                let mut wrote = false;
-                if is_in_memory {
-                    if let Some(row_id) = columnar_row_id {
-                        if let Some(master) = graph.column_stores.get_mut(node_type) {
-                            Arc::make_mut(master).set(row_id, key, pval, None);
-                            touched_columnar_types.insert(node_type.clone());
-                            graph.graph.note_recorded_node_upsert(*node_idx);
-                            wrote = true;
-                        }
-                    }
-                }
+                let wrote = set_via_column_master(
+                    graph,
+                    ColumnMasterWrite {
+                        node_idx: *node_idx,
+                        node_type,
+                        property: pname,
+                        value: pval,
+                        row_id: columnar_row_id,
+                    },
+                    &mut touched_columnar_types,
+                );
                 if !wrote {
                     if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, *node_idx) {
                         node.set_property(pname, pval.clone(), &mut graph.interner);

--- a/crates/kglite/src/graph/storage/impls.rs
+++ b/crates/kglite/src/graph/storage/impls.rs
@@ -347,6 +347,23 @@ impl GraphWrite for MemoryGraph {
         self.inner.node_weight_mut(idx)
     }
 
+    /// Bypasses the undo journal as well as the WAL recorder.
+    ///
+    /// The one caller is the columnar handle-refresh sweep, which re-points
+    /// every node of a type at a forked master store. Capturing a `NodeData`
+    /// pre-image for each of them would make a one-row `SET` cost one clone
+    /// per node *of the type* — the O(V+E)-per-write cost this journal exists
+    /// to remove, reintroduced at a smaller constant. The sweep's inverse is
+    /// journalled once per type instead, as
+    /// [`UndoEntry::ColumnarHandles`](crate::graph::storage::undo::UndoEntry::ColumnarHandles).
+    ///
+    /// Nothing else may use this method to skip capture: a caller that
+    /// changes a node's *content* silently is unrecoverable on rollback.
+    #[inline]
+    fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
+        self.inner.node_weight_mut(idx)
+    }
+
     #[inline]
     fn edge_weight_mut(&mut self, idx: EdgeIndex) -> Option<&mut EdgeData> {
         self.invalidate_peer_counts();

--- a/crates/kglite/src/graph/storage/recording.rs
+++ b/crates/kglite/src/graph/storage/recording.rs
@@ -581,8 +581,11 @@ impl<G: GraphWrite> GraphWrite for RecordingGraph<G> {
     #[inline]
     fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
         // Bypass recording — internal bookkeeping (columnar handle refresh),
-        // not a logical mutation. See the trait method docs.
-        self.inner.node_weight_mut(idx)
+        // not a logical mutation. See the trait method docs. Delegated to the
+        // inner backend's *silent* method rather than its recorded one so the
+        // silence composes: `MemoryGraph` also skips undo-journal capture
+        // here, and wrapping it must not put that capture back.
+        self.inner.node_weight_mut_silent(idx)
     }
 
     #[inline]

--- a/crates/kglite/src/graph/storage/undo.rs
+++ b/crates/kglite/src/graph/storage/undo.rs
@@ -56,6 +56,7 @@
 //!   `NodeData` clone, not five.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
 
@@ -64,6 +65,33 @@ use crate::graph::features::timeseries::NodeTimeseries;
 use crate::graph::schema::{
     CompositeIndexKey, CompositeValue, EdgeData, IndexKey, InternedKey, NodeData,
 };
+use crate::graph::storage::column_store::ColumnStore;
+
+#[cfg(test)]
+thread_local! {
+    /// Node pre-images actually cloned into an undo journal since the last
+    /// reset.
+    ///
+    /// The complement of `BACKEND_CLONE_NODES` (`storage/backend.rs`), which
+    /// counts nodes copied by a *backend* clone and is therefore blind to the
+    /// journal path by construction: the whole point of the journal checkpoint
+    /// is that it clones no backend. A statement that captures a pre-image per
+    /// node of a type rather than per node it changed is O(type)-per-write,
+    /// which is the cost class the journal exists to remove, and this is the
+    /// only counter that can see it.
+    static JOURNAL_NODE_PRE_IMAGES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_journal_node_pre_images() {
+    JOURNAL_NODE_PRE_IMAGES.set(0);
+}
+
+/// Node pre-images cloned into an undo journal since the last reset.
+#[cfg(test)]
+pub(crate) fn journal_node_pre_images() -> usize {
+    JOURNAL_NODE_PRE_IMAGES.get()
+}
 
 /// A `Vec<NodeIndex>` bucket in one of `DirGraph`'s inverted indexes.
 /// Bucket edits are journalled with a *position* so a rollback restores the
@@ -141,6 +169,22 @@ pub enum UndoEntry {
         node: usize,
         prior: Box<NodeTimeseries>,
     },
+    /// `execute_set`'s columnar fast path wrote through the master
+    /// `Arc<ColumnStore>` for `node_type`, forking it, and then re-pointed
+    /// every node of that type at the fork. `prior` is the master as it stood
+    /// before the statement's first such write; undo re-points them all back.
+    ///
+    /// **One entry per type per statement, not per node.** That is the whole
+    /// reason this variant exists: the refresh sweep touches every node of the
+    /// type, so journalling it through the ordinary weight-capture seam would
+    /// cost a `NodeData` clone per node of the type on every single-row `SET`.
+    /// The store itself needs no copy — `ColumnStore` has no interior
+    /// mutability and the fork already left `prior` pristine, so holding the
+    /// handle is the entire pre-image.
+    ColumnarHandles {
+        node_type: String,
+        prior: Arc<ColumnStore>,
+    },
 }
 
 /// Buffer of inverse operations for exactly one statement.
@@ -157,6 +201,11 @@ pub struct UndoJournal {
     weighed_nodes: HashSet<NodeIndex>,
     /// Edge counterpart of `weighed_nodes`.
     weighed_edges: HashSet<EdgeIndex>,
+    /// Node types whose pre-statement master column store is already captured.
+    /// First touch wins, exactly like `weighed_nodes`: a statement can write
+    /// through the same master in several clauses, and only the first one saw
+    /// the pre-statement store.
+    forked_columnar_types: HashSet<String>,
 }
 
 impl UndoJournal {
@@ -189,6 +238,8 @@ impl UndoJournal {
     pub fn note_node_weight(&mut self, idx: NodeIndex, prior: impl FnOnce() -> Option<NodeData>) {
         if self.weighed_nodes.insert(idx) {
             if let Some(prior) = prior() {
+                #[cfg(test)]
+                JOURNAL_NODE_PRE_IMAGES.set(JOURNAL_NODE_PRE_IMAGES.get() + 1);
                 self.entries.push(UndoEntry::NodeWeight { idx, prior });
             }
         }
@@ -275,6 +326,31 @@ impl UndoJournal {
         for (pos, idx) in hits {
             self.note_bucket_removed(bucket.clone(), idx, pos);
         }
+    }
+
+    /// The master column store for `node_type` is about to be forked by a
+    /// columnar write. `prior` is only taken on the statement's first fork of
+    /// that type, so the captured handle is the pre-statement one.
+    ///
+    /// Returns whether the capture happened, so the caller can skip the
+    /// `Arc::clone` on later writes of the same statement.
+    #[inline]
+    pub fn note_columnar_fork(
+        &mut self,
+        node_type: &str,
+        prior: impl FnOnce() -> Option<Arc<ColumnStore>>,
+    ) -> bool {
+        if !self.forked_columnar_types.contains(node_type) {
+            self.forked_columnar_types.insert(node_type.to_string());
+            if let Some(prior) = prior() {
+                self.entries.push(UndoEntry::ColumnarHandles {
+                    node_type: node_type.to_string(),
+                    prior,
+                });
+                return true;
+            }
+        }
+        false
     }
 
     /// A node's timeseries was dropped.

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 536,
-      "branches": 75,
+      "lines": 507,
+      "branches": 70,
       "nesting": 8
     },
     {

--- a/tests/benchmarks/test_bench_delete_scaling.py
+++ b/tests/benchmarks/test_bench_delete_scaling.py
@@ -1,0 +1,460 @@
+"""Why is deleting so much more expensive than inserting?
+
+The 2026-07-27 competitive benchmark left exactly one finding **deliberately
+unattributed**, and this file is its instrument. At 100k nodes, with no index
+and at matched durability, in the very same configuration where an insert hit
+**exact parity with SQLite (3.668 ms vs 3.666 ms)**:
+
+| operation               | kglite     | SQLite    | ratio |
+|-------------------------|-----------:|----------:|------:|
+| `delete_comment`        |  10.09 ms  | 5.462 ms  | 1.8x  |
+| `cascade_delete_issue`  |  24.71 ms  | 5.476 ms  | 4.5x  |
+
+Against SQLite's `wal_normal` rung the gap is 2.6-6.1x. Inserts were at parity;
+deletes were not. Nothing in the suite measured a delete shape across sizes, so
+the *scaling* of that gap is simply unknown — which is why it stayed a mystery
+rather than becoming a bug report.
+
+**This file deliberately does not encode a cause.** The standing hypothesis at
+the time of writing was `check_auto_vacuum` being reachable on the delete path
+and not the insert path, and the probe was never run. A benchmark built around
+that hypothesis would measure the hypothesis; these cells measure the *shapes*
+instead — leaf delete, `DETACH DELETE` with edges, cascade — across three sizes,
+so the scaling is visible whatever the cause turns out to be, including a cause
+nobody has thought of yet.
+
+Two candidate costs *are* separated, because both are known to exist and would
+otherwise be summed into one uninterpretable number:
+
+* **the id-index rebuild.** A delete invalidates the type's id index, so the
+  next lookup by id pays an O(V) rebuild. `test_bench_write_scaling.py`
+  measured that term alone at 34,486 us vs 4.1 us at 1M. Its cost lands on
+  whoever queries next, not on the deleting statement, so it is split into its
+  own cell rather than left to contaminate the others.
+* **auto-vacuum.** `check_auto_vacuum` (`dir_graph/mod.rs:1901-1922`) is
+  called only from `after_mutation` (`kglite-py/src/graph/mod.rs:361-376`) and
+  only when `nodes_deleted > 0 || relationships_deleted > 0` — so it is, in
+  fact, structurally unreachable from an insert. It fires when tombstones
+  exceed a hard floor of 100 **and** the fragmentation ratio exceeds a
+  threshold, and `vacuum()` then rebuilds column stores and reindexes. See
+  `test_bench_bulk_delete_by_auto_vacuum` for what that cell can and cannot
+  tell you.
+
+**Every other cell here pins `set_auto_vacuum(None)`.** Not to hide the cost,
+but because an auto-vacuum firing on an arbitrary round turns a per-delete
+measurement into a bimodal one, and pytest-benchmark reports the blend. Leaving
+it enabled would produce the sort of plausible, mildly-elevated,
+completely-uninterpretable number this project's own methodology note warns
+about.
+
+Nothing here is in the `make bench-check` tracked set — that gate runs
+`tests/benchmarks/test_bench_core.py` only (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_delete_scaling.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from kglite import KnowledgeGraph
+
+# Three decades, because this defect is unexplained and the *slope* is the
+# entire finding. Two points give a ratio; three distinguish "linear in graph
+# size" from "linear in edges touched" from "flat with a large constant" — and
+# the answer decides where anyone looks next. 1k is also the scale at which the
+# competitive run found deletes to be *fine*, so it doubles as the control that
+# localises the problem to scale rather than to the delete path as such.
+SIZES = [1_000, 10_000, 100_000]
+
+#: Comments per issue in the fixture, and therefore edges detached by a cascade.
+COMMENTS_PER_ISSUE = 10
+
+#: Victims pre-created per shape, one consumed per round. Must exceed
+#: ROUNDS + WARMUP_ROUNDS or a cell runs out mid-measurement.
+VICTIM_POOL = 80
+
+# Explicit rounds rather than plain `benchmark(fn)`. Auto-calibration times the
+# first call to size the round count, and a delete's first call is not
+# representative: the fixture leaves the id index warm and the first delete
+# invalidates it. `test_bench_write_scaling.py:46-63` records that exact
+# pattern scheduling 12,686 rounds of a 24 ms call — five minutes from one
+# test, uninterruptible because `-m benchmark` is exempt from the 120 s hang
+# ceiling (`tests/conftest.py:34`).
+#
+# The pool size caps rounds independently: each round destroys a victim, so
+# rounds must stay under VICTIM_POOL.
+ROUNDS = 50
+WARMUP_ROUNDS = 5
+
+#: Id-space partitions, kept far apart so a victim id can never collide with a
+#: base-graph id and turn a delete into a silent no-op — which would read as a
+#: very fast delete rather than as an error.
+LEAF_BASE = 10_000_000
+DETACH_BASE = 20_000_000
+CASCADE_ISSUE_BASE = 30_000_000
+CASCADE_COMMENT_BASE = 40_000_000
+PROBE_BASE = 50_000_000
+BULK_BASE = 60_000_000
+
+
+def _issue_comment_graph(size: int) -> KnowledgeGraph:
+    """`size` Comments hanging off `size // COMMENTS_PER_ISSUE` Issues.
+
+    Mirrors the application the competitive benchmark implemented three times
+    (kglite / SQLite / ArcadeDB), so the numbers here are comparable to the
+    table in this file's docstring rather than merely internally consistent.
+
+    Primary keys are declared on both types. Without one, `CREATE` invalidates
+    the whole type's id index and the next id lookup rebuilds it — an O(V) cost
+    per statement that has nothing to do with deletion but is large enough to
+    swamp it (34,486 us vs 4.1 us at 1M).
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema(
+        {
+            "nodes": {
+                "Issue": {"primary_key": "id"},
+                "Comment": {"primary_key": "id"},
+            }
+        }
+    )
+    issue_count = max(1, size // COMMENTS_PER_ISSUE)
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(issue_count),
+                "title": [f"issue-{i}" for i in range(issue_count)],
+                "state": ["open" if i % 3 else "closed" for i in range(issue_count)],
+            }
+        ),
+        "Issue",
+        "id",
+        "title",
+        columns=["state"],
+    )
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "body": [f"comment body {i}" for i in range(size)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    graph.add_connections(
+        pd.DataFrame({"src": range(size), "dst": [i % issue_count for i in range(size)]}),
+        "ON",
+        "Comment",
+        "src",
+        "Issue",
+        "dst",
+    )
+    return graph
+
+
+def _add_victims(graph: KnowledgeGraph, base: int, *, attached: bool) -> None:
+    """A pool of throwaway Comments, optionally wired to an Issue.
+
+    Pre-created in the fixture rather than in a `pedantic` setup so the timed
+    region is a delete and nothing else. A setup that created the victim would
+    also warm the id index the delete then invalidates, which quietly changes
+    what the following round measures.
+    """
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(base, base + VICTIM_POOL),
+                "body": [f"victim body {i}" for i in range(VICTIM_POOL)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    if attached:
+        graph.add_connections(
+            pd.DataFrame({"src": range(base, base + VICTIM_POOL), "dst": [0] * VICTIM_POOL}),
+            "ON",
+            "Comment",
+            "src",
+            "Issue",
+            "dst",
+        )
+
+
+def _add_cascade_victims(graph: KnowledgeGraph) -> None:
+    """`VICTIM_POOL` Issues, each carrying `COMMENTS_PER_ISSUE` Comments."""
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(CASCADE_ISSUE_BASE, CASCADE_ISSUE_BASE + VICTIM_POOL),
+                "title": [f"victim issue {i}" for i in range(VICTIM_POOL)],
+                "state": ["open"] * VICTIM_POOL,
+            }
+        ),
+        "Issue",
+        "id",
+        "title",
+        columns=["state"],
+    )
+    total = VICTIM_POOL * COMMENTS_PER_ISSUE
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(CASCADE_COMMENT_BASE, CASCADE_COMMENT_BASE + total),
+                "body": [f"cascade body {i}" for i in range(total)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    graph.add_connections(
+        pd.DataFrame(
+            {
+                "src": range(CASCADE_COMMENT_BASE, CASCADE_COMMENT_BASE + total),
+                "dst": [CASCADE_ISSUE_BASE + (i // COMMENTS_PER_ISSUE) for i in range(total)],
+            }
+        ),
+        "ON",
+        "Comment",
+        "src",
+        "Issue",
+        "dst",
+    )
+
+
+@pytest.fixture(scope="module")
+def delete_graphs() -> dict[int, KnowledgeGraph]:
+    """One graph per size, pre-loaded with every shape's victim pool.
+
+    Module-scoped: three graphs, one of them 100k nodes plus 100k edges, is
+    seconds of build time that must not repeat per cell.
+
+    `set_auto_vacuum(None)` is the load-bearing line — see the module
+    docstring. Without it a vacuum fires on an arbitrary round once tombstones
+    pass 100, rebuilding column stores and reindexing, and every cell in this
+    file reports a blend of two populations.
+    """
+    graphs = {}
+    for size in SIZES:
+        graph = _issue_comment_graph(size)
+        _add_victims(graph, LEAF_BASE, attached=False)
+        _add_victims(graph, DETACH_BASE, attached=True)
+        _add_cascade_victims(graph)
+        graph.set_auto_vacuum(None)
+        graphs[size] = graph
+    return graphs
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_delete_leaf(benchmark, delete_graphs, size):
+    """Delete one Comment that has no edges at all.
+
+    The floor of the delete path: node removal, tombstone, index maintenance,
+    and nothing else. If this scales with graph size then the cost is in the
+    delete machinery itself and has nothing to do with edges — which would rule
+    out the whole "detaching relationships is expensive" family of explanations
+    in a single reading.
+
+    Defends the unattributed 100x-of-insert gap: `delete_comment` measured
+    **10.09 ms at 100k against a 3.668 ms insert in the same cell**
+    (2026-07-27).
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(LEAF_BASE, LEAF_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher("MATCH (c:Comment {id: $i}) DELETE c", params={"i": next(ids)})
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_detach_delete_one_edge(benchmark, delete_graphs, size):
+    """`DETACH DELETE` one Comment that owns exactly one edge.
+
+    Read against `test_bench_delete_leaf` at the same size: the difference is
+    the per-edge detach cost, isolated at one edge so it cannot be confused
+    with the cascade cell's fan-out. If leaf and detach diverge *with size*,
+    the edge-detach path is doing something proportional to the graph rather
+    than to the node's degree — the single most useful thing this file can
+    establish.
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(DETACH_BASE, DETACH_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher("MATCH (c:Comment {id: $i}) DETACH DELETE c", params={"i": next(ids)})
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_cascade_delete_issue(benchmark, delete_graphs, size):
+    """Delete an Issue together with its `COMMENTS_PER_ISSUE` Comments.
+
+    The worst cell in the competitive table: **24.71 ms at 100k against
+    SQLite's 5.476 ms, a 4.5x gap**, in a configuration where inserts were at
+    parity (2026-07-27).
+
+    Eleven nodes and ten edges per round. Against `test_bench_detach_delete_
+    one_edge` this says whether cascade cost is simply 11x a single delete
+    (a constant-factor story, uninteresting) or superlinear in the number of
+    entities removed per statement (a real defect).
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(CASCADE_ISSUE_BASE, CASCADE_ISSUE_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher(
+            "MATCH (i:Issue {id: $i})<-[:ON]-(c:Comment) DETACH DELETE i, c",
+            params={"i": next(ids)},
+        )
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_delete_then_id_lookup(benchmark, delete_graphs, size):
+    """A delete plus the id lookup that pays for it.
+
+    The deleting statement invalidates the type's id index; the *rebuild* is
+    paid by whoever looks up by id next. Splitting it out matters because the
+    two costs land on different statements and scale differently, and an
+    application's real per-delete cost is this cell, not `test_bench_delete_
+    leaf`.
+
+    Read the difference between this and `test_bench_delete_leaf` as the
+    rebuild term. It is expected to scale with size — that is a known open
+    issue (`test_bench_write_scaling.py::test_bench_id_index_invalidation_on_
+    create`), not a regression — so the question this cell answers is how much
+    of the unexplained delete gap it accounts for. If it accounts for all of
+    it, the mystery is solved and it was never about deletion.
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(PROBE_BASE, PROBE_BASE + VICTIM_POOL))
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(PROBE_BASE, PROBE_BASE + VICTIM_POOL),
+                "body": [f"probe body {i}" for i in range(VICTIM_POOL)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+
+    def delete_then_lookup():
+        graph.cypher("MATCH (c:Comment {id: $i}) DELETE c", params={"i": next(ids)})
+        graph.cypher("MATCH (c:Comment {id: 0}) RETURN c.id")
+
+    benchmark.pedantic(delete_then_lookup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+# ── the auto-vacuum discriminator ────────────────────────────────────
+#
+# Read the caveat before quoting this cell. `check_auto_vacuum` fires only when
+# BOTH conditions hold (`dir_graph/mod.rs:1901-1922`):
+#
+#     tombstones = node_bound() - node_count() > 100
+#     tombstones / node_bound() > threshold          (default 0.3)
+#
+# A per-round single delete produces one tombstone per round, so at the default
+# threshold a bounded benchmark never crosses either condition and the on/off
+# pair reads *identical*. That null result would look like evidence that
+# auto-vacuum is not the cost — while actually being evidence that the
+# benchmark never reached it. Under-powered nulls are how this defect stayed
+# unexplained in the first place.
+#
+# So this cell does two things differently: it deletes in a batch large enough
+# to clear the 100-tombstone floor within a few rounds, and it uses an
+# artificially low threshold so the ratio condition is reachable at all.
+#
+# WHAT IT MEASURES: whether the vacuum path, once entered, is expensive enough
+# to explain a delete gap. That is the open question.
+# WHAT IT DOES NOT MEASURE: the cost of the DEFAULT configuration. At
+# threshold=0.3 a real application vacuums rarely, and this cell says nothing
+# about how rarely. Do not quote it as "auto-vacuum costs X per delete".
+
+#: Comments removed per round — comfortably over the 100-tombstone floor, so
+#: the ratio condition is the only thing left gating the vacuum.
+BULK_DELETE_BATCH = 150
+
+#: Low enough that the ratio condition is satisfiable within a bounded run.
+#: The default is 0.3; see the caveat above before comparing the two.
+PROBE_VACUUM_THRESHOLD = 0.001
+
+#: Few rounds: each round deletes BULK_DELETE_BATCH nodes and a fired vacuum
+#: rebuilds column stores and reindexes the whole graph.
+BULK_ROUNDS = 6
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("auto_vacuum", [None, PROBE_VACUUM_THRESHOLD], ids=["vacuum_off", "vacuum_on"])
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_bulk_delete_by_auto_vacuum(benchmark, size, auto_vacuum):
+    """A batched delete with auto-vacuum reachable, versus disabled.
+
+    The discriminating pair for the standing hypothesis, run without asserting
+    it. Builds its own graph rather than sharing `delete_graphs`, because a
+    fired vacuum remaps every `NodeIndex` and rebuilds the column stores — it
+    would leave a shared fixture in a different state for whichever cell ran
+    next, making results depend on collection order.
+
+    Read `vacuum_on` against `vacuum_off` at the same size — **only against
+    each other, never against the single-delete cells above.** The `WHERE c.id
+    IN $ids` predicate is a label scan, so each round carries an O(V) term that
+    the point-lookup cells do not. Both arms pay it identically, so it cancels
+    in the comparison this cell exists to make, but it makes the absolute
+    number meaningless on its own. (The scan is deliberate: an `UNWIND` +
+    id-match spelling would be cheaper, and is also the exact shape of a fixed
+    0.11.2 bug where a bare point lookup silently returned nothing once the
+    list passed ~64 entries. A cell that quietly deleted zero nodes would be a
+    very fast delete benchmark and a completely false one.)
+
+    A large gap means the vacuum path is worth investigating as the delete
+    cost; a small one retires the hypothesis and points elsewhere. Either way
+    the answer is recorded rather than assumed.
+    """
+    graph = _issue_comment_graph(size)
+    graph.set_auto_vacuum(auto_vacuum)
+    total = BULK_DELETE_BATCH * (BULK_ROUNDS + 2)
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(BULK_BASE, BULK_BASE + total),
+                "body": [f"bulk body {i}" for i in range(total)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    batches = iter(
+        [
+            list(range(BULK_BASE + n * BULK_DELETE_BATCH, BULK_BASE + (n + 1) * BULK_DELETE_BATCH))
+            for n in range(BULK_ROUNDS + 2)
+        ]
+    )
+
+    def delete_batch():
+        graph.cypher(
+            "MATCH (c:Comment) WHERE c.id IN $ids DETACH DELETE c",
+            params={"ids": next(batches)},
+        )
+
+    benchmark.pedantic(delete_batch, rounds=BULK_ROUNDS, iterations=1, warmup_rounds=1)

--- a/tests/benchmarks/test_bench_fast_write_path.py
+++ b/tests/benchmarks/test_bench_fast_write_path.py
@@ -1,0 +1,503 @@
+"""Does an ordinary user action silently move every later write onto a
+whole-graph clone?
+
+Two independent defects live here. Both make a single write O(V+E) instead of
+O(changes), both are invisible at small scale, and both were found by an
+external competitive benchmark rather than by this suite — because nothing in
+this suite was shaped to see them.
+
+────────────────────────────────────────────────────────────────────────────
+Defect A — the ``journal_covers`` vetoes (fixed in PR #86, ``59478b43``)
+────────────────────────────────────────────────────────────────────────────
+
+Until that fix, ``journal_covers`` had two independent veto terms, each
+permanently tripped by an ordinary user action, each sending every subsequent
+mutating statement through ``fork_transaction()`` — a full copy of the node
+and edge stores — for the rest of the session:
+
+* **``save()``** calls ``enable_columnar()``, which permanently populates
+  ``DirGraph.column_stores``. The old gate required that field to be *empty*.
+  Measured at 100k (2026-07-27): a single insert went **0.0062 ms → 3.0931 ms
+  and stayed there** — a ~500× permanent degradation from one ``save()``. A
+  second ``save()`` did not clear it. ``min ≈ mean``, so *every* write paid.
+* **any user index** vetoed the same path. Measured at 100k, ``durable=False``,
+  no ``save()``: **0.0127 ms → 15.22 ms**, reported as a 6–10× range rather
+  than a point estimate because the indexed cells were 17% noisy (two takes of
+  identical code gave 21.18 and 37.77 ms).
+
+With neither trigger, the same 100k insert costs **3.668 ms against SQLite's
+3.666 ms — exact parity**. So this was not an architectural deficit; it was a
+gate that excluded every realistic application graph.
+
+After PR #86 ``journal_covers`` (``rollback.rs:195-198``) has **exactly one**
+term left — ``graph.graph.supports_undo_journal()``. Neither ``save()`` nor any
+index family vetoes it any more. The only remaining way to force the clone is
+the *backend*: ``Memory`` journals, ``Recording`` forwards to its inner
+backend, and ``Mapped`` / ``Disk`` return ``false``
+(``storage/backend.rs:110-116``). A reintroduced veto is therefore a new
+conjunct in a one-conjunct predicate — cheap to add by accident, and these
+cells are what would notice.
+
+⚠ **The statement shape is load-bearing — see the STATEMENT SHAPE comment
+below.** A bare single-node ``CREATE`` cannot see this defect at all, in
+either direction, because it never opens a checkpoint in the first place.
+
+**Why the existing suite could not see it.** The Rust guard
+(``rollback_tests.rs::journalled_statements_copy_zero_nodes``) ran only on
+``seeded()`` — a graph with no column stores and no indexes, which cannot take
+the clone path *no matter what the gate says*. PR #86 added ``seeded_columnar``
+and ``seeded_indexed`` arms, and those are the authoritative, deterministic
+guard: they assert ``backend_clone_nodes() == 0``, an exact oracle for *which
+path ran*. This file cannot do that — ``backend_clone_nodes`` is ``#[cfg(test)]
+pub(crate)`` on a thread-local (``storage/backend.rs:42``) and is not reachable
+from Python by any route. **These benchmarks are the cost/scaling complement,
+not a replacement**: they measure that the fast path is still *cheap* and still
+*flat*, and they cover the one combination the Rust arms do not — saved **and**
+indexed at once, through a real ``save()`` rather than a bare
+``enable_columnar()``.
+
+────────────────────────────────────────────────────────────────────────────
+Defect B — ``Arc::make_mut`` deep clone on a merely-held reference
+────────────────────────────────────────────────────────────────────────────
+
+Holding a returned result view across a write triggers one full graph clone.
+Measured at 100k (2026-07-27): mean 0.0561 ms, p50 0.0044 ms, **max 5.17 ms**,
+with full recovery once the reference is released; ``freeze()`` held behaves
+the same (max 5.83 ms); ~28 ms at 1M. No threading, no snapshot API, no
+explicit copy — merely keeping the ``ResultView`` a query returned.
+
+See the measurement-trap comment above that section. It is the reason this
+defect survived a benchmark suite that already had a cell pointed at it.
+
+────────────────────────────────────────────────────────────────────────────
+How to read these, and the scale rule that governs the sizes
+────────────────────────────────────────────────────────────────────────────
+
+Like ``test_bench_write_scaling.py``, this file asserts no timing threshold —
+the signal is a **ratio**, and there are two of them:
+
+1. **Across variants at one size.** ``saved`` / ``indexed`` / ``saved_indexed``
+   must each stay close to ``fresh``. A variant that is orders of magnitude
+   worse has had its fast path vetoed.
+2. **Across sizes within one variant.** Every variant must be flat from 1k to
+   100k. A reintroduced O(V+E) term shows up as *divergence between the sizes*,
+   which is a far more robust detector than any absolute number: it survives a
+   change of machine, and it cannot be explained away as thermal noise.
+
+Nothing here is in the ``make bench-check`` tracked set. That gate runs
+``tests/benchmarks/test_bench_core.py`` only (see ``Makefile:85``), so a new
+file cannot perturb it — and, for defect B specifically, that gate compares on
+``--metric min``, which is structurally blind to it (again, see the trap
+comment).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_fast_write_path.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from kglite import KnowledgeGraph
+
+# ⚠ THE 100k CELL IS THE ONLY ONE THAT CAN SEE DEFECT A. DO NOT "SIMPLIFY"
+# THIS DOWN TO 1k.
+#
+# A fixed per-operation cost masks any multiplicative defect below the scale at
+# which the defect exceeds it. In the 2026-07-27 competitive run the index
+# penalty was *completely invisible* at 1k — 3.597 ms with no index vs 3.759 ms
+# with one, well inside noise — because the 3.4 ms F_FULLFSYNC floor swamped a
+# defect that is unmissable two decades up. A suite run only at small scale
+# would have certified this write path as healthy, which is exactly what
+# happened.
+#
+# 1k is kept as the *control*, not as the measurement: its job is to be the
+# denominator that makes the 100k divergence legible. Deleting it is as wrong
+# as deleting 100k.
+#
+# 1M is deliberately omitted. The defect is already unambiguous at two decades,
+# and four variants x 1M nodes is minutes of fixture build for no added signal.
+SIZES = [1_000, 100_000]
+
+#: The four corners of the ``journal_covers`` gate. ``saved_indexed`` is the
+#: one a real application actually is, and the one combination the Rust-side
+#: arms never build.
+VARIANTS = ["fresh", "saved", "indexed", "saved_indexed"]
+
+# Every cell here drives `benchmark.pedantic` with an explicit round count
+# rather than plain `benchmark(fn)`.
+#
+# This is a termination requirement, not a style choice. `pytest-benchmark`
+# auto-calibration times the first call to size the round count, and this file
+# exists precisely to compare a world where a write costs ~6 us against a world
+# where it costs ~15-38 ms. Calibration performed in the cheap world and then
+# applied in the expensive one schedules thousands of rounds of a
+# multi-millisecond call; `test_bench_write_scaling.py` records a real instance
+# of that pattern costing 5 minutes from a single test. A `-m benchmark` run is
+# exempt from the 120 s pytest hang ceiling (`tests/conftest.py`), so nothing
+# would interrupt it.
+#
+# `pedantic` skips calibration entirely, so runtime is bounded in BOTH worlds:
+# ~2 ms per cell when healthy, ~2 s per cell when the defect is back.
+ROUNDS = 50
+WARMUP_ROUNDS = 5
+
+#: Rounds for the reference-held cells (defect B). Lower, because each round
+#: forces a whole-graph copy by construction when the defect is present, and
+#: because a pinned reference keeps the pre-clone copy alive.
+REF_ROUNDS = 20
+REF_WARMUP_ROUNDS = 2
+
+
+# ⚠ STATEMENT SHAPE — THE SINGLE EASIEST WAY TO SILENTLY DISABLE THIS FILE.
+#
+# `session/execute.rs:390-394` opens a `StatementCheckpoint` only when
+# `can_skip_rollback_checkpoint(...)` is false. That whitelist
+# (`execute.rs:309-337`) returns true — meaning NO CHECKPOINT IS OPENED AT ALL,
+# `StatementCheckpoint::None` — for a query that is exactly one `Clause::Create`
+# with a single-node pattern, on a backend with
+# `supports_checkpoint_free_mutation()` (`backend.rs:94-96`: `Memory` only).
+#
+# So `CREATE (:Item {id: 1})` on an in-memory graph takes the same free path
+# before and after PR #86, on every variant. A benchmark built on it reads
+# identical everywhere and certifies health unconditionally — the exact
+# failure this file was written to end.
+#
+# `MERGE` is used instead: still a one-node insert, but not on the whitelist,
+# so it opens a real checkpoint and is therefore sensitive to which one opens.
+# The other non-whitelisted shapes are `SET`, a multi-element `CREATE`, and an
+# edge `CREATE` (they are what makes `rollback_tests.rs::ZERO_COPY_QUERIES`
+# non-vacuous — note its first entry, a bare `CREATE`, satisfies the assertion
+# trivially for this same reason).
+#
+# `test_bench_checkpoint_free_create_control` below pins the whitelist itself,
+# so that if it ever narrows, the cost shows up somewhere rather than nowhere.
+INSERT_STATEMENT = "MERGE (n:Item {id: $i}) ON CREATE SET n.name = 'x', n.code = 'c', n.qty = 1"
+
+
+def _base_graph(size: int) -> KnowledgeGraph:
+    """`size` nodes of one type, with a primary key and an indexable property.
+
+    The declared primary key is load-bearing and is not incidental tidiness.
+    Without one, `CREATE` invalidates the whole type's id index, so the next
+    lookup by id rebuilds it — an O(V) cost per statement that has nothing to
+    do with the rollback checkpoint but is large enough to swamp it entirely
+    (34,486 us vs 4.1 us at 1M, per `test_bench_write_scaling.py`). Measuring
+    the checkpoint through that noise would be measuring the wrong thing.
+
+    The string property matters too: a `Compact` `NodeData` clone allocates per
+    `Value::String`, so strings are what make a whole-graph clone expensive in
+    bytes rather than merely in node count.
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "name": [f"item-{i}" for i in range(size)],
+                "code": [f"code-{i}" for i in range(size)],
+                "qty": [i % 977 for i in range(size)],
+            }
+        ),
+        "Item",
+        "id",
+        "name",
+        columns=["code", "qty"],
+    )
+    # Warm the id index so the measurement is the write, not a first-touch
+    # index build landing in an arbitrary sample.
+    graph.cypher("MATCH (n:Item {id: 0}) RETURN n.id")
+    return graph
+
+
+def _variant_graph(size: int, variant: str, tmp_dir) -> KnowledgeGraph:
+    """A `_base_graph` pushed into one corner of the `journal_covers` gate.
+
+    ⚠ The save here is a **plain `KnowledgeGraph().save()`, never
+    `kglite.open()`**, and that is the single most important decision in this
+    file. `kglite.open()` defaults to `durable="full"`, which puts an
+    F_FULLFSYNC barrier — measured at 3.37 ms on this machine — on every commit.
+    The clone this file is trying to detect costs ~3.06 ms at 100k. Opening the
+    graph durably would therefore bury the entire signal underneath a fixed
+    cost of the same magnitude, and the cell would read "healthy" in both
+    worlds. Durability cost is measured in `test_bench_write_scaling.py`, on
+    purpose, separately.
+
+    `fsync=False` for the same reason: this save exists to flip
+    `column_stores` from empty to populated, not to benchmark a disk flush.
+    """
+    graph = _base_graph(size)
+    if variant in ("indexed", "saved_indexed"):
+        # A secondary property index — a lookup structure, not a constraint.
+        # Two of them, matching the shape the competitive run measured.
+        graph.create_index("Item", "code")
+        graph.create_index("Item", "qty")
+    if variant in ("saved", "saved_indexed"):
+        graph.save(str(tmp_dir / f"veto-{variant}-{size}.kgl"), fsync=False)
+
+    # Vacuity guards. The 2026-07-27 run's own methodology note earned this:
+    # every harness defect it caught was found because a number was
+    # inconsistent with the configuration it *claimed* to represent, never
+    # because a number looked implausible. A `saved` cell that silently isn't
+    # columnar, or an `indexed` cell whose index didn't take, would report a
+    # healthy fast path under a label promising otherwise — indistinguishable
+    # from the fix working. These are cheap and they fail loudly.
+    expect_columnar = variant in ("saved", "saved_indexed")
+    assert graph.is_columnar is expect_columnar, (
+        f"{variant} must{'' if expect_columnar else ' not'} own column stores; "
+        "save() populates DirGraph.column_stores via enable_columnar() "
+        "(io/file.rs:1495) and that is what the old gate vetoed on"
+    )
+    expect_indexed = variant in ("indexed", "saved_indexed")
+    assert graph.has_index("Item", "code") is expect_indexed
+    assert graph.has_index("Item", "qty") is expect_indexed
+    return graph
+
+
+@pytest.fixture(scope="module")
+def veto_graphs(tmp_path_factory) -> dict[tuple[int, str], KnowledgeGraph]:
+    """One graph per (size, variant) corner.
+
+    Module-scoped: eight fixtures, two of them 100k nodes, are seconds of build
+    time that must not be repeated per cell. `tmp_path_factory` rather than
+    `tmp_path` because the latter is function-scoped and cannot be reached from
+    here — and because nothing in this file may write outside a pytest-managed
+    temporary directory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("veto")
+    return {(size, variant): _variant_graph(size, variant, tmp_dir) for size in SIZES for variant in VARIANTS}
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_insert_after_veto_trigger(benchmark, veto_graphs, size, variant):
+    """One node inserted, on a graph in each corner of the `journal_covers` gate.
+
+    The headline cell. Defends: 100k insert **3.668 ms with neither trigger**
+    vs **21–38 ms with two secondary indexes**, and **0.0062 → 3.0931 ms
+    permanently after a single `save()`** (measured 2026-07-27).
+
+    Read `saved` / `indexed` / `saved_indexed` against `fresh` at the same
+    size, and each variant's 100k against its own 1k. Both ratios flat means
+    the journal path still covers real application graphs.
+
+    Uses `MERGE`, not `CREATE` — see the STATEMENT SHAPE comment above. This is
+    not interchangeable.
+    """
+    graph = veto_graphs[(size, variant)]
+    ids = iter(range(10_000_000, 1 << 30))
+
+    def write():
+        graph.cypher(INSERT_STATEMENT, params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_checkpoint_free_create_control(benchmark, veto_graphs, size, variant):
+    """A bare single-node `CREATE` — the statement that opens no checkpoint.
+
+    This cell is **expected to be flat and fast in every variant**, including
+    the ones where the defect would be present, because
+    `can_skip_rollback_checkpoint` gives it `StatementCheckpoint::None`
+    outright. It is here for two reasons, neither of them regression-gating:
+
+    1. It documents, executably, why the obvious insert benchmark cannot see
+       defect A — the next person to reach for `CREATE` here finds the answer
+       next to the code rather than re-deriving it from a null result.
+    2. It is the tripwire for the whitelist *narrowing*. If the checkpoint-free
+       path stops covering single-node `CREATE`, this cell moves and
+       `test_bench_insert_after_veto_trigger` does not, which localises the
+       change immediately.
+
+    A divergence between this cell and the `MERGE` cell in the `fresh` variant
+    is the cost of opening a journal checkpoint at all — worth knowing, and
+    currently unmeasured anywhere else.
+    """
+    graph = veto_graphs[(size, variant)]
+    ids = iter(range(40_000_000, 1 << 30))
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x', code: 'c', qty: 1})", params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_update_after_veto_trigger(benchmark, veto_graphs, size, variant):
+    """One `SET` by primary key, in each corner of the gate.
+
+    The update half of the same defect: `update_by_id` measured **3.986 ms with
+    no index vs 43.6 ms with indexes** at 100k (2026-07-27). `SET` is the
+    shape most exposed to the columnar veto, because a columnar graph routes
+    the write through the master column store and the journal has to be able to
+    reverse that sweep.
+
+    `qty` is written rather than `name` deliberately: `execute_set`'s columnar
+    fast path only fires for a property that is neither `title` nor `name`, so
+    writing `name` would quietly exercise the per-node fallback — the write
+    path that was never at risk. `rollback_tests.rs::
+    the_columnar_fixture_writes_through_the_master_store` pins the same
+    precondition on the Rust side.
+    """
+    graph = veto_graphs[(size, variant)]
+    counter = iter(range(1, 1 << 30))
+
+    def write():
+        graph.cypher("MATCH (n:Item {id: 7}) SET n.qty = $v", params={"v": next(counter)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    assert graph.cypher("MATCH (n:Item {id: 7}) RETURN n.qty AS q").to_list()[0]["q"] > 0
+
+
+# ── defect B: the whole-graph clone a held reference forces ──────────
+#
+# ⚠⚠ THIS SECTION DELIBERATELY DEPARTS FROM THIS PROJECT'S `min` CONVENTION.
+# DO NOT "FIX" IT BACK. READ THIS FIRST.
+#
+# CLAUDE.md's performance protocol says to trust `min` over `median` for
+# sub-millisecond benchmarks, because median pulls upward with system load.
+# That guidance is correct in general and WRONG HERE, and this comment exists
+# because the obvious "cleanup" silently disables the benchmark.
+#
+# The clone fires on the FIRST write after a second `Arc<DirGraph>` appears,
+# and once only — afterwards the graph is uniquely owned again and every
+# subsequent write is back to normal speed. The measured 100k signature is
+# exactly that: mean 0.0561 ms, p50 0.0044 ms, max 5.17 ms. So over N rounds
+# with a single reference taken once:
+#
+#   * `min`  sees round 2..N  -> healthy. Blind by construction.
+#   * `p50`  sees round N/2   -> healthy. Blind by construction.
+#   * `p95`  is healthy for any N > 20. Blind by construction.
+#   * only `max` sees it, and `max` is the one statistic nobody gates on
+#     because it is where genuine noise lands.
+#
+# `test_bench_write_scaling.py` already had a cell aimed at this defect
+# (`test_bench_create_with_lazy_result_alive`) and it reported NO DIFFERENCE —
+# doubly blinded, by the averaging above and by running only at 1k where the
+# clone is ~1000x too small to see. It has been removed and consolidated here;
+# a cell that cannot see the defect it was written for is worse than no cell,
+# because it certifies health.
+#
+# The fix is structural rather than statistical: `pedantic(setup=...)` runs
+# `setup` before EVERY round and does not time it, so each round takes a fresh
+# reference and each timed call is therefore a genuine first-write-after-a-
+# reference. Every round pays the clone, which makes mean, min and p50 all
+# meaningful again and needs no special-casing downstream.
+#
+# The invariant to preserve if you ever touch this: **the reference must be
+# acquired inside `setup`, never once outside the measurement.** Hoisting it
+# out is the one edit that turns this back into a benchmark that always passes.
+
+
+def _wide_result(graph: KnowledgeGraph):
+    """A lazy `ResultView` that keeps its own `Arc<DirGraph>` alive.
+
+    Every clause of this query is chosen against the laziness rules in
+    `planner/fusion/aggregate.rs:1733-1819` and `result_view.rs:112,203-217`,
+    because a view that materialises eagerly drops its `Arc` and silently
+    becomes the `holder="none"` case under a name claiming otherwise:
+
+    * **>32 cells.** `EAGER_MATERIALISE_MAX_CELLS = 32`, applied as
+      `rows * columns`. Two columns x `LIMIT 100` = 200 cells, comfortably past
+      it while staying cheap to build.
+    * **No standalone `WHERE`, no `WITH` / `UNWIND` / `CALL` / `ORDER BY`, one
+      `RETURN`, not `DISTINCT`.** Any of those disqualifies laziness outright.
+    * **Every `RETURN` item is a `PropertyAccess`.** Bare `RETURN n` is not one
+      and would force eager materialisation; `n.name` and `n.qty` are.
+    * **`streaming=True`** (the default) — `streaming=False` guarantees no pin.
+
+    Sessions, transactions and frozen views set `lazy_eligible: false`
+    explicitly, so they never produce a lazy view; `freeze()` pins the `Arc`
+    directly instead, which is the `holder="frozen"` arm.
+    """
+    return graph.cypher("MATCH (n:Item) RETURN n.name, n.qty LIMIT 100")
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("holder", ["none", "result_view", "frozen"])
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_first_write_after_reference(benchmark, veto_graphs, size, holder):
+    """The first write after a reference to the graph appears.
+
+    Defends (measured 2026-07-27, 100k): holding a returned `ResultView` across
+    a write costs **max 5.17 ms** against a 0.0044 ms p50, with full recovery
+    on release; `freeze()` held is the same at **max 5.83 ms**; ~28 ms at 1M.
+    `holder="none"` is the control and must stay at the ordinary write cost.
+
+    Read this as `result_view` / `frozen` against `none` at the same size, and
+    each against itself across sizes — the clone is O(V+E), so a present defect
+    shows a ~100x gap between 1k and 100k while the control stays flat.
+
+    Every round re-acquires the reference in an untimed `setup`; see the long
+    comment above for why that is load-bearing and not refactorable.
+
+    A bare single-node `CREATE` is deliberately correct here, unlike in the
+    defect-A cells. `Arc::make_mut` fires in `get_graph_mut`
+    (`kg_core.rs:1569` -> `handle.rs:630`) *before* the checkpoint whitelist is
+    ever consulted, so the cheapest possible statement still triggers the
+    clone — which isolates defect B from checkpoint cost rather than summing
+    the two.
+    """
+    graph = veto_graphs[(size, "fresh")]
+    ids = iter(range(20_000_000, 1 << 30))
+
+    def setup():
+        if holder == "result_view":
+            reference = _wide_result(graph)
+        elif holder == "frozen":
+            reference = graph.freeze()
+        else:
+            reference = None
+        return (reference,), {}
+
+    def write(reference):
+        graph.cypher("CREATE (:Item {id: $i, name: 'y', code: 'c', qty: 1})", params={"i": next(ids)})
+        # Returned, not merely closed over, so the reference is unambiguously
+        # live for the whole timed call and cannot be collected early — which
+        # would quietly turn this into the `none` case.
+        return reference
+
+    benchmark.pedantic(
+        write,
+        setup=setup,
+        rounds=REF_ROUNDS,
+        iterations=1,
+        warmup_rounds=REF_WARMUP_ROUNDS,
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_write_recovers_after_reference_released(benchmark, veto_graphs, size):
+    """Steady-state writes with no reference held — the recovery control.
+
+    The competitive run's key attribution: after the reference is released,
+    write cost returns fully to baseline. That is what separates defect B (one
+    write, then recovery) from defect A (every write, forever). Without this
+    cell a future reader cannot tell which of the two a regression in
+    `test_bench_first_write_after_reference` represents.
+
+    Expect this to match `test_bench_insert_after_veto_trigger[*-fresh]`.
+    """
+    graph = veto_graphs[(size, "fresh")]
+    ids = iter(range(30_000_000, 1 << 30))
+    # Taken and dropped before the measurement, so the graph has definitely
+    # been through the clone-and-recover cycle by the time timing starts.
+    _wide_result(graph)
+    graph.cypher("CREATE (:Item {id: 29999999, name: 'settle', code: 'c', qty: 1})")
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'z', code: 'c', qty: 1})", params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)

--- a/tests/benchmarks/test_bench_fast_write_path.py
+++ b/tests/benchmarks/test_bench_fast_write_path.py
@@ -99,6 +99,8 @@ Run with::
 
 from __future__ import annotations
 
+import itertools
+
 import pandas as pd
 import pytest
 
@@ -151,6 +153,14 @@ WARMUP_ROUNDS = 5
 #: because a pinned reference keeps the pre-clone copy alive.
 REF_ROUNDS = 20
 REF_WARMUP_ROUNDS = 2
+
+# Module-level, NOT per-test. The defect-B cells are parametrized over `holder`
+# but every parametrization writes to the SAME shared `(size, "fresh")` graph,
+# so a per-test `iter(range(BASE, ...))` hands the second parametrization ids
+# the first one already inserted -- a `duplicate primary key` failure that only
+# appears when the cells run together, never in isolation. A shared counter is
+# immune to that however these cells are parametrized in future.
+_FRESH_GRAPH_IDS = itertools.count(20_000_000)
 
 
 # ⚠ STATEMENT SHAPE — THE SINGLE EASIEST WAY TO SILENTLY DISABLE THIS FILE.
@@ -450,7 +460,7 @@ def test_bench_first_write_after_reference(benchmark, veto_graphs, size, holder)
     the two.
     """
     graph = veto_graphs[(size, "fresh")]
-    ids = iter(range(20_000_000, 1 << 30))
+    ids = _FRESH_GRAPH_IDS
 
     def setup():
         if holder == "result_view":
@@ -491,7 +501,7 @@ def test_bench_write_recovers_after_reference_released(benchmark, veto_graphs, s
     Expect this to match `test_bench_insert_after_veto_trigger[*-fresh]`.
     """
     graph = veto_graphs[(size, "fresh")]
-    ids = iter(range(30_000_000, 1 << 30))
+    ids = _FRESH_GRAPH_IDS
     # Taken and dropped before the measurement, so the graph has definitely
     # been through the clone-and-recover cycle by the time timing starts.
     _wide_result(graph)

--- a/tests/benchmarks/test_bench_startup.py
+++ b/tests/benchmarks/test_bench_startup.py
@@ -1,0 +1,231 @@
+"""How long until an embedded database can answer its first question?
+
+For a library that starts with the process, this is a cost paid on every cold
+request, every CLI invocation, every worker respawn — and it is the one number
+where the 2026-07-27 competitive benchmark found the largest structural gap:
+
+| graph  | kglite open -> first query | SQLite `wal_normal` |
+|--------|---------------------------:|--------------------:|
+| 100k   |                   113.5 ms |             1.44 ms |
+
+**79x**, and unlike a per-query gap it cannot be amortised by doing more work
+per process. SQLite opens a file handle and reads a page; kglite deserializes
+the entire graph.
+
+Nothing in this suite measured it. The nearest existing cell,
+`test_bench_phase19.py::test_bench_disk_reopen_query_mutate_promote`, covers
+**disk** mode only and bundles a query, a write and a `save()` into one number.
+There was no benchmark timing `kglite.open()` or `kglite.load()` of a `.kgl`
+file in memory mode at all.
+
+────────────────────────────────────────────────────────────────────────────
+⚠ The `storage="mapped"` reading from that run is void. Do not repeat it.
+────────────────────────────────────────────────────────────────────────────
+
+The competitive run recorded `storage="mapped"` at **116.5 ms against Default's
+113.5 ms** and concluded "mapped does not help — so this is not a Default-mode
+artifact". The conclusion is right; the evidence is not evidence. Reading the
+source (2026-07-27), those two cells ran **identical code**, for two
+independent reasons:
+
+1. `storage=` is **ignored when opening an existing file**. `kglite.open`
+   passes it to the constructor only on the file-does-not-exist branch
+   (`lib.rs:397-403`), and both the docstring (`__init__.pyi:757-759`) and
+   `lib.rs:264-265` say so.
+2. Even if it were honoured, it could not matter: `impl Deserialize for
+   GraphBackend` (`storage/backend.rs:494-499`) **always** yields
+   `GraphBackend::Memory`, and `io/file.rs` contains no occurrence of `Mapped`.
+   Mapped-ness is not a property of a loaded `.kgl`. The only mmap decision on
+   load is per-column and size-driven — a column spills to a temp file at
+   `MMAP_THRESHOLD` = 256 KB (`column_store.rs:137,2294-2306`) — identically
+   for both "modes".
+
+So 3 ms out of 115 ms was noise between two runs of the same code path, and no
+mapped cell appears in this file. A future mapped-vs-default startup comparison
+would have to build the graph mapped *and* teach the loader to preserve the
+mode; until then such a cell can only mislead. `graph_info()["columnar_is_
+mapped"]` is the field that would actually tell you whether mapped did
+anything.
+
+────────────────────────────────────────────────────────────────────────────
+What the three arms separate
+────────────────────────────────────────────────────────────────────────────
+
+The load is fully eager — `open()` does not return before the work is done, so
+timing `open()` *is* timing the load. Four O(graph) passes run in sequence
+(`io/file.rs:2395-2422`): a full Postcard deserialize of the `StableDiGraph`
+plus `rebuild_type_indices_and_compact()`; per-type column decompress; a
+per-node sweep in `attach_portable_column_stores` plus
+`rebuild_indices_from_keys()`; then embeddings, timeseries, secondary labels
+and the vector index. Nothing is deferred.
+
+* **`load`** — `kglite.load()`. The deserialize alone: no writer lease, no WAL
+  recovery, no header barriers.
+* **`open_off`** — `kglite.open(durable="off")`. Adds the cross-process writer
+  lease. `load` -> `open_off` is the lease cost.
+* **`open_full`** — the default. Adds WAL creation, which pays a `sync_all()`
+  **and** a `sync_parent_dir()` (`wal.rs:598-606`), plus recovery/replay of any
+  existing frames. `open_off` -> `open_full` is the cost of durability at
+  startup, and on macOS those barriers are `F_FULLFSYNC` — measured on this
+  machine at 3.37 ms each.
+
+Read every arm across sizes. All three are expected to be O(graph) today; the
+cells exist so that the *constant* is tracked and so that any future lazy-load
+work has a before number to point at.
+
+Nothing here is in the `make bench-check` tracked set (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_startup.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+# Three decades, because the finding IS the slope. A single size would report a
+# large constant and say nothing about whether it is O(graph) — which is the
+# whole claim being defended. 1M is omitted: at ~1.1 s per open it would
+# dominate the file's runtime while only confirming a line already drawn by
+# three points.
+SIZES = [1_000, 10_000, 100_000]
+
+# Explicit rounds. At 100k an open is ~113 ms, so auto-calibration would
+# schedule a round count from a first call that is not representative (cold
+# page cache) and could run for minutes; `-m benchmark` is exempt from the
+# 120 s hang ceiling, so nothing would stop it.
+#
+# 20 rounds x 113 ms x 9 cells is ~25 s for the file, which is the right budget
+# for a number quoted this often.
+ROUNDS = 20
+WARMUP_ROUNDS = 2
+
+#: `open()` variants under test. See the module docstring for what each adds.
+OPEN_MODES = ["load", "open_off", "open_full"]
+
+
+def _saved_graph_path(tmp_dir, size: int) -> str:
+    """Write a `size`-node `.kgl` once and return its path.
+
+    A primary key is declared because a real application graph has one, and
+    because `rebuild_indices_from_keys()` is one of the O(graph) load passes
+    being measured — a keyless graph would skip work that every real open pays.
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "name": [f"item-{i}" for i in range(size)],
+                "code": [f"code-{i}" for i in range(size)],
+                "qty": [i % 977 for i in range(size)],
+            }
+        ),
+        "Item",
+        "id",
+        "name",
+        columns=["code", "qty"],
+    )
+    graph.add_connections(
+        pd.DataFrame({"src": range(size), "dst": [(i * 7 + 13) % size for i in range(size)]}),
+        "LINKS",
+        "Item",
+        "src",
+        "Item",
+        "dst",
+    )
+    path = str(tmp_dir / f"startup-{size}.kgl")
+    graph.save(path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def startup_paths(tmp_path_factory) -> dict[int, str]:
+    """One saved `.kgl` per size, under a pytest-managed temp dir.
+
+    `tmp_path_factory` rather than `tmp_path`: this is module-scoped, and
+    nothing in this file may write outside a temp directory pytest owns and
+    cleans.
+    """
+    tmp_dir = tmp_path_factory.mktemp("startup")
+    return {size: _saved_graph_path(tmp_dir, size) for size in SIZES}
+
+
+def _open_graph(mode: str, path: str) -> KnowledgeGraph:
+    """Open `path` under one of the three arms.
+
+    `lock=False` on both `open` arms is a measurement decision, not a
+    convenience. The writer lease is held until `close()`, and `close()`
+    *persists the graph to its origin path* — a full O(graph) serialize. A
+    benchmark that opened with the lease would therefore have to choose between
+    leaking a lock per round and paying a whole save inside the loop, and the
+    save is far larger than the open being measured. Opting out of the lease
+    keeps the timed region to the load.
+
+    The lease cost is consequently **not measured anywhere in this file**. It
+    is a file creation plus an advisory lock — small next to a 113 ms load, but
+    unquantified, and that should be stated rather than assumed.
+    """
+    if mode == "load":
+        return kglite.load(path)
+    if mode == "open_off":
+        return kglite.open(path, durable="off", lock=False)
+    return kglite.open(path, lock=False)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("mode", OPEN_MODES)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_open_to_first_query(benchmark, startup_paths, size, mode):
+    """Open a saved graph and answer one point query — time to first answer.
+
+    The headline cell. Defends **113.5 ms at 100k against SQLite's 1.44 ms**
+    (2026-07-27), a cost paid on every process start.
+
+    The query is included because "open to first query" is the number a caller
+    actually experiences, and excluded from interpretation because it is
+    negligible: a cold plan-cache miss is tens of microseconds against a
+    hundred-plus milliseconds of load.
+    `test_bench_first_query_on_open_graph` measures it alone so that claim is
+    checked rather than asserted.
+
+    The returned graph is handed back to pytest-benchmark rather than dropped,
+    so deallocation of a 100k-node graph cannot land inside the next round's
+    timing.
+    """
+    path = startup_paths[size]
+
+    def open_and_query():
+        graph = _open_graph(mode, path)
+        graph.cypher("MATCH (n:Item {id: 7}) RETURN n.name").to_list()
+        return graph
+
+    benchmark.pedantic(open_and_query, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_first_query_on_open_graph(benchmark, startup_paths, size):
+    """The first point query on an already-open graph — the control.
+
+    Exists to keep `test_bench_open_to_first_query` honest. If this is ever a
+    meaningful fraction of the open cell, then "startup is O(graph)" has become
+    the wrong description of that number and the attribution above needs
+    revisiting. Expect microseconds, flat across sizes.
+    """
+    graph = kglite.load(startup_paths[size])
+    counter = iter(range(1 << 30))
+
+    def query():
+        node_id = next(counter) % 1000
+        return graph.cypher("MATCH (n:Item {id: $i}) RETURN n.name", params={"i": node_id}).to_list()
+
+    benchmark.pedantic(query, rounds=ROUNDS * 5, iterations=1, warmup_rounds=WARMUP_ROUNDS)

--- a/tests/benchmarks/test_bench_wal_payload.py
+++ b/tests/benchmarks/test_bench_wal_payload.py
@@ -1,0 +1,298 @@
+"""Does one `add_nodes` call write a write-ahead-log frame quadratic in its
+own row count?
+
+Measured 2026-07-27 against mapped mode: **payload ~= 0.1496 * n^2 bytes** at
+116-byte strings, fitted exponent **2.00 twice**, three points to 0.1%. Because
+the 4 GiB ceiling is **per call** (`MAX_WAL_FRAME_BYTES = u32::MAX`,
+`wal.rs:115`), a large bulk load fails with `payload is 4920896785 bytes` and
+chunking the same rows into smaller calls is a complete workaround — the shape
+of a bug, not of a limit.
+
+────────────────────────────────────────────────────────────────────────────
+The attribution in the original report is probably wrong, and these cells
+are built to settle it rather than to inherit it
+────────────────────────────────────────────────────────────────────────────
+
+It was recorded as a **mapped-mode** defect, because that is where it was hit.
+Reading the source says the storage mode is incidental and the real ingredient
+is the **WAL**:
+
+* `add_nodes` -> `apply_node_batch` -> `commit_wal` (`kg_mutation.rs:1123`) ->
+  `flush_wal` (`kglite-py/src/graph/mod.rs:404-437`), which drains the capture
+  buffer, resolves it, and appends **one** `WalFrame`.
+* The op count is inflated by two loops in the columnar bulk-append path:
+  `Batch::detach_columnar_stores` (`batch.rs:354-390`, the iteration at
+  **`batch.rs:367`**) and `Batch::reattach_columnar_stores` (`batch.rs:396-437`,
+  at **`batch.rs:417`**). Both iterate *every existing node of the affected
+  type* calling `GraphWrite::node_weight_mut`, and `RecordingGraph::
+  node_weight_mut` (`recording.rs:568-579`) pushes a `RawOp::UpsertNode` on
+  every call. Each resolved op then carries the node's whole property map
+  (`recording.rs:195-200`).
+* With `LARGE_BATCH_CHUNK_SIZE = 1000` (`batch.rs:24`), an `n`-row call records
+  roughly `2 * sum_k 1000k ~= n^2/1000` ops. At ~150 bytes per op with
+  116-byte strings that is **0.15 * n^2 bytes** — which is the measured
+  0.1496 * n^2, including the constant.
+
+Two ingredients are therefore required, and **neither of them is "mapped"**:
+the type must already own a column store (so the detach/reattach loops run at
+all), and the WAL must be on (so the ops are recorded rather than discarded).
+The competitive run had both without intending either — `kglite.open(path,
+storage="mapped")` resolves `durable=None` to **`Full`** (`lib.rs:422-431`),
+silently turning the log on, whereas `KnowledgeGraph(storage="mapped")` has no
+WAL at all.
+
+The three arms below are chosen to decide this. If `default_normal` matches
+`mapped_normal`, the mapped attribution is refuted and the bug belongs to the
+WAL path, where an ordinary `kglite.open(...)` application after a `save()`
+would hit it too. If `default_off` stays linear while both logged arms go
+quadratic, the WAL is confirmed as the carrier.
+
+**This looks like a defect with a fix already sitting in the codebase.**
+`GraphWrite::node_weight_mut_silent` exists for exactly this
+(`storage/mod.rs:448`, impl `recording.rs:582-586`) and its doc reads *"Bypass
+recording — internal bookkeeping (columnar handle refresh), not a logical
+mutation."* Both loops are precisely that: the detach writes a temporary empty
+map that reattach restores before the flush, and genuinely-new nodes already
+got their op from `RecordingGraph::add_node` (`recording.rs:597-601`). Since
+`resolve_ops` reads *final* state, switching both call sites to the silent
+variant should collapse the payload to O(n). Not attempted here — this branch
+only adds benchmarks. Filed as a finding.
+
+────────────────────────────────────────────────────────────────────────────
+Why payload bytes, and not just wall time
+────────────────────────────────────────────────────────────────────────────
+
+The WAL sidecar is `<path>-wal` (`wal.rs:520-524`), so
+`os.path.getsize(path + "-wal")` is a **deterministic, noise-free** measurement
+of the thing that is actually broken. An exponent fitted from byte counts needs
+no idle machine, no warmup, no `min`-vs-`mean` argument and no thermal settle —
+it is either 1.0 or 2.0. Wall time is reported too, because that is what a user
+feels, but the byte count is the evidence.
+
+Each cell records `wal_bytes` and `wal_bytes_per_row` into
+`benchmark.extra_info`, so both land in `--benchmark-json` output. Read
+`wal_bytes_per_row` across the row counts: **flat = linear = fixed; growing
+proportionally to `rows` = the quadratic is still there.**
+
+⚠ This file asserts nothing about the exponent, because at the time of writing
+**the defect is live** and a guard would fail on `main`. It is a marker for a
+known open issue in the sense `test_bench_write_scaling.py::test_bench_id_
+index_invalidation_on_create` is one. Once the two `batch.rs` call sites are
+switched to the silent accessor, `wal_bytes_per_row` becomes flat and a real
+assertion can be added here — that is the follow-up this file is setting up.
+
+Row counts stop at 32k on purpose: `postcard::to_stdvec` materialises the whole
+payload before the limit is checked (`postcard_v1.rs:27-31`), so approaching
+the 4 GiB ceiling means a multi-gigabyte allocation and then an error. 32k rows
+is ~150 MB — enough to fit the curve to several decimal places, nowhere near
+enough to reproduce the crash. **Do not raise this to "see the failure"**; the
+failure is arithmetic, and the curve already predicts it.
+
+Nothing here is in the `make bench-check` tracked set (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_wal_payload.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+# Six geometric points. A quadratic is a straight line of slope 2 on a log-log
+# plot, and six points make the fit obvious by eye without any curve-fitting
+# machinery — the original finding needed only three to reach 0.1%.
+#
+# The top of the range is bounded by the payload it produces, not by runtime:
+# 32k rows is ~0.1496 * 32000^2 ~= 153 MB. See the module docstring before
+# raising it.
+ROW_COUNTS = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000]
+
+#: Seed rows written and checkpointed before the measured call, so the type
+#: already owns a column store when `add_nodes` runs. Without a pre-existing
+#: column store the detach/reattach loops never execute (`batch.rs:402-404`
+#: early-returns when nothing was detached) and the cell would measure a code
+#: path the defect does not live on.
+SEED_ROWS = 1_000
+
+#: 116-byte strings, matching the payload constant quoted in the report. The
+#: property payload is what each amplified op carries, so string width is a
+#: direct multiplier on the measured bytes — a narrower fixture would show the
+#: same exponent with a different constant and would not be comparable to the
+#: 0.1496 figure.
+FILLER = "x" * 116
+
+# The three arms that decide storage-mode versus WAL. `normal` rather than
+# `full`: the amplification is in the frame's *size*, and `full` would add one
+# F_FULLFSYNC per commit (3.37 ms on this machine) to a wall-time number
+# without changing a single payload byte.
+ARMS = ["default_off", "default_normal", "mapped_normal"]
+
+# Few rounds, and deliberately so. Each round rebuilds the fixture graph from
+# scratch in an untimed setup, and at the top row count each round writes
+# ~150 MB of WAL. The payload measurement — the part that matters — is exact
+# and needs no repetition at all; the rounds exist only to give the wall-time
+# figure a little stability.
+ROUNDS = 3
+WARMUP_ROUNDS = 1
+
+
+def _frame(rows: int, offset: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "id": range(offset, offset + rows),
+            "name": [f"item-{i}" for i in range(rows)],
+            "body": [FILLER] * rows,
+        }
+    )
+
+
+def _wal_bytes(path: str) -> int:
+    """Size of the `<path>-wal` sidecar, or 0 when there is no log.
+
+    At `durable="off"` the file is never created, which is why the control arm
+    reports 0 rather than a small number — that is the correct reading, not a
+    missing measurement.
+    """
+    try:
+        return os.path.getsize(path + "-wal")
+    except FileNotFoundError:
+        return 0
+
+
+def _reset(path: str) -> None:
+    """Remove a previous round's graph and its sidecars.
+
+    Called before every rebuild so that at most one graph's files exist at a
+    time. Without this, a cell at the top row count would leave ~150 MB per
+    round behind, and the file as a whole would leave gigabytes in the pytest
+    temp directory — the kind of ungated accumulation CLAUDE.md requires an
+    owner for.
+    """
+    for suffix in ("", "-wal", ".lock"):
+        try:
+            os.unlink(path + suffix)
+        except FileNotFoundError:
+            pass
+
+
+def _seeded_columnar_graph(path: str, arm: str) -> KnowledgeGraph:
+    """A file-backed graph whose `Item` type already owns a column store.
+
+    `save()` is what populates `DirGraph.column_stores`, via `enable_columnar()`
+    (`io/file.rs:1495`) — and it also truncates the WAL back to its 5-byte
+    header (`wal.rs:557-566`), which is what makes the post-save sidecar size a
+    clean zero point for the delta the cells measure.
+    """
+    _reset(path)
+    if arm == "default_off":
+        graph = kglite.open(path, durable="off", lock=False)
+    elif arm == "default_normal":
+        graph = kglite.open(path, durable="normal", lock=False)
+    else:
+        graph = kglite.open(path, storage="mapped", durable="normal", lock=False)
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(_frame(SEED_ROWS, 0), "Item", "id", "name")
+    graph.save()
+    return graph
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("arm", ARMS)
+@pytest.mark.parametrize("rows", ROW_COUNTS)
+def test_bench_add_nodes_wal_payload(benchmark, tmp_path, rows, arm):
+    """One `add_nodes` call of `rows` rows — wall time, and the bytes it logged.
+
+    Defends the measured **0.1496 * n^2** payload with exponent **2.00**
+    (2026-07-27) and the per-call 4 GiB ceiling it eventually overflows.
+
+    Read `wal_bytes_per_row` from `extra_info` across the `rows` parameter, at
+    a fixed `arm`. Flat means the amplification is gone; proportional to `rows`
+    means it is still there. Then read the same row count across arms to decide
+    whether this belongs to mapped mode or to the WAL — see the module
+    docstring for what each answer implies.
+    """
+    path = str(tmp_path / "ingest.kgl")
+
+    # The payload measurement is exact, so it is taken once and untimed rather
+    # than averaged over rounds. Taking it inside the timed callable would put
+    # two `stat` calls inside the measurement for no gain.
+    probe = _seeded_columnar_graph(path, arm)
+    before = _wal_bytes(path)
+    probe.add_nodes(_frame(rows, SEED_ROWS), "Item", "id", "name")
+    logged = _wal_bytes(path) - before
+    benchmark.extra_info["arm"] = arm
+    benchmark.extra_info["rows"] = rows
+    benchmark.extra_info["wal_bytes"] = logged
+    benchmark.extra_info["wal_bytes_per_row"] = logged / rows
+    del probe
+
+    offsets = iter(range(SEED_ROWS, 1 << 30, rows))
+
+    def setup():
+        graph = _seeded_columnar_graph(path, arm)
+        return (graph, _frame(rows, next(offsets))), {}
+
+    def ingest(graph, frame):
+        graph.add_nodes(frame, "Item", "id", "name")
+        # Returned so the graph is unambiguously alive for the whole timed
+        # call and its deallocation cannot land inside the next round.
+        return graph
+
+    benchmark.pedantic(ingest, setup=setup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    _reset(path)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("arm", ARMS)
+def test_bench_add_nodes_chunked_workaround(benchmark, tmp_path, arm):
+    """The same rows ingested in 1k-row calls instead of one large call.
+
+    The ceiling is **per call**, so chunking is the documented workaround — and
+    if the amplification is real, chunking is not merely a way to stay under
+    4 GiB but a large throughput win, because it caps the quadratic term at the
+    chunk size. That makes this cell the measurement of what the workaround is
+    worth, and the natural before/after for a fix: once the two `batch.rs` call
+    sites stop recording bookkeeping writes, this cell and the 32k row of
+    `test_bench_add_nodes_wal_payload` should converge.
+
+    Same total rows as the largest cell above, so the two are directly
+    comparable.
+    """
+    path = str(tmp_path / "chunked.kgl")
+    total = ROW_COUNTS[-1]
+    chunk = 1_000
+
+    probe = _seeded_columnar_graph(path, arm)
+    before = _wal_bytes(path)
+    for start in range(SEED_ROWS, SEED_ROWS + total, chunk):
+        probe.add_nodes(_frame(chunk, start), "Item", "id", "name")
+    logged = _wal_bytes(path) - before
+    benchmark.extra_info["arm"] = arm
+    benchmark.extra_info["rows"] = total
+    benchmark.extra_info["chunk"] = chunk
+    benchmark.extra_info["wal_bytes"] = logged
+    benchmark.extra_info["wal_bytes_per_row"] = logged / total
+    del probe
+
+    offsets = iter(range(SEED_ROWS, 1 << 30, total))
+
+    def setup():
+        graph = _seeded_columnar_graph(path, arm)
+        return (graph, next(offsets)), {}
+
+    def ingest(graph, offset):
+        for start in range(offset, offset + total, chunk):
+            graph.add_nodes(_frame(chunk, start), "Item", "id", "name")
+        return graph
+
+    benchmark.pedantic(ingest, setup=setup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    _reset(path)

--- a/tests/benchmarks/test_bench_write_scaling.py
+++ b/tests/benchmarks/test_bench_write_scaling.py
@@ -28,6 +28,8 @@ Run with:
 
 from __future__ import annotations
 
+import os
+
 import pandas as pd
 import pytest
 
@@ -235,6 +237,43 @@ def test_bench_id_index_invalidation_on_create(benchmark, scaled_graphs_no_pk, s
 # true cost of the barrier. Both are per-commit and neither should scale with
 # graph size, which is why one fixed size is enough here.
 #
+# ── correction, 2026-07-27: what `off` is, and what it is not ────────
+#
+# A competitive benchmark read the `off` cell at 1.8 us and called it
+# impossible, on the grounds that it beat the tracked `cypher_match` READ
+# baseline of 6.2 us and a write must do strictly more work than a read.
+# Both halves of that are wrong, and the correction is worth keeping because
+# the cell invites the mistake:
+#
+#   * The comparison is not like-for-like. `test_bench_cypher_match` is
+#     `MATCH (n:Item) RETURN n.title, n.value LIMIT 100` *without* `.to_list()`
+#     — a lazy 100-row scan, tracked at 5.42 us min / 6.22 us mean. Its
+#     materialized sibling is 19.08 us min. A single-node insert with a warm
+#     plan cache producing no rows is simply less work than planning and
+#     scanning 100 rows. 1.8 us (a min) against 6.2 us (a mean) compares two
+#     different statistics of two different workloads.
+#   * Nothing is being skipped. At `off`, `logs()` is false, so `setup_durable`
+#     never runs (`lib.rs:416-418`), the backend is never wrapped in
+#     `RecordingGraph`, and `flush_wal` returns immediately on
+#     `durable.is_none()` (`graph/mod.rs:405-407`). The mutation itself is
+#     applied in place and synchronously at every level; there is no write
+#     buffer, no deferred commit, no background thread, and no coalescing
+#     anywhere in `wal.rs`. At `off` the write is a petgraph insert and index
+#     bookkeeping, full stop.
+#
+# So the number is real. What was unsound is the FRAMING: `off` is not a
+# cheaper commit, it is **no commit at all**, and there is no per-commit
+# durable work at `off` to measure. Its durability boundary is `save()`.
+# Labelling it a "durability level" alongside two levels that do write to disk
+# invites reading 1.8 us as "what a commit costs at off".
+#
+# Two cells below now hold that framing in place rather than leaving it to a
+# comment: `test_bench_unlogged_write_control` shows a plain in-memory graph
+# produces the same number (so file-backing buys nothing at `off`), and
+# `test_durable_off_loses_unsaved_writes` is the ordinary test proving what the
+# 1.8 us did *not* buy. The `wal_bytes` guard on the headline cell pins each
+# level to the configuration it claims.
+#
 # Not in `test_bench_core.py` on purpose: everything in this file is outside
 # the `make bench-check` tracked set, so adding cells here cannot break the
 # gate. Absolute numbers are machine- and device-specific — a barrier is
@@ -277,11 +316,38 @@ def _persisted_graph(path, level: str) -> KnowledgeGraph:
     return graph
 
 
+def _wal_bytes(path) -> int:
+    """Size of the `<path>-wal` sidecar, or 0 when no log exists.
+
+    `wal_path` is `<checkpoint>-wal` (`wal.rs:520-524`). This is the only
+    Python-visible window onto the WAL — `DurableState` exposes no getter for
+    `wal`, `next_lsn` or `level` — and it is enough to prove which level a cell
+    actually ran at.
+    """
+    try:
+        return os.path.getsize(str(path) + "-wal")
+    except FileNotFoundError:
+        return 0
+
+
 @pytest.mark.benchmark
 @pytest.mark.parametrize("level", DURABILITY_LEVELS)
 def test_bench_single_create_by_durability_level(benchmark, tmp_path, level):
-    """One `CREATE` of one node, per durability level. The headline cell."""
-    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    """One `CREATE` of one node, per durability level. The headline cell.
+
+    The trailing assertion is a vacuity guard, not a correctness test. A cell
+    that silently ran at the wrong level would report a plausible number under
+    a wrong label, and the 2026-07-27 methodology note is emphatic that this is
+    how benchmark harness defects actually present — every one caught in that
+    run was found because a number contradicted the configuration it claimed,
+    never because it looked implausible. A config-key collision there nearly
+    erased the headline finding while the table looked entirely normal.
+
+    At `off` the sidecar is never created, so a non-zero reading means the log
+    is on and the number is not an `off` number.
+    """
+    path = tmp_path / "bench.kgl"
+    graph = _persisted_graph(path, level)
     ids = iter(range(10_000_000, 1 << 30))
 
     def write():
@@ -289,66 +355,144 @@ def test_bench_single_create_by_durability_level(benchmark, tmp_path, level):
 
     benchmark(write)
 
+    logged = _wal_bytes(path)
+    if level == "off":
+        assert logged == 0, f"durable='off' must write no WAL; found {logged} bytes"
+    else:
+        assert logged > 0, f"durable='{level}' must write a WAL; sidecar is empty or absent"
+
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("level", ["full", "normal"])
-def test_bench_explicit_sync(benchmark, tmp_path, level):
-    """`sync()` — the on-demand barrier.
+def test_bench_unlogged_write_control(benchmark):
+    """The same `CREATE` on a plain in-memory graph — the control for `off`.
 
-    Under `"normal"` this is a real barrier and should cost about what
-    `full`'s per-commit barrier costs; under `"full"` it returns immediately
-    because every commit was already barriered. That gap is the number a
-    caller needs to decide how often to call it.
+    `durable="off"` opens no log and never wraps the backend, so a file-backed
+    graph at `off` should be indistinguishable from one that was never given a
+    path. This cell is what turns that from a claim into a reading: if it
+    differs materially from `test_bench_single_create_by_durability_level
+    [off]`, then something about file-backing costs per-write time and the
+    `off` row means something other than what it says.
+
+    It also gives the `off` number a name that cannot be misread. There is no
+    per-commit durable work at `off` to measure — the honest cost of durability
+    there is `save()` amortised over N writes, and `save()` is O(graph)
+    (tracked separately as `test_bench_columnar_save_kgl`, 300 us min at 1k and
+    `fsync=False`).
     """
-    graph = _persisted_graph(tmp_path / "bench.kgl", level)
-    ids = iter(range(60_000_000, 1 << 30))
-
-    def commit_then_sync():
-        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
-        graph.sync()
-
-    benchmark(commit_then_sync)
-
-
-# ── diagnostic: what is the non-durable commit actually spending? ────
-#
-# `durable="off"` is the engine's own per-commit cost with no durability
-# excuse, and reading the commit path turns up three candidate explanations
-# that reading alone cannot rank:
-#
-#   1. The Cypher plan cache is keyed on graph `version`, which is bumped
-#      before the lookup — so a write can never hit it and re-runs the full
-#      parse + optimizer pipeline every time.
-#   2. `Arc::make_mut` deep-clones the whole graph when a second
-#      `Arc<DirGraph>` is alive; a lazy `ResultView` above the 32-cell
-#      materialisation budget holds one.
-#   3. The statement rollback checkpoint, when it falls off its skip
-#      whitelist.
-#
-# The pair below discriminates (2) from the rest without changing a line of
-# engine code: same statement, once with the result dropped immediately and
-# once with it held across the next write. If `result_held` is dramatically
-# worse, it is the Arc clone; if the two are close, the cost is elsewhere and
-# (1) is the next suspect.
-#
-# This is a diagnostic, not a regression guard — it exists to attribute a
-# cost, and its conclusion belongs in an issue rather than in a threshold.
-
-
-@pytest.mark.benchmark
-@pytest.mark.parametrize("held", [False, True], ids=["result_dropped", "result_held"])
-def test_bench_create_with_lazy_result_alive(benchmark, held):
-    """One `CREATE`, with and without a lazy `ResultView` pinning the graph."""
     graph = _graph(DURABILITY_BENCH_SIZE)
-    ids = iter(range(50_000_000, 1 << 30))
-    # Wide enough to exceed the eager-materialisation budget, so the view
-    # stays lazy and keeps its own `Arc<DirGraph>` alive.
-    pinned = graph.cypher("MATCH (n:Item) RETURN n.id AS i, n.name AS nm") if held else None
+    ids = iter(range(70_000_000, 1 << 30))
 
     def write():
         graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
 
     benchmark(write)
-    # Keep `pinned` referenced past the measurement, or the interpreter is
-    # free to collect it early and quietly turn this into the other case.
-    assert pinned is None or pinned is not None
+
+
+def test_durable_off_loses_unsaved_writes(tmp_path):
+    """What the 1.8 us at `durable="off"` did not buy.
+
+    Not a benchmark — an ordinary test, and deliberately so. The `off` cell's
+    speed is only interpretable next to the guarantee it declines, and a
+    comment saying "off loses your data" is worth less than a test that
+    demonstrates it. Reopening is the closest in-process stand-in for the
+    process dying: no `save()`, so no checkpoint, so nothing to recover from.
+    """
+    path = tmp_path / "off.kgl"
+    graph = _persisted_graph(path, "off")
+    graph.cypher("CREATE (:Item {id: 999000, name: 'lost'})")
+    assert graph.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar() == 1
+
+    # The first handle is deliberately NOT closed. `close()` performs a full
+    # save, which would persist the very write this test exists to lose — and
+    # an assertion taken after it would be vacuous. Read the file as it stands
+    # on disk instead: the last checkpoint is `_persisted_graph`'s `seed.save()`
+    # from before the write. `lock=False` because the live handle still holds
+    # the writer lease.
+    on_disk = kglite.open(str(path), durable="off", lock=False)
+    survived = on_disk.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar()
+
+    assert survived == 0, (
+        "durable='off' wrote to a checkpoint it should not have; the speed of "
+        "the 'off' benchmark cell is only meaningful because this write is lost"
+    )
+    assert graph.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar() == 1
+
+
+# ── repaired 2026-07-27: `sync()` is timed alone, not after a create ──
+#
+# This cell used to time `CREATE` + `sync()` together, and at `full` it read
+# **1439 us — below the same file's create-only cost at `full`**. Create+sync
+# cannot be cheaper than create, so the pair was reported as an impossible
+# measurement. Reading the source says the cell was not measuring an ordering
+# at all:
+#
+#   * `sync()` at `full` is a **hard early return** (`kg_core.rs:711-713`). It
+#     touches no state — no flush, no barrier, no flag — because every commit
+#     was already barriered. `SyncMode` is fixed at `Wal::open` and never
+#     mutated afterwards, and nothing anywhere caches, batches or amortises
+#     across commits.
+#   * `Wal::append` is unconditional (`wal.rs:704-711`): no size threshold, no
+#     timer, no coalescing window. So at `full`, `CREATE` + `sync()` performs
+#     *exactly* the same work as `CREATE` alone.
+#
+# The old cell therefore duplicated `test_bench_single_create_by_durability_
+# level[full]` by construction and could never carry information — and 1439 vs
+# ~3400 us is F_FULLFSYNC variance between two runs of identical work, not an
+# ordering. A device-level barrier is the noisiest thing this suite measures.
+#
+# The repair is to move the `CREATE` into an untimed `pedantic` setup so the
+# timed region is the barrier and nothing else. `full` should now read ~0
+# (pinning the early return) and `normal` should read one barrier — which is
+# the number a caller actually needs to decide how often to call it, and was
+# previously buried under a create.
+#
+# `off` is absent from the parametrisation because `sync()` raises `ValueError`
+# there (`kg_core.rs:693-701`) rather than silently doing nothing.
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("level", ["full", "normal"])
+def test_bench_explicit_sync(benchmark, tmp_path, level):
+    """`sync()` alone — the on-demand barrier, with the commit untimed.
+
+    Under `"normal"` this is one real `F_FULLFSYNC`; under `"full"` it is an
+    early return. The gap between the two arms is the cost of taking a
+    power-safe point on demand, and it is what makes `"normal"` adoptable
+    rather than merely fast.
+
+    See the comment above before changing the shape of this cell — folding the
+    `CREATE` back into the timed region is what made its predecessor
+    uninterpretable.
+    """
+    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    ids = iter(range(60_000_000, 1 << 30))
+
+    def setup():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
+        return (), {}
+
+    benchmark.pedantic(graph.sync, setup=setup, rounds=OV_ROUNDS, iterations=1, warmup_rounds=OV_WARMUP_ROUNDS)
+
+
+# ── the lazy-`ResultView` diagnostic moved, 2026-07-27 ───────────────
+#
+# A `test_bench_create_with_lazy_result_alive` pair used to sit here, aimed at
+# the `Arc::make_mut` whole-graph clone that a held `ResultView` forces. It
+# reported **no difference**, and that null was wrong twice over:
+#
+#   1. **Under-powered.** It ran only at `DURABILITY_BENCH_SIZE` (1k), where
+#      the clone is ~1000x too small to separate from a write. The clone is
+#      O(V+E); at 100k it is ~5 ms, at 1M ~28 ms.
+#   2. **Structurally blind.** The reference was taken ONCE, outside the
+#      measurement. The clone fires on the first write after a second
+#      `Arc<DirGraph>` appears and once only — so `min`, `p50` and `p95` all
+#      saw post-clone rounds and read healthy. Only `max` could see it.
+#
+# It has been rewritten and moved to `test_bench_fast_write_path.py::
+# test_bench_first_write_after_reference`, which takes the reference in an
+# untimed per-round `setup` and runs at 1k and 100k. Consolidated rather than
+# duplicated: that file also owns the `journal_covers` cells, and both defects
+# are answers to "why did this one write cost milliseconds".
+#
+# Left here as a signpost because a null result that was believed for a while
+# is worth being able to trace.

--- a/tests/test_encoding_hygiene.py
+++ b/tests/test_encoding_hygiene.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -96,10 +97,37 @@ def _missing_encoding(call: ast.Call) -> str | None:
 
 
 def _python_files() -> list[Path]:
-    files: list[Path] = []
-    for root in SCANNED_ROOTS:
-        files.extend((REPO_ROOT / root).rglob("*.py"))
-    return sorted(files)
+    """Every *tracked* Python file under the scanned roots.
+
+    Enumerated via `git ls-files`, not `rglob`, and that distinction is the
+    whole point: this gate exists to protect files the repo ships, and several
+    scanned roots have gitignored siblings holding local scratch work
+    (`.gitignore` ignores `/benchmarks/competitive/*`, for one). Walking the
+    filesystem made the gate fail on a developer's untracked scratch file
+    while CI — which only ever checks out tracked files — stayed green. A
+    hygiene check that depends on what happens to be lying around is worse
+    than no check: it trains people to ignore it.
+
+    Falls back to the filesystem walk outside a git checkout (a source
+    tarball, say), where there are no untracked files to confuse it anyway.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--", *SCANNED_ROOTS],
+            capture_output=True,
+            check=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        files: list[Path] = []
+        for root in SCANNED_ROOTS:
+            files.extend((REPO_ROOT / root).rglob("*.py"))
+        return sorted(files)
+
+    tracked = [REPO_ROOT / name for name in out.split("\0") if name.endswith(".py")]
+    # A tracked-but-deleted file still lists; skip rather than raise.
+    return sorted(p for p in tracked if p.is_file())
 
 
 def test_text_io_pins_utf8():


### PR DESCRIPTION
Three independently-green branches merged so the combined tree gets one CI run. No CHANGELOG heading collision this time — verified one of each section.

- **#88 — `perf: journal the columnar handle refresh once per type`.** Post-`save()` `SET` at 100k: **5.51 → 1.08 ms**, 5.1× better than `main` and 2.8× better than pre-#86. Fixes a regression a post-merge benchmark caught, and lands past the prior baseline. Also fixes a correctness obligation that was being discharged *by accident*: the per-node captures were the only thing reporting a type into `stale_unique_indices` for the post-rollback unique rebuild.
- **#89 — 84 benchmark cells** across four new files, covering six defects nothing in this suite could observe. Nothing added to the tracked `bench-check` set — the source run showed a 78% spread between two takes of identical code, 3.9× the gate's threshold from variance alone.
- **encoding-gate fix.** `test_text_io_pins_utf8` walked the filesystem with `rglob`, so it failed on a developer's gitignored scratch file while CI stayed green (CI only checks out tracked files). Now enumerates via `git ls-files`. Verified non-vacuous: 338 tracked files scanned, and the detector still fires on a synthetic offender.

**Local verification on the merged tree:** `cargo test -p kglite` 1309 passed / 0 failed. On `main` immediately prior: Python suite **4906 passed / 108 skipped**, parity oracles **109 passed**, `make gate` clean, workspace clippy `-D warnings` clean, source-quality OK, and the tracked 27-benchmark gate showed **no regressions >20%** (max +16.1%, a uniformly-positive skew consistent with ambient warmth rather than any single regression).

All correctness testing ran against a **debug** extension, per the project rule that a release build silently disables the parser stack-depth and disk arena-guard assertions.

No version bump — workspace stays 0.14.5, entries under `[Unreleased]`.