### PR TITLE
fix: reject unknown node labels under a locked schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`lock_schema()` now catches a typo'd node label in a query, not just in a
+  write.** `MATCH (i:Isue) RETURN i` used to return `[]` with no error even on
+  a locked schema, while the equivalent property typo —
+  `MATCH (i:Issue {titel: 1})` — was rejected with a message naming the
+  mistake and listing the valid properties. That asymmetry was the bug: an
+  empty result set reads as *"no matching data"* rather than *"you made a
+  mistake"*, so a typo'd label survives code review and reaches production
+  looking like a legitimate empty state, whereas a wrong property value is at
+  least visibly wrong at the point of use. A locked schema now rejects an
+  unknown label with the same shape of message the unknown-property path has
+  always produced, and the same wording the `CREATE` write path has always
+  used:
+
+  ```text
+  Schema error: Unknown node type 'Isue'. Did you mean 'Issue'?
+    Valid types: Issue, Person
+  ```
+
+  It is raised as `kglite.SchemaError` (`.code == "Schema"`) from every clause
+  that can carry a label — `MATCH`, `OPTIONAL MATCH`, `MERGE`, multi-label
+  patterns like `(n:A:B)`, `WHERE EXISTS { … }` pattern predicates, `CALL { … }`
+  subqueries, and `UNION` branches.
+
+  **The schemaless default is unchanged.** kglite is open-schema by design, so
+  on an unlocked graph an unknown label still matches nothing without error —
+  the zero-row existence-check idiom stays valid, and the existing non-fatal
+  `warning:` on stderr is still how the typo is surfaced there. Labels applied
+  via `add_label` count as known, and creating a genuinely new label on an
+  unlocked graph is unaffected. Relationship types are deliberately still not
+  rejected: only the node-label gap was asymmetric with properties.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/crates/kglite/src/error.rs
+++ b/crates/kglite/src/error.rs
@@ -297,7 +297,8 @@ pub enum KgError {
     Cancelled,
 
     // ── Schema / validation ──────────────────────────────────────────
-    /// Query validation failure (unknown property or undefined variable).
+    /// Query validation failure (unknown property, unknown node type under
+    /// a locked schema, or undefined variable).
     /// Bridged from
     /// [`SchemaError`](crate::graph::languages::cypher::planner::schema_check::SchemaError)
     /// via `From`.
@@ -433,6 +434,7 @@ pub enum KgError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaErrorKindRepr {
     UnknownProperty,
+    UnknownNodeType,
     UndefinedVariable,
 }
 
@@ -445,6 +447,7 @@ impl From<crate::graph::languages::cypher::planner::schema_check::SchemaErrorKin
         use crate::graph::languages::cypher::planner::schema_check::SchemaErrorKind;
         match value {
             SchemaErrorKind::UnknownProperty => SchemaErrorKindRepr::UnknownProperty,
+            SchemaErrorKind::UnknownNodeType => SchemaErrorKindRepr::UnknownNodeType,
             SchemaErrorKind::UndefinedVariable => SchemaErrorKindRepr::UndefinedVariable,
         }
     }

--- a/crates/kglite/src/graph/introspection/describe.rs
+++ b/crates/kglite/src/graph/introspection/describe.rs
@@ -67,7 +67,7 @@ fn write_read_only_notice(xml: &mut String, graph: &DirGraph) {
     }
     if graph.schema_locked {
         xml.push_str(
-            "  <schema-locked>Mutations validated against schema — unknown types/properties rejected</schema-locked>\n",
+            "  <schema-locked>Queries and mutations validated against schema — unknown node types/properties rejected. A typo'd label in MATCH raises rather than returning zero rows</schema-locked>\n",
         );
     }
 }

--- a/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
@@ -15,9 +15,27 @@
 //!
 //! Deliberately *does not reject* (these are legal, so they are warned about
 //! non-fatally instead — see below — never turned into errors):
-//! - Unknown node types in MATCH (`MATCH (n:Nonexistent)` legitimately
-//!   returns zero rows and is a common existence-check idiom).
-//! - Unknown connection types (same rationale).
+//! - Unknown node types in MATCH **on an open schema** (`MATCH
+//!   (n:Nonexistent)` legitimately returns zero rows and is a common
+//!   existence-check idiom). Under `lock_schema()` this *is* rejected —
+//!   see [`validate_label`] and the note below.
+//! - Unknown connection types (same rationale, both schema states — an
+//!   edge type is not yet part of what a schema lock covers).
+//!
+//! ## Locked schemas reject unknown labels
+//!
+//! `lock_schema()` is the opt-in "catch my typos" mechanism, and it must
+//! cover labels and properties symmetrically. Before this check, a locked
+//! schema rejected `MATCH (i:Issue {titel: 1})` (unknown property) but
+//! silently returned `[]` for `MATCH (i:Isue)` (unknown label) — and an
+//! empty result set reads as "no matching data" rather than "you made a
+//! mistake", so the typo survived review and reached production. The write
+//! path had already made this call: `CREATE (i:Isue)` under a lock has
+//! always failed with `Unknown node type 'Isue'`. [`validate_label`]
+//! applies the same rule, and the same message, to reads.
+//!
+//! The open-schema default is untouched — schemalessness is the product,
+//! and the check is gated entirely on `graph.schema_locked`.
 //!
 //! Deliberately *ignores entirely*:
 //! - Property references in WHERE / RETURN expressions (virtual columns,
@@ -61,6 +79,8 @@ const BUILTIN_FIELDS: &[&str] = &["id", "title", "name", "type"];
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaErrorKind {
     UnknownProperty,
+    /// Raised **only under a locked schema** — see [`validate_label`].
+    UnknownNodeType,
     UndefinedVariable,
 }
 
@@ -1099,6 +1119,16 @@ fn validate_pattern(
 ) -> Result<(), SchemaError> {
     for element in &pattern.elements {
         if let PatternElement::Node(np) = element {
+            // Label check first: on a locked schema an unknown label is a
+            // typo, not an empty result set. Checked before the property
+            // loop so `MATCH (i:Isue {titel: 1})` reports the label — the
+            // outer mistake — rather than a property of a type that does
+            // not exist.
+            if graph.schema_locked {
+                for label in np.node_type.iter().chain(np.extra_labels.iter()) {
+                    validate_label(label, graph)?;
+                }
+            }
             if let Some(ref node_type) = np.node_type {
                 if let Some(ref var) = np.variable {
                     var_types.insert(var.clone(), node_type.clone());
@@ -1145,6 +1175,72 @@ fn walk_predicate_for_nested_patterns(
         _ => {}
     }
     Ok(())
+}
+
+/// A label is "known" if it is a declared primary type, currently has live
+/// nodes, or is a secondary label applied via `add_label` — `MATCH
+/// (n:Reviewer)` is valid even though `Reviewer` is no node's primary type.
+/// Mirrors the identical three-way test in
+/// [`collect_unknown_pattern_warnings`]; keep the two in step.
+fn label_known(label: &str, graph: &DirGraph) -> bool {
+    graph.node_type_metadata.contains_key(label)
+        || graph.type_indices.contains_key(label)
+        || graph
+            .secondary_label_index
+            .contains_key(&InternedKey::from_str(label))
+}
+
+/// Reject an unknown node label. **Caller gates on `graph.schema_locked`.**
+///
+/// On an open schema kglite is schemaless by design and `MATCH
+/// (n:Nonexistent)` legitimately returns zero rows (the existence-check
+/// idiom), so this is never reached and
+/// [`collect_unknown_pattern_warnings`] delivers the typo hint non-fatally
+/// instead. `lock_schema()` is the opt-in "catch my typos" mechanism: it
+/// already rejects an unknown *property* here, and an unknown *node type*
+/// on the CREATE write path
+/// ([`validate_node_creation`](crate::graph::mutation::validation::validate_node_creation)).
+/// This closes the read side, where a typo'd label previously returned `[]`
+/// — indistinguishable from "no matching data".
+///
+/// The message deliberately reuses the write path's wording so a locked
+/// schema reports the same mistake identically whether it is read or
+/// written, and enumerates the valid set exactly like the unknown-property
+/// message above it.
+fn validate_label(label: &str, graph: &DirGraph) -> Result<(), SchemaError> {
+    if label_known(label, graph) {
+        return Ok(());
+    }
+    // Cold path only — the candidate list is built solely to explain a
+    // confirmed typo.
+    let mut valid: Vec<&str> = graph
+        .node_type_metadata
+        .keys()
+        .map(|s| s.as_str())
+        .chain(graph.type_indices.keys())
+        .collect();
+    // `try_resolve`, not `resolve`: the latter panics on a key the interner
+    // has no entry for, and an error-message builder must never be the thing
+    // that takes the process down. A key we cannot name is simply omitted
+    // from the hint.
+    valid.extend(
+        graph
+            .secondary_label_index
+            .keys()
+            .filter_map(|k| graph.interner.try_resolve(*k)),
+    );
+    valid.sort_unstable();
+    valid.dedup();
+    let hint = did_you_mean(label, &valid);
+    Err(SchemaError {
+        kind: SchemaErrorKind::UnknownNodeType,
+        message: format!(
+            "Unknown node type '{}'.{}\n  Valid types: {}",
+            label,
+            hint,
+            valid.join(", ")
+        ),
+    })
 }
 
 fn validate_property(node_type: &str, property: &str, graph: &DirGraph) -> Result<(), SchemaError> {
@@ -1518,5 +1614,173 @@ mod tests {
         // (avoids false positives on dynamically-typed graphs).
         let q = parse_cypher("MATCH (n) WHERE n.whatever = 1 RETURN n").unwrap();
         assert!(collect_unknown_pattern_warnings(&q, &g).is_empty());
+    }
+
+    // ── Locked-schema label rejection ────────────────────────────────────
+    //
+    // `lock_schema()` is the "catch my typos" mechanism; it has always
+    // rejected an unknown *property*, and an unknown *node type* on the
+    // CREATE write path. These cover the read side. Every clause that can
+    // carry a label gets a case — a fix covering only MATCH would recreate
+    // the same asymmetry one level down.
+
+    /// Adds an `Issue` type so `Isue` has a real near-miss to suggest —
+    /// this is the scenario from the field report, verbatim.
+    fn locked_graph() -> DirGraph {
+        let mut g = graph_with_schema();
+        let mut issue_props = HashMap::new();
+        issue_props.insert("status".to_string(), "string".to_string());
+        g.upsert_node_type_metadata("Issue", issue_props);
+        g.schema_locked = true;
+        g
+    }
+
+    /// The one assertion that matters: the offending label is named AND the
+    /// valid set is enumerated, exactly like the unknown-property message.
+    fn assert_rejects_isue(query: &str) {
+        let g = locked_graph();
+        let q = parse_cypher(query).unwrap();
+        let err =
+            validate_schema(&q, &g).expect_err(&format!("locked schema should reject: {query}"));
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType, "for `{query}`");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Isue'. Did you mean 'Issue'?\n  Valid types: Issue, Paper, Person",
+            "for `{query}`"
+        );
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_match() {
+        assert_rejects_isue("MATCH (i:Isue) RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_optional_match() {
+        assert_rejects_isue("MATCH (p:Person) OPTIONAL MATCH (i:Isue) RETURN p, i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_where_pattern_predicate() {
+        assert_rejects_isue("MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_call_subquery() {
+        assert_rejects_isue("CALL { MATCH (i:Isue) RETURN i } RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_union_branch() {
+        assert_rejects_isue("MATCH (p:Person) RETURN p UNION MATCH (i:Isue) RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_extra_label() {
+        // `(n:A:B)` puts the first label in `node_type` and the rest in
+        // `extra_labels` — a typo in the tail must be caught too.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (n:Person:Revewer) RETURN n").unwrap();
+        let err = validate_schema(&q, &g).expect_err("extra label typo should be rejected");
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType);
+        assert!(
+            err.message.starts_with("Unknown node type 'Revewer'."),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn locked_schema_offers_did_you_mean_for_near_miss() {
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (n:Persn) RETURN n").unwrap();
+        let err = validate_schema(&q, &g).expect_err("near-miss label should be rejected");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Persn'. Did you mean 'Person'?\n  Valid types: Issue, Paper, Person"
+        );
+    }
+
+    #[test]
+    fn locked_schema_accepts_known_labels_everywhere() {
+        let g = locked_graph();
+        for query in [
+            "MATCH (p:Person) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Paper) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Paper) } RETURN p",
+            "CALL { MATCH (q:Paper) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p UNION MATCH (q:Paper) RETURN q",
+            // Untyped patterns carry no label to check.
+            "MATCH (n) RETURN n",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                validate_schema(&q, &g).is_ok(),
+                "locked schema wrongly rejected `{query}`: {:?}",
+                validate_schema(&q, &g).err()
+            );
+        }
+    }
+
+    #[test]
+    fn locked_schema_reports_the_label_before_the_property() {
+        // When both are wrong, the label is the outer mistake — reporting a
+        // property of a type that does not exist would be nonsense.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (i:Isue {titel: 'x'}) RETURN i").unwrap();
+        let err = validate_schema(&q, &g).expect_err("should reject");
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType);
+    }
+
+    #[test]
+    fn open_schema_still_tolerates_unknown_label() {
+        // The schemaless default is the product — the zero-row
+        // existence-check idiom must keep working untouched. This is the
+        // regression guard for the gate on `schema_locked`.
+        let g = graph_with_schema();
+        assert!(!g.schema_locked);
+        for query in [
+            "MATCH (i:Isue) RETURN i",
+            "MATCH (p:Person) OPTIONAL MATCH (i:Isue) RETURN p, i",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p",
+            "CALL { MATCH (i:Isue) RETURN i } RETURN i",
+            "MATCH (p:Person) RETURN p UNION MATCH (i:Isue) RETURN i",
+            "MATCH (n:Person:Revewer) RETURN n",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                validate_schema(&q, &g).is_ok(),
+                "open schema must not reject `{query}`"
+            );
+        }
+    }
+
+    #[test]
+    fn locked_schema_leaves_unknown_relationship_types_alone() {
+        // Edge types are not part of what a schema lock covers on the read
+        // path; only the node-label gap was asymmetric with properties.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (a:Person)-[:NOSUCH]->(b:Person) RETURN a").unwrap();
+        assert!(validate_schema(&q, &g).is_ok());
+    }
+
+    #[test]
+    fn locked_schema_accepts_secondary_labels() {
+        // A label applied via `add_label` is legitimately matchable even
+        // though it is no node's primary type — rejecting it would be a
+        // false positive.
+        let mut g = locked_graph();
+        let key = g.interner.try_get_or_intern("Reviewer").unwrap();
+        g.secondary_label_index.insert(key, Vec::new());
+        g.has_secondary_labels = true;
+        let q = parse_cypher("MATCH (n:Reviewer) RETURN n").unwrap();
+        assert!(validate_schema(&q, &g).is_ok());
+        // …and it appears in the enumerated valid set for a real typo.
+        let q2 = parse_cypher("MATCH (n:Isue) RETURN n").unwrap();
+        let err = validate_schema(&q2, &g).expect_err("should reject");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Isue'. Did you mean 'Issue'?\n  Valid types: Issue, Paper, Person, Reviewer"
+        );
     }
 }

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -2375,11 +2375,25 @@ class KnowledgeGraph:
         ...
 
     def lock_schema(self) -> KnowledgeGraph:
-        """Lock the schema: future Cypher mutations must conform to current types.
+        """Lock the schema: Cypher must conform to the current types.
 
         When locked, CREATE, SET, and MERGE operations are validated against
-        the graph's known node types, connection types, and property types.
-        Invalid writes return descriptive errors with 'did you mean?' suggestions.
+        the graph's known node types, connection types, and property types,
+        and **reads are validated too**: an unknown node label in a MATCH,
+        OPTIONAL MATCH, MERGE, ``WHERE EXISTS { ... }`` pattern predicate, or
+        ``CALL { ... }`` subquery raises :class:`SchemaError` instead of
+        silently returning zero rows. Errors name the offending label or
+        property, enumerate the valid set, and add a 'did you mean?'
+        suggestion.
+
+        This is the "catch my typos" mechanism — an empty result set is
+        indistinguishable from "no matching data", so a typo'd label would
+        otherwise reach production looking like a legitimate empty state.
+
+        On an **unlocked** graph (the default) kglite is schemaless: an
+        unknown label matches nothing and is reported only as a non-fatal
+        ``warning:`` on stderr, keeping the zero-row existence-check idiom
+        valid.
 
         Returns:
             Self for method chaining.
@@ -2387,7 +2401,10 @@ class KnowledgeGraph:
         Example::
 
             graph.lock_schema()
-            graph.cypher("CREATE (p:Typo {name: 'x'})")  # raises RuntimeError
+            graph.cypher("CREATE (p:Typo {name: 'x'})")  # raises SchemaError
+            graph.cypher("MATCH (p:Persom) RETURN p")    # raises SchemaError
+            # Schema error: Unknown node type 'Persom'. Did you mean 'Person'?
+            #   Valid types: Paper, Person
 
         See Also:
             :meth:`unlock_schema`, :attr:`schema_locked`

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3158,6 +3159,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3128,6 +3129,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3143,6 +3144,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3128,6 +3129,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3143,6 +3144,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/test_schema_lock.py
+++ b/tests/test_schema_lock.py
@@ -182,10 +182,11 @@ class TestUnlock:
         # Should succeed now — schema unlocked
         g.cypher("CREATE (x:NewType {name: 'anything'})")
 
-    def test_reads_always_allowed(self):
+    def test_valid_reads_always_allowed(self):
         g = _make_graph()
         g.lock_schema()
-        # MATCH should always work regardless of lock
+        # A read against a *known* label is never blocked by the lock — the
+        # lock rejects typos, it does not gate reading.
         result = g.cypher("MATCH (p:Person) RETURN p.name")
         assert len(result) == 2
 
@@ -194,6 +195,122 @@ class TestUnlock:
         g.lock_schema()
         # DELETE should work even when schema locked
         g.cypher("MATCH (p:Person {name: 'Bob'}) DETACH DELETE p")
+
+
+# ── Read-side label validation ───────────────────────────────────────────────
+#
+# `lock_schema()` is the opt-in "catch my typos" mechanism. It has always
+# rejected an unknown *property* and an unknown *node type* on writes, but a
+# typo'd label in a MATCH used to return `[]` with no error — and an empty
+# result set reads as "no matching data" rather than "you made a mistake", so
+# it survives review and reaches production. These lock the symmetry in.
+
+
+class TestMatchLabelValidation:
+    def test_unknown_label_in_match_raises(self):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match="Unknown node type 'Persom'"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_enumerates_the_valid_labels(self):
+        # Mirrors the unknown-property message, which lists valid properties.
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match=r"Valid types: Paper, Person"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_suggests_the_near_miss(self):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match="Did you mean 'Person'"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_carries_the_schema_code(self):
+        # Applications branch on `.code`, not on message prose.
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError) as exc:
+            g.cypher("MATCH (p:Persom) RETURN p")
+        assert exc.value.code == "Schema"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # Every clause that can carry a label — covering only MATCH would
+            # recreate the same asymmetry one level down.
+            "MATCH (p:Persom) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Persom) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Persom) } RETURN p",
+            "CALL { MATCH (q:Persom) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Persom) RETURN q.name AS n",
+            "MATCH (n:Person:Persom) RETURN n",
+            "MERGE (q:Persom {name: 'x'})",
+        ],
+    )
+    def test_every_label_carrying_clause_is_covered(self, query):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.KgError, match="Unknown node type 'Persom'"):
+            g.cypher(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "MATCH (p:Person) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Paper) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Paper) } RETURN p",
+            "CALL { MATCH (q:Paper) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Paper) RETURN q.title AS n",
+            "MATCH (n) RETURN n",
+            "MATCH (p:Person)-[:AUTHORED]->(q:Paper) RETURN p, q",
+        ],
+    )
+    def test_known_labels_are_never_rejected(self, query):
+        g = _make_graph()
+        g.lock_schema()
+        g.cypher(query)  # must not raise
+
+    def test_unlocking_restores_the_zero_row_idiom(self):
+        g = _make_graph()
+        g.lock_schema()
+        g.unlock_schema()
+        assert len(g.cypher("MATCH (p:Persom) RETURN p")) == 0
+
+
+class TestOpenSchemaUnchanged:
+    """The schemaless default is the product — it must be untouched."""
+
+    @pytest.mark.parametrize(
+        ("query", "rows"),
+        [
+            ("MATCH (p:Nonexistent) RETURN p", 0),
+            ("CALL { MATCH (q:Nonexistent) RETURN q } RETURN q", 0),
+            (
+                "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Nonexistent) RETURN q.name AS n",
+                2,
+            ),
+            # OPTIONAL MATCH keeps the left rows with a null right side —
+            # still no error, which is the point.
+            ("MATCH (p:Person) OPTIONAL MATCH (q:Nonexistent) RETURN p, q", 2),
+        ],
+    )
+    def test_unknown_label_does_not_error(self, query, rows):
+        # The existence-check idiom: an unknown label is legal Cypher on an
+        # open schema and simply matches nothing.
+        g = _make_graph()
+        assert g.schema_locked is False
+        assert len(g.cypher(query)) == rows
+
+    def test_create_of_a_brand_new_label_still_works(self):
+        g = _make_graph()
+        g.cypher("CREATE (x:BrandNewType {name: 'anything'})")
+        assert len(g.cypher("MATCH (x:BrandNewType) RETURN x")) == 1
+
+    def test_merge_of_a_brand_new_label_still_works(self):
+        g = _make_graph()
+        g.cypher("MERGE (x:AnotherNewType {name: 'anything'})")
+        assert len(g.cypher("MATCH (x:AnotherNewType) RETURN x")) == 1
 
 
 # ── Introspection ────────────────────────────────────────────────────────────


### PR DESCRIPTION
`MATCH (i:Isue) RETURN i` returned `[]` with no error even under `lock_schema()`. Both competitors error (`no such table: isue` / `Type with name 'Isue' was not found`).

**The defect was the asymmetry, not the open-schema default.** The typo'd *property* path is handled well — under a lock it enumerates the valid set. `lock_schema()` is precisely the catch-my-typos mechanism, and it covered properties but not labels. An empty result set is the worse failure of the two: it reads as "no matching data" rather than "you made a mistake", so it survives review and reaches production as a plausible empty state.

**~40 lines of production logic**, added to the existing shared `validate_pattern` traversal rather than as a parallel mechanism — so `MATCH`, `OPTIONAL MATCH`, `(n:A:B)` extra labels, `WHERE EXISTS { }`, `CALL { }` and `UNION` branches all came free. `MERGE`/`CREATE` were already rejected on the write path.

The wording was not invented: `mutation::validation::validate_node_creation` has always produced an unknown-node-type message for locked `CREATE`, so it is reused verbatim. Likewise the error type — `SchemaError` → `KgError::Schema` → `kglite.SchemaError` is the existing engine-failure path the unknown-property case already travels; this adds `SchemaErrorKind::UnknownNodeType` rather than a new class.

```
Schema error: Unknown node type 'Isue'. Did you mean 'Issue'?
  Valid types: Issue, Person
```

now structurally identical to the existing property message. Open-schema behaviour is unchanged; the path is gated entirely on `schema_locked`.

**A panic avoided rather than shipped:** the first draft used `StringInterner::resolve` to name secondary labels in the hint, which *panics* on an unregistered key. Switched to `try_resolve` — an error-message builder must not be able to abort the process.

Verified: `cargo test -p kglite` 1312 passed, `tests/test_schema_lock.py` 50 passed (21 new), clippy `-D warnings`, `make gate`, `make source-quality`, `cargo fmt --check` all clean.

Two follow-ups surfaced, not fixed — both tracked separately: `did_you_mean`'s threshold accepts edit distance 4 on a 4-char input (so `Isue` can suggest `Paper`), pre-existing and shared with the property message; and the open-schema *warning* path has the same asymmetry one level down — it never descends into `CALL {}`/`WHERE EXISTS {}`/`UNION`.

No version bump; entry under `[Unreleased]`.