### PR TITLE
fix: linear WAL payload for columnar bulk load; refuse a storage mode that cannot be honoured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`add_nodes()` on a durable mapped or disk graph no longer writes a
+  quadratic write-ahead-log payload.** Appending rows to a columnar graph
+  detaches every existing node of the type from its shared column store and
+  re-attaches it afterwards — pure internal bookkeeping, but it ran through the
+  *recorded* mutation seam, so each sweep logged one full property-map copy per
+  pre-existing node. Because the append is chunked, an `n`-row call re-logged
+  the whole type once per chunk: WAL bytes grew as `n²`, and a large enough
+  single call could exceed the 4 GiB per-frame ceiling. Both sweeps now use the
+  silent borrow that the columnar `SET` handle-refresh already used, so the log
+  records exactly one op per row written. Measured on the regression fixture: a
+  1,000-row append logged 2,000 ops (84 B/row) and a 4,000-row append 20,000
+  ops (213 B/row); both now log one op per row at a flat byte cost. No
+  behavioural change to the graph itself or to log replay — the ops removed
+  were byte-identical restatements of nodes the sweep had not modified.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — behaviour
 
+- **Documented: mapped and disk graphs take the whole-graph checkpoint path for
+  statement rollback.** No behaviour change — this is long-standing and
+  deliberate, but it was recorded nowhere a user would look. One mutating
+  Cypher statement is atomic; in-memory graphs deliver that with an undo
+  journal costing O(changes), while mapped and disk graphs cannot express an
+  inverse edit against their mmap-columnar indexes or generation overlays and
+  so fall back to an O(V+E) whole-graph checkpoint before *every* mutating
+  statement. This follows from "in-memory wins", but it means per-statement
+  write overhead scales with graph size in precisely the two modes chosen for
+  large graphs. Now stated in the storage-mode guide, the `KnowledgeGraph`
+  constructor docstring, and at the engine decision point.
+
+- **Documented: the `KnowledgeGraph(...)` constructor is never durable.** It
+  takes no `durable` argument and returns a detached graph with no
+  `source_path`, so there is nowhere for a write-ahead log to live, whereas
+  `kglite.open()` defaults to `durable="full"`. The asymmetry is structural
+  rather than a defaulting inconsistency, but it is easy to trip over when
+  comparing `KnowledgeGraph(storage="mapped")` against
+  `kglite.open(path, storage="mapped")`; both call sites now say so.
+
 - **`define_schema()` now merges per node/connection type instead of replacing
   the whole schema.** A type the call names takes the new declaration entire; a
   type it does not name keeps the declaration it already had. Previously any
@@ -520,6 +540,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour.
 
 ### Fixed
+
+- **`kglite.open(path, storage=...)` no longer ignores the mode when the path
+  already exists.** `storage=` selects a backend for a graph being *created*;
+  an existing path is loaded, and the load decides the backend. Because a
+  `.kgl` checkpoint records no storage mode, a reopened one always comes back
+  as memory — so `open(path, storage="mapped")` produced a genuinely mapped
+  graph on the call that created the file and a silently memory-backed one on
+  every call after that, with nothing reported. An unknown mode such as
+  `storage="banana"` was not even validated on that branch. Both now raise
+  `kglite.ArgumentError`, naming the mode requested, the mode actually
+  produced, and the way forward. This is a deliberate break: the previous
+  behaviour was indistinguishable from success and had already invalidated a
+  mapped-vs-memory comparison in which both arms unknowingly ran on memory.
+  Callers who want whatever the file provides should omit `storage=`. Note
+  there is no saved-graph-to-mapped conversion — a mapped graph has to be
+  built with `KnowledgeGraph(storage="mapped")` and populated from source.
 
 - **`add_nodes()` on a durable mapped or disk graph no longer writes a
   quadratic write-ahead-log payload.** Appending rows to a columnar graph

--- a/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
@@ -957,6 +957,16 @@ fn build_extend_report_dict<'py>(
 
 #[pymethods]
 impl KnowledgeGraph {
+    /// Create an empty graph in the given storage mode.
+    ///
+    /// **Never durable, and there is deliberately no `durable` argument.**
+    /// This produces a *detached* graph — `GraphLifecycle::detached()`, so no
+    /// `source_path` and nowhere for a write-ahead log to live. `kglite.open`
+    /// is the durable entry point: it binds the graph to a path and defaults
+    /// to `DurabilityLevel::Full`. The asymmetry is structural, not a
+    /// defaulting inconsistency, but it means `KnowledgeGraph(storage=
+    /// "mapped")` and `kglite.open(new_path, storage="mapped")` differ in
+    /// whether every commit is logged — worth knowing before comparing them.
     #[new]
     #[pyo3(signature = (*, storage=None, path=None))]
     fn new(storage: Option<&str>, path: Option<&str>) -> PyResult<Self> {

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -261,8 +261,24 @@ fn from_bytes(py: Python<'_>, data: &[u8]) -> PyResult<KnowledgeGraph> {
 /// bare `save()` (or the context-manager auto-save-on-close) writes back to
 /// it without re-specifying the target.
 ///
-/// `storage` (`"mapped"` / `"disk"`) applies only when *creating* a new
-/// graph; opening an existing file uses whatever mode it was saved in.
+/// `storage` (`"mapped"` / `"disk"`) applies only when *creating* a new graph.
+/// Opening an existing path uses the mode the load produces, which is not
+/// necessarily the mode that wrote it: a `.kgl` checkpoint records no storage
+/// mode, so it always loads as `"memory"`, while a disk graph is a directory
+/// and always loads as `"disk"`. Passing a `storage=` that disagrees with the
+/// loaded backend raises `kglite.ArgumentError` rather than being ignored — a
+/// silently-downgraded mode is indistinguishable from success, and in
+/// particular `open(path, storage="mapped")` gives a genuinely mapped graph
+/// only on the call that *creates* the file.
+///
+/// **Durability differs between the two ways to build a graph, and the
+/// difference is structural.** `kglite.open()` attaches a WAL sidecar next to
+/// `path` and defaults to `durable="full"`. The `KnowledgeGraph(...)`
+/// constructor has no `durable` argument at all and is never durable: it
+/// produces a *detached* graph with no `source_path`, so there is no location
+/// for a log to live. `KnowledgeGraph(storage="mapped")` is therefore
+/// mapped-and-unlogged, while `open(path, storage="mapped")` on a fresh path is
+/// mapped-and-logged.
 ///
 /// The `durable=` argument: a level name, a bool, or `None`.
 ///
@@ -394,13 +410,55 @@ fn open(
         None
     };
 
-    let mut kg = if std::path::Path::new(&path).exists() {
+    // Parse the mode up front, on *both* branches. Validating it only inside
+    // `construct` meant an unknown spelling was silently accepted whenever the
+    // path happened to exist already.
+    let requested_mode = storage
+        .map(|mode_str| {
+            kglite_core::api::storage::StorageMode::parse(mode_str)
+                .map_err(|e| crate::error_py::kg_to_pyerr(crate::error::KgError::Argument(e)))
+        })
+        .transpose()?;
+
+    let existed = std::path::Path::new(&path).exists();
+    let mut kg = if existed {
         py.detach(|| load_file(&path))
             .map(KnowledgeGraph::from_arc)
             .map_err(|e| load_err_to_pyerr(e, Some(&path)))?
     } else {
         KnowledgeGraph::construct(storage, Some(&path))?
     };
+    // An existing path is *loaded*, and the load decides the backend — so a
+    // `storage=` that disagrees with what came back cannot be honoured. Refuse
+    // instead of ignoring it: silently handing back a different mode than the
+    // caller asked for is indistinguishable from success, and has already
+    // invalidated at least one mapped-vs-memory comparison where both arms
+    // unknowingly ran on the memory backend.
+    if existed {
+        if let Some(requested) = requested_mode {
+            let actual = actual_storage_mode(&kg);
+            if requested != actual {
+                // `ArgumentError`, matching `KnowledgeGraph(storage="invalid")`
+                // and the parse failure above — one error class for one kwarg.
+                // (The neighbouring disk-plus-`durable` refusal raises
+                // `ValueError`; that is about `durable=`, not about this.)
+                let message = format!(
+                    "cannot open existing graph {path:?} with storage={:?}: it loaded as {:?}. \
+                     `storage=` selects a backend for a graph being *created*; an existing \
+                     path is loaded, and the load decides the backend. A `.kgl` checkpoint \
+                     does not record which mode wrote it, so loading one always yields \
+                     'memory'; a disk graph is a directory and always yields 'disk'. {} \
+                     To accept whatever the file provides, omit `storage=`.",
+                    requested.as_str(),
+                    actual.as_str(),
+                    storage_mode_remedy(requested),
+                );
+                return Err(crate::error_py::kg_to_pyerr(
+                    crate::error::KgError::Argument(message),
+                ));
+            }
+        }
+    }
     kg.lifecycle.source_path = Some(std::path::PathBuf::from(&path));
     kg.lifecycle.writer_lease = writer_lease;
     // Resolved after the graph exists, because the mode of an *existing* path
@@ -417,6 +475,46 @@ fn open(
         setup_durable(&mut kg, &path, level)?;
     }
     Ok(kg)
+}
+
+/// The storage mode `kg` actually ended up in, for comparison against a
+/// caller's `storage=` request.
+fn actual_storage_mode(kg: &KnowledgeGraph) -> kglite_core::api::storage::StorageMode {
+    use kglite_core::api::storage::StorageMode;
+    use kglite_core::api::GraphRead;
+    if kg.inner.graph.is_disk() {
+        StorageMode::Disk
+    } else if kg.inner.graph.is_mapped() {
+        StorageMode::Mapped
+    } else {
+        StorageMode::Memory
+    }
+}
+
+/// The actionable half of the "mode cannot be honoured on open" error: what to
+/// do instead, per requested mode.
+///
+/// `mapped` is the blunt one. There is no load-into-an-existing-graph call and
+/// no saved-graph-to-mapped conversion, so the only route is to build a mapped
+/// graph and re-ingest from the original source data. That is worth saying
+/// plainly rather than implying a conversion exists.
+fn storage_mode_remedy(requested: kglite_core::api::storage::StorageMode) -> &'static str {
+    use kglite_core::api::storage::StorageMode;
+    match requested {
+        StorageMode::Mapped => {
+            "Mapped mode cannot be recovered from a saved graph: build one with \
+             `kglite.KnowledgeGraph(storage=\"mapped\")` and re-ingest from your source data, \
+             or delete the path and let this call create it."
+        }
+        StorageMode::Disk => {
+            "To move a loaded graph onto disk storage, call `g.enable_disk_mode()` after \
+             opening it, or delete the path and let this call create it."
+        }
+        StorageMode::Memory => {
+            "To get a memory-backed graph, open a `.kgl` file rather than a disk-graph \
+             directory."
+        }
+    }
 }
 
 /// Turn `kg` into a durable graph: replay any WAL frames committed since

--- a/crates/kglite/src/graph/mutation/batch.rs
+++ b/crates/kglite/src/graph/mutation/batch.rs
@@ -350,6 +350,32 @@ impl BatchProcessor {
     /// ref dropped the refcount is 1, `try_unwrap` succeeds, and the append
     /// mutates in place. [`Self::reattach_columnar_stores`] restores the refs.
     ///
+    /// ## Why the detach borrow is silent
+    ///
+    /// The sweep touches *every existing node of the type*, once per chunk.
+    /// Through the recorded [`GraphWrite::node_weight_mut`] that is one
+    /// `RawOp::UpsertNode` per existing node per chunk — with
+    /// `LARGE_BATCH_CHUNK_SIZE`-sized chunks, `O(n²/chunk)` ops for an
+    /// `n`-row append, each resolving at flush to a full property-map clone.
+    /// A one-shot `add_nodes` therefore wrote a *quadratic* WAL payload and
+    /// could overflow the per-frame `u32` byte ceiling.
+    ///
+    /// Silencing it is sound because the detach/reattach pair is a logical
+    /// no-op for an already-existing node: it swaps the node's
+    /// `Arc<ColumnStore>` handle while preserving its `row_id`, and
+    /// `ColumnStore::row_properties` skips null columns, so even a
+    /// schema-growing chunk leaves `id`/`title`/`properties_cloned`
+    /// byte-identical. The rows this chunk genuinely creates are recorded by
+    /// [`GraphWrite::add_node`], and `resolve_ops` reads *final* state at
+    /// flush time — so those ops still carry the columnar values that
+    /// `reattach_columnar_stores` installs after `add_node` returns.
+    ///
+    /// No undo obligation is dropped either: both columnar sweeps run only
+    /// when `is_mapped() || is_disk()`, and `GraphBackend::undo_journal_mut`
+    /// yields `None` for `Mapped` and `Disk` (see
+    /// `GraphBackend::supports_undo_journal`) — there is never a journal
+    /// installed on this path to capture into.
+    ///
     /// Returns `(rows awaiting reattachment, owned stores keyed by node type)`.
     fn detach_columnar_stores(
         creates: &[NodeCreationInterned],
@@ -364,7 +390,7 @@ impl BatchProcessor {
             // Detach existing nodes — record their (NodeIndex, row_id) for pass 2
             if let Some(indices) = graph.type_indices.get(node_type) {
                 for idx in indices.iter() {
-                    if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, idx) {
+                    if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
                         if let PropertyStorage::Columnar { row_id, .. } = &node.properties {
                             let rid = *row_id;
                             node.properties = PropertyStorage::Map(HashMap::new());
@@ -394,6 +420,12 @@ impl BatchProcessor {
     ///
     /// No-op when pass 1 found nothing to detach and no columnar row was
     /// appended, which is every in-memory flush.
+    ///
+    /// The handle assignment goes through
+    /// [`GraphWrite::node_weight_mut_silent`] for the same reason pass 1
+    /// does — see [`Self::detach_columnar_stores`] for the full argument.
+    /// Newly created rows are already covered by the `RawOp::UpsertNode` that
+    /// `add_node` pushed, which resolves against post-reattachment state.
     fn reattach_columnar_stores(
         graph: &mut DirGraph,
         deferred_columnar: DeferredColumnarRows,
@@ -414,7 +446,7 @@ impl BatchProcessor {
         // keeps the slot-index value assigned by add_node().
         for (node_idx, node_type, row_id) in deferred_columnar {
             let arc_store = graph.column_stores.get(&node_type).unwrap().clone();
-            if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, node_idx) {
+            if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, node_idx) {
                 node.properties = PropertyStorage::Columnar {
                     store: arc_store,
                     row_id,
@@ -1054,5 +1086,116 @@ mod tests {
     fn test_sum_values_null_cases() {
         assert_eq!(sum_values(&Value::Null, &Value::Int64(5)), Value::Int64(5));
         assert_eq!(sum_values(&Value::Int64(5), &Value::Null), Value::Null);
+    }
+}
+
+/// The WAL payload a mapped/disk `add_nodes` produces must scale with the
+/// number of rows written, not with the number of rows the type already holds.
+///
+/// Regression guard for the quadratic-amplification bug: the columnar
+/// detach/reattach sweeps in [`BatchProcessor::detach_columnar_stores`] and
+/// [`BatchProcessor::reattach_columnar_stores`] touch every existing node of
+/// the type, once per `LARGE_BATCH_CHUNK_SIZE` chunk. Through the *recorded*
+/// `node_weight_mut` that was `O(n²/chunk)` `RawOp::UpsertNode`s for an
+/// `n`-row append, each resolving to a full property-map clone in the frame.
+///
+/// This is deliberately a **byte-count** assertion, not a timing one: it needs
+/// no idle machine, has no `min`-vs-`mean` ambiguity, and fails deterministically
+/// on any reintroduction of a recorded borrow in either sweep.
+#[cfg(test)]
+mod wal_amplification_tests {
+    use crate::datatypes::{DataFrame, Value};
+    use crate::graph::mutation::maintain::add_nodes;
+    use crate::graph::schema::GraphBackend;
+    use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+    use crate::graph::storage::recording::{resolve_ops, RecordingGraph};
+    use crate::graph::storage::GraphRead;
+    use crate::graph::wal::{append_frame, WalFrame};
+
+    /// Append `n` rows to a fresh mapped graph through a recording backend and
+    /// return `(number of resolved WAL ops, encoded frame bytes)`.
+    fn wal_cost_of_appending(n: i64) -> (usize, usize) {
+        let mut dir = new_dir_graph_in_mode(StorageMode::Mapped, None).expect("mapped graph");
+        // Wrap the mapped backend exactly as `setup_durable` does, so the
+        // capture seam under test is the real one.
+        let inner = std::mem::replace(&mut dir.graph, GraphBackend::new());
+        dir.graph = GraphBackend::Recording(Box::new(RecordingGraph::new(inner)));
+        assert!(
+            dir.graph.is_mapped(),
+            "the sweeps under test are mapped-only"
+        );
+
+        let columns = vec!["id".to_string(), "name".to_string(), "dept".to_string()];
+        let rows: Vec<Vec<Value>> = (0..n)
+            .map(|i| {
+                vec![
+                    Value::Int64(i),
+                    Value::String(format!("person-{i}")),
+                    Value::String("engineering".to_string()),
+                ]
+            })
+            .collect();
+        let df = DataFrame::from_cypher_rows(columns, rows).expect("dataframe");
+
+        add_nodes(
+            &mut dir,
+            df,
+            "Person".to_string(),
+            "id".to_string(),
+            Some("name".to_string()),
+            None,
+        )
+        .expect("add_nodes");
+
+        let raw = match &mut dir.graph {
+            GraphBackend::Recording(rg) => rg.take_ops(),
+            _ => unreachable!("wrapped in Recording above"),
+        };
+        let ops = resolve_ops(&raw, &dir.graph, &dir.interner, |idx| {
+            dir.secondary_label_names(idx)
+        });
+        let op_count = ops.len();
+
+        let mut encoded = Vec::new();
+        append_frame(&mut encoded, &WalFrame { lsn: 1, ops }).expect("frame encodes");
+        (op_count, encoded.len())
+    }
+
+    /// One op per row, at every size — the crisp form of the invariant.
+    ///
+    /// `n` spans four `LARGE_BATCH_CHUNK_SIZE` chunks, so the amplifying
+    /// shape (chunk `k` re-touching the `k * 1000` rows already present) is
+    /// exercised. Pre-fix this was 2 ops/row at 1k and 5 ops/row at 4k.
+    #[test]
+    fn add_nodes_records_exactly_one_wal_op_per_row() {
+        for n in [1000_i64, 4000] {
+            let (ops, _) = wal_cost_of_appending(n);
+            assert_eq!(
+                ops, n as usize,
+                "a {n}-row mapped append must record exactly {n} WAL ops, got {ops}; \
+                 a columnar detach/reattach sweep is recording again"
+            );
+        }
+    }
+
+    /// WAL bytes per row stay flat as the row count grows.
+    ///
+    /// The tolerance absorbs the genuine per-row growth in the encoding (id
+    /// and title widen by a byte or two as values get longer) while staying
+    /// far below the pre-fix blow-up, which was ~2.5x over this same span and
+    /// unbounded beyond it.
+    #[test]
+    fn add_nodes_wal_bytes_per_row_are_flat() {
+        let (_, small_bytes) = wal_cost_of_appending(1000);
+        let (_, large_bytes) = wal_cost_of_appending(4000);
+        let small_per_row = small_bytes as f64 / 1000.0;
+        let large_per_row = large_bytes as f64 / 4000.0;
+        let ratio = large_per_row / small_per_row;
+        assert!(
+            ratio < 1.15,
+            "WAL bytes/row must not grow with graph size: {small_per_row:.1} B/row at 1k rows \
+             vs {large_per_row:.1} B/row at 4k rows (ratio {ratio:.2}). A quadratic payload \
+             means a columnar sweep is recording one op per pre-existing node again."
+        );
     }
 }

--- a/crates/kglite/src/graph/storage/backend.rs
+++ b/crates/kglite/src/graph/storage/backend.rs
@@ -106,6 +106,19 @@ impl GraphBackend {
     /// wraps, so a durable graph participates exactly when its underlying
     /// backend would: `Recording(Memory)` journals, `Recording(Mapped)` keeps
     /// the clone. Durability and rollback strategy are independent concerns.
+    ///
+    /// **This is deliberate, and it is the only remaining veto term in
+    /// `journal_covers`** — every other term was retired as the journal grew
+    /// to cover saved, indexed and columnar graphs. The user-visible cost is
+    /// worth stating plainly, because nothing else surfaces it: every mutating
+    /// statement on a mapped or disk graph still opens an O(V+E)
+    /// `fork_transaction()` whole-graph checkpoint, which is the pre-journal
+    /// behaviour. Under the "in-memory wins" doctrine that is the right
+    /// trade — the journal exists to make the *core* product cheap, and
+    /// neither larger-than-RAM backend can express an inverse petgraph edit
+    /// today — but it does mean statement rollback cost scales with graph
+    /// size in exactly the modes chosen for large graphs. Mirrored in the
+    /// user-facing storage-mode guide (`docs/python/core-concepts.md`).
     #[inline]
     pub(crate) fn supports_undo_journal(&self) -> bool {
         match self {

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -66,7 +66,7 @@ Wikidata scale where you want the OS to page data in lazily.
 | If your graph is… | …and you want | Use | `open()` crash safety |
 |---|---|---|---|
 | Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) | Per-commit WAL, on by default |
-| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL, on by default |
+| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL on the creating `open()`; a reopened `.kgl` comes back as **memory** (see below) |
 | 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** | **No WAL** — durability is your `save()` calls |
 
 When in doubt, stay in-memory; switch only once you hit a real RAM
@@ -84,6 +84,31 @@ and bounded guarantee — the published generation always survives intact — bu
 it is *your* `save()` calls, not the engine, that decide how much a crash can
 cost. Pick `disk` for its scale, not because a graph outgrew RAM; `mapped`
 covers that case with the guarantee intact. See {doc}`guides/durable-apps`.
+
+**`storage=` selects a backend only when a graph is *created*.** The mode is
+not recorded in a saved graph, so `kglite.open(path, storage="mapped")` builds
+a mapped graph on the call that creates `path` and loads a **memory** graph on
+every call after that — a `.kgl` checkpoint always loads as `memory`, and a
+disk graph (a directory) always loads as `disk`. Rather than ignore the
+argument, `open()` raises `kglite.ArgumentError` when the requested mode disagrees with
+what the load produced; omit `storage=` to accept whatever the file provides.
+There is no saved-graph-to-mapped conversion: to get a mapped graph from data
+you have already saved, construct `KnowledgeGraph(storage="mapped")` and
+re-ingest from the original source. This matters most for benchmarks — a
+create-then-reopen script that passed `storage="mapped"` on both runs was
+previously measuring the memory backend twice.
+
+**Statement rollback is cheap only in memory mode.** One mutating Cypher
+statement is atomic: if it fails partway through, the graph is restored to its
+pre-statement state. In-memory graphs do that with an undo journal costing
+O(changes). Mapped and disk graphs cannot — neither backend can express an
+inverse edit against its mmap-columnar indexes or generation overlays — so both
+fall back to taking a **whole-graph O(V+E) checkpoint before every mutating
+statement**. This is a deliberate consequence of "in-memory wins", but it means
+per-statement write overhead grows with graph size in precisely the two modes
+you would choose for a large graph. If a mapped graph's writes feel slow
+relative to its reads, this is why; batching more work into fewer statements is
+the lever that helps.
 
 ## Return Types
 

--- a/docs/python/guides/durable-apps.md
+++ b/docs/python/guides/durable-apps.md
@@ -200,7 +200,7 @@ optimising for:
 | Every committed write to survive a hard crash | `open(path)` (the default) | One barrier per commit; reopen is O(graph) (loads the whole graph). |
 | Committed writes to survive a crashing *process*, cheaply | `open(path, durable="normal")` | No barrier per commit; an OS crash or power cut loses work since the last `save()`. Call `sync()` for a power-safe point. |
 | Maximum write throughput on rebuildable data | `open(path, durable="off")` | Nothing logged; a crash loses work since the last checkpoint. |
-| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` | Same per-commit WAL guarantee; property columns spill to mmap. |
+| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` **on the call that creates it** | Same per-commit WAL guarantee; property columns spill to mmap. A `.kgl` records no storage mode, so reopening returns a **memory** graph — pass `storage="mapped"` only when creating, or the reopen raises `kglite.ArgumentError`. See [Choosing a storage mode](../core-concepts.md#choosing-a-storage-mode). |
 | 100 M+ nodes (Wikidata-scale), cheap cold-open | `open(path, storage="disk")` | Paged mmap, lazy load; **no per-commit WAL** — durability is your `save()` calls. |
 
 The first three are **in-memory** — the whole graph lives in RAM, which is what

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -755,8 +755,24 @@ def open(
             exists, otherwise created on first ``save()`` (or immediately, for
             ``storage="disk"``, which materializes the directory).
         storage: Storage mode for a *newly created* graph (``"mapped"`` /
-            ``"disk"``); ignored when opening an existing file, which keeps the
-            mode it was saved in.
+            ``"disk"``). Opening an existing path uses the mode the load
+            produces, which is not necessarily the mode that wrote it: a
+            ``.kgl`` checkpoint records no storage mode, so it always loads as
+            ``"memory"``; a disk graph is a directory and always loads as
+            ``"disk"``. A ``storage=`` that disagrees with the loaded backend
+            raises :class:`kglite.ArgumentError` rather than being ignored, so
+            ``open(path, storage="mapped")`` yields a genuinely mapped graph
+            only on the call that *creates* the file, and says so on every call
+            after that. Omit ``storage=`` to accept whatever the file provides.
+
+            Note the durability asymmetry between the two ways to build a
+            graph, which is structural rather than incidental: ``open()``
+            attaches a WAL sidecar next to ``path`` and defaults to
+            ``durable="full"``, whereas :class:`KnowledgeGraph` takes no
+            ``durable`` argument and is never durable — it produces a detached
+            graph with no ``source_path``, so there is nowhere for a log to
+            live. ``KnowledgeGraph(storage="mapped")`` is mapped-and-unlogged;
+            ``open(new_path, storage="mapped")`` is mapped-and-logged.
         durable: Write-ahead logging — **on by default**. Each committed
             mutation is appended to a ``<path>-wal`` sidecar, and on open any
             WAL frames are replayed onto the loaded checkpoint to recover work
@@ -1229,6 +1245,22 @@ class KnowledgeGraph:
                 ``storage="disk"``. The directory IS the graph — data is
                 written directly to disk via mmap. Load with
                 ``kglite.load(path)``.
+
+        Note:
+            **This constructor is never durable, and takes no ``durable``
+            argument.** It returns a *detached* graph — no ``source_path``, so
+            a bare ``save()`` asks for an explicit path and there is nowhere
+            for a write-ahead log to live. :func:`kglite.open` is the durable
+            entry point: it binds the graph to a path and defaults to
+            ``durable="full"``. So ``KnowledgeGraph(storage="mapped")`` is
+            mapped-and-unlogged while ``kglite.open(new_path,
+            storage="mapped")`` is mapped-and-logged. The difference is
+            structural rather than a defaulting inconsistency, but it is easy
+            to trip over when comparing the two.
+
+            Note also that mutating statements on a ``"mapped"`` or ``"disk"``
+            graph do **not** use the cheap statement-rollback journal — see
+            :func:`kglite.open` and the storage-mode guide.
         """
         ...
 

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -61,19 +61,43 @@ requires_sigkill = pytest.mark.skipif(
 )
 
 
-def _open_kwargs(storage: str, durable: object = True) -> str:
-    """``kglite.open`` kwargs, as source text for a child script."""
-    parts = [f"durable={durable!r}"]
-    if storage != "memory":
-        parts.insert(0, f"storage={storage!r}")
-    return ", ".join(parts)
+# `storage=` selects a backend for a graph being *created*; an existing path is
+# loaded, and the load decides the backend. A `.kgl` checkpoint records no
+# storage mode, so a reopened one always comes back as memory — passing the mode
+# again is now an `ArgumentError` rather than being silently ignored.
+#
+# So the `[mapped]` parametrisation below means **"created mapped, recovered as
+# memory"**, and cannot mean anything else while `.kgl` carries no mode. That is
+# still a real durability test — the WAL frames under replay were written by a
+# mapped graph — but it does not exercise recovery *into* the mapped backend,
+# and before the kwarg was gated it silently claimed to.
+
+
+def _open_body(storage: str, durable: object = True) -> str:
+    """Source text for a child script's `open_durable()`.
+
+    Emitted as a runtime check rather than a fixed kwarg string because a child
+    may call `open_durable()` more than once — creating the graph on the first
+    call and reopening it after a checkpoint on later ones.
+    """
+    mode = "None" if storage == "memory" else repr(storage)
+    return textwrap.dedent(
+        f"""
+        def open_durable():
+            kwargs = {{"durable": {durable!r}}}
+            storage = {mode}
+            if storage is not None and not os.path.exists(path):
+                kwargs["storage"] = storage
+            return kglite.open(path, **kwargs)
+        """
+    ).strip()
 
 
 def _open(path, storage: str = "memory", durable: object = True):
     """Open *path* in *storage* mode at durability level *durable*
     (parent-side counterpart)."""
     kwargs = {"durable": durable}
-    if storage != "memory":
+    if storage != "memory" and not os.path.exists(str(path)):
         kwargs["storage"] = storage
     return kglite.open(str(path), **kwargs)
 
@@ -84,8 +108,7 @@ def _child_script(tmp_path, body: str, storage: str, ending: str, durable: objec
         import kglite, os, signal
         path = {str(tmp_path / "app.kgl")!r}
 
-        def open_durable():
-            return kglite.open(path, {_open_kwargs(storage, durable)})
+        {textwrap.indent(_open_body(storage, durable), "        ").strip()}
 
         {textwrap.indent(textwrap.dedent(body), "        ").strip()}
         {ending}

--- a/tests/test_open_storage_kwarg.py
+++ b/tests/test_open_storage_kwarg.py
@@ -1,0 +1,117 @@
+"""`kglite.open(..., storage=...)` must never be silently ignored.
+
+`storage=` picks a backend for a graph being *created*. An existing path is
+loaded instead, and the load decides the backend: a `.kgl` checkpoint records
+no storage mode, so it always comes back as memory. Before this was gated, the
+argument was simply dropped on the existing-file branch — so a
+create-then-reopen script asking for ``storage="mapped"`` got a mapped graph on
+run 1 and a memory graph on every run after, with nothing said. That silently
+invalidated a published mapped-vs-memory comparison in which both arms were
+unknowingly measuring the memory backend.
+
+These tests pin the contract that replaced the silence: agreeing modes pass,
+disagreeing modes raise, and an unknown mode is rejected on both branches.
+"""
+
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+
+def _seed(path):
+    """Create a graph at ``path`` in mapped mode and leave it on disk."""
+    with kglite.open(str(path), storage="mapped") as g:
+        g.cypher("CREATE (:Person {name: 'Alice'})")
+    return path
+
+
+class TestStorageKwargOnExistingPath:
+    def test_creating_call_accepts_mapped(self, tmp_path):
+        """The call that *creates* the file honours the mode, as documented."""
+        target = tmp_path / "fresh.kgl"
+        with kglite.open(str(target), storage="mapped") as g:
+            g.cypher("CREATE (:Person {name: 'Alice'})")
+        assert target.exists()
+
+    def test_reopen_with_mapped_raises_instead_of_downgrading(self, tmp_path):
+        """The regression: reopening used to hand back memory in silence."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError) as excinfo:
+            kglite.open(str(target), storage="mapped")
+
+        message = str(excinfo.value)
+        # The error must name what was asked for, what actually happened, and
+        # a way forward — a bare "invalid argument" would not have prevented
+        # the benchmark mix-up this guards against.
+        assert "mapped" in message
+        assert "memory" in message
+        assert "KnowledgeGraph(storage=" in message
+
+    def test_reopen_without_storage_still_works(self, tmp_path):
+        """No new failure mode for callers who never passed `storage=`."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target)) as g:
+            assert g.cypher("MATCH (n:Person) RETURN n.name").to_list() == [{"n.name": "Alice"}]
+
+    def test_reopen_with_agreeing_mode_is_accepted(self, tmp_path):
+        """`storage="memory"` matches what a `.kgl` load produces, so it passes."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target), storage="memory") as g:
+            assert g.select("Person").len() == 1
+
+    def test_default_alias_agrees_with_a_loaded_kgl(self, tmp_path):
+        """`"default"` is a documented alias of `"memory"` and must behave alike."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target), storage="default") as g:
+            assert g.select("Person").len() == 1
+
+    def test_unknown_mode_rejected_on_the_existing_path_too(self, tmp_path):
+        """Validation used to happen only inside the create branch."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError, match="Unknown storage mode"):
+            kglite.open(str(target), storage="banana")
+
+    def test_unknown_mode_still_rejected_on_the_creating_path(self, tmp_path):
+        with pytest.raises(kglite.ArgumentError, match="Unknown storage mode"):
+            kglite.open(str(tmp_path / "nope.kgl"), storage="banana")
+
+    def test_refusal_does_not_strand_the_writer_lease(self, tmp_path):
+        """A refused open must release the lock it took before loading.
+
+        `open()` acquires the single-writer lease *before* reading a byte, so
+        an error raised after the load has to leave the path openable. If it
+        did not, one typo would lock the graph out for the process lifetime.
+        """
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError):
+            kglite.open(str(target), storage="mapped")
+
+        with kglite.open(str(target)) as g:
+            assert g.select("Person").len() == 1
+
+
+class TestConstructorIsUnaffected:
+    """The constructor always creates, so it always honours the mode."""
+
+    def test_mapped_constructor_still_works(self):
+        g = KnowledgeGraph(storage="mapped")
+        g.cypher("CREATE (:Person {name: 'Bob'})")
+        assert g.select("Person").len() == 1
+
+    def test_constructor_takes_no_durable_argument(self):
+        """Pins the documented asymmetry: only `open()` is durable.
+
+        `KnowledgeGraph(...)` returns a detached graph with no `source_path`,
+        so there is nowhere for a write-ahead log to live. This is structural,
+        not an oversight, and both docstrings say so — a `durable=` here must
+        stay a `TypeError` rather than quietly doing nothing.
+        """
+        with pytest.raises(TypeError):
+            KnowledgeGraph(storage="mapped", durable=True)


### PR DESCRIPTION
## `add_nodes` WAL payload was quadratic — two-line fix

`Batch::detach_columnar_stores` / `reattach_columnar_stores` iterated every existing node of the type calling the **recorded** `node_weight_mut`, pushing a `RawOp::UpsertNode` per call carrying the node's whole property map. At `LARGE_BATCH_CHUNK_SIZE = 1000` that is ≈`n²/1000` ops. Measured: `payload ≈ 0.1496·n²` bytes, exponent **2.00** twice, overflowing a per-call 4 GiB ceiling; wall time approached 4× per doubling (2,572 → 637,835 µs, 1k → 32k).

Both sweeps now use `node_weight_mut_silent`, which exists for exactly this and is documented as *"internal bookkeeping (columnar handle refresh), not a logical mutation."*

**Soundness turned out stronger than expected.** The worry was PR #88's finding that `_silent` was silent only towards the WAL and still captured undo. That premise doesn't apply here: both sweeps run only under `is_mapped() || is_disk()`, and `undo_journal_mut` returns `None` for Mapped and Disk — **no journal is ever installed on this path**, before or after #88. No analogue of #88's hidden `stale_unique_indices` obligation exists. The argument is recorded in the code so a future rebase needn't re-derive it.

**Guard is deterministic byte counts, not timings** — exactly one WAL op per row, and flat bytes/row across 1k vs 4k. **Verified to fail without the fix:** 2,000 ops for 1,000 rows, and 84 → 213 B/row (ratio 2.54).

## `storage=` was silently ignored on open — now refused

`storage="mapped"` was ignored when opening an existing file, because `impl Deserialize for GraphBackend` always yields `Memory`. You asked for mapped, got memory, and nothing said so.

**Chosen: refuse, not honour.** Honouring needs a post-load Memory→Mapped swap *plus* persisting the mode — and `.kgl` stores no mode at all (no discriminant in `Serialize`, no field in `FileMetadata`). It would also silently opt callers into mapped mode's whole-graph rollback checkpoint. `open()` now parses the mode on both branches and raises `kglite.ArgumentError` when it disagrees with the loaded backend; agreeing modes still pass, so `storage="disk"` on a disk directory is unaffected.

⚠️ **This is a deliberate break** for `open(path, storage="mapped")` in create-then-reopen scripts — a workflow the CHANGELOG once advertised. It converts a silent wrong result into a hard error. For a database that is the right trade: a user who believed they had mapped mode has been running memory all along and should find out.

**It immediately flushed out a live instance in this repo:** `test_durability.py`'s five `[mapped]` cases reopened with `storage="mapped"` and were **recovering as memory** — so they were not testing what their id said. Helpers now pass the mode only on the creating call, with the residual gap named in the file.

The `open()` vs `KnowledgeGraph()` durability asymmetry is **documented, not unified** — it is structural: the constructor returns a *detached* graph with no `source_path`, so there is nowhere for a log to live.

`supports_undo_journal() == false` for Mapped/Disk was **left alone** — the evidence says deliberate, and `backend.rs:100-109` already carried a good "why". What was missing was the user-visible *cost*, now added there and in `docs/python/core-concepts.md`.

## Verified

`cargo test -p kglite` 1302 pass; clippy `-D warnings` (kglite + kglite-py); source-quality, lint-allowances, api-chokepoint, docs-facts, ruff — all **per commit** via `rebase --exec`. Broad Python sweep 3378 passed. Debug extension throughout; no timings taken.

**Surfaced, not fixed:** `.kgl` cannot round-trip a storage mode (the real fix for the above), and there is no saved-graph→mapped conversion — `enable_disk_mode()` has no mapped analogue, so mapped graphs must be rebuilt from source. That is a capability gap, not a docs issue.

No version bump; entries under `[Unreleased]`.