### PR TITLE
fix: delete no longer drops the type's id index; columnar REMOVE clears through the master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`REMOVE` on a columnar node no longer leaves the property in the graph's
+  master column store, where a later write brought it back.** Each node of a
+  columnar type holds its own `Arc<ColumnStore>` handle and the graph holds the
+  master. `REMOVE` wrote through the node's handle, and `Arc::make_mut` forks
+  it — so the node stopped reporting the property while the master kept it. The
+  next `SET` on that type re-pointed every node's handle at the master and the
+  removed property reappeared, with no `save()` involved. `REMOVE` now clears
+  through the master, the same chokepoint `SET` already used. This also removes
+  a full `ColumnStore` clone per node removed, so `REMOVE` over R rows of a
+  type with N nodes is no longer O(R × N).
+
 - **Deleting a node no longer costs a full rebuild of its type's id index.**
   `DELETE` dropped the whole `id_indices` entry for every affected node type,
   so the next `MATCH (n {id: …})` rebuilt the map by scanning every node of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deleting a node no longer costs a full rebuild of its type's id index.**
+  `DELETE` dropped the whole `id_indices` entry for every affected node type,
+  so the next `MATCH (n {id: …})` rebuilt the map by scanning every node of
+  that type — one node-weight read and `Value` clone each. A single-node
+  delete was therefore O(nodes of that type), while the create path had
+  already been maintaining the same index incrementally. Deletes now evict
+  just the removed ids in place. Types with duplicate ids still fall back to
+  the full rebuild, since only a rebuild can surface a duplicate that the
+  index had shadowed; that case is detected in O(1) by comparing the index
+  length against the type's live node count. Statement rollback is unchanged
+  — it invalidates whole types by design, on the already-failed path.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -308,10 +308,12 @@ impl DirGraph {
 /// fields that are rebuilt instead of journal-reversed.
 #[derive(Default)]
 struct ReplayFallout {
-    /// Node types whose id-index the replay perturbed. `IdIndexStore` has no
-    /// per-entry removal, and its read path self-heals via `lookup_or_build`,
-    /// so whole-type invalidation is both the cheapest correct move and
-    /// exactly what the delete path already does.
+    /// Node types whose id-index the replay perturbed. Whole-type
+    /// invalidation, not the per-entry `evict_entries` the delete path uses:
+    /// a replay restores and removes nodes in the same pass, so the surviving
+    /// set is not known per entry, and the read path self-heals via
+    /// `lookup_or_build` anyway. This runs only after a statement has already
+    /// failed, so the rebuild lands on the rare path.
     stale_id_indices: HashSet<String>,
     /// Node types whose unique-occupancy maps must be recomputed from the
     /// restored data. Wider than `stale_id_indices`: a plain property

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1708,12 +1708,26 @@ fn execute_set(
         }
     }
 
-    // Refresh per-node `Arc<ColumnStore>` handles for every type we wrote
-    // into during this batch. Each node holds its own Arc clone for
-    // efficient property reads; after the batch wrote through the
-    // graph master, those per-node handles are stale and would surface
-    // pre-batch values. This sweep is O(N) per touched type and runs
-    // once per SET clause regardless of row count.
+    refresh_columnar_node_handles(graph, touched_columnar_types);
+    Ok(())
+}
+
+/// Re-point every node's `Arc<ColumnStore>` handle at the graph master, for
+/// each type written through the master during this clause.
+///
+/// Each node holds its own Arc clone for efficient property reads; after a
+/// clause wrote through the graph master those per-node handles are stale and
+/// would surface pre-clause values. This sweep is O(N) per touched type and
+/// runs once per clause regardless of row count — which is the whole reason
+/// the master fast paths accumulate a type set instead of refreshing per row.
+///
+/// Shared by `execute_set` and `execute_remove`, which must agree: a node
+/// whose property was removed on its own forked store while the master kept
+/// the value has the value resurrected by the *next* clause's sweep.
+fn refresh_columnar_node_handles(
+    graph: &mut DirGraph,
+    touched_columnar_types: std::collections::HashSet<String>,
+) {
     for node_type in touched_columnar_types {
         let new_master = match graph.column_stores.get(&node_type) {
             Some(m) => Arc::clone(m),
@@ -1727,7 +1741,7 @@ fn execute_set(
         for idx in indices {
             // `_silent`: re-pointing per-node Arc handles is internal storage
             // bookkeeping, not a logical mutation — must not be captured by the
-            // WAL recorder (the actual SET was recorded in the fast path above).
+            // WAL recorder (the actual write was recorded in the fast path).
             if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
                 if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
                     &mut node.properties
@@ -1737,7 +1751,6 @@ fn execute_set(
             }
         }
     }
-    Ok(())
 }
 
 /// Execute a DELETE clause, removing nodes and/or edges from the graph.
@@ -1879,6 +1892,12 @@ fn execute_remove(
     stats: &mut MutationStats,
     interrupt: &Interrupt,
 ) -> Result<(), String> {
+    // Same batching contract as `execute_set`: Columnar types written through
+    // the graph master get their per-node `Arc<ColumnStore>` handles refreshed
+    // in one O(N-per-type) sweep at the end, not once per row.
+    let mut touched_columnar_types: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
     for (row_idx, row) in result_set.rows.iter().enumerate() {
         check_interrupt_periodic(interrupt, row_idx)?;
         for item in &remove.items {
@@ -1948,7 +1967,58 @@ fn execute_remove(
                     // writes through, matching SET-to-null semantics
                     // (verified working on disk).
                     let is_disk = graph.graph.is_disk();
-                    let removed_value = if let Some(node) = graph.get_node_mut(*node_idx) {
+
+                    // In-memory Columnar: clear through the graph master, the
+                    // same chokepoint `execute_set` writes through, and refresh
+                    // the per-node handles once at the end of the clause.
+                    //
+                    // Going through the node's own `Arc<ColumnStore>` instead
+                    // (what `PropertyStorage::remove` does) is both wrong and
+                    // slow. Wrong: `Arc::make_mut` forks the node's store, so
+                    // the master keeps the removed value and the next clause's
+                    // refresh sweep re-points this node at the master and
+                    // resurrects it — no save required. Slow: the fork is a
+                    // full `ColumnStore` clone per node removed, so a REMOVE
+                    // over R rows of a type with N nodes was O(R x N).
+                    //
+                    // title/name are excluded for the same reason as in
+                    // `execute_set`: they live inline on the node and are
+                    // consolidated by `enable_columnar` at save time.
+                    let mut cleared_via_master = None;
+                    if !is_disk && property != "name" && property != "title" {
+                        let columnar_row_id = {
+                            let _arena_guard = graph.graph.begin_query();
+                            match graph.graph.node_weight(*node_idx).map(|n| &n.properties) {
+                                Some(crate::graph::schema::PropertyStorage::Columnar {
+                                    row_id,
+                                    ..
+                                }) => Some(*row_id),
+                                _ => None,
+                            }
+                        };
+                        if let Some(row_id) = columnar_row_id {
+                            let key = graph.interner.get_or_intern(property);
+                            let prior = graph
+                                .column_stores
+                                .get(&node_type_str)
+                                .and_then(|master| master.get(row_id, key));
+                            if let Some(master) = graph.column_stores.get_mut(&node_type_str) {
+                                Arc::make_mut(master).set(row_id, key, &Value::Null, None);
+                                touched_columnar_types.insert(node_type_str.clone());
+                                // The master write bypasses the recorded
+                                // GraphWrite path, so capture the one mutated
+                                // node for the WAL explicitly. (The silent
+                                // refresh sweep must NOT be captured — else one
+                                // REMOVE would log every node of the type.)
+                                graph.graph.note_recorded_node_upsert(*node_idx);
+                                cleared_via_master = Some(prior);
+                            }
+                        }
+                    }
+
+                    let removed_value = if let Some(prior) = cleared_via_master {
+                        prior
+                    } else if let Some(node) = graph.get_node_mut(*node_idx) {
                         if property == "name" || property == "title" {
                             let old = std::mem::replace(&mut node.title, Value::Null);
                             node.remove_property("name");
@@ -1993,6 +2063,8 @@ fn execute_remove(
             }
         }
     }
+
+    refresh_columnar_node_handles(graph, touched_columnar_types);
     Ok(())
 }
 
@@ -2314,6 +2386,10 @@ fn try_match_merge_pattern(
         _ => Err("MERGE supports single-node or single-edge patterns only".to_string()),
     }
 }
+
+#[cfg(test)]
+#[path = "write_remove_columnar_tests.rs"]
+mod remove_columnar_tests;
 
 #[cfg(test)]
 mod is_mutation_query_tests {

--- a/crates/kglite/src/graph/languages/cypher/executor/write_remove_columnar_tests.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write_remove_columnar_tests.rs
@@ -1,0 +1,136 @@
+//! `REMOVE` on an in-memory Columnar node must clear the graph master store.
+//!
+//! Split into its own file to keep `write.rs` under the source-quality line
+//! ceiling.
+//!
+//! Each node of a columnar type holds its own `Arc<ColumnStore>` clone for
+//! cheap property reads, and `graph.column_stores` holds the master. Writing
+//! through the node's handle calls `Arc::make_mut`, which **forks** it: the
+//! node sees the write and the master does not. `execute_set` avoids this by
+//! writing through the master and refreshing the per-node handles in one sweep
+//! at the end of the clause; `execute_remove` did not, so a removed property
+//! survived in the master and came back the moment any later clause ran that
+//! sweep.
+
+use crate::datatypes::Value;
+use crate::graph::schema::{DirGraph, InternedKey, PropertyStorage};
+use crate::graph::session::execute::{execute_mut, ExecuteOptions};
+use crate::graph::storage::GraphRead;
+
+fn run(graph: &mut DirGraph, query: &str) {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::eager(&params);
+    execute_mut(graph, query, &opts).unwrap_or_else(|e| panic!("query failed: {query}: {e}"));
+}
+
+/// One columnar `Item`, with the fixture's columnar-ness asserted rather than
+/// assumed — every test here is vacuous against a `Map`-storage node.
+fn columnar_item() -> DirGraph {
+    let mut graph = DirGraph::new();
+    run(&mut graph, "CREATE (a:Item {id: 1, name: 'a', qty: 10})");
+    graph.enable_columnar();
+    assert!(
+        graph.column_stores.contains_key("Item"),
+        "the fixture must own a master column store, or these tests are vacuous"
+    );
+    let idx = graph
+        .lookup_by_id_readonly("Item", &Value::Int64(1))
+        .expect("seeded node");
+    assert!(
+        matches!(
+            graph.graph.node_weight(idx).map(|n| &n.properties),
+            Some(PropertyStorage::Columnar { .. })
+        ),
+        "the node must read through a column store, or these tests are vacuous"
+    );
+    graph
+}
+
+fn master_qty(graph: &DirGraph) -> Option<Value> {
+    graph
+        .column_stores
+        .get("Item")
+        .and_then(|m| m.get(0, InternedKey::from_str("qty")))
+}
+
+fn node_qty(graph: &DirGraph) -> Option<Value> {
+    graph
+        .lookup_by_id_readonly("Item", &Value::Int64(1))
+        .and_then(|i| graph.graph.node_weight(i))
+        .and_then(|n| n.get_property("qty"))
+        .map(|v| v.into_owned())
+}
+
+/// The removal must reach the master, not just the node's forked handle.
+#[test]
+fn remove_clears_the_master_column_store() {
+    let mut graph = columnar_item();
+    assert_eq!(master_qty(&graph), Some(Value::Int64(10)));
+
+    run(&mut graph, "MATCH (a:Item {id: 1}) REMOVE a.qty");
+
+    assert_eq!(node_qty(&graph), None, "the node must not see the property");
+    assert_eq!(
+        master_qty(&graph),
+        None,
+        "the master must not keep a value the node no longer has — it is what \
+         save() persists and what the next handle-refresh sweep broadcasts"
+    );
+}
+
+/// The user-visible symptom: a removed property comes back.
+///
+/// No save is involved. `SET a.other = 5` writes through the master and then
+/// refreshes every node handle of the type, which re-points the node at a
+/// master that still carried `qty`.
+#[test]
+fn removed_columnar_property_does_not_resurrect_on_the_next_set() {
+    let mut graph = columnar_item();
+    run(&mut graph, "MATCH (a:Item {id: 1}) REMOVE a.qty");
+    assert_eq!(node_qty(&graph), None);
+
+    // Any later master-routed write on the same type triggers the sweep.
+    run(&mut graph, "MATCH (a:Item {id: 1}) SET a.other = 5");
+
+    assert_eq!(
+        node_qty(&graph),
+        None,
+        "a removed property must stay removed across a later SET on its type"
+    );
+    assert_eq!(master_qty(&graph), None);
+}
+
+/// REMOVE over several rows must still be correct per node — the batched
+/// handle refresh happens once at the end of the clause, so a bug there shows
+/// up as one node keeping its value.
+#[test]
+fn remove_over_many_rows_clears_every_node() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Item {id: 1, qty: 10}), (:Item {id: 2, qty: 20}), (:Item {id: 3, qty: 30})",
+    );
+    graph.enable_columnar();
+    assert!(graph.column_stores.contains_key("Item"));
+
+    run(&mut graph, "MATCH (a:Item) REMOVE a.qty");
+
+    for id in 1..=3 {
+        let value = graph
+            .lookup_by_id_readonly("Item", &Value::Int64(id))
+            .and_then(|i| graph.graph.node_weight(i))
+            .and_then(|n| n.get_property("qty"))
+            .map(|v| v.into_owned());
+        assert_eq!(value, None, "node {id} kept its removed property");
+    }
+    // And a later SET does not bring any of them back.
+    run(&mut graph, "MATCH (a:Item {id: 1}) SET a.other = 1");
+    for id in 1..=3 {
+        let value = graph
+            .lookup_by_id_readonly("Item", &Value::Int64(id))
+            .and_then(|i| graph.graph.node_weight(i))
+            .and_then(|n| n.get_property("qty"))
+            .map(|v| v.into_owned());
+        assert_eq!(value, None, "node {id} resurrected its removed property");
+    }
+}

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1149,14 +1149,49 @@ pub(crate) fn detach_delete_nodes(
     // Same guard scoping as the edge collection above (node_weight
     // materializes on the disk backend).
     let mut affected_types: HashSet<String> = HashSet::new();
+    // The doomed nodes' ids, per type, so the id index can be edited in place
+    // instead of being dropped and rebuilt by the next lookup. Read here
+    // because after `remove_node` below the weights are gone.
+    let mut doomed_ids: HashMap<String, Vec<(Value, NodeIndex)>> = HashMap::new();
     {
         let _guard = graph.graph.begin_query();
         for &node_idx in nodes_to_delete {
             if let Some(node) = graph.graph.node_weight(node_idx) {
-                affected_types.insert(node.get_node_type_ref(&graph.interner).to_string());
+                let node_type = node.get_node_type_ref(&graph.interner).to_string();
+                let node_id = node.id().into_owned();
+                doomed_ids
+                    .entry(node_type.clone())
+                    .or_default()
+                    .push((node_id, node_idx));
+                affected_types.insert(node_type);
             }
         }
     }
+
+    // Whether each type's id index may be edited in place rather than dropped.
+    //
+    // In-place eviction removes exactly the ids handed to it; a rebuild
+    // re-derives the map from the surviving nodes. The two agree only while
+    // ids are unique within the type. If two live nodes share an id the index
+    // holds one of them, and deleting that one must leave the *other*
+    // reachable by id — which only a rebuild achieves. Duplicates are
+    // detectable in O(1): the index was built with one entry per node of the
+    // type, so a shorter index is exactly the signature of collapsed
+    // duplicates. Unequal (or unbuilt, or base-resident) falls back to the
+    // whole-type invalidation this path has always done.
+    //
+    // Note this differs from the create path, which may maintain the index
+    // incrementally unconditionally: inserting a duplicate collapses it the
+    // same way a rebuild would, so the two stay in agreement there.
+    let evictable: HashSet<String> = affected_types
+        .iter()
+        .filter(|node_type| {
+            let indexed = graph.id_indices.overlay_len(node_type);
+            let live = graph.type_indices.get(node_type).map(|m| m.len());
+            matches!((indexed, live), (Some(i), Some(l)) if i == l)
+        })
+        .cloned()
+        .collect();
 
     for &node_idx in nodes_to_delete {
         GraphWrite::remove_node(&mut graph.graph, node_idx);
@@ -1179,7 +1214,14 @@ pub(crate) fn detach_delete_nodes(
         graph
             .type_indices
             .retain_in_type(node_type, |idx| !nodes_to_delete.contains(idx));
-        graph.id_indices.remove(node_type);
+        match doomed_ids.get(node_type) {
+            Some(entries) if evictable.contains(node_type) => {
+                graph.id_indices.evict_entries(node_type, entries);
+            }
+            _ => {
+                graph.id_indices.remove(node_type);
+            }
+        }
         let prop_keys: Vec<_> = graph
             .property_indices
             .keys()
@@ -2267,3 +2309,7 @@ mod replace_connections_tests {
         assert_eq!(count_edges_of_type(&g, "Doc", 1, "MENTIONS"), 1);
     }
 }
+
+#[cfg(test)]
+#[path = "maintain_delete_id_index_tests.rs"]
+mod delete_id_index_tests;

--- a/crates/kglite/src/graph/mutation/maintain_delete_id_index_tests.rs
+++ b/crates/kglite/src/graph/mutation/maintain_delete_id_index_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for in-place id-index maintenance on the delete path.
+//!
+//! Split out of `maintain.rs` to keep that file under the source-quality
+//! line ceiling, matching the existing `maintain_edge_spec_tests.rs`.
+
+use super::*;
+use crate::graph::session::execute::{execute_mut, ExecuteOptions};
+
+fn run(graph: &mut DirGraph, query: &str) {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::eager(&params);
+    execute_mut(graph, query, &opts).unwrap_or_else(|e| panic!("setup query failed: {query}: {e}"));
+}
+
+/// Three `Person` nodes with distinct ids and a warm id index.
+fn seeded_people() -> DirGraph {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Person {id: 1, name: 'a'}), (:Person {id: 2, name: 'b'}), \
+         (:Person {id: 3, name: 'c'})",
+    );
+    graph.build_id_index("Person");
+    assert!(graph.id_indices.contains_key("Person"));
+    graph
+}
+
+/// Deleting one node must edit the type's id index in place, not drop it.
+///
+/// Dropping it makes a single-node delete O(N_type): the next id lookup
+/// rebuilds the whole map via `compute_id_index`, one node-weight read and
+/// `Value` clone per node of the type. That is the delete-side twin of the
+/// incremental maintenance the create path already does.
+///
+/// Asserted through `IdIndexStore::lookup`, the **non-building** read, so
+/// the self-healing `lookup_or_build` path cannot mask a dropped index:
+/// after a drop the survivor probe returns `None` and this fails.
+#[test]
+fn delete_edits_id_index_in_place() {
+    let mut graph = seeded_people();
+    let doomed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .expect("id 2 must be indexed");
+    let survivor = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(3))
+        .expect("id 3 must be indexed");
+
+    let mut to_delete = HashSet::new();
+    to_delete.insert(doomed);
+    assert_eq!(detach_delete_nodes(&mut graph, &to_delete), (1, 0));
+
+    // The index survived the delete: a non-building lookup still resolves
+    // an untouched id. This is the assertion the fix exists for.
+    assert_eq!(
+        graph.id_indices.lookup("Person", &Value::Int64(3)),
+        Some(survivor),
+        "the delete must leave the id index usable, not force a rebuild"
+    );
+    // And it is correct: the deleted id is gone, the count dropped by one.
+    assert_eq!(graph.id_indices.lookup("Person", &Value::Int64(2)), None);
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+    // The self-healing path agrees with the in-place edit.
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_none());
+    assert_eq!(
+        graph.lookup_by_id_readonly("Person", &Value::Int64(1)),
+        graph.id_indices.lookup("Person", &Value::Int64(1))
+    );
+}
+
+/// Duplicate ids must still force a full rebuild.
+///
+/// In-place eviction removes exactly the ids it is handed; a rebuild
+/// re-derives the map from the survivors. They disagree only when two live
+/// nodes share an id: the index holds one of them, and deleting *that* one
+/// must leave the other reachable — which only a rebuild achieves.
+/// `detach_delete_nodes` detects this in O(1) by comparing the index length
+/// against the type's live node count.
+///
+/// Removing the `evictable` guard makes this fail: the id-1 entry is
+/// evicted, the index stays "built", and the shadowed survivor becomes
+/// permanently unreachable by id.
+#[test]
+fn delete_with_duplicate_ids_falls_back_to_rebuild() {
+    let mut graph = DirGraph::new();
+    // No primary key declared, so duplicate ids are admitted.
+    run(&mut graph, "CREATE (:Person {id: 1, name: 'first'})");
+    run(&mut graph, "CREATE (:Person {id: 1, name: 'second'})");
+    run(&mut graph, "CREATE (:Person {id: 2, name: 'other'})");
+    graph.build_id_index("Person");
+
+    // Two nodes share id 1, so the index collapsed them: three nodes, two
+    // entries. That inequality is exactly what the guard keys on.
+    assert_eq!(graph.type_indices.get("Person").map(|m| m.len()), Some(3));
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+
+    let indexed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .expect("id 1 resolves to one of the two");
+    let mut to_delete = HashSet::new();
+    to_delete.insert(indexed);
+    assert_eq!(detach_delete_nodes(&mut graph, &to_delete), (1, 0));
+
+    // The shadowed duplicate is now the only node with id 1, and must be
+    // reachable by id.
+    let survivor = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .expect("the shadowed duplicate must remain reachable by id");
+    assert_ne!(survivor, indexed);
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_some());
+}
+
+/// An unbuilt id index must stay unbuilt.
+///
+/// Exercised directly against `IdIndexStore`, **not** through
+/// `detach_delete_nodes`: the `evictable` guard already excludes any type
+/// that is not overlay-resident, so routing this through a delete would
+/// never reach `evict_entries` and the test would pass no matter what
+/// `evict_entries` did. This is the store-level contract the delete path
+/// relies on — a half-populated entry would be trusted as complete by
+/// `build_id_index`, which short-circuits whenever an entry exists.
+#[test]
+fn evicting_an_absent_id_index_does_not_materialize_it() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Person {id: 1, name: 'a'}), (:Person {id: 2, name: 'b'})",
+    );
+    graph.build_id_index("Person");
+    let doomed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .unwrap();
+    graph.id_indices.remove("Person");
+    assert!(!graph.id_indices.contains_key("Person"));
+
+    let evicted = graph
+        .id_indices
+        .evict_entries("Person", &[(Value::Int64(1), doomed)]);
+
+    assert!(!evicted, "an absent index cannot be edited in place");
+    assert!(
+        !graph.id_indices.contains_key("Person"),
+        "an absent index must not be partially materialized by an evict"
+    );
+    // The later rebuild is therefore complete: both nodes are still live.
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_some());
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+}
+
+/// A multi-type delete must edit each affected type's index independently.
+#[test]
+fn detach_delete_edits_every_affected_type() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (i:Issue {id: 1}), (c:Comment {id: 10}), (c2:Comment {id: 11})",
+    );
+    run(
+        &mut graph,
+        "MATCH (i:Issue {id: 1}), (c:Comment {id: 10}) CREATE (c)-[:ON]->(i)",
+    );
+    run(
+        &mut graph,
+        "MATCH (i:Issue {id: 1}), (c:Comment {id: 11}) CREATE (c)-[:ON]->(i)",
+    );
+    assert_eq!(graph.graph.edge_count(), 2);
+    graph.build_id_index("Issue");
+    graph.build_id_index("Comment");
+
+    let issue = graph
+        .lookup_by_id_readonly("Issue", &Value::Int64(1))
+        .unwrap();
+    let comment = graph
+        .lookup_by_id_readonly("Comment", &Value::Int64(10))
+        .unwrap();
+    let survivor = graph
+        .lookup_by_id_readonly("Comment", &Value::Int64(11))
+        .unwrap();
+
+    let mut to_delete = HashSet::new();
+    to_delete.insert(issue);
+    to_delete.insert(comment);
+    let (nodes, edges) = detach_delete_nodes(&mut graph, &to_delete);
+    assert_eq!((nodes, edges), (2, 2));
+
+    // Both indices survived, both are correct.
+    assert_eq!(graph.id_indices.lookup("Issue", &Value::Int64(1)), None);
+    assert_eq!(graph.id_indices.overlay_len("Issue"), Some(0));
+    assert_eq!(graph.id_indices.lookup("Comment", &Value::Int64(10)), None);
+    assert_eq!(
+        graph.id_indices.lookup("Comment", &Value::Int64(11)),
+        Some(survivor),
+        "an untouched sibling must stay indexed without a rebuild"
+    );
+    assert_eq!(graph.id_indices.overlay_len("Comment"), Some(1));
+}

--- a/crates/kglite/src/graph/schema.rs
+++ b/crates/kglite/src/graph/schema.rs
@@ -1001,6 +1001,77 @@ impl TypeIdIndex {
         }
     }
 
+    /// Number of indexed ids.
+    pub fn len(&self) -> usize {
+        match self {
+            TypeIdIndex::Integer(map) => map.len(),
+            TypeIdIndex::General(map) => map.len(),
+        }
+    }
+
+    /// Whether the index holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drop the entry for `id`, but only when it currently resolves to `idx`.
+    ///
+    /// The `idx` check is what makes this safe to call while deleting: if the
+    /// id has since been re-pointed at a different node, the live mapping is
+    /// left alone rather than silently unindexing the survivor. Resolution
+    /// goes through [`get`](Self::get), so the same `Int64`/`UniqueId`/
+    /// `Float64` coercions apply — the key is removed under whichever
+    /// spelling it was actually stored, not under the caller's spelling.
+    ///
+    /// Returns whether an entry was removed.
+    pub fn remove_matching(&mut self, id: &Value, idx: NodeIndex) -> bool {
+        if self.get(id) != Some(idx) {
+            return false;
+        }
+        match self {
+            TypeIdIndex::Integer(map) => {
+                let key = match id {
+                    Value::UniqueId(u) => Some(*u),
+                    Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => Some(*i as u32),
+                    Value::Float64(f) if f.fract() == 0.0 => {
+                        let i = *f as i64;
+                        if i >= 0 && i <= u32::MAX as i64 {
+                            Some(i as u32)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                key.is_some_and(|k| map.remove(&k).is_some())
+            }
+            TypeIdIndex::General(map) => {
+                if map.remove(id).is_some() {
+                    return true;
+                }
+                // `get` resolved it, so it is stored under a coerced spelling.
+                let coerced = match id {
+                    Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => {
+                        Some(Value::UniqueId(*i as u32))
+                    }
+                    Value::UniqueId(u) => Some(Value::Int64(*u as i64)),
+                    Value::Float64(f) if f.fract() == 0.0 => {
+                        let i = *f as i64;
+                        if map.contains_key(&Value::Int64(i)) {
+                            Some(Value::Int64(i))
+                        } else if i >= 0 && i <= u32::MAX as i64 {
+                            Some(Value::UniqueId(i as u32))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                coerced.is_some_and(|k| map.remove(&k).is_some())
+            }
+        }
+    }
+
     /// Iterate over all (Value, NodeIndex) pairs.
     pub fn iter(&self) -> Box<dyn Iterator<Item = (Value, NodeIndex)> + '_> {
         match self {

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -514,6 +514,44 @@ impl IdIndexStore {
         self.overlay.get_mut().unwrap().insert(name, idx);
     }
 
+    /// Number of ids indexed for `name` in the mutable overlay, or `None`
+    /// when the type is not overlay-resident. Deliberately does not consult
+    /// the mmap'd base: the only caller uses this to decide whether an
+    /// in-place edit is safe, and base entries are never edited in place.
+    pub fn overlay_len(&self, name: &str) -> Option<usize> {
+        self.overlay.read().unwrap().get(name).map(|idx| idx.len())
+    }
+
+    /// Drop `entries` (`id → node`) from `name`'s index in place, instead of
+    /// invalidating the whole type.
+    ///
+    /// Deleting one node used to `remove()` the entire type index, so the next
+    /// id lookup rebuilt it by scanning every node of the type — an O(N_type)
+    /// cost charged to a single-node delete. The create path already maintains
+    /// this index incrementally (see the `pk_id` match in the Cypher create
+    /// executor); this is the same treatment for the delete side.
+    ///
+    /// Falls back to whole-type invalidation, and returns `false`, whenever the
+    /// index is not overlay-resident — an unbuilt type has nothing to edit, and
+    /// a base-resident type lives in an immutable mmap. Each entry is removed
+    /// only if it still resolves to the given node, so a re-pointed id is left
+    /// intact.
+    ///
+    /// The caller is responsible for the duplicate-id precondition: this edits
+    /// exactly the ids it is given, whereas a rebuild re-derives the whole map
+    /// and would surface a shadowed duplicate. See `detach_delete_nodes`.
+    pub fn evict_entries(&mut self, name: &str, entries: &[(Value, NodeIndex)]) -> bool {
+        let overlay = self.overlay.get_mut().unwrap();
+        let Some(index) = overlay.get_mut(name) else {
+            self.remove(name);
+            return false;
+        };
+        for (id, idx) in entries {
+            index.remove_matching(id, *idx);
+        }
+        true
+    }
+
     pub fn remove(&mut self, name: &str) -> Option<TypeIdIndex> {
         let prev = self.overlay.get_mut().unwrap().remove(name);
         if self.base.as_ref().is_some_and(|b| b.contains(name)) {

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 536,
-      "branches": 75,
+      "lines": 508,
+      "branches": 69,
       "nesting": 8
     },
     {


### PR DESCRIPTION
Two mutation-path defects. **The second is a silent data-corruption bug**, found while investigating a performance cost.

## `REMOVE` resurrects removed properties (correctness)

Reproduced in memory, no `save()` involved, on a columnar type:

```cypher
CREATE (a:Item {id: 1, qty: 10})
MATCH (a:Item {id: 1}) REMOVE a.qty      // a.qty -> null, correct
MATCH (a:Item {id: 1}) SET a.other = 5   // a.qty -> 10 AGAIN
```

`execute_remove` wrote only the node's `Arc::make_mut` **fork**; the master column store kept the value. The next `SET`'s handle-refresh sweep then re-points the node at a master that still carries the removed property. So an unrelated write to an unrelated property silently restores deleted data.

`REMOVE` now takes the same master route as `SET` — which fixes the resurrection *and* removes a per-node full-`ColumnStore` clone. The sweep is extracted into `refresh_columnar_node_handles` so the two clauses cannot drift apart again.

## Deletes dropped the whole type's id index (performance)

**Measured** (release, `min` µs): `delete_leaf` 64.1 → 312.3 → 2,845.5 across 1k/10k/100k, while an insert is ~3.7 µs and flat.

**Cause:** `maintain.rs:1182` did `graph.id_indices.remove(node_type)` — deleting *one* node dropped the **entire type's** id index, and the next id lookup paid `compute_id_index`: a node-weight read, `Value` clone and hash insert per node of the type. Every neighbouring index on the same lines already had incremental `retain` treatment, and the **create** path already maintains this index incrementally — which is exactly why inserts measure flat. The delete side was simply never given the same treatment.

Two facts in the measured data force this explanation and rule out "delete work":
- `cascade_delete_issue` deletes 11 nodes and 10 edges yet is uniformly **3.7× cheaper** than `delete_leaf`'s single node — impossible if cost tracked deletion, required if it tracks the *type's* index size (Issue's is 10× smaller than Comment's).
- `delete_then_id_lookup ≈ delete_leaf` at every size — an entire extra lookup query costs nothing, which only holds if exactly one rebuild happens per round either way.

So the slope is **O(N_type), not O(N_graph)**. Refuted along the way: the rollback checkpoint (in-memory deletes are whitelisted and open none) and petgraph (`remove_node` is O(degree)).

The fix evicts just the removed ids. Duplicate ids keep the old full invalidation — in-place eviction and a rebuild agree only while ids are unique, and deleting the indexed one of a duplicate pair must leave the other reachable, which only a rebuild achieves. Detected in O(1) by comparing index length against the type's live node count. Rollback is untouched: it invalidates whole types independently, so it never depended on the delete path's drop as a side effect.

## `MERGE`'s per-row `SET` — confirmed, deliberately not fixed

MERGE with `ON CREATE/MATCH SET` over R rows on a columnar type is O(R × N_type). **Batching is unsound:** `try_match_merge_pattern` runs against the *live* graph per row, so deferring the SETs changes what later rows match whenever a SET writes a property the merge key reads. Two narrower variants also fail — deferring only the handle refresh has the identical hazard, and refreshing only written nodes trades time for an equivalent *space* cost, since `ColumnStore::clone` deep-copies its columns so each un-collapsed generation is a full store. The real fix is architectural and needs benchmarking.

## Verification

Every regression test confirmed non-vacuous by removing the fix and watching it fail (3 breakages for the index fix, 1 for the resurrection fix). **Two tests were caught as vacuous and repaired rather than shipped** — one never reached `evict_entries` because the evictability guard excluded it, and one passed either way because `enable_columnar` rebuilds from node weights rather than the master (dropped; its stated rationale was wrong).

1307 engine tests green including all 15 rollback shapes against `seeded_columnar()`/`seeded_indexed()`. clippy `-D warnings` workspace-wide, `make gate`, `make source-quality`, `cargo fmt --check` verified **per commit**. `maintain.rs` crossed the 2500-line ceiling so its tests were split into their own file per project doctrine rather than raising the allowlist.

No version bump; entries under `[Unreleased]`.