### PR TITLE
Release candidate: merge #90, #91, #92, #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `SET` on a saved graph no longer costs one node copy per node of the
+  type.** Writing a single property to a type with N nodes journalled N
+  `NodeData` pre-images rather than one, making a one-row `SET` on a saved
+  100k-node graph measurably *slower* (~1.8×) than the whole-graph clone the
+  undo journal replaced. The cause is the end-of-statement sweep that
+  re-points every node's shared column-store handle after a columnar write
+  forks the master: that sweep is bookkeeping rather than a logical mutation,
+  but it ran through the recorded write path and so captured an undo pre-image
+  for each node it touched. The sweep's inverse is now journalled once per
+  node type — the pre-statement master handle, no store copy — so the cost of
+  a `SET` again scales with the number of rows it changes. `CREATE` and
+  indexed-write throughput are unaffected, and rollback fidelity is unchanged:
+  a failed statement still restores the master store, every node's handle, and
+  any unique claims the write moved.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`lock_schema()` now catches a typo'd node label in a query, not just in a
+  write.** `MATCH (i:Isue) RETURN i` used to return `[]` with no error even on
+  a locked schema, while the equivalent property typo —
+  `MATCH (i:Issue {titel: 1})` — was rejected with a message naming the
+  mistake and listing the valid properties. That asymmetry was the bug: an
+  empty result set reads as *"no matching data"* rather than *"you made a
+  mistake"*, so a typo'd label survives code review and reaches production
+  looking like a legitimate empty state, whereas a wrong property value is at
+  least visibly wrong at the point of use. A locked schema now rejects an
+  unknown label with the same shape of message the unknown-property path has
+  always produced, and the same wording the `CREATE` write path has always
+  used:
+
+  ```text
+  Schema error: Unknown node type 'Isue'. Did you mean 'Issue'?
+    Valid types: Issue, Person
+  ```
+
+  It is raised as `kglite.SchemaError` (`.code == "Schema"`) from every clause
+  that can carry a label — `MATCH`, `OPTIONAL MATCH`, `MERGE`, multi-label
+  patterns like `(n:A:B)`, `WHERE EXISTS { … }` pattern predicates, `CALL { … }`
+  subqueries, and `UNION` branches.
+
+  **The schemaless default is unchanged.** kglite is open-schema by design, so
+  on an unlocked graph an unknown label still matches nothing without error —
+  the zero-row existence-check idiom stays valid, and the existing non-fatal
+  `warning:` on stderr is still how the typo is surfaced there. Labels applied
+  via `add_label` count as known, and creating a genuinely new label on an
+  unlocked graph is unaffected. Relationship types are deliberately still not
+  rejected: only the node-label gap was asymmetric with properties.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`REMOVE` on a columnar node no longer leaves the property in the graph's
+  master column store, where a later write brought it back.** Each node of a
+  columnar type holds its own `Arc<ColumnStore>` handle and the graph holds the
+  master. `REMOVE` wrote through the node's handle, and `Arc::make_mut` forks
+  it — so the node stopped reporting the property while the master kept it. The
+  next `SET` on that type re-pointed every node's handle at the master and the
+  removed property reappeared, with no `save()` involved. `REMOVE` now clears
+  through the master, the same chokepoint `SET` already used. This also removes
+  a full `ColumnStore` clone per node removed, so `REMOVE` over R rows of a
+  type with N nodes is no longer O(R × N).
+
 - **Deleting a node no longer costs a full rebuild of its type's id index.**
   `DELETE` dropped the whole `id_indices` entry for every affected node type,
   so the next `MATCH (n {id: …})` rebuilt the map by scanning every node of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`add_nodes()` on a durable mapped or disk graph no longer writes a
+  quadratic write-ahead-log payload.** Appending rows to a columnar graph
+  detaches every existing node of the type from its shared column store and
+  re-attaches it afterwards — pure internal bookkeeping, but it ran through the
+  *recorded* mutation seam, so each sweep logged one full property-map copy per
+  pre-existing node. Because the append is chunked, an `n`-row call re-logged
+  the whole type once per chunk: WAL bytes grew as `n²`, and a large enough
+  single call could exceed the 4 GiB per-frame ceiling. Both sweeps now use the
+  silent borrow that the columnar `SET` handle-refresh already used, so the log
+  records exactly one op per row written. Measured on the regression fixture: a
+  1,000-row append logged 2,000 ops (84 B/row) and a 4,000-row append 20,000
+  ops (213 B/row); both now log one op per row at a flat byte cost. No
+  behavioural change to the graph itself or to log replay — the ops removed
+  were byte-identical restatements of nodes the sweep had not modified.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deleting a node no longer costs a full rebuild of its type's id index.**
+  `DELETE` dropped the whole `id_indices` entry for every affected node type,
+  so the next `MATCH (n {id: …})` rebuilt the map by scanning every node of
+  that type — one node-weight read and `Value` clone each. A single-node
+  delete was therefore O(nodes of that type), while the create path had
+  already been maintaining the same index incrementally. Deletes now evict
+  just the removed ids in place. Types with duplicate ids still fall back to
+  the full rebuild, since only a rebuild can surface a duplicate that the
+  index had shadowed; that case is detected in O(1) by comparing the index
+  length against the type's live node count. Statement rollback is unchanged
+  — it invalidates whole types by design, on the already-failed path.
+
 - **`save()` now barriers the write-ahead log before writing its
   checkpoint.** A checkpoint truncates the log, and recovery folds the
   surviving frames into net per-entity state. Previously the log was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — behaviour
 
+- **Documented: mapped and disk graphs take the whole-graph checkpoint path for
+  statement rollback.** No behaviour change — this is long-standing and
+  deliberate, but it was recorded nowhere a user would look. One mutating
+  Cypher statement is atomic; in-memory graphs deliver that with an undo
+  journal costing O(changes), while mapped and disk graphs cannot express an
+  inverse edit against their mmap-columnar indexes or generation overlays and
+  so fall back to an O(V+E) whole-graph checkpoint before *every* mutating
+  statement. This follows from "in-memory wins", but it means per-statement
+  write overhead scales with graph size in precisely the two modes chosen for
+  large graphs. Now stated in the storage-mode guide, the `KnowledgeGraph`
+  constructor docstring, and at the engine decision point.
+
+- **Documented: the `KnowledgeGraph(...)` constructor is never durable.** It
+  takes no `durable` argument and returns a detached graph with no
+  `source_path`, so there is nowhere for a write-ahead log to live, whereas
+  `kglite.open()` defaults to `durable="full"`. The asymmetry is structural
+  rather than a defaulting inconsistency, but it is easy to trip over when
+  comparing `KnowledgeGraph(storage="mapped")` against
+  `kglite.open(path, storage="mapped")`; both call sites now say so.
+
 - **`define_schema()` now merges per node/connection type instead of replacing
   the whole schema.** A type the call names takes the new declaration entire; a
   type it does not name keeps the declaration it already had. Previously any
@@ -520,6 +540,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour.
 
 ### Fixed
+
+- **`kglite.open(path, storage=...)` no longer ignores the mode when the path
+  already exists.** `storage=` selects a backend for a graph being *created*;
+  an existing path is loaded, and the load decides the backend. Because a
+  `.kgl` checkpoint records no storage mode, a reopened one always comes back
+  as memory — so `open(path, storage="mapped")` produced a genuinely mapped
+  graph on the call that created the file and a silently memory-backed one on
+  every call after that, with nothing reported. An unknown mode such as
+  `storage="banana"` was not even validated on that branch. Both now raise
+  `kglite.ArgumentError`, naming the mode requested, the mode actually
+  produced, and the way forward. This is a deliberate break: the previous
+  behaviour was indistinguishable from success and had already invalidated a
+  mapped-vs-memory comparison in which both arms unknowingly ran on memory.
+  Callers who want whatever the file provides should omit `storage=`. Note
+  there is no saved-graph-to-mapped conversion — a mapped graph has to be
+  built with `KnowledgeGraph(storage="mapped")` and populated from source.
 
 - **`add_nodes()` on a durable mapped or disk graph no longer writes a
   quadratic write-ahead-log payload.** Appending rows to a columnar graph

--- a/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_mutation.rs
@@ -957,6 +957,16 @@ fn build_extend_report_dict<'py>(
 
 #[pymethods]
 impl KnowledgeGraph {
+    /// Create an empty graph in the given storage mode.
+    ///
+    /// **Never durable, and there is deliberately no `durable` argument.**
+    /// This produces a *detached* graph — `GraphLifecycle::detached()`, so no
+    /// `source_path` and nowhere for a write-ahead log to live. `kglite.open`
+    /// is the durable entry point: it binds the graph to a path and defaults
+    /// to `DurabilityLevel::Full`. The asymmetry is structural, not a
+    /// defaulting inconsistency, but it means `KnowledgeGraph(storage=
+    /// "mapped")` and `kglite.open(new_path, storage="mapped")` differ in
+    /// whether every commit is logged — worth knowing before comparing them.
     #[new]
     #[pyo3(signature = (*, storage=None, path=None))]
     fn new(storage: Option<&str>, path: Option<&str>) -> PyResult<Self> {

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -261,8 +261,24 @@ fn from_bytes(py: Python<'_>, data: &[u8]) -> PyResult<KnowledgeGraph> {
 /// bare `save()` (or the context-manager auto-save-on-close) writes back to
 /// it without re-specifying the target.
 ///
-/// `storage` (`"mapped"` / `"disk"`) applies only when *creating* a new
-/// graph; opening an existing file uses whatever mode it was saved in.
+/// `storage` (`"mapped"` / `"disk"`) applies only when *creating* a new graph.
+/// Opening an existing path uses the mode the load produces, which is not
+/// necessarily the mode that wrote it: a `.kgl` checkpoint records no storage
+/// mode, so it always loads as `"memory"`, while a disk graph is a directory
+/// and always loads as `"disk"`. Passing a `storage=` that disagrees with the
+/// loaded backend raises `kglite.ArgumentError` rather than being ignored — a
+/// silently-downgraded mode is indistinguishable from success, and in
+/// particular `open(path, storage="mapped")` gives a genuinely mapped graph
+/// only on the call that *creates* the file.
+///
+/// **Durability differs between the two ways to build a graph, and the
+/// difference is structural.** `kglite.open()` attaches a WAL sidecar next to
+/// `path` and defaults to `durable="full"`. The `KnowledgeGraph(...)`
+/// constructor has no `durable` argument at all and is never durable: it
+/// produces a *detached* graph with no `source_path`, so there is no location
+/// for a log to live. `KnowledgeGraph(storage="mapped")` is therefore
+/// mapped-and-unlogged, while `open(path, storage="mapped")` on a fresh path is
+/// mapped-and-logged.
 ///
 /// The `durable=` argument: a level name, a bool, or `None`.
 ///
@@ -394,13 +410,55 @@ fn open(
         None
     };
 
-    let mut kg = if std::path::Path::new(&path).exists() {
+    // Parse the mode up front, on *both* branches. Validating it only inside
+    // `construct` meant an unknown spelling was silently accepted whenever the
+    // path happened to exist already.
+    let requested_mode = storage
+        .map(|mode_str| {
+            kglite_core::api::storage::StorageMode::parse(mode_str)
+                .map_err(|e| crate::error_py::kg_to_pyerr(crate::error::KgError::Argument(e)))
+        })
+        .transpose()?;
+
+    let existed = std::path::Path::new(&path).exists();
+    let mut kg = if existed {
         py.detach(|| load_file(&path))
             .map(KnowledgeGraph::from_arc)
             .map_err(|e| load_err_to_pyerr(e, Some(&path)))?
     } else {
         KnowledgeGraph::construct(storage, Some(&path))?
     };
+    // An existing path is *loaded*, and the load decides the backend — so a
+    // `storage=` that disagrees with what came back cannot be honoured. Refuse
+    // instead of ignoring it: silently handing back a different mode than the
+    // caller asked for is indistinguishable from success, and has already
+    // invalidated at least one mapped-vs-memory comparison where both arms
+    // unknowingly ran on the memory backend.
+    if existed {
+        if let Some(requested) = requested_mode {
+            let actual = actual_storage_mode(&kg);
+            if requested != actual {
+                // `ArgumentError`, matching `KnowledgeGraph(storage="invalid")`
+                // and the parse failure above — one error class for one kwarg.
+                // (The neighbouring disk-plus-`durable` refusal raises
+                // `ValueError`; that is about `durable=`, not about this.)
+                let message = format!(
+                    "cannot open existing graph {path:?} with storage={:?}: it loaded as {:?}. \
+                     `storage=` selects a backend for a graph being *created*; an existing \
+                     path is loaded, and the load decides the backend. A `.kgl` checkpoint \
+                     does not record which mode wrote it, so loading one always yields \
+                     'memory'; a disk graph is a directory and always yields 'disk'. {} \
+                     To accept whatever the file provides, omit `storage=`.",
+                    requested.as_str(),
+                    actual.as_str(),
+                    storage_mode_remedy(requested),
+                );
+                return Err(crate::error_py::kg_to_pyerr(
+                    crate::error::KgError::Argument(message),
+                ));
+            }
+        }
+    }
     kg.lifecycle.source_path = Some(std::path::PathBuf::from(&path));
     kg.lifecycle.writer_lease = writer_lease;
     // Resolved after the graph exists, because the mode of an *existing* path
@@ -417,6 +475,46 @@ fn open(
         setup_durable(&mut kg, &path, level)?;
     }
     Ok(kg)
+}
+
+/// The storage mode `kg` actually ended up in, for comparison against a
+/// caller's `storage=` request.
+fn actual_storage_mode(kg: &KnowledgeGraph) -> kglite_core::api::storage::StorageMode {
+    use kglite_core::api::storage::StorageMode;
+    use kglite_core::api::GraphRead;
+    if kg.inner.graph.is_disk() {
+        StorageMode::Disk
+    } else if kg.inner.graph.is_mapped() {
+        StorageMode::Mapped
+    } else {
+        StorageMode::Memory
+    }
+}
+
+/// The actionable half of the "mode cannot be honoured on open" error: what to
+/// do instead, per requested mode.
+///
+/// `mapped` is the blunt one. There is no load-into-an-existing-graph call and
+/// no saved-graph-to-mapped conversion, so the only route is to build a mapped
+/// graph and re-ingest from the original source data. That is worth saying
+/// plainly rather than implying a conversion exists.
+fn storage_mode_remedy(requested: kglite_core::api::storage::StorageMode) -> &'static str {
+    use kglite_core::api::storage::StorageMode;
+    match requested {
+        StorageMode::Mapped => {
+            "Mapped mode cannot be recovered from a saved graph: build one with \
+             `kglite.KnowledgeGraph(storage=\"mapped\")` and re-ingest from your source data, \
+             or delete the path and let this call create it."
+        }
+        StorageMode::Disk => {
+            "To move a loaded graph onto disk storage, call `g.enable_disk_mode()` after \
+             opening it, or delete the path and let this call create it."
+        }
+        StorageMode::Memory => {
+            "To get a memory-backed graph, open a `.kgl` file rather than a disk-graph \
+             directory."
+        }
+    }
 }
 
 /// Turn `kg` into a durable graph: replay any WAL frames committed since

--- a/crates/kglite/src/error.rs
+++ b/crates/kglite/src/error.rs
@@ -297,7 +297,8 @@ pub enum KgError {
     Cancelled,
 
     // ── Schema / validation ──────────────────────────────────────────
-    /// Query validation failure (unknown property or undefined variable).
+    /// Query validation failure (unknown property, unknown node type under
+    /// a locked schema, or undefined variable).
     /// Bridged from
     /// [`SchemaError`](crate::graph::languages::cypher::planner::schema_check::SchemaError)
     /// via `From`.
@@ -433,6 +434,7 @@ pub enum KgError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaErrorKindRepr {
     UnknownProperty,
+    UnknownNodeType,
     UndefinedVariable,
 }
 
@@ -445,6 +447,7 @@ impl From<crate::graph::languages::cypher::planner::schema_check::SchemaErrorKin
         use crate::graph::languages::cypher::planner::schema_check::SchemaErrorKind;
         match value {
             SchemaErrorKind::UnknownProperty => SchemaErrorKindRepr::UnknownProperty,
+            SchemaErrorKind::UnknownNodeType => SchemaErrorKindRepr::UnknownNodeType,
             SchemaErrorKind::UndefinedVariable => SchemaErrorKindRepr::UndefinedVariable,
         }
     }

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -308,10 +308,12 @@ impl DirGraph {
 /// fields that are rebuilt instead of journal-reversed.
 #[derive(Default)]
 struct ReplayFallout {
-    /// Node types whose id-index the replay perturbed. `IdIndexStore` has no
-    /// per-entry removal, and its read path self-heals via `lookup_or_build`,
-    /// so whole-type invalidation is both the cheapest correct move and
-    /// exactly what the delete path already does.
+    /// Node types whose id-index the replay perturbed. Whole-type
+    /// invalidation, not the per-entry `evict_entries` the delete path uses:
+    /// a replay restores and removes nodes in the same pass, so the surviving
+    /// set is not known per entry, and the read path self-heals via
+    /// `lookup_or_build` anyway. This runs only after a statement has already
+    /// failed, so the rebuild lands on the rare path.
     stale_id_indices: HashSet<String>,
     /// Node types whose unique-occupancy maps must be recomputed from the
     /// restored data. Wider than `stale_id_indices`: a plain property

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -52,38 +52,45 @@
 //! explicit addition to [`swap_data_scale`] can introduce a correctness gap,
 //! and that is a change a reviewer is looking straight at.
 //!
-//! ## Columnar mode rides on the unparked half
+//! ## Columnar mode: master from the shell, node handles from the journal
 //!
 //! `column_stores` — the per-type master `Arc<ColumnStore>` map that `save()`
-//! installs via `enable_columnar` — is deliberately **not** parked, and that
-//! is the whole of its undo story. The shell clone captures one pre-statement
-//! `Arc` handle per type and `restore_schema_shell` reinstalls it verbatim.
-//! What makes that sufficient rather than merely hopeful:
+//! installs via `enable_columnar` — is deliberately **not** parked, so the
+//! shell clone captures one pre-statement `Arc` handle per type and
+//! `restore_schema_shell` reinstalls it verbatim. That covers the master.
+//! The other half is per-node: every node of a columnar type holds its own
+//! `Arc` clone of the store, and `execute_set`'s fast path re-points all of
+//! them at the fork its write created. That sweep is journalled as a single
+//! [`UndoEntry::ColumnarHandles`] per type, whose replay re-points them back.
+//!
+//! What makes the pair sufficient rather than merely hopeful:
 //!
 //! - `ColumnStore` has no interior mutability, and the only in-statement
-//!   writer of a master store is `execute_set`'s columnar fast path, which
-//!   goes through `Arc::make_mut`. The shell's handle keeps the refcount above
-//!   one for the whole statement, so `make_mut` provably copies-on-write and
-//!   the shell's store is never mutated in place.
-//! - Every node of a columnar type holds its own `Arc` clone of the store, so
-//!   the post-`make_mut` handle-refresh sweep re-points them all. That sweep
-//!   runs through `node_weight_mut_silent`, which is silent only towards the
-//!   WAL recorder — `MemoryGraph` does not override it, so each re-pointed
-//!   node's pre-statement `NodeData` (old handle and row id included) lands in
-//!   the journal as a `NodeWeight` entry.
+//!   writer of a master store is that fast path, which goes through
+//!   `Arc::make_mut`. The refcount is above one before any checkpoint exists —
+//!   every node of the type holds a handle — so `make_mut` copies on write and
+//!   the pre-statement store is never mutated in place. **The shell's handle
+//!   is not what forces that copy**, so dropping it would buy nothing; see
+//!   `every_node_shares_the_master_column_store_handle` in `rollback_tests`.
 //! - `CREATE` and `DELETE` never reach a master store in memory mode: the
 //!   in-memory insert branch always builds a `Compact` node, and node removal
 //!   is a plain backend edit. Every other writer of `column_stores`
 //!   (`enable_columnar`, `disable_columnar`, `vacuum`, the spill and bulk-batch
 //!   paths, disk sync) runs outside the statement window.
 //!
-//! So a columnar graph is restored on both halves — master by verbatim shell
-//! restore, per-node handles by the journal — and needs no veto. The one cost
-//! to know about: because the refresh sweep touches every node of the type, a
-//! columnar `SET` journals one `NodeData` pre-image per node of that type
-//! rather than per row written. That is O(type), not O(changes) — still
-//! strictly cheaper than the O(V+E) fork it replaces, and it is the sweep's
-//! own cost that dominates either way.
+//! The per-type entry is load-bearing for *cost*, not just tidiness. The sweep
+//! touches every node of the type, so routing it through the ordinary weight
+//! seam made a one-row `SET` clone a `NodeData` per node of the type — O(type)
+//! per write, and measured at ~1.8× the whole-graph clone it was supposed to
+//! replace on a 100k-node graph. `MemoryGraph::node_weight_mut_silent`
+//! therefore skips undo capture as well as WAL capture, and
+//! `a_columnar_set_journals_one_pre_image_per_changed_node` pins it.
+//!
+//! One consequence to keep in view when touching this path: a columnar `SET`
+//! writes into the master, never into a node's weight, so it produces **no**
+//! `NodeWeight` entry for the node it changed. `ColumnarHandles` is the only
+//! entry that knows the type was written at all, which is why its replay is
+//! what reports the type into `stale_unique_indices`.
 //!
 //! ## When the journal is not used
 //!
@@ -105,6 +112,7 @@
 //! next insert reuses the slot.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::NodeIndex;
 
@@ -503,6 +511,44 @@ fn apply(graph: &mut DirGraph, entry: UndoEntry, fallout: &mut ReplayFallout) {
         },
         UndoEntry::TimeseriesRemoved { node, prior } => {
             graph.timeseries_store.insert(node, *prior);
+        }
+        UndoEntry::ColumnarHandles { node_type, prior } => {
+            // The master half of the restore belongs to the shell —
+            // `column_stores` is not parked, so `restore_schema_shell` puts
+            // the pre-statement `Arc` back into the map. What the shell
+            // cannot reach is the copy of that handle each node of the type
+            // holds; the refresh sweep moved every one of them to the fork.
+            //
+            // Reading the membership from `type_indices` is correct because
+            // this entry was captured at the statement's *first* columnar
+            // write, so it replays near the end — after the bucket entries
+            // have already restored `type_indices` to its pre-statement
+            // contents. Nodes the statement created are gone by now, and
+            // nodes it deleted are back holding their own pre-image handles;
+            // re-pointing those again is a no-op.
+            let members: Vec<NodeIndex> = graph
+                .type_indices
+                .get(&node_type)
+                .map(|members| members.iter().collect())
+                .unwrap_or_default();
+            for idx in members {
+                if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
+                    if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
+                        &mut node.properties
+                    {
+                        *store = Arc::clone(&prior);
+                    }
+                }
+            }
+            // A columnar `SET` lands in the master store, not in any node's
+            // weight, so it produces no `NodeWeight` entry for the node it
+            // changed — this entry is the only signal that a value under a
+            // declared unique constraint may have moved. Without it a failed
+            // columnar `SET` would leave the claim it took behind (a phantom
+            // occupant) or the claim it released free (a real duplicate
+            // admitted), which is exactly the failure mode `swap_data_scale`
+            // warns about for the parked `unique_indices`.
+            fallout.stale_unique_indices.insert(node_type);
         }
     }
 }

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -747,6 +747,134 @@ fn the_columnar_fixture_writes_through_the_master_store() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Columnar SET cost: O(changes), not O(type)
+// ─────────────────────────────────────────────────────────────────────
+
+/// How many `Item` nodes [`wide_columnar`] seeds.
+///
+/// Large enough that an O(type) capture is unmistakable next to the single
+/// node a one-row `SET` actually changes, small enough to stay a unit test.
+const WIDE_ITEMS: usize = 200;
+
+/// A saved graph with many nodes of one type — the shape that separates
+/// "captures per node changed" from "captures per node of the type".
+///
+/// The narrow fixtures cannot do this: `seeded_columnar()` holds three
+/// `Item`s, so a per-node sweep and a per-change capture differ by two
+/// entries and any threshold that catches the difference is indistinguishable
+/// from noise.
+fn wide_columnar() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let rows: Vec<String> = (0..WIDE_ITEMS)
+        .map(|i| format!("(:Item {{id: {i}, name: 'n{i}', qty: {i}}})"))
+        .collect();
+    run(&mut graph, &format!("CREATE {}", rows.join(", ")));
+    graph.enable_columnar();
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the fixture must own a master column store, or this test is vacuous"
+    );
+    graph
+}
+
+/// A one-row columnar `SET` must journal a pre-image for the node it changed,
+/// not for every node of the type.
+///
+/// This is the guard for the cost regression the post-merge benchmark caught:
+/// `MATCH (i:Item {id: …}) SET i.priority = …` on a saved 100k-node graph ran
+/// ~1.8× slower than the whole-graph clone it replaced. The mechanism is the
+/// end-of-batch handle-refresh sweep in `execute_set`, which re-points every
+/// node's `Arc<ColumnStore>` at the forked master. That sweep goes through
+/// `node_weight_mut_silent` — silent towards the WAL recorder, but until this
+/// guard existed it fell through to the *recorded* `node_weight_mut` on
+/// `MemoryGraph`, so a single-property write cloned a `NodeData` per node of
+/// the type into the journal.
+///
+/// Why the existing guards cannot see it: `journalled_statements_copy_zero_nodes`
+/// reads `BACKEND_CLONE_NODES`, which counts backend clones only — the journal
+/// path deliberately clones no backend, so the counter reads zero whether the
+/// journal captured one pre-image or two hundred. The cost lives entirely
+/// inside the journal, so the counter has to as well.
+#[test]
+fn a_columnar_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row columnar SET captured {captured} node pre-images across \
+         {WIDE_ITEMS} nodes of the type; it must be O(nodes changed), not \
+         O(nodes of the type) — the handle-refresh sweep is being journalled"
+    );
+}
+
+/// The same statement on a *plain* (never-saved) graph, as the control.
+///
+/// Pins that the bound above is a property of the columnar path rather than of
+/// this fixture's size: if the plain path ever started capturing per type, the
+/// columnar assertion alone would not say which layer regressed.
+#[test]
+fn a_plain_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar();
+    graph.disable_columnar();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row SET on a non-columnar graph captured {captured} node \
+         pre-images across {WIDE_ITEMS} nodes"
+    );
+}
+
+/// Why the checkpoint's second `Arc` on the master is *not* what makes the
+/// columnar fast path fork the store.
+///
+/// The natural reading of `Arc::make_mut(master)` forking is that something
+/// else holds a handle, and the statement checkpoint's schema shell does hold
+/// one. It is not the cause and removing it would not help: `enable_columnar`
+/// points every node of the type at the master, so its strong count is
+/// `1 + nodes-of-type` before any checkpoint is opened, and the first write of
+/// every statement forks regardless. Pinned here because "drop the shell's
+/// handle to stop the fork" is a plausible-sounding fix that would trade the
+/// rollback guarantee for nothing.
+#[test]
+fn every_node_shares_the_master_column_store_handle() {
+    let graph = wide_columnar();
+    let master = graph
+        .column_stores
+        .get("Item")
+        .expect("the fixture installs a master store for Item");
+
+    assert!(
+        Arc::strong_count(master) > 1,
+        "the master must be shared with the per-node handles; if it were not, \
+         the columnar fast path would mutate in place and need no refresh sweep"
+    );
+    let sharing = graph
+        .graph
+        .node_indices()
+        .filter(
+            |idx| match graph.graph.node_weight(*idx).map(|n| &n.properties) {
+                Some(PropertyStorage::Columnar { store, .. }) => Arc::ptr_eq(store, master),
+                _ => false,
+            },
+        )
+        .count();
+    assert_eq!(
+        sharing, WIDE_ITEMS,
+        "every node of the type must hold its own handle on the master"
+    );
+}
+
 /// An indexed graph rolls back through the journal, not through a whole-graph
 /// clone. The fidelity half is covered by the `indexed` arm of every shape
 /// above; what this pins is the *cost* half — that a user index no longer
@@ -885,6 +1013,71 @@ fn seeded_with_unique_name() -> DirGraph {
          would exercise the clone checkpoint instead of the journal"
     );
     graph
+}
+
+/// `seeded()` with a UNIQUE constraint over `Item.qty`, then saved.
+///
+/// `qty` rather than `name` because the columnar fast path deliberately skips
+/// `name`/`title` (they fall through to the inline node setter), so a
+/// constraint over `name` would exercise the ordinary journalled write and
+/// prove nothing about the master side channel. The seeded `qty` values are
+/// distinct, so the constraint is satisfiable.
+fn seeded_columnar_with_unique_qty() -> DirGraph {
+    let mut graph = seeded();
+    run(
+        &mut graph,
+        "CREATE CONSTRAINT FOR (i:Item) REQUIRE i.qty IS UNIQUE",
+    );
+    graph.enable_columnar();
+    assert_eq!(
+        graph.unique_indices.len(),
+        1,
+        "the constraint must be declared and enforcing"
+    );
+    assert!(
+        !graph.column_stores.is_empty(),
+        "the graph must be saved, or this is the plain unique fixture again"
+    );
+    graph
+}
+
+/// A unique claim moved by a *columnar* `SET` must come back.
+///
+/// This is the shape with no `NodeWeight` entry behind it: the value goes into
+/// the master column store, so the node's weight never changes and the journal
+/// sees only the per-type `ColumnarHandles` entry. Until that entry started
+/// reporting the type as stale, the rebuild was reached only by accident —
+/// the handle-refresh sweep captured a pre-image for every node of the type,
+/// and each of those marked the type stale on the way past. Removing that
+/// per-node capture is what made the report explicit, and this test is what
+/// says so: without it a failed columnar `SET` leaves the claim it took behind
+/// and the claim it released free.
+#[test]
+fn rollback_restores_claims_moved_by_a_columnar_property_overwrite() {
+    let mut graph = seeded_columnar_with_unique_qty();
+    let before = unique_fingerprint(&graph);
+    assert!(
+        !before.is_empty() && !before[0].2.is_empty(),
+        "the constraint must hold claims, or this test is vacuous"
+    );
+
+    let error = expect_failure(
+        &mut graph,
+        "MATCH (i:Item {id: 1}) SET i.qty = 999 \
+         WITH i MATCH (j:Item {id: 2}) SET j.bad = duration({months: 2147483648})",
+        None,
+    );
+
+    assert_eq!(
+        unique_fingerprint(&graph),
+        before,
+        "a claim moved through the master column store must move back.\
+         \nerror: {error}"
+    );
+    // The observable half: 10 is claimed again (no lost claim) and 999 is free
+    // (no phantom occupant).
+    expect_failure(&mut graph, "CREATE (:Item {id: 40, qty: 10})", None);
+    run(&mut graph, "CREATE (:Item {id: 41, qty: 999})");
 }
 
 /// A statement that claims a new value and *then* fails must not leave the

--- a/crates/kglite/src/graph/introspection/describe.rs
+++ b/crates/kglite/src/graph/introspection/describe.rs
@@ -67,7 +67,7 @@ fn write_read_only_notice(xml: &mut String, graph: &DirGraph) {
     }
     if graph.schema_locked {
         xml.push_str(
-            "  <schema-locked>Mutations validated against schema — unknown types/properties rejected</schema-locked>\n",
+            "  <schema-locked>Queries and mutations validated against schema — unknown node types/properties rejected. A typo'd label in MATCH raises rather than returning zero rows</schema-locked>\n",
         );
     }
 }

--- a/crates/kglite/src/graph/languages/cypher/executor/columnar_write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/columnar_write.rs
@@ -1,0 +1,143 @@
+//! The in-memory columnar master-store write path.
+//!
+//! Extracted from `write.rs` rather than left in place: `write.rs` reached its
+//! 2500-line ceiling, and project doctrine is to split a file that outgrows it
+//! rather than raise the allowlist. These three items are the natural seam --
+//! they are the only ones that reach the per-type master `Arc<ColumnStore>`,
+//! and `execute_set` / `execute_remove` must agree on all of them (a property
+//! removed on a node's forked store while the master keeps the value is
+//! resurrected by the next clause's handle sweep).
+
+use crate::datatypes::values::Value;
+use crate::graph::schema::DirGraph;
+use crate::graph::storage::{GraphRead, GraphWrite};
+use petgraph::graph::NodeIndex;
+use std::sync::Arc;
+
+/// One property write aimed at a node type's master column store.
+///
+/// `row_id` is `None` for a node whose properties are not `Columnar`, which is
+/// one of the fallthrough conditions rather than a caller error — carrying the
+/// `Option` here keeps the whole "can this go through the master?" decision in
+/// one place.
+pub(super) struct ColumnMasterWrite<'a> {
+    pub(super) node_idx: NodeIndex,
+    pub(super) node_type: &'a str,
+    pub(super) property: &'a str,
+    pub(super) value: &'a Value,
+    pub(super) row_id: Option<u32>,
+}
+
+/// Write one property through the in-memory columnar master store, reporting
+/// whether it landed there.
+///
+/// The fast path for `Columnar` storage: route the write through the per-type
+/// master `Arc<ColumnStore>` once, instead of through each node's own handle.
+/// Every node of the type points at the same allocation, so `Arc::make_mut` on
+/// a *node's* handle would clone the whole store on every write — O(N²) for a
+/// batch `SET`. Going through the master forks once; the per-node handles are
+/// re-pointed in a single sweep at the end of the clause.
+///
+/// Returns `false` — leaving the caller to fall through to the per-node setter
+/// — for disk-backed graphs (which have their own write path), for non-
+/// `Columnar` nodes, for a `Columnar` node whose type is absent from
+/// `column_stores`, and for `title`/`name`.
+///
+/// `title`/`name` are excluded deliberately: the fallthrough sets the inline
+/// `node.title`, and `enable_columnar` detects that inline override on save
+/// (it differs from the stale `__title__` column) and rebuilds, consolidating
+/// the fresh title. That single save-side chokepoint covers every title-write
+/// path — Cypher `SET`, `add_nodes` update/replace, connection titles —
+/// without per-path master writes (petekSuite bug 2).
+///
+/// The property name is interned into the graph's `StringInterner` *before*
+/// `column_stores` is borrowed. The per-node path gets this free via
+/// `node.set_property(…, &mut graph.interner)`; the master path once used
+/// `InternedKey::from_str()`, which only hashes, leaving `save()` unable to
+/// resolve the key back to a string at serialize time. Symptom: every
+/// Cypher-`SET` property on a 0.8.39 in-memory Sodir-scale graph survived
+/// in-memory but vanished after save+load, with
+/// `BUG: InternedKey N not found in StringInterner`.
+///
+/// Both journals are handled here, and they pull in opposite directions:
+///
+/// - **WAL**: the write bypasses the recorded `GraphWrite` path, so the one
+///   mutated node is captured explicitly. The end-of-clause refresh sweep must
+///   *not* be, or a single `SET` would log every node of the type.
+/// - **Undo**: the pre-statement master is captured once per type, as
+///   [`UndoEntry::ColumnarHandles`], which is what lets the refresh sweep skip
+///   per-node capture entirely. The store itself is never copied — the fork
+///   already left the pre-statement one pristine, so holding its handle is the
+///   whole pre-image. `touched_columnar_types` keeps this to one attempt per
+///   type per clause; the journal's own first-touch rule covers a later clause
+///   writing the same type again.
+pub(super) fn set_via_column_master(
+    graph: &mut DirGraph,
+    write: ColumnMasterWrite<'_>,
+    touched_columnar_types: &mut std::collections::HashSet<String>,
+) -> bool {
+    // Disk-backed graphs use a separate write path; the master `column_stores`
+    // Arc is for the in-memory Columnar mode only.
+    let Some(row_id) = write.row_id else {
+        return false;
+    };
+    if graph.graph.is_disk() || write.property == "title" || write.property == "name" {
+        return false;
+    }
+    let key = graph.interner.get_or_intern(write.property);
+    if !touched_columnar_types.contains(write.node_type) {
+        if let Some(prior) = graph.column_stores.get(write.node_type).map(Arc::clone) {
+            if let Some(journal) = graph.graph.undo_journal_mut() {
+                journal.note_columnar_fork(write.node_type, || Some(prior));
+            }
+        }
+    }
+    let Some(master) = graph.column_stores.get_mut(write.node_type) else {
+        return false;
+    };
+    Arc::make_mut(master).set(row_id, key, write.value, None);
+    touched_columnar_types.insert(write.node_type.to_string());
+    graph.graph.note_recorded_node_upsert(write.node_idx);
+    true
+}
+
+/// Re-point every node's `Arc<ColumnStore>` handle at the graph master, for
+/// each type written through the master during this clause.
+///
+/// Each node holds its own Arc clone for efficient property reads; after a
+/// clause wrote through the graph master those per-node handles are stale and
+/// would surface pre-clause values. This sweep is O(N) per touched type and
+/// runs once per clause regardless of row count — which is the whole reason
+/// the master fast paths accumulate a type set instead of refreshing per row.
+///
+/// Shared by `execute_set` and `execute_remove`, which must agree: a node
+/// whose property was removed on its own forked store while the master kept
+/// the value has the value resurrected by the *next* clause's sweep.
+pub(super) fn refresh_columnar_node_handles(
+    graph: &mut DirGraph,
+    touched_columnar_types: std::collections::HashSet<String>,
+) {
+    for node_type in touched_columnar_types {
+        let new_master = match graph.column_stores.get(&node_type) {
+            Some(m) => Arc::clone(m),
+            None => continue,
+        };
+        let indices: Vec<NodeIndex> = graph
+            .type_indices
+            .get(&node_type)
+            .map(|s| s.iter().collect())
+            .unwrap_or_default();
+        for idx in indices {
+            // `_silent`: re-pointing per-node Arc handles is internal storage
+            // bookkeeping, not a logical mutation — must not be captured by the
+            // WAL recorder (the actual write was recorded in the fast path).
+            if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
+                if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
+                    &mut node.properties
+                {
+                    *store = Arc::clone(&new_master);
+                }
+            }
+        }
+    }
+}

--- a/crates/kglite/src/graph/languages/cypher/executor/mod.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/mod.rs
@@ -888,6 +888,7 @@ pub(crate) mod budget;
 pub mod call_clause;
 pub mod call_subquery;
 mod centrality_procedures;
+mod columnar_write;
 pub mod dead_code;
 mod execution_support;
 pub mod expression;

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -3,6 +3,9 @@
 
 use super::super::ast::*;
 use super::super::result::*;
+use super::columnar_write::{
+    refresh_columnar_node_handles, set_via_column_master, ColumnMasterWrite,
+};
 use super::{clause_display_name, schema_ddl, CypherExecutor};
 use crate::datatypes::values::Value;
 use crate::graph::algorithms::Interrupt;
@@ -1145,93 +1148,6 @@ fn is_null_write_target(row: &ResultRow, variable: &str) -> bool {
         && matches!(row.projected.get(variable), None | Some(Value::Null))
 }
 
-/// One property write aimed at a node type's master column store.
-///
-/// `row_id` is `None` for a node whose properties are not `Columnar`, which is
-/// one of the fallthrough conditions rather than a caller error — carrying the
-/// `Option` here keeps the whole "can this go through the master?" decision in
-/// one place.
-struct ColumnMasterWrite<'a> {
-    node_idx: NodeIndex,
-    node_type: &'a str,
-    property: &'a str,
-    value: &'a Value,
-    row_id: Option<u32>,
-}
-
-/// Write one property through the in-memory columnar master store, reporting
-/// whether it landed there.
-///
-/// The fast path for `Columnar` storage: route the write through the per-type
-/// master `Arc<ColumnStore>` once, instead of through each node's own handle.
-/// Every node of the type points at the same allocation, so `Arc::make_mut` on
-/// a *node's* handle would clone the whole store on every write — O(N²) for a
-/// batch `SET`. Going through the master forks once; the per-node handles are
-/// re-pointed in a single sweep at the end of the clause.
-///
-/// Returns `false` — leaving the caller to fall through to the per-node setter
-/// — for disk-backed graphs (which have their own write path), for non-
-/// `Columnar` nodes, for a `Columnar` node whose type is absent from
-/// `column_stores`, and for `title`/`name`.
-///
-/// `title`/`name` are excluded deliberately: the fallthrough sets the inline
-/// `node.title`, and `enable_columnar` detects that inline override on save
-/// (it differs from the stale `__title__` column) and rebuilds, consolidating
-/// the fresh title. That single save-side chokepoint covers every title-write
-/// path — Cypher `SET`, `add_nodes` update/replace, connection titles —
-/// without per-path master writes (petekSuite bug 2).
-///
-/// The property name is interned into the graph's `StringInterner` *before*
-/// `column_stores` is borrowed. The per-node path gets this free via
-/// `node.set_property(…, &mut graph.interner)`; the master path once used
-/// `InternedKey::from_str()`, which only hashes, leaving `save()` unable to
-/// resolve the key back to a string at serialize time. Symptom: every
-/// Cypher-`SET` property on a 0.8.39 in-memory Sodir-scale graph survived
-/// in-memory but vanished after save+load, with
-/// `BUG: InternedKey N not found in StringInterner`.
-///
-/// Both journals are handled here, and they pull in opposite directions:
-///
-/// - **WAL**: the write bypasses the recorded `GraphWrite` path, so the one
-///   mutated node is captured explicitly. The end-of-clause refresh sweep must
-///   *not* be, or a single `SET` would log every node of the type.
-/// - **Undo**: the pre-statement master is captured once per type, as
-///   [`UndoEntry::ColumnarHandles`], which is what lets the refresh sweep skip
-///   per-node capture entirely. The store itself is never copied — the fork
-///   already left the pre-statement one pristine, so holding its handle is the
-///   whole pre-image. `touched_columnar_types` keeps this to one attempt per
-///   type per clause; the journal's own first-touch rule covers a later clause
-///   writing the same type again.
-fn set_via_column_master(
-    graph: &mut DirGraph,
-    write: ColumnMasterWrite<'_>,
-    touched_columnar_types: &mut std::collections::HashSet<String>,
-) -> bool {
-    // Disk-backed graphs use a separate write path; the master `column_stores`
-    // Arc is for the in-memory Columnar mode only.
-    let Some(row_id) = write.row_id else {
-        return false;
-    };
-    if graph.graph.is_disk() || write.property == "title" || write.property == "name" {
-        return false;
-    }
-    let key = graph.interner.get_or_intern(write.property);
-    if !touched_columnar_types.contains(write.node_type) {
-        if let Some(prior) = graph.column_stores.get(write.node_type).map(Arc::clone) {
-            if let Some(journal) = graph.graph.undo_journal_mut() {
-                journal.note_columnar_fork(write.node_type, || Some(prior));
-            }
-        }
-    }
-    let Some(master) = graph.column_stores.get_mut(write.node_type) else {
-        return false;
-    };
-    Arc::make_mut(master).set(row_id, key, write.value, None);
-    touched_columnar_types.insert(write.node_type.to_string());
-    graph.graph.note_recorded_node_upsert(write.node_idx);
-    true
-}
-
 /// Execute a SET clause, modifying node properties in the graph.
 /// A single-property node `SET` that has already landed in storage, as the
 /// post-write bookkeeping needs to see it.
@@ -1768,47 +1684,6 @@ fn execute_set(
 
     refresh_columnar_node_handles(graph, touched_columnar_types);
     Ok(())
-}
-
-/// Re-point every node's `Arc<ColumnStore>` handle at the graph master, for
-/// each type written through the master during this clause.
-///
-/// Each node holds its own Arc clone for efficient property reads; after a
-/// clause wrote through the graph master those per-node handles are stale and
-/// would surface pre-clause values. This sweep is O(N) per touched type and
-/// runs once per clause regardless of row count — which is the whole reason
-/// the master fast paths accumulate a type set instead of refreshing per row.
-///
-/// Shared by `execute_set` and `execute_remove`, which must agree: a node
-/// whose property was removed on its own forked store while the master kept
-/// the value has the value resurrected by the *next* clause's sweep.
-fn refresh_columnar_node_handles(
-    graph: &mut DirGraph,
-    touched_columnar_types: std::collections::HashSet<String>,
-) {
-    for node_type in touched_columnar_types {
-        let new_master = match graph.column_stores.get(&node_type) {
-            Some(m) => Arc::clone(m),
-            None => continue,
-        };
-        let indices: Vec<NodeIndex> = graph
-            .type_indices
-            .get(&node_type)
-            .map(|s| s.iter().collect())
-            .unwrap_or_default();
-        for idx in indices {
-            // `_silent`: re-pointing per-node Arc handles is internal storage
-            // bookkeeping, not a logical mutation — must not be captured by the
-            // WAL recorder (the actual write was recorded in the fast path).
-            if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
-                if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
-                    &mut node.properties
-                {
-                    *store = Arc::clone(&new_master);
-                }
-            }
-        }
-    }
 }
 
 /// Execute a DELETE clause, removing nodes and/or edges from the graph.

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1145,6 +1145,93 @@ fn is_null_write_target(row: &ResultRow, variable: &str) -> bool {
         && matches!(row.projected.get(variable), None | Some(Value::Null))
 }
 
+/// One property write aimed at a node type's master column store.
+///
+/// `row_id` is `None` for a node whose properties are not `Columnar`, which is
+/// one of the fallthrough conditions rather than a caller error — carrying the
+/// `Option` here keeps the whole "can this go through the master?" decision in
+/// one place.
+struct ColumnMasterWrite<'a> {
+    node_idx: NodeIndex,
+    node_type: &'a str,
+    property: &'a str,
+    value: &'a Value,
+    row_id: Option<u32>,
+}
+
+/// Write one property through the in-memory columnar master store, reporting
+/// whether it landed there.
+///
+/// The fast path for `Columnar` storage: route the write through the per-type
+/// master `Arc<ColumnStore>` once, instead of through each node's own handle.
+/// Every node of the type points at the same allocation, so `Arc::make_mut` on
+/// a *node's* handle would clone the whole store on every write — O(N²) for a
+/// batch `SET`. Going through the master forks once; the per-node handles are
+/// re-pointed in a single sweep at the end of the clause.
+///
+/// Returns `false` — leaving the caller to fall through to the per-node setter
+/// — for disk-backed graphs (which have their own write path), for non-
+/// `Columnar` nodes, for a `Columnar` node whose type is absent from
+/// `column_stores`, and for `title`/`name`.
+///
+/// `title`/`name` are excluded deliberately: the fallthrough sets the inline
+/// `node.title`, and `enable_columnar` detects that inline override on save
+/// (it differs from the stale `__title__` column) and rebuilds, consolidating
+/// the fresh title. That single save-side chokepoint covers every title-write
+/// path — Cypher `SET`, `add_nodes` update/replace, connection titles —
+/// without per-path master writes (petekSuite bug 2).
+///
+/// The property name is interned into the graph's `StringInterner` *before*
+/// `column_stores` is borrowed. The per-node path gets this free via
+/// `node.set_property(…, &mut graph.interner)`; the master path once used
+/// `InternedKey::from_str()`, which only hashes, leaving `save()` unable to
+/// resolve the key back to a string at serialize time. Symptom: every
+/// Cypher-`SET` property on a 0.8.39 in-memory Sodir-scale graph survived
+/// in-memory but vanished after save+load, with
+/// `BUG: InternedKey N not found in StringInterner`.
+///
+/// Both journals are handled here, and they pull in opposite directions:
+///
+/// - **WAL**: the write bypasses the recorded `GraphWrite` path, so the one
+///   mutated node is captured explicitly. The end-of-clause refresh sweep must
+///   *not* be, or a single `SET` would log every node of the type.
+/// - **Undo**: the pre-statement master is captured once per type, as
+///   [`UndoEntry::ColumnarHandles`], which is what lets the refresh sweep skip
+///   per-node capture entirely. The store itself is never copied — the fork
+///   already left the pre-statement one pristine, so holding its handle is the
+///   whole pre-image. `touched_columnar_types` keeps this to one attempt per
+///   type per clause; the journal's own first-touch rule covers a later clause
+///   writing the same type again.
+fn set_via_column_master(
+    graph: &mut DirGraph,
+    write: ColumnMasterWrite<'_>,
+    touched_columnar_types: &mut std::collections::HashSet<String>,
+) -> bool {
+    // Disk-backed graphs use a separate write path; the master `column_stores`
+    // Arc is for the in-memory Columnar mode only.
+    let Some(row_id) = write.row_id else {
+        return false;
+    };
+    if graph.graph.is_disk() || write.property == "title" || write.property == "name" {
+        return false;
+    }
+    let key = graph.interner.get_or_intern(write.property);
+    if !touched_columnar_types.contains(write.node_type) {
+        if let Some(prior) = graph.column_stores.get(write.node_type).map(Arc::clone) {
+            if let Some(journal) = graph.graph.undo_journal_mut() {
+                journal.note_columnar_fork(write.node_type, || Some(prior));
+            }
+        }
+    }
+    let Some(master) = graph.column_stores.get_mut(write.node_type) else {
+        return false;
+    };
+    Arc::make_mut(master).set(row_id, key, write.value, None);
+    touched_columnar_types.insert(write.node_type.to_string());
+    graph.graph.note_recorded_node_upsert(write.node_idx);
+    true
+}
+
 /// Execute a SET clause, modifying node properties in the graph.
 /// A single-property node `SET` that has already landed in storage, as the
 /// post-write bookkeeping needs to see it.
@@ -1399,47 +1486,19 @@ fn execute_set(
                             _ => None,
                         }
                     };
-                    let mut wrote_via_master = false;
-                    // Disk-backed graphs use a separate write path; the
-                    // master `column_stores` Arc is for the in-memory
-                    // Columnar mode only.
-                    let is_in_memory = !graph.graph.is_disk();
-                    // NB: title/name are intentionally NOT routed through the
-                    // master store here — the fallthrough sets the inline
-                    // `node.title`, and `enable_columnar` detects that inline
-                    // override on save (it differs from the stale `__title__`
-                    // column) and rebuilds, consolidating the fresh title. That
-                    // single save-side chokepoint covers every title-write path
-                    // (Cypher SET, add_nodes update/replace, connection titles)
-                    // without per-path master writes (petekSuite bug 2).
-                    if is_in_memory && property != "title" && property != "name" {
-                        if let Some(row_id) = columnar_row_id {
-                            // Register the property name in the graph's
-                            // StringInterner BEFORE borrowing column_stores.
-                            // The non-master path does this via
-                            // `node.set_property(..., &mut graph.interner)`;
-                            // the master path used `InternedKey::from_str()`
-                            // which only hashes — leaving `save()` unable
-                            // to resolve the key back to a string at
-                            // serialize time. Symptom: every Cypher-SET
-                            // property on a 0.8.39 in-memory Sodir-scale
-                            // graph survived in-memory but vanished after
-                            // save+load, accompanied by
-                            // `BUG: InternedKey N not found in StringInterner`.
-                            let key = graph.interner.get_or_intern(property);
-                            if let Some(master) = graph.column_stores.get_mut(&node_type_str) {
-                                Arc::make_mut(master).set(row_id, key, &value, None);
-                                touched_columnar_types.insert(node_type_str.clone());
-                                stats.properties_set += 1;
-                                wrote_via_master = true;
-                                // This master-store write bypasses the recorded
-                                // GraphWrite path, so explicitly capture the one
-                                // mutated node for the WAL. (The silent refresh
-                                // sweep below must NOT be captured — else a
-                                // single SET would log every node of the type.)
-                                graph.graph.note_recorded_node_upsert(*node_idx);
-                            }
-                        }
+                    let wrote_via_master = set_via_column_master(
+                        graph,
+                        ColumnMasterWrite {
+                            node_idx: *node_idx,
+                            node_type: &node_type_str,
+                            property,
+                            value: &value,
+                            row_id: columnar_row_id,
+                        },
+                        &mut touched_columnar_types,
+                    );
+                    if wrote_via_master {
+                        stats.properties_set += 1;
                     }
                     if !wrote_via_master {
                         // Compact / Map storage, or title/name, or a Columnar
@@ -1639,7 +1698,6 @@ fn execute_set(
     // equality-index update — provenance is range-queried, not equality-matched.
     if !nodes_to_stamp.is_empty() {
         let prov = graph.provenance_props();
-        let is_in_memory = !graph.graph.is_disk();
         for (node_idx, node_type) in &nodes_to_stamp {
             // Arena guard: node_weight materializes on the disk backend
             // (protocol in disk/graph.rs); scoped so the borrow ends before
@@ -1660,17 +1718,17 @@ fn execute_set(
                         Arc::make_mut(schema_arc).add_key(key);
                     }
                 }
-                let mut wrote = false;
-                if is_in_memory {
-                    if let Some(row_id) = columnar_row_id {
-                        if let Some(master) = graph.column_stores.get_mut(node_type) {
-                            Arc::make_mut(master).set(row_id, key, pval, None);
-                            touched_columnar_types.insert(node_type.clone());
-                            graph.graph.note_recorded_node_upsert(*node_idx);
-                            wrote = true;
-                        }
-                    }
-                }
+                let wrote = set_via_column_master(
+                    graph,
+                    ColumnMasterWrite {
+                        node_idx: *node_idx,
+                        node_type,
+                        property: pname,
+                        value: pval,
+                        row_id: columnar_row_id,
+                    },
+                    &mut touched_columnar_types,
+                );
                 if !wrote {
                     if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, *node_idx) {
                         node.set_property(pname, pval.clone(), &mut graph.interner);

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1708,12 +1708,26 @@ fn execute_set(
         }
     }
 
-    // Refresh per-node `Arc<ColumnStore>` handles for every type we wrote
-    // into during this batch. Each node holds its own Arc clone for
-    // efficient property reads; after the batch wrote through the
-    // graph master, those per-node handles are stale and would surface
-    // pre-batch values. This sweep is O(N) per touched type and runs
-    // once per SET clause regardless of row count.
+    refresh_columnar_node_handles(graph, touched_columnar_types);
+    Ok(())
+}
+
+/// Re-point every node's `Arc<ColumnStore>` handle at the graph master, for
+/// each type written through the master during this clause.
+///
+/// Each node holds its own Arc clone for efficient property reads; after a
+/// clause wrote through the graph master those per-node handles are stale and
+/// would surface pre-clause values. This sweep is O(N) per touched type and
+/// runs once per clause regardless of row count — which is the whole reason
+/// the master fast paths accumulate a type set instead of refreshing per row.
+///
+/// Shared by `execute_set` and `execute_remove`, which must agree: a node
+/// whose property was removed on its own forked store while the master kept
+/// the value has the value resurrected by the *next* clause's sweep.
+fn refresh_columnar_node_handles(
+    graph: &mut DirGraph,
+    touched_columnar_types: std::collections::HashSet<String>,
+) {
     for node_type in touched_columnar_types {
         let new_master = match graph.column_stores.get(&node_type) {
             Some(m) => Arc::clone(m),
@@ -1727,7 +1741,7 @@ fn execute_set(
         for idx in indices {
             // `_silent`: re-pointing per-node Arc handles is internal storage
             // bookkeeping, not a logical mutation — must not be captured by the
-            // WAL recorder (the actual SET was recorded in the fast path above).
+            // WAL recorder (the actual write was recorded in the fast path).
             if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
                 if let crate::graph::schema::PropertyStorage::Columnar { store, .. } =
                     &mut node.properties
@@ -1737,7 +1751,6 @@ fn execute_set(
             }
         }
     }
-    Ok(())
 }
 
 /// Execute a DELETE clause, removing nodes and/or edges from the graph.
@@ -1879,6 +1892,12 @@ fn execute_remove(
     stats: &mut MutationStats,
     interrupt: &Interrupt,
 ) -> Result<(), String> {
+    // Same batching contract as `execute_set`: Columnar types written through
+    // the graph master get their per-node `Arc<ColumnStore>` handles refreshed
+    // in one O(N-per-type) sweep at the end, not once per row.
+    let mut touched_columnar_types: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
     for (row_idx, row) in result_set.rows.iter().enumerate() {
         check_interrupt_periodic(interrupt, row_idx)?;
         for item in &remove.items {
@@ -1948,7 +1967,58 @@ fn execute_remove(
                     // writes through, matching SET-to-null semantics
                     // (verified working on disk).
                     let is_disk = graph.graph.is_disk();
-                    let removed_value = if let Some(node) = graph.get_node_mut(*node_idx) {
+
+                    // In-memory Columnar: clear through the graph master, the
+                    // same chokepoint `execute_set` writes through, and refresh
+                    // the per-node handles once at the end of the clause.
+                    //
+                    // Going through the node's own `Arc<ColumnStore>` instead
+                    // (what `PropertyStorage::remove` does) is both wrong and
+                    // slow. Wrong: `Arc::make_mut` forks the node's store, so
+                    // the master keeps the removed value and the next clause's
+                    // refresh sweep re-points this node at the master and
+                    // resurrects it — no save required. Slow: the fork is a
+                    // full `ColumnStore` clone per node removed, so a REMOVE
+                    // over R rows of a type with N nodes was O(R x N).
+                    //
+                    // title/name are excluded for the same reason as in
+                    // `execute_set`: they live inline on the node and are
+                    // consolidated by `enable_columnar` at save time.
+                    let mut cleared_via_master = None;
+                    if !is_disk && property != "name" && property != "title" {
+                        let columnar_row_id = {
+                            let _arena_guard = graph.graph.begin_query();
+                            match graph.graph.node_weight(*node_idx).map(|n| &n.properties) {
+                                Some(crate::graph::schema::PropertyStorage::Columnar {
+                                    row_id,
+                                    ..
+                                }) => Some(*row_id),
+                                _ => None,
+                            }
+                        };
+                        if let Some(row_id) = columnar_row_id {
+                            let key = graph.interner.get_or_intern(property);
+                            let prior = graph
+                                .column_stores
+                                .get(&node_type_str)
+                                .and_then(|master| master.get(row_id, key));
+                            if let Some(master) = graph.column_stores.get_mut(&node_type_str) {
+                                Arc::make_mut(master).set(row_id, key, &Value::Null, None);
+                                touched_columnar_types.insert(node_type_str.clone());
+                                // The master write bypasses the recorded
+                                // GraphWrite path, so capture the one mutated
+                                // node for the WAL explicitly. (The silent
+                                // refresh sweep must NOT be captured — else one
+                                // REMOVE would log every node of the type.)
+                                graph.graph.note_recorded_node_upsert(*node_idx);
+                                cleared_via_master = Some(prior);
+                            }
+                        }
+                    }
+
+                    let removed_value = if let Some(prior) = cleared_via_master {
+                        prior
+                    } else if let Some(node) = graph.get_node_mut(*node_idx) {
                         if property == "name" || property == "title" {
                             let old = std::mem::replace(&mut node.title, Value::Null);
                             node.remove_property("name");
@@ -1993,6 +2063,8 @@ fn execute_remove(
             }
         }
     }
+
+    refresh_columnar_node_handles(graph, touched_columnar_types);
     Ok(())
 }
 
@@ -2314,6 +2386,10 @@ fn try_match_merge_pattern(
         _ => Err("MERGE supports single-node or single-edge patterns only".to_string()),
     }
 }
+
+#[cfg(test)]
+#[path = "write_remove_columnar_tests.rs"]
+mod remove_columnar_tests;
 
 #[cfg(test)]
 mod is_mutation_query_tests {

--- a/crates/kglite/src/graph/languages/cypher/executor/write_remove_columnar_tests.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write_remove_columnar_tests.rs
@@ -1,0 +1,136 @@
+//! `REMOVE` on an in-memory Columnar node must clear the graph master store.
+//!
+//! Split into its own file to keep `write.rs` under the source-quality line
+//! ceiling.
+//!
+//! Each node of a columnar type holds its own `Arc<ColumnStore>` clone for
+//! cheap property reads, and `graph.column_stores` holds the master. Writing
+//! through the node's handle calls `Arc::make_mut`, which **forks** it: the
+//! node sees the write and the master does not. `execute_set` avoids this by
+//! writing through the master and refreshing the per-node handles in one sweep
+//! at the end of the clause; `execute_remove` did not, so a removed property
+//! survived in the master and came back the moment any later clause ran that
+//! sweep.
+
+use crate::datatypes::Value;
+use crate::graph::schema::{DirGraph, InternedKey, PropertyStorage};
+use crate::graph::session::execute::{execute_mut, ExecuteOptions};
+use crate::graph::storage::GraphRead;
+
+fn run(graph: &mut DirGraph, query: &str) {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::eager(&params);
+    execute_mut(graph, query, &opts).unwrap_or_else(|e| panic!("query failed: {query}: {e}"));
+}
+
+/// One columnar `Item`, with the fixture's columnar-ness asserted rather than
+/// assumed — every test here is vacuous against a `Map`-storage node.
+fn columnar_item() -> DirGraph {
+    let mut graph = DirGraph::new();
+    run(&mut graph, "CREATE (a:Item {id: 1, name: 'a', qty: 10})");
+    graph.enable_columnar();
+    assert!(
+        graph.column_stores.contains_key("Item"),
+        "the fixture must own a master column store, or these tests are vacuous"
+    );
+    let idx = graph
+        .lookup_by_id_readonly("Item", &Value::Int64(1))
+        .expect("seeded node");
+    assert!(
+        matches!(
+            graph.graph.node_weight(idx).map(|n| &n.properties),
+            Some(PropertyStorage::Columnar { .. })
+        ),
+        "the node must read through a column store, or these tests are vacuous"
+    );
+    graph
+}
+
+fn master_qty(graph: &DirGraph) -> Option<Value> {
+    graph
+        .column_stores
+        .get("Item")
+        .and_then(|m| m.get(0, InternedKey::from_str("qty")))
+}
+
+fn node_qty(graph: &DirGraph) -> Option<Value> {
+    graph
+        .lookup_by_id_readonly("Item", &Value::Int64(1))
+        .and_then(|i| graph.graph.node_weight(i))
+        .and_then(|n| n.get_property("qty"))
+        .map(|v| v.into_owned())
+}
+
+/// The removal must reach the master, not just the node's forked handle.
+#[test]
+fn remove_clears_the_master_column_store() {
+    let mut graph = columnar_item();
+    assert_eq!(master_qty(&graph), Some(Value::Int64(10)));
+
+    run(&mut graph, "MATCH (a:Item {id: 1}) REMOVE a.qty");
+
+    assert_eq!(node_qty(&graph), None, "the node must not see the property");
+    assert_eq!(
+        master_qty(&graph),
+        None,
+        "the master must not keep a value the node no longer has — it is what \
+         save() persists and what the next handle-refresh sweep broadcasts"
+    );
+}
+
+/// The user-visible symptom: a removed property comes back.
+///
+/// No save is involved. `SET a.other = 5` writes through the master and then
+/// refreshes every node handle of the type, which re-points the node at a
+/// master that still carried `qty`.
+#[test]
+fn removed_columnar_property_does_not_resurrect_on_the_next_set() {
+    let mut graph = columnar_item();
+    run(&mut graph, "MATCH (a:Item {id: 1}) REMOVE a.qty");
+    assert_eq!(node_qty(&graph), None);
+
+    // Any later master-routed write on the same type triggers the sweep.
+    run(&mut graph, "MATCH (a:Item {id: 1}) SET a.other = 5");
+
+    assert_eq!(
+        node_qty(&graph),
+        None,
+        "a removed property must stay removed across a later SET on its type"
+    );
+    assert_eq!(master_qty(&graph), None);
+}
+
+/// REMOVE over several rows must still be correct per node — the batched
+/// handle refresh happens once at the end of the clause, so a bug there shows
+/// up as one node keeping its value.
+#[test]
+fn remove_over_many_rows_clears_every_node() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Item {id: 1, qty: 10}), (:Item {id: 2, qty: 20}), (:Item {id: 3, qty: 30})",
+    );
+    graph.enable_columnar();
+    assert!(graph.column_stores.contains_key("Item"));
+
+    run(&mut graph, "MATCH (a:Item) REMOVE a.qty");
+
+    for id in 1..=3 {
+        let value = graph
+            .lookup_by_id_readonly("Item", &Value::Int64(id))
+            .and_then(|i| graph.graph.node_weight(i))
+            .and_then(|n| n.get_property("qty"))
+            .map(|v| v.into_owned());
+        assert_eq!(value, None, "node {id} kept its removed property");
+    }
+    // And a later SET does not bring any of them back.
+    run(&mut graph, "MATCH (a:Item {id: 1}) SET a.other = 1");
+    for id in 1..=3 {
+        let value = graph
+            .lookup_by_id_readonly("Item", &Value::Int64(id))
+            .and_then(|i| graph.graph.node_weight(i))
+            .and_then(|n| n.get_property("qty"))
+            .map(|v| v.into_owned());
+        assert_eq!(value, None, "node {id} resurrected its removed property");
+    }
+}

--- a/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
@@ -15,9 +15,27 @@
 //!
 //! Deliberately *does not reject* (these are legal, so they are warned about
 //! non-fatally instead — see below — never turned into errors):
-//! - Unknown node types in MATCH (`MATCH (n:Nonexistent)` legitimately
-//!   returns zero rows and is a common existence-check idiom).
-//! - Unknown connection types (same rationale).
+//! - Unknown node types in MATCH **on an open schema** (`MATCH
+//!   (n:Nonexistent)` legitimately returns zero rows and is a common
+//!   existence-check idiom). Under `lock_schema()` this *is* rejected —
+//!   see [`validate_label`] and the note below.
+//! - Unknown connection types (same rationale, both schema states — an
+//!   edge type is not yet part of what a schema lock covers).
+//!
+//! ## Locked schemas reject unknown labels
+//!
+//! `lock_schema()` is the opt-in "catch my typos" mechanism, and it must
+//! cover labels and properties symmetrically. Before this check, a locked
+//! schema rejected `MATCH (i:Issue {titel: 1})` (unknown property) but
+//! silently returned `[]` for `MATCH (i:Isue)` (unknown label) — and an
+//! empty result set reads as "no matching data" rather than "you made a
+//! mistake", so the typo survived review and reached production. The write
+//! path had already made this call: `CREATE (i:Isue)` under a lock has
+//! always failed with `Unknown node type 'Isue'`. [`validate_label`]
+//! applies the same rule, and the same message, to reads.
+//!
+//! The open-schema default is untouched — schemalessness is the product,
+//! and the check is gated entirely on `graph.schema_locked`.
 //!
 //! Deliberately *ignores entirely*:
 //! - Property references in WHERE / RETURN expressions (virtual columns,
@@ -61,6 +79,8 @@ const BUILTIN_FIELDS: &[&str] = &["id", "title", "name", "type"];
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaErrorKind {
     UnknownProperty,
+    /// Raised **only under a locked schema** — see [`validate_label`].
+    UnknownNodeType,
     UndefinedVariable,
 }
 
@@ -1099,6 +1119,16 @@ fn validate_pattern(
 ) -> Result<(), SchemaError> {
     for element in &pattern.elements {
         if let PatternElement::Node(np) = element {
+            // Label check first: on a locked schema an unknown label is a
+            // typo, not an empty result set. Checked before the property
+            // loop so `MATCH (i:Isue {titel: 1})` reports the label — the
+            // outer mistake — rather than a property of a type that does
+            // not exist.
+            if graph.schema_locked {
+                for label in np.node_type.iter().chain(np.extra_labels.iter()) {
+                    validate_label(label, graph)?;
+                }
+            }
             if let Some(ref node_type) = np.node_type {
                 if let Some(ref var) = np.variable {
                     var_types.insert(var.clone(), node_type.clone());
@@ -1145,6 +1175,72 @@ fn walk_predicate_for_nested_patterns(
         _ => {}
     }
     Ok(())
+}
+
+/// A label is "known" if it is a declared primary type, currently has live
+/// nodes, or is a secondary label applied via `add_label` — `MATCH
+/// (n:Reviewer)` is valid even though `Reviewer` is no node's primary type.
+/// Mirrors the identical three-way test in
+/// [`collect_unknown_pattern_warnings`]; keep the two in step.
+fn label_known(label: &str, graph: &DirGraph) -> bool {
+    graph.node_type_metadata.contains_key(label)
+        || graph.type_indices.contains_key(label)
+        || graph
+            .secondary_label_index
+            .contains_key(&InternedKey::from_str(label))
+}
+
+/// Reject an unknown node label. **Caller gates on `graph.schema_locked`.**
+///
+/// On an open schema kglite is schemaless by design and `MATCH
+/// (n:Nonexistent)` legitimately returns zero rows (the existence-check
+/// idiom), so this is never reached and
+/// [`collect_unknown_pattern_warnings`] delivers the typo hint non-fatally
+/// instead. `lock_schema()` is the opt-in "catch my typos" mechanism: it
+/// already rejects an unknown *property* here, and an unknown *node type*
+/// on the CREATE write path
+/// ([`validate_node_creation`](crate::graph::mutation::validation::validate_node_creation)).
+/// This closes the read side, where a typo'd label previously returned `[]`
+/// — indistinguishable from "no matching data".
+///
+/// The message deliberately reuses the write path's wording so a locked
+/// schema reports the same mistake identically whether it is read or
+/// written, and enumerates the valid set exactly like the unknown-property
+/// message above it.
+fn validate_label(label: &str, graph: &DirGraph) -> Result<(), SchemaError> {
+    if label_known(label, graph) {
+        return Ok(());
+    }
+    // Cold path only — the candidate list is built solely to explain a
+    // confirmed typo.
+    let mut valid: Vec<&str> = graph
+        .node_type_metadata
+        .keys()
+        .map(|s| s.as_str())
+        .chain(graph.type_indices.keys())
+        .collect();
+    // `try_resolve`, not `resolve`: the latter panics on a key the interner
+    // has no entry for, and an error-message builder must never be the thing
+    // that takes the process down. A key we cannot name is simply omitted
+    // from the hint.
+    valid.extend(
+        graph
+            .secondary_label_index
+            .keys()
+            .filter_map(|k| graph.interner.try_resolve(*k)),
+    );
+    valid.sort_unstable();
+    valid.dedup();
+    let hint = did_you_mean(label, &valid);
+    Err(SchemaError {
+        kind: SchemaErrorKind::UnknownNodeType,
+        message: format!(
+            "Unknown node type '{}'.{}\n  Valid types: {}",
+            label,
+            hint,
+            valid.join(", ")
+        ),
+    })
 }
 
 fn validate_property(node_type: &str, property: &str, graph: &DirGraph) -> Result<(), SchemaError> {
@@ -1518,5 +1614,173 @@ mod tests {
         // (avoids false positives on dynamically-typed graphs).
         let q = parse_cypher("MATCH (n) WHERE n.whatever = 1 RETURN n").unwrap();
         assert!(collect_unknown_pattern_warnings(&q, &g).is_empty());
+    }
+
+    // ── Locked-schema label rejection ────────────────────────────────────
+    //
+    // `lock_schema()` is the "catch my typos" mechanism; it has always
+    // rejected an unknown *property*, and an unknown *node type* on the
+    // CREATE write path. These cover the read side. Every clause that can
+    // carry a label gets a case — a fix covering only MATCH would recreate
+    // the same asymmetry one level down.
+
+    /// Adds an `Issue` type so `Isue` has a real near-miss to suggest —
+    /// this is the scenario from the field report, verbatim.
+    fn locked_graph() -> DirGraph {
+        let mut g = graph_with_schema();
+        let mut issue_props = HashMap::new();
+        issue_props.insert("status".to_string(), "string".to_string());
+        g.upsert_node_type_metadata("Issue", issue_props);
+        g.schema_locked = true;
+        g
+    }
+
+    /// The one assertion that matters: the offending label is named AND the
+    /// valid set is enumerated, exactly like the unknown-property message.
+    fn assert_rejects_isue(query: &str) {
+        let g = locked_graph();
+        let q = parse_cypher(query).unwrap();
+        let err =
+            validate_schema(&q, &g).expect_err(&format!("locked schema should reject: {query}"));
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType, "for `{query}`");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Isue'. Did you mean 'Issue'?\n  Valid types: Issue, Paper, Person",
+            "for `{query}`"
+        );
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_match() {
+        assert_rejects_isue("MATCH (i:Isue) RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_optional_match() {
+        assert_rejects_isue("MATCH (p:Person) OPTIONAL MATCH (i:Isue) RETURN p, i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_where_pattern_predicate() {
+        assert_rejects_isue("MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_call_subquery() {
+        assert_rejects_isue("CALL { MATCH (i:Isue) RETURN i } RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_label_in_union_branch() {
+        assert_rejects_isue("MATCH (p:Person) RETURN p UNION MATCH (i:Isue) RETURN i");
+    }
+
+    #[test]
+    fn locked_schema_rejects_unknown_extra_label() {
+        // `(n:A:B)` puts the first label in `node_type` and the rest in
+        // `extra_labels` — a typo in the tail must be caught too.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (n:Person:Revewer) RETURN n").unwrap();
+        let err = validate_schema(&q, &g).expect_err("extra label typo should be rejected");
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType);
+        assert!(
+            err.message.starts_with("Unknown node type 'Revewer'."),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn locked_schema_offers_did_you_mean_for_near_miss() {
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (n:Persn) RETURN n").unwrap();
+        let err = validate_schema(&q, &g).expect_err("near-miss label should be rejected");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Persn'. Did you mean 'Person'?\n  Valid types: Issue, Paper, Person"
+        );
+    }
+
+    #[test]
+    fn locked_schema_accepts_known_labels_everywhere() {
+        let g = locked_graph();
+        for query in [
+            "MATCH (p:Person) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Paper) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Paper) } RETURN p",
+            "CALL { MATCH (q:Paper) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p UNION MATCH (q:Paper) RETURN q",
+            // Untyped patterns carry no label to check.
+            "MATCH (n) RETURN n",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                validate_schema(&q, &g).is_ok(),
+                "locked schema wrongly rejected `{query}`: {:?}",
+                validate_schema(&q, &g).err()
+            );
+        }
+    }
+
+    #[test]
+    fn locked_schema_reports_the_label_before_the_property() {
+        // When both are wrong, the label is the outer mistake — reporting a
+        // property of a type that does not exist would be nonsense.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (i:Isue {titel: 'x'}) RETURN i").unwrap();
+        let err = validate_schema(&q, &g).expect_err("should reject");
+        assert_eq!(err.kind, SchemaErrorKind::UnknownNodeType);
+    }
+
+    #[test]
+    fn open_schema_still_tolerates_unknown_label() {
+        // The schemaless default is the product — the zero-row
+        // existence-check idiom must keep working untouched. This is the
+        // regression guard for the gate on `schema_locked`.
+        let g = graph_with_schema();
+        assert!(!g.schema_locked);
+        for query in [
+            "MATCH (i:Isue) RETURN i",
+            "MATCH (p:Person) OPTIONAL MATCH (i:Isue) RETURN p, i",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p",
+            "CALL { MATCH (i:Isue) RETURN i } RETURN i",
+            "MATCH (p:Person) RETURN p UNION MATCH (i:Isue) RETURN i",
+            "MATCH (n:Person:Revewer) RETURN n",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                validate_schema(&q, &g).is_ok(),
+                "open schema must not reject `{query}`"
+            );
+        }
+    }
+
+    #[test]
+    fn locked_schema_leaves_unknown_relationship_types_alone() {
+        // Edge types are not part of what a schema lock covers on the read
+        // path; only the node-label gap was asymmetric with properties.
+        let g = locked_graph();
+        let q = parse_cypher("MATCH (a:Person)-[:NOSUCH]->(b:Person) RETURN a").unwrap();
+        assert!(validate_schema(&q, &g).is_ok());
+    }
+
+    #[test]
+    fn locked_schema_accepts_secondary_labels() {
+        // A label applied via `add_label` is legitimately matchable even
+        // though it is no node's primary type — rejecting it would be a
+        // false positive.
+        let mut g = locked_graph();
+        let key = g.interner.try_get_or_intern("Reviewer").unwrap();
+        g.secondary_label_index.insert(key, Vec::new());
+        g.has_secondary_labels = true;
+        let q = parse_cypher("MATCH (n:Reviewer) RETURN n").unwrap();
+        assert!(validate_schema(&q, &g).is_ok());
+        // …and it appears in the enumerated valid set for a real typo.
+        let q2 = parse_cypher("MATCH (n:Isue) RETURN n").unwrap();
+        let err = validate_schema(&q2, &g).expect_err("should reject");
+        assert_eq!(
+            err.message,
+            "Unknown node type 'Isue'. Did you mean 'Issue'?\n  Valid types: Issue, Paper, Person, Reviewer"
+        );
     }
 }

--- a/crates/kglite/src/graph/mutation/batch.rs
+++ b/crates/kglite/src/graph/mutation/batch.rs
@@ -350,6 +350,32 @@ impl BatchProcessor {
     /// ref dropped the refcount is 1, `try_unwrap` succeeds, and the append
     /// mutates in place. [`Self::reattach_columnar_stores`] restores the refs.
     ///
+    /// ## Why the detach borrow is silent
+    ///
+    /// The sweep touches *every existing node of the type*, once per chunk.
+    /// Through the recorded [`GraphWrite::node_weight_mut`] that is one
+    /// `RawOp::UpsertNode` per existing node per chunk — with
+    /// `LARGE_BATCH_CHUNK_SIZE`-sized chunks, `O(n²/chunk)` ops for an
+    /// `n`-row append, each resolving at flush to a full property-map clone.
+    /// A one-shot `add_nodes` therefore wrote a *quadratic* WAL payload and
+    /// could overflow the per-frame `u32` byte ceiling.
+    ///
+    /// Silencing it is sound because the detach/reattach pair is a logical
+    /// no-op for an already-existing node: it swaps the node's
+    /// `Arc<ColumnStore>` handle while preserving its `row_id`, and
+    /// `ColumnStore::row_properties` skips null columns, so even a
+    /// schema-growing chunk leaves `id`/`title`/`properties_cloned`
+    /// byte-identical. The rows this chunk genuinely creates are recorded by
+    /// [`GraphWrite::add_node`], and `resolve_ops` reads *final* state at
+    /// flush time — so those ops still carry the columnar values that
+    /// `reattach_columnar_stores` installs after `add_node` returns.
+    ///
+    /// No undo obligation is dropped either: both columnar sweeps run only
+    /// when `is_mapped() || is_disk()`, and `GraphBackend::undo_journal_mut`
+    /// yields `None` for `Mapped` and `Disk` (see
+    /// `GraphBackend::supports_undo_journal`) — there is never a journal
+    /// installed on this path to capture into.
+    ///
     /// Returns `(rows awaiting reattachment, owned stores keyed by node type)`.
     fn detach_columnar_stores(
         creates: &[NodeCreationInterned],
@@ -364,7 +390,7 @@ impl BatchProcessor {
             // Detach existing nodes — record their (NodeIndex, row_id) for pass 2
             if let Some(indices) = graph.type_indices.get(node_type) {
                 for idx in indices.iter() {
-                    if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, idx) {
+                    if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, idx) {
                         if let PropertyStorage::Columnar { row_id, .. } = &node.properties {
                             let rid = *row_id;
                             node.properties = PropertyStorage::Map(HashMap::new());
@@ -394,6 +420,12 @@ impl BatchProcessor {
     ///
     /// No-op when pass 1 found nothing to detach and no columnar row was
     /// appended, which is every in-memory flush.
+    ///
+    /// The handle assignment goes through
+    /// [`GraphWrite::node_weight_mut_silent`] for the same reason pass 1
+    /// does — see [`Self::detach_columnar_stores`] for the full argument.
+    /// Newly created rows are already covered by the `RawOp::UpsertNode` that
+    /// `add_node` pushed, which resolves against post-reattachment state.
     fn reattach_columnar_stores(
         graph: &mut DirGraph,
         deferred_columnar: DeferredColumnarRows,
@@ -414,7 +446,7 @@ impl BatchProcessor {
         // keeps the slot-index value assigned by add_node().
         for (node_idx, node_type, row_id) in deferred_columnar {
             let arc_store = graph.column_stores.get(&node_type).unwrap().clone();
-            if let Some(node) = GraphWrite::node_weight_mut(&mut graph.graph, node_idx) {
+            if let Some(node) = GraphWrite::node_weight_mut_silent(&mut graph.graph, node_idx) {
                 node.properties = PropertyStorage::Columnar {
                     store: arc_store,
                     row_id,
@@ -1054,5 +1086,116 @@ mod tests {
     fn test_sum_values_null_cases() {
         assert_eq!(sum_values(&Value::Null, &Value::Int64(5)), Value::Int64(5));
         assert_eq!(sum_values(&Value::Int64(5), &Value::Null), Value::Null);
+    }
+}
+
+/// The WAL payload a mapped/disk `add_nodes` produces must scale with the
+/// number of rows written, not with the number of rows the type already holds.
+///
+/// Regression guard for the quadratic-amplification bug: the columnar
+/// detach/reattach sweeps in [`BatchProcessor::detach_columnar_stores`] and
+/// [`BatchProcessor::reattach_columnar_stores`] touch every existing node of
+/// the type, once per `LARGE_BATCH_CHUNK_SIZE` chunk. Through the *recorded*
+/// `node_weight_mut` that was `O(n²/chunk)` `RawOp::UpsertNode`s for an
+/// `n`-row append, each resolving to a full property-map clone in the frame.
+///
+/// This is deliberately a **byte-count** assertion, not a timing one: it needs
+/// no idle machine, has no `min`-vs-`mean` ambiguity, and fails deterministically
+/// on any reintroduction of a recorded borrow in either sweep.
+#[cfg(test)]
+mod wal_amplification_tests {
+    use crate::datatypes::{DataFrame, Value};
+    use crate::graph::mutation::maintain::add_nodes;
+    use crate::graph::schema::GraphBackend;
+    use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+    use crate::graph::storage::recording::{resolve_ops, RecordingGraph};
+    use crate::graph::storage::GraphRead;
+    use crate::graph::wal::{append_frame, WalFrame};
+
+    /// Append `n` rows to a fresh mapped graph through a recording backend and
+    /// return `(number of resolved WAL ops, encoded frame bytes)`.
+    fn wal_cost_of_appending(n: i64) -> (usize, usize) {
+        let mut dir = new_dir_graph_in_mode(StorageMode::Mapped, None).expect("mapped graph");
+        // Wrap the mapped backend exactly as `setup_durable` does, so the
+        // capture seam under test is the real one.
+        let inner = std::mem::replace(&mut dir.graph, GraphBackend::new());
+        dir.graph = GraphBackend::Recording(Box::new(RecordingGraph::new(inner)));
+        assert!(
+            dir.graph.is_mapped(),
+            "the sweeps under test are mapped-only"
+        );
+
+        let columns = vec!["id".to_string(), "name".to_string(), "dept".to_string()];
+        let rows: Vec<Vec<Value>> = (0..n)
+            .map(|i| {
+                vec![
+                    Value::Int64(i),
+                    Value::String(format!("person-{i}")),
+                    Value::String("engineering".to_string()),
+                ]
+            })
+            .collect();
+        let df = DataFrame::from_cypher_rows(columns, rows).expect("dataframe");
+
+        add_nodes(
+            &mut dir,
+            df,
+            "Person".to_string(),
+            "id".to_string(),
+            Some("name".to_string()),
+            None,
+        )
+        .expect("add_nodes");
+
+        let raw = match &mut dir.graph {
+            GraphBackend::Recording(rg) => rg.take_ops(),
+            _ => unreachable!("wrapped in Recording above"),
+        };
+        let ops = resolve_ops(&raw, &dir.graph, &dir.interner, |idx| {
+            dir.secondary_label_names(idx)
+        });
+        let op_count = ops.len();
+
+        let mut encoded = Vec::new();
+        append_frame(&mut encoded, &WalFrame { lsn: 1, ops }).expect("frame encodes");
+        (op_count, encoded.len())
+    }
+
+    /// One op per row, at every size — the crisp form of the invariant.
+    ///
+    /// `n` spans four `LARGE_BATCH_CHUNK_SIZE` chunks, so the amplifying
+    /// shape (chunk `k` re-touching the `k * 1000` rows already present) is
+    /// exercised. Pre-fix this was 2 ops/row at 1k and 5 ops/row at 4k.
+    #[test]
+    fn add_nodes_records_exactly_one_wal_op_per_row() {
+        for n in [1000_i64, 4000] {
+            let (ops, _) = wal_cost_of_appending(n);
+            assert_eq!(
+                ops, n as usize,
+                "a {n}-row mapped append must record exactly {n} WAL ops, got {ops}; \
+                 a columnar detach/reattach sweep is recording again"
+            );
+        }
+    }
+
+    /// WAL bytes per row stay flat as the row count grows.
+    ///
+    /// The tolerance absorbs the genuine per-row growth in the encoding (id
+    /// and title widen by a byte or two as values get longer) while staying
+    /// far below the pre-fix blow-up, which was ~2.5x over this same span and
+    /// unbounded beyond it.
+    #[test]
+    fn add_nodes_wal_bytes_per_row_are_flat() {
+        let (_, small_bytes) = wal_cost_of_appending(1000);
+        let (_, large_bytes) = wal_cost_of_appending(4000);
+        let small_per_row = small_bytes as f64 / 1000.0;
+        let large_per_row = large_bytes as f64 / 4000.0;
+        let ratio = large_per_row / small_per_row;
+        assert!(
+            ratio < 1.15,
+            "WAL bytes/row must not grow with graph size: {small_per_row:.1} B/row at 1k rows \
+             vs {large_per_row:.1} B/row at 4k rows (ratio {ratio:.2}). A quadratic payload \
+             means a columnar sweep is recording one op per pre-existing node again."
+        );
     }
 }

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -1149,14 +1149,49 @@ pub(crate) fn detach_delete_nodes(
     // Same guard scoping as the edge collection above (node_weight
     // materializes on the disk backend).
     let mut affected_types: HashSet<String> = HashSet::new();
+    // The doomed nodes' ids, per type, so the id index can be edited in place
+    // instead of being dropped and rebuilt by the next lookup. Read here
+    // because after `remove_node` below the weights are gone.
+    let mut doomed_ids: HashMap<String, Vec<(Value, NodeIndex)>> = HashMap::new();
     {
         let _guard = graph.graph.begin_query();
         for &node_idx in nodes_to_delete {
             if let Some(node) = graph.graph.node_weight(node_idx) {
-                affected_types.insert(node.get_node_type_ref(&graph.interner).to_string());
+                let node_type = node.get_node_type_ref(&graph.interner).to_string();
+                let node_id = node.id().into_owned();
+                doomed_ids
+                    .entry(node_type.clone())
+                    .or_default()
+                    .push((node_id, node_idx));
+                affected_types.insert(node_type);
             }
         }
     }
+
+    // Whether each type's id index may be edited in place rather than dropped.
+    //
+    // In-place eviction removes exactly the ids handed to it; a rebuild
+    // re-derives the map from the surviving nodes. The two agree only while
+    // ids are unique within the type. If two live nodes share an id the index
+    // holds one of them, and deleting that one must leave the *other*
+    // reachable by id — which only a rebuild achieves. Duplicates are
+    // detectable in O(1): the index was built with one entry per node of the
+    // type, so a shorter index is exactly the signature of collapsed
+    // duplicates. Unequal (or unbuilt, or base-resident) falls back to the
+    // whole-type invalidation this path has always done.
+    //
+    // Note this differs from the create path, which may maintain the index
+    // incrementally unconditionally: inserting a duplicate collapses it the
+    // same way a rebuild would, so the two stay in agreement there.
+    let evictable: HashSet<String> = affected_types
+        .iter()
+        .filter(|node_type| {
+            let indexed = graph.id_indices.overlay_len(node_type);
+            let live = graph.type_indices.get(node_type).map(|m| m.len());
+            matches!((indexed, live), (Some(i), Some(l)) if i == l)
+        })
+        .cloned()
+        .collect();
 
     for &node_idx in nodes_to_delete {
         GraphWrite::remove_node(&mut graph.graph, node_idx);
@@ -1179,7 +1214,14 @@ pub(crate) fn detach_delete_nodes(
         graph
             .type_indices
             .retain_in_type(node_type, |idx| !nodes_to_delete.contains(idx));
-        graph.id_indices.remove(node_type);
+        match doomed_ids.get(node_type) {
+            Some(entries) if evictable.contains(node_type) => {
+                graph.id_indices.evict_entries(node_type, entries);
+            }
+            _ => {
+                graph.id_indices.remove(node_type);
+            }
+        }
         let prop_keys: Vec<_> = graph
             .property_indices
             .keys()
@@ -2267,3 +2309,7 @@ mod replace_connections_tests {
         assert_eq!(count_edges_of_type(&g, "Doc", 1, "MENTIONS"), 1);
     }
 }
+
+#[cfg(test)]
+#[path = "maintain_delete_id_index_tests.rs"]
+mod delete_id_index_tests;

--- a/crates/kglite/src/graph/mutation/maintain_delete_id_index_tests.rs
+++ b/crates/kglite/src/graph/mutation/maintain_delete_id_index_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for in-place id-index maintenance on the delete path.
+//!
+//! Split out of `maintain.rs` to keep that file under the source-quality
+//! line ceiling, matching the existing `maintain_edge_spec_tests.rs`.
+
+use super::*;
+use crate::graph::session::execute::{execute_mut, ExecuteOptions};
+
+fn run(graph: &mut DirGraph, query: &str) {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::eager(&params);
+    execute_mut(graph, query, &opts).unwrap_or_else(|e| panic!("setup query failed: {query}: {e}"));
+}
+
+/// Three `Person` nodes with distinct ids and a warm id index.
+fn seeded_people() -> DirGraph {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Person {id: 1, name: 'a'}), (:Person {id: 2, name: 'b'}), \
+         (:Person {id: 3, name: 'c'})",
+    );
+    graph.build_id_index("Person");
+    assert!(graph.id_indices.contains_key("Person"));
+    graph
+}
+
+/// Deleting one node must edit the type's id index in place, not drop it.
+///
+/// Dropping it makes a single-node delete O(N_type): the next id lookup
+/// rebuilds the whole map via `compute_id_index`, one node-weight read and
+/// `Value` clone per node of the type. That is the delete-side twin of the
+/// incremental maintenance the create path already does.
+///
+/// Asserted through `IdIndexStore::lookup`, the **non-building** read, so
+/// the self-healing `lookup_or_build` path cannot mask a dropped index:
+/// after a drop the survivor probe returns `None` and this fails.
+#[test]
+fn delete_edits_id_index_in_place() {
+    let mut graph = seeded_people();
+    let doomed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .expect("id 2 must be indexed");
+    let survivor = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(3))
+        .expect("id 3 must be indexed");
+
+    let mut to_delete = HashSet::new();
+    to_delete.insert(doomed);
+    assert_eq!(detach_delete_nodes(&mut graph, &to_delete), (1, 0));
+
+    // The index survived the delete: a non-building lookup still resolves
+    // an untouched id. This is the assertion the fix exists for.
+    assert_eq!(
+        graph.id_indices.lookup("Person", &Value::Int64(3)),
+        Some(survivor),
+        "the delete must leave the id index usable, not force a rebuild"
+    );
+    // And it is correct: the deleted id is gone, the count dropped by one.
+    assert_eq!(graph.id_indices.lookup("Person", &Value::Int64(2)), None);
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+    // The self-healing path agrees with the in-place edit.
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_none());
+    assert_eq!(
+        graph.lookup_by_id_readonly("Person", &Value::Int64(1)),
+        graph.id_indices.lookup("Person", &Value::Int64(1))
+    );
+}
+
+/// Duplicate ids must still force a full rebuild.
+///
+/// In-place eviction removes exactly the ids it is handed; a rebuild
+/// re-derives the map from the survivors. They disagree only when two live
+/// nodes share an id: the index holds one of them, and deleting *that* one
+/// must leave the other reachable — which only a rebuild achieves.
+/// `detach_delete_nodes` detects this in O(1) by comparing the index length
+/// against the type's live node count.
+///
+/// Removing the `evictable` guard makes this fail: the id-1 entry is
+/// evicted, the index stays "built", and the shadowed survivor becomes
+/// permanently unreachable by id.
+#[test]
+fn delete_with_duplicate_ids_falls_back_to_rebuild() {
+    let mut graph = DirGraph::new();
+    // No primary key declared, so duplicate ids are admitted.
+    run(&mut graph, "CREATE (:Person {id: 1, name: 'first'})");
+    run(&mut graph, "CREATE (:Person {id: 1, name: 'second'})");
+    run(&mut graph, "CREATE (:Person {id: 2, name: 'other'})");
+    graph.build_id_index("Person");
+
+    // Two nodes share id 1, so the index collapsed them: three nodes, two
+    // entries. That inequality is exactly what the guard keys on.
+    assert_eq!(graph.type_indices.get("Person").map(|m| m.len()), Some(3));
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+
+    let indexed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .expect("id 1 resolves to one of the two");
+    let mut to_delete = HashSet::new();
+    to_delete.insert(indexed);
+    assert_eq!(detach_delete_nodes(&mut graph, &to_delete), (1, 0));
+
+    // The shadowed duplicate is now the only node with id 1, and must be
+    // reachable by id.
+    let survivor = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .expect("the shadowed duplicate must remain reachable by id");
+    assert_ne!(survivor, indexed);
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_some());
+}
+
+/// An unbuilt id index must stay unbuilt.
+///
+/// Exercised directly against `IdIndexStore`, **not** through
+/// `detach_delete_nodes`: the `evictable` guard already excludes any type
+/// that is not overlay-resident, so routing this through a delete would
+/// never reach `evict_entries` and the test would pass no matter what
+/// `evict_entries` did. This is the store-level contract the delete path
+/// relies on — a half-populated entry would be trusted as complete by
+/// `build_id_index`, which short-circuits whenever an entry exists.
+#[test]
+fn evicting_an_absent_id_index_does_not_materialize_it() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (:Person {id: 1, name: 'a'}), (:Person {id: 2, name: 'b'})",
+    );
+    graph.build_id_index("Person");
+    let doomed = graph
+        .lookup_by_id_readonly("Person", &Value::Int64(1))
+        .unwrap();
+    graph.id_indices.remove("Person");
+    assert!(!graph.id_indices.contains_key("Person"));
+
+    let evicted = graph
+        .id_indices
+        .evict_entries("Person", &[(Value::Int64(1), doomed)]);
+
+    assert!(!evicted, "an absent index cannot be edited in place");
+    assert!(
+        !graph.id_indices.contains_key("Person"),
+        "an absent index must not be partially materialized by an evict"
+    );
+    // The later rebuild is therefore complete: both nodes are still live.
+    assert!(graph
+        .lookup_by_id_readonly("Person", &Value::Int64(2))
+        .is_some());
+    assert_eq!(graph.id_indices.overlay_len("Person"), Some(2));
+}
+
+/// A multi-type delete must edit each affected type's index independently.
+#[test]
+fn detach_delete_edits_every_affected_type() {
+    let mut graph = DirGraph::new();
+    run(
+        &mut graph,
+        "CREATE (i:Issue {id: 1}), (c:Comment {id: 10}), (c2:Comment {id: 11})",
+    );
+    run(
+        &mut graph,
+        "MATCH (i:Issue {id: 1}), (c:Comment {id: 10}) CREATE (c)-[:ON]->(i)",
+    );
+    run(
+        &mut graph,
+        "MATCH (i:Issue {id: 1}), (c:Comment {id: 11}) CREATE (c)-[:ON]->(i)",
+    );
+    assert_eq!(graph.graph.edge_count(), 2);
+    graph.build_id_index("Issue");
+    graph.build_id_index("Comment");
+
+    let issue = graph
+        .lookup_by_id_readonly("Issue", &Value::Int64(1))
+        .unwrap();
+    let comment = graph
+        .lookup_by_id_readonly("Comment", &Value::Int64(10))
+        .unwrap();
+    let survivor = graph
+        .lookup_by_id_readonly("Comment", &Value::Int64(11))
+        .unwrap();
+
+    let mut to_delete = HashSet::new();
+    to_delete.insert(issue);
+    to_delete.insert(comment);
+    let (nodes, edges) = detach_delete_nodes(&mut graph, &to_delete);
+    assert_eq!((nodes, edges), (2, 2));
+
+    // Both indices survived, both are correct.
+    assert_eq!(graph.id_indices.lookup("Issue", &Value::Int64(1)), None);
+    assert_eq!(graph.id_indices.overlay_len("Issue"), Some(0));
+    assert_eq!(graph.id_indices.lookup("Comment", &Value::Int64(10)), None);
+    assert_eq!(
+        graph.id_indices.lookup("Comment", &Value::Int64(11)),
+        Some(survivor),
+        "an untouched sibling must stay indexed without a rebuild"
+    );
+    assert_eq!(graph.id_indices.overlay_len("Comment"), Some(1));
+}

--- a/crates/kglite/src/graph/schema.rs
+++ b/crates/kglite/src/graph/schema.rs
@@ -1001,6 +1001,77 @@ impl TypeIdIndex {
         }
     }
 
+    /// Number of indexed ids.
+    pub fn len(&self) -> usize {
+        match self {
+            TypeIdIndex::Integer(map) => map.len(),
+            TypeIdIndex::General(map) => map.len(),
+        }
+    }
+
+    /// Whether the index holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drop the entry for `id`, but only when it currently resolves to `idx`.
+    ///
+    /// The `idx` check is what makes this safe to call while deleting: if the
+    /// id has since been re-pointed at a different node, the live mapping is
+    /// left alone rather than silently unindexing the survivor. Resolution
+    /// goes through [`get`](Self::get), so the same `Int64`/`UniqueId`/
+    /// `Float64` coercions apply — the key is removed under whichever
+    /// spelling it was actually stored, not under the caller's spelling.
+    ///
+    /// Returns whether an entry was removed.
+    pub fn remove_matching(&mut self, id: &Value, idx: NodeIndex) -> bool {
+        if self.get(id) != Some(idx) {
+            return false;
+        }
+        match self {
+            TypeIdIndex::Integer(map) => {
+                let key = match id {
+                    Value::UniqueId(u) => Some(*u),
+                    Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => Some(*i as u32),
+                    Value::Float64(f) if f.fract() == 0.0 => {
+                        let i = *f as i64;
+                        if i >= 0 && i <= u32::MAX as i64 {
+                            Some(i as u32)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                key.is_some_and(|k| map.remove(&k).is_some())
+            }
+            TypeIdIndex::General(map) => {
+                if map.remove(id).is_some() {
+                    return true;
+                }
+                // `get` resolved it, so it is stored under a coerced spelling.
+                let coerced = match id {
+                    Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => {
+                        Some(Value::UniqueId(*i as u32))
+                    }
+                    Value::UniqueId(u) => Some(Value::Int64(*u as i64)),
+                    Value::Float64(f) if f.fract() == 0.0 => {
+                        let i = *f as i64;
+                        if map.contains_key(&Value::Int64(i)) {
+                            Some(Value::Int64(i))
+                        } else if i >= 0 && i <= u32::MAX as i64 {
+                            Some(Value::UniqueId(i as u32))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                coerced.is_some_and(|k| map.remove(&k).is_some())
+            }
+        }
+    }
+
     /// Iterate over all (Value, NodeIndex) pairs.
     pub fn iter(&self) -> Box<dyn Iterator<Item = (Value, NodeIndex)> + '_> {
         match self {

--- a/crates/kglite/src/graph/storage/backend.rs
+++ b/crates/kglite/src/graph/storage/backend.rs
@@ -106,6 +106,19 @@ impl GraphBackend {
     /// wraps, so a durable graph participates exactly when its underlying
     /// backend would: `Recording(Memory)` journals, `Recording(Mapped)` keeps
     /// the clone. Durability and rollback strategy are independent concerns.
+    ///
+    /// **This is deliberate, and it is the only remaining veto term in
+    /// `journal_covers`** — every other term was retired as the journal grew
+    /// to cover saved, indexed and columnar graphs. The user-visible cost is
+    /// worth stating plainly, because nothing else surfaces it: every mutating
+    /// statement on a mapped or disk graph still opens an O(V+E)
+    /// `fork_transaction()` whole-graph checkpoint, which is the pre-journal
+    /// behaviour. Under the "in-memory wins" doctrine that is the right
+    /// trade — the journal exists to make the *core* product cheap, and
+    /// neither larger-than-RAM backend can express an inverse petgraph edit
+    /// today — but it does mean statement rollback cost scales with graph
+    /// size in exactly the modes chosen for large graphs. Mirrored in the
+    /// user-facing storage-mode guide (`docs/python/core-concepts.md`).
     #[inline]
     pub(crate) fn supports_undo_journal(&self) -> bool {
         match self {

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -514,6 +514,44 @@ impl IdIndexStore {
         self.overlay.get_mut().unwrap().insert(name, idx);
     }
 
+    /// Number of ids indexed for `name` in the mutable overlay, or `None`
+    /// when the type is not overlay-resident. Deliberately does not consult
+    /// the mmap'd base: the only caller uses this to decide whether an
+    /// in-place edit is safe, and base entries are never edited in place.
+    pub fn overlay_len(&self, name: &str) -> Option<usize> {
+        self.overlay.read().unwrap().get(name).map(|idx| idx.len())
+    }
+
+    /// Drop `entries` (`id → node`) from `name`'s index in place, instead of
+    /// invalidating the whole type.
+    ///
+    /// Deleting one node used to `remove()` the entire type index, so the next
+    /// id lookup rebuilt it by scanning every node of the type — an O(N_type)
+    /// cost charged to a single-node delete. The create path already maintains
+    /// this index incrementally (see the `pk_id` match in the Cypher create
+    /// executor); this is the same treatment for the delete side.
+    ///
+    /// Falls back to whole-type invalidation, and returns `false`, whenever the
+    /// index is not overlay-resident — an unbuilt type has nothing to edit, and
+    /// a base-resident type lives in an immutable mmap. Each entry is removed
+    /// only if it still resolves to the given node, so a re-pointed id is left
+    /// intact.
+    ///
+    /// The caller is responsible for the duplicate-id precondition: this edits
+    /// exactly the ids it is given, whereas a rebuild re-derives the whole map
+    /// and would surface a shadowed duplicate. See `detach_delete_nodes`.
+    pub fn evict_entries(&mut self, name: &str, entries: &[(Value, NodeIndex)]) -> bool {
+        let overlay = self.overlay.get_mut().unwrap();
+        let Some(index) = overlay.get_mut(name) else {
+            self.remove(name);
+            return false;
+        };
+        for (id, idx) in entries {
+            index.remove_matching(id, *idx);
+        }
+        true
+    }
+
     pub fn remove(&mut self, name: &str) -> Option<TypeIdIndex> {
         let prev = self.overlay.get_mut().unwrap().remove(name);
         if self.base.as_ref().is_some_and(|b| b.contains(name)) {

--- a/crates/kglite/src/graph/storage/impls.rs
+++ b/crates/kglite/src/graph/storage/impls.rs
@@ -347,6 +347,23 @@ impl GraphWrite for MemoryGraph {
         self.inner.node_weight_mut(idx)
     }
 
+    /// Bypasses the undo journal as well as the WAL recorder.
+    ///
+    /// The one caller is the columnar handle-refresh sweep, which re-points
+    /// every node of a type at a forked master store. Capturing a `NodeData`
+    /// pre-image for each of them would make a one-row `SET` cost one clone
+    /// per node *of the type* — the O(V+E)-per-write cost this journal exists
+    /// to remove, reintroduced at a smaller constant. The sweep's inverse is
+    /// journalled once per type instead, as
+    /// [`UndoEntry::ColumnarHandles`](crate::graph::storage::undo::UndoEntry::ColumnarHandles).
+    ///
+    /// Nothing else may use this method to skip capture: a caller that
+    /// changes a node's *content* silently is unrecoverable on rollback.
+    #[inline]
+    fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
+        self.inner.node_weight_mut(idx)
+    }
+
     #[inline]
     fn edge_weight_mut(&mut self, idx: EdgeIndex) -> Option<&mut EdgeData> {
         self.invalidate_peer_counts();

--- a/crates/kglite/src/graph/storage/recording.rs
+++ b/crates/kglite/src/graph/storage/recording.rs
@@ -581,8 +581,11 @@ impl<G: GraphWrite> GraphWrite for RecordingGraph<G> {
     #[inline]
     fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
         // Bypass recording — internal bookkeeping (columnar handle refresh),
-        // not a logical mutation. See the trait method docs.
-        self.inner.node_weight_mut(idx)
+        // not a logical mutation. See the trait method docs. Delegated to the
+        // inner backend's *silent* method rather than its recorded one so the
+        // silence composes: `MemoryGraph` also skips undo-journal capture
+        // here, and wrapping it must not put that capture back.
+        self.inner.node_weight_mut_silent(idx)
     }
 
     #[inline]

--- a/crates/kglite/src/graph/storage/undo.rs
+++ b/crates/kglite/src/graph/storage/undo.rs
@@ -56,6 +56,7 @@
 //!   `NodeData` clone, not five.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
 
@@ -64,6 +65,33 @@ use crate::graph::features::timeseries::NodeTimeseries;
 use crate::graph::schema::{
     CompositeIndexKey, CompositeValue, EdgeData, IndexKey, InternedKey, NodeData,
 };
+use crate::graph::storage::column_store::ColumnStore;
+
+#[cfg(test)]
+thread_local! {
+    /// Node pre-images actually cloned into an undo journal since the last
+    /// reset.
+    ///
+    /// The complement of `BACKEND_CLONE_NODES` (`storage/backend.rs`), which
+    /// counts nodes copied by a *backend* clone and is therefore blind to the
+    /// journal path by construction: the whole point of the journal checkpoint
+    /// is that it clones no backend. A statement that captures a pre-image per
+    /// node of a type rather than per node it changed is O(type)-per-write,
+    /// which is the cost class the journal exists to remove, and this is the
+    /// only counter that can see it.
+    static JOURNAL_NODE_PRE_IMAGES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_journal_node_pre_images() {
+    JOURNAL_NODE_PRE_IMAGES.set(0);
+}
+
+/// Node pre-images cloned into an undo journal since the last reset.
+#[cfg(test)]
+pub(crate) fn journal_node_pre_images() -> usize {
+    JOURNAL_NODE_PRE_IMAGES.get()
+}
 
 /// A `Vec<NodeIndex>` bucket in one of `DirGraph`'s inverted indexes.
 /// Bucket edits are journalled with a *position* so a rollback restores the
@@ -141,6 +169,22 @@ pub enum UndoEntry {
         node: usize,
         prior: Box<NodeTimeseries>,
     },
+    /// `execute_set`'s columnar fast path wrote through the master
+    /// `Arc<ColumnStore>` for `node_type`, forking it, and then re-pointed
+    /// every node of that type at the fork. `prior` is the master as it stood
+    /// before the statement's first such write; undo re-points them all back.
+    ///
+    /// **One entry per type per statement, not per node.** That is the whole
+    /// reason this variant exists: the refresh sweep touches every node of the
+    /// type, so journalling it through the ordinary weight-capture seam would
+    /// cost a `NodeData` clone per node of the type on every single-row `SET`.
+    /// The store itself needs no copy — `ColumnStore` has no interior
+    /// mutability and the fork already left `prior` pristine, so holding the
+    /// handle is the entire pre-image.
+    ColumnarHandles {
+        node_type: String,
+        prior: Arc<ColumnStore>,
+    },
 }
 
 /// Buffer of inverse operations for exactly one statement.
@@ -157,6 +201,11 @@ pub struct UndoJournal {
     weighed_nodes: HashSet<NodeIndex>,
     /// Edge counterpart of `weighed_nodes`.
     weighed_edges: HashSet<EdgeIndex>,
+    /// Node types whose pre-statement master column store is already captured.
+    /// First touch wins, exactly like `weighed_nodes`: a statement can write
+    /// through the same master in several clauses, and only the first one saw
+    /// the pre-statement store.
+    forked_columnar_types: HashSet<String>,
 }
 
 impl UndoJournal {
@@ -189,6 +238,8 @@ impl UndoJournal {
     pub fn note_node_weight(&mut self, idx: NodeIndex, prior: impl FnOnce() -> Option<NodeData>) {
         if self.weighed_nodes.insert(idx) {
             if let Some(prior) = prior() {
+                #[cfg(test)]
+                JOURNAL_NODE_PRE_IMAGES.set(JOURNAL_NODE_PRE_IMAGES.get() + 1);
                 self.entries.push(UndoEntry::NodeWeight { idx, prior });
             }
         }
@@ -275,6 +326,31 @@ impl UndoJournal {
         for (pos, idx) in hits {
             self.note_bucket_removed(bucket.clone(), idx, pos);
         }
+    }
+
+    /// The master column store for `node_type` is about to be forked by a
+    /// columnar write. `prior` is only taken on the statement's first fork of
+    /// that type, so the captured handle is the pre-statement one.
+    ///
+    /// Returns whether the capture happened, so the caller can skip the
+    /// `Arc::clone` on later writes of the same statement.
+    #[inline]
+    pub fn note_columnar_fork(
+        &mut self,
+        node_type: &str,
+        prior: impl FnOnce() -> Option<Arc<ColumnStore>>,
+    ) -> bool {
+        if !self.forked_columnar_types.contains(node_type) {
+            self.forked_columnar_types.insert(node_type.to_string());
+            if let Some(prior) = prior() {
+                self.entries.push(UndoEntry::ColumnarHandles {
+                    node_type: node_type.to_string(),
+                    prior,
+                });
+                return true;
+            }
+        }
+        false
     }
 
     /// A node's timeseries was dropped.

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -66,7 +66,7 @@ Wikidata scale where you want the OS to page data in lazily.
 | If your graph is… | …and you want | Use | `open()` crash safety |
 |---|---|---|---|
 | Up to a few million nodes | Lowest latency, simplest setup | **memory** (default) | Per-commit WAL, on by default |
-| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL, on by default |
+| Large but you still query it interactively | RAM headroom without giving up typed-lookup speed | **mapped** | Per-commit WAL on the creating `open()`; a reopened `.kgl` comes back as **memory** (see below) |
 | 100 M+ nodes / won't fit in RAM | Lazy, page-on-demand access to a huge graph | **disk** | **No WAL** — durability is your `save()` calls |
 
 When in doubt, stay in-memory; switch only once you hit a real RAM
@@ -84,6 +84,31 @@ and bounded guarantee — the published generation always survives intact — bu
 it is *your* `save()` calls, not the engine, that decide how much a crash can
 cost. Pick `disk` for its scale, not because a graph outgrew RAM; `mapped`
 covers that case with the guarantee intact. See {doc}`guides/durable-apps`.
+
+**`storage=` selects a backend only when a graph is *created*.** The mode is
+not recorded in a saved graph, so `kglite.open(path, storage="mapped")` builds
+a mapped graph on the call that creates `path` and loads a **memory** graph on
+every call after that — a `.kgl` checkpoint always loads as `memory`, and a
+disk graph (a directory) always loads as `disk`. Rather than ignore the
+argument, `open()` raises `kglite.ArgumentError` when the requested mode disagrees with
+what the load produced; omit `storage=` to accept whatever the file provides.
+There is no saved-graph-to-mapped conversion: to get a mapped graph from data
+you have already saved, construct `KnowledgeGraph(storage="mapped")` and
+re-ingest from the original source. This matters most for benchmarks — a
+create-then-reopen script that passed `storage="mapped"` on both runs was
+previously measuring the memory backend twice.
+
+**Statement rollback is cheap only in memory mode.** One mutating Cypher
+statement is atomic: if it fails partway through, the graph is restored to its
+pre-statement state. In-memory graphs do that with an undo journal costing
+O(changes). Mapped and disk graphs cannot — neither backend can express an
+inverse edit against its mmap-columnar indexes or generation overlays — so both
+fall back to taking a **whole-graph O(V+E) checkpoint before every mutating
+statement**. This is a deliberate consequence of "in-memory wins", but it means
+per-statement write overhead grows with graph size in precisely the two modes
+you would choose for a large graph. If a mapped graph's writes feel slow
+relative to its reads, this is why; batching more work into fewer statements is
+the lever that helps.
 
 ## Return Types
 

--- a/docs/python/guides/durable-apps.md
+++ b/docs/python/guides/durable-apps.md
@@ -200,7 +200,7 @@ optimising for:
 | Every committed write to survive a hard crash | `open(path)` (the default) | One barrier per commit; reopen is O(graph) (loads the whole graph). |
 | Committed writes to survive a crashing *process*, cheaply | `open(path, durable="normal")` | No barrier per commit; an OS crash or power cut loses work since the last `save()`. Call `sync()` for a power-safe point. |
 | Maximum write throughput on rebuildable data | `open(path, durable="off")` | Nothing logged; a crash loses work since the last checkpoint. |
-| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` | Same per-commit WAL guarantee; property columns spill to mmap. |
+| Crash safety on a graph that outgrows RAM | `open(path, storage="mapped")` **on the call that creates it** | Same per-commit WAL guarantee; property columns spill to mmap. A `.kgl` records no storage mode, so reopening returns a **memory** graph — pass `storage="mapped"` only when creating, or the reopen raises `kglite.ArgumentError`. See [Choosing a storage mode](../core-concepts.md#choosing-a-storage-mode). |
 | 100 M+ nodes (Wikidata-scale), cheap cold-open | `open(path, storage="disk")` | Paged mmap, lazy load; **no per-commit WAL** — durability is your `save()` calls. |
 
 The first three are **in-memory** — the whole graph lives in RAM, which is what

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -755,8 +755,24 @@ def open(
             exists, otherwise created on first ``save()`` (or immediately, for
             ``storage="disk"``, which materializes the directory).
         storage: Storage mode for a *newly created* graph (``"mapped"`` /
-            ``"disk"``); ignored when opening an existing file, which keeps the
-            mode it was saved in.
+            ``"disk"``). Opening an existing path uses the mode the load
+            produces, which is not necessarily the mode that wrote it: a
+            ``.kgl`` checkpoint records no storage mode, so it always loads as
+            ``"memory"``; a disk graph is a directory and always loads as
+            ``"disk"``. A ``storage=`` that disagrees with the loaded backend
+            raises :class:`kglite.ArgumentError` rather than being ignored, so
+            ``open(path, storage="mapped")`` yields a genuinely mapped graph
+            only on the call that *creates* the file, and says so on every call
+            after that. Omit ``storage=`` to accept whatever the file provides.
+
+            Note the durability asymmetry between the two ways to build a
+            graph, which is structural rather than incidental: ``open()``
+            attaches a WAL sidecar next to ``path`` and defaults to
+            ``durable="full"``, whereas :class:`KnowledgeGraph` takes no
+            ``durable`` argument and is never durable — it produces a detached
+            graph with no ``source_path``, so there is nowhere for a log to
+            live. ``KnowledgeGraph(storage="mapped")`` is mapped-and-unlogged;
+            ``open(new_path, storage="mapped")`` is mapped-and-logged.
         durable: Write-ahead logging — **on by default**. Each committed
             mutation is appended to a ``<path>-wal`` sidecar, and on open any
             WAL frames are replayed onto the loaded checkpoint to recover work
@@ -1229,6 +1245,22 @@ class KnowledgeGraph:
                 ``storage="disk"``. The directory IS the graph — data is
                 written directly to disk via mmap. Load with
                 ``kglite.load(path)``.
+
+        Note:
+            **This constructor is never durable, and takes no ``durable``
+            argument.** It returns a *detached* graph — no ``source_path``, so
+            a bare ``save()`` asks for an explicit path and there is nowhere
+            for a write-ahead log to live. :func:`kglite.open` is the durable
+            entry point: it binds the graph to a path and defaults to
+            ``durable="full"``. So ``KnowledgeGraph(storage="mapped")`` is
+            mapped-and-unlogged while ``kglite.open(new_path,
+            storage="mapped")`` is mapped-and-logged. The difference is
+            structural rather than a defaulting inconsistency, but it is easy
+            to trip over when comparing the two.
+
+            Note also that mutating statements on a ``"mapped"`` or ``"disk"``
+            graph do **not** use the cheap statement-rollback journal — see
+            :func:`kglite.open` and the storage-mode guide.
         """
         ...
 

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -2375,11 +2375,25 @@ class KnowledgeGraph:
         ...
 
     def lock_schema(self) -> KnowledgeGraph:
-        """Lock the schema: future Cypher mutations must conform to current types.
+        """Lock the schema: Cypher must conform to the current types.
 
         When locked, CREATE, SET, and MERGE operations are validated against
-        the graph's known node types, connection types, and property types.
-        Invalid writes return descriptive errors with 'did you mean?' suggestions.
+        the graph's known node types, connection types, and property types,
+        and **reads are validated too**: an unknown node label in a MATCH,
+        OPTIONAL MATCH, MERGE, ``WHERE EXISTS { ... }`` pattern predicate, or
+        ``CALL { ... }`` subquery raises :class:`SchemaError` instead of
+        silently returning zero rows. Errors name the offending label or
+        property, enumerate the valid set, and add a 'did you mean?'
+        suggestion.
+
+        This is the "catch my typos" mechanism — an empty result set is
+        indistinguishable from "no matching data", so a typo'd label would
+        otherwise reach production looking like a legitimate empty state.
+
+        On an **unlocked** graph (the default) kglite is schemaless: an
+        unknown label matches nothing and is reported only as a non-fatal
+        ``warning:`` on stderr, keeping the zero-row existence-check idiom
+        valid.
 
         Returns:
             Self for method chaining.
@@ -2387,7 +2401,10 @@ class KnowledgeGraph:
         Example::
 
             graph.lock_schema()
-            graph.cypher("CREATE (p:Typo {name: 'x'})")  # raises RuntimeError
+            graph.cypher("CREATE (p:Typo {name: 'x'})")  # raises SchemaError
+            graph.cypher("MATCH (p:Persom) RETURN p")    # raises SchemaError
+            # Schema error: Unknown node type 'Persom'. Did you mean 'Person'?
+            #   Valid types: Paper, Person
 
         See Also:
             :meth:`unlock_schema`, :attr:`schema_locked`

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3158,6 +3159,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3128,6 +3129,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3143,6 +3144,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3128,6 +3129,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -452,6 +452,7 @@ pub fn kglite::api::cypher::planner::rel_predicate_pushdown::extract_pushable_re
 pub mod kglite::api::cypher::planner::schema_check
 pub enum kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UndefinedVariable
+pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownNodeType
 pub kglite::api::cypher::planner::schema_check::SchemaErrorKind::UnknownProperty
 impl core::clone::Clone for kglite::api::cypher::planner::schema_check::SchemaErrorKind
 pub fn kglite::api::cypher::planner::schema_check::SchemaErrorKind::clone(&self) -> kglite::api::cypher::planner::schema_check::SchemaErrorKind
@@ -3143,6 +3144,7 @@ impl core::marker::Copy for kglite::error::KgErrorCode
 impl core::marker::StructuralPartialEq for kglite::error::KgErrorCode
 pub enum kglite::error::SchemaErrorKindRepr
 pub kglite::error::SchemaErrorKindRepr::UndefinedVariable
+pub kglite::error::SchemaErrorKindRepr::UnknownNodeType
 pub kglite::error::SchemaErrorKindRepr::UnknownProperty
 impl core::clone::Clone for kglite::error::SchemaErrorKindRepr
 pub fn kglite::error::SchemaErrorKindRepr::clone(&self) -> kglite::error::SchemaErrorKindRepr

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 536,
-      "branches": 75,
+      "lines": 508,
+      "branches": 69,
       "nesting": 8
     },
     {

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 508,
-      "branches": 70,
+      "lines": 479,
+      "branches": 64,
       "nesting": 8
     },
     {

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -406,8 +406,8 @@
     {
       "path": "crates/kglite/src/graph/languages/cypher/executor/write.rs",
       "qualified_name": "crate::execute_set",
-      "lines": 536,
-      "branches": 75,
+      "lines": 507,
+      "branches": 70,
       "nesting": 8
     },
     {

--- a/tests/benchmarks/test_bench_delete_scaling.py
+++ b/tests/benchmarks/test_bench_delete_scaling.py
@@ -1,0 +1,460 @@
+"""Why is deleting so much more expensive than inserting?
+
+The 2026-07-27 competitive benchmark left exactly one finding **deliberately
+unattributed**, and this file is its instrument. At 100k nodes, with no index
+and at matched durability, in the very same configuration where an insert hit
+**exact parity with SQLite (3.668 ms vs 3.666 ms)**:
+
+| operation               | kglite     | SQLite    | ratio |
+|-------------------------|-----------:|----------:|------:|
+| `delete_comment`        |  10.09 ms  | 5.462 ms  | 1.8x  |
+| `cascade_delete_issue`  |  24.71 ms  | 5.476 ms  | 4.5x  |
+
+Against SQLite's `wal_normal` rung the gap is 2.6-6.1x. Inserts were at parity;
+deletes were not. Nothing in the suite measured a delete shape across sizes, so
+the *scaling* of that gap is simply unknown — which is why it stayed a mystery
+rather than becoming a bug report.
+
+**This file deliberately does not encode a cause.** The standing hypothesis at
+the time of writing was `check_auto_vacuum` being reachable on the delete path
+and not the insert path, and the probe was never run. A benchmark built around
+that hypothesis would measure the hypothesis; these cells measure the *shapes*
+instead — leaf delete, `DETACH DELETE` with edges, cascade — across three sizes,
+so the scaling is visible whatever the cause turns out to be, including a cause
+nobody has thought of yet.
+
+Two candidate costs *are* separated, because both are known to exist and would
+otherwise be summed into one uninterpretable number:
+
+* **the id-index rebuild.** A delete invalidates the type's id index, so the
+  next lookup by id pays an O(V) rebuild. `test_bench_write_scaling.py`
+  measured that term alone at 34,486 us vs 4.1 us at 1M. Its cost lands on
+  whoever queries next, not on the deleting statement, so it is split into its
+  own cell rather than left to contaminate the others.
+* **auto-vacuum.** `check_auto_vacuum` (`dir_graph/mod.rs:1901-1922`) is
+  called only from `after_mutation` (`kglite-py/src/graph/mod.rs:361-376`) and
+  only when `nodes_deleted > 0 || relationships_deleted > 0` — so it is, in
+  fact, structurally unreachable from an insert. It fires when tombstones
+  exceed a hard floor of 100 **and** the fragmentation ratio exceeds a
+  threshold, and `vacuum()` then rebuilds column stores and reindexes. See
+  `test_bench_bulk_delete_by_auto_vacuum` for what that cell can and cannot
+  tell you.
+
+**Every other cell here pins `set_auto_vacuum(None)`.** Not to hide the cost,
+but because an auto-vacuum firing on an arbitrary round turns a per-delete
+measurement into a bimodal one, and pytest-benchmark reports the blend. Leaving
+it enabled would produce the sort of plausible, mildly-elevated,
+completely-uninterpretable number this project's own methodology note warns
+about.
+
+Nothing here is in the `make bench-check` tracked set — that gate runs
+`tests/benchmarks/test_bench_core.py` only (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_delete_scaling.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from kglite import KnowledgeGraph
+
+# Three decades, because this defect is unexplained and the *slope* is the
+# entire finding. Two points give a ratio; three distinguish "linear in graph
+# size" from "linear in edges touched" from "flat with a large constant" — and
+# the answer decides where anyone looks next. 1k is also the scale at which the
+# competitive run found deletes to be *fine*, so it doubles as the control that
+# localises the problem to scale rather than to the delete path as such.
+SIZES = [1_000, 10_000, 100_000]
+
+#: Comments per issue in the fixture, and therefore edges detached by a cascade.
+COMMENTS_PER_ISSUE = 10
+
+#: Victims pre-created per shape, one consumed per round. Must exceed
+#: ROUNDS + WARMUP_ROUNDS or a cell runs out mid-measurement.
+VICTIM_POOL = 80
+
+# Explicit rounds rather than plain `benchmark(fn)`. Auto-calibration times the
+# first call to size the round count, and a delete's first call is not
+# representative: the fixture leaves the id index warm and the first delete
+# invalidates it. `test_bench_write_scaling.py:46-63` records that exact
+# pattern scheduling 12,686 rounds of a 24 ms call — five minutes from one
+# test, uninterruptible because `-m benchmark` is exempt from the 120 s hang
+# ceiling (`tests/conftest.py:34`).
+#
+# The pool size caps rounds independently: each round destroys a victim, so
+# rounds must stay under VICTIM_POOL.
+ROUNDS = 50
+WARMUP_ROUNDS = 5
+
+#: Id-space partitions, kept far apart so a victim id can never collide with a
+#: base-graph id and turn a delete into a silent no-op — which would read as a
+#: very fast delete rather than as an error.
+LEAF_BASE = 10_000_000
+DETACH_BASE = 20_000_000
+CASCADE_ISSUE_BASE = 30_000_000
+CASCADE_COMMENT_BASE = 40_000_000
+PROBE_BASE = 50_000_000
+BULK_BASE = 60_000_000
+
+
+def _issue_comment_graph(size: int) -> KnowledgeGraph:
+    """`size` Comments hanging off `size // COMMENTS_PER_ISSUE` Issues.
+
+    Mirrors the application the competitive benchmark implemented three times
+    (kglite / SQLite / ArcadeDB), so the numbers here are comparable to the
+    table in this file's docstring rather than merely internally consistent.
+
+    Primary keys are declared on both types. Without one, `CREATE` invalidates
+    the whole type's id index and the next id lookup rebuilds it — an O(V) cost
+    per statement that has nothing to do with deletion but is large enough to
+    swamp it (34,486 us vs 4.1 us at 1M).
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema(
+        {
+            "nodes": {
+                "Issue": {"primary_key": "id"},
+                "Comment": {"primary_key": "id"},
+            }
+        }
+    )
+    issue_count = max(1, size // COMMENTS_PER_ISSUE)
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(issue_count),
+                "title": [f"issue-{i}" for i in range(issue_count)],
+                "state": ["open" if i % 3 else "closed" for i in range(issue_count)],
+            }
+        ),
+        "Issue",
+        "id",
+        "title",
+        columns=["state"],
+    )
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "body": [f"comment body {i}" for i in range(size)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    graph.add_connections(
+        pd.DataFrame({"src": range(size), "dst": [i % issue_count for i in range(size)]}),
+        "ON",
+        "Comment",
+        "src",
+        "Issue",
+        "dst",
+    )
+    return graph
+
+
+def _add_victims(graph: KnowledgeGraph, base: int, *, attached: bool) -> None:
+    """A pool of throwaway Comments, optionally wired to an Issue.
+
+    Pre-created in the fixture rather than in a `pedantic` setup so the timed
+    region is a delete and nothing else. A setup that created the victim would
+    also warm the id index the delete then invalidates, which quietly changes
+    what the following round measures.
+    """
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(base, base + VICTIM_POOL),
+                "body": [f"victim body {i}" for i in range(VICTIM_POOL)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    if attached:
+        graph.add_connections(
+            pd.DataFrame({"src": range(base, base + VICTIM_POOL), "dst": [0] * VICTIM_POOL}),
+            "ON",
+            "Comment",
+            "src",
+            "Issue",
+            "dst",
+        )
+
+
+def _add_cascade_victims(graph: KnowledgeGraph) -> None:
+    """`VICTIM_POOL` Issues, each carrying `COMMENTS_PER_ISSUE` Comments."""
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(CASCADE_ISSUE_BASE, CASCADE_ISSUE_BASE + VICTIM_POOL),
+                "title": [f"victim issue {i}" for i in range(VICTIM_POOL)],
+                "state": ["open"] * VICTIM_POOL,
+            }
+        ),
+        "Issue",
+        "id",
+        "title",
+        columns=["state"],
+    )
+    total = VICTIM_POOL * COMMENTS_PER_ISSUE
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(CASCADE_COMMENT_BASE, CASCADE_COMMENT_BASE + total),
+                "body": [f"cascade body {i}" for i in range(total)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    graph.add_connections(
+        pd.DataFrame(
+            {
+                "src": range(CASCADE_COMMENT_BASE, CASCADE_COMMENT_BASE + total),
+                "dst": [CASCADE_ISSUE_BASE + (i // COMMENTS_PER_ISSUE) for i in range(total)],
+            }
+        ),
+        "ON",
+        "Comment",
+        "src",
+        "Issue",
+        "dst",
+    )
+
+
+@pytest.fixture(scope="module")
+def delete_graphs() -> dict[int, KnowledgeGraph]:
+    """One graph per size, pre-loaded with every shape's victim pool.
+
+    Module-scoped: three graphs, one of them 100k nodes plus 100k edges, is
+    seconds of build time that must not repeat per cell.
+
+    `set_auto_vacuum(None)` is the load-bearing line — see the module
+    docstring. Without it a vacuum fires on an arbitrary round once tombstones
+    pass 100, rebuilding column stores and reindexing, and every cell in this
+    file reports a blend of two populations.
+    """
+    graphs = {}
+    for size in SIZES:
+        graph = _issue_comment_graph(size)
+        _add_victims(graph, LEAF_BASE, attached=False)
+        _add_victims(graph, DETACH_BASE, attached=True)
+        _add_cascade_victims(graph)
+        graph.set_auto_vacuum(None)
+        graphs[size] = graph
+    return graphs
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_delete_leaf(benchmark, delete_graphs, size):
+    """Delete one Comment that has no edges at all.
+
+    The floor of the delete path: node removal, tombstone, index maintenance,
+    and nothing else. If this scales with graph size then the cost is in the
+    delete machinery itself and has nothing to do with edges — which would rule
+    out the whole "detaching relationships is expensive" family of explanations
+    in a single reading.
+
+    Defends the unattributed 100x-of-insert gap: `delete_comment` measured
+    **10.09 ms at 100k against a 3.668 ms insert in the same cell**
+    (2026-07-27).
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(LEAF_BASE, LEAF_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher("MATCH (c:Comment {id: $i}) DELETE c", params={"i": next(ids)})
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_detach_delete_one_edge(benchmark, delete_graphs, size):
+    """`DETACH DELETE` one Comment that owns exactly one edge.
+
+    Read against `test_bench_delete_leaf` at the same size: the difference is
+    the per-edge detach cost, isolated at one edge so it cannot be confused
+    with the cascade cell's fan-out. If leaf and detach diverge *with size*,
+    the edge-detach path is doing something proportional to the graph rather
+    than to the node's degree — the single most useful thing this file can
+    establish.
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(DETACH_BASE, DETACH_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher("MATCH (c:Comment {id: $i}) DETACH DELETE c", params={"i": next(ids)})
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_cascade_delete_issue(benchmark, delete_graphs, size):
+    """Delete an Issue together with its `COMMENTS_PER_ISSUE` Comments.
+
+    The worst cell in the competitive table: **24.71 ms at 100k against
+    SQLite's 5.476 ms, a 4.5x gap**, in a configuration where inserts were at
+    parity (2026-07-27).
+
+    Eleven nodes and ten edges per round. Against `test_bench_detach_delete_
+    one_edge` this says whether cascade cost is simply 11x a single delete
+    (a constant-factor story, uninteresting) or superlinear in the number of
+    entities removed per statement (a real defect).
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(CASCADE_ISSUE_BASE, CASCADE_ISSUE_BASE + VICTIM_POOL))
+
+    def delete():
+        graph.cypher(
+            "MATCH (i:Issue {id: $i})<-[:ON]-(c:Comment) DETACH DELETE i, c",
+            params={"i": next(ids)},
+        )
+
+    benchmark.pedantic(delete, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_delete_then_id_lookup(benchmark, delete_graphs, size):
+    """A delete plus the id lookup that pays for it.
+
+    The deleting statement invalidates the type's id index; the *rebuild* is
+    paid by whoever looks up by id next. Splitting it out matters because the
+    two costs land on different statements and scale differently, and an
+    application's real per-delete cost is this cell, not `test_bench_delete_
+    leaf`.
+
+    Read the difference between this and `test_bench_delete_leaf` as the
+    rebuild term. It is expected to scale with size — that is a known open
+    issue (`test_bench_write_scaling.py::test_bench_id_index_invalidation_on_
+    create`), not a regression — so the question this cell answers is how much
+    of the unexplained delete gap it accounts for. If it accounts for all of
+    it, the mystery is solved and it was never about deletion.
+    """
+    graph = delete_graphs[size]
+    ids = iter(range(PROBE_BASE, PROBE_BASE + VICTIM_POOL))
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(PROBE_BASE, PROBE_BASE + VICTIM_POOL),
+                "body": [f"probe body {i}" for i in range(VICTIM_POOL)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+
+    def delete_then_lookup():
+        graph.cypher("MATCH (c:Comment {id: $i}) DELETE c", params={"i": next(ids)})
+        graph.cypher("MATCH (c:Comment {id: 0}) RETURN c.id")
+
+    benchmark.pedantic(delete_then_lookup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+# ── the auto-vacuum discriminator ────────────────────────────────────
+#
+# Read the caveat before quoting this cell. `check_auto_vacuum` fires only when
+# BOTH conditions hold (`dir_graph/mod.rs:1901-1922`):
+#
+#     tombstones = node_bound() - node_count() > 100
+#     tombstones / node_bound() > threshold          (default 0.3)
+#
+# A per-round single delete produces one tombstone per round, so at the default
+# threshold a bounded benchmark never crosses either condition and the on/off
+# pair reads *identical*. That null result would look like evidence that
+# auto-vacuum is not the cost — while actually being evidence that the
+# benchmark never reached it. Under-powered nulls are how this defect stayed
+# unexplained in the first place.
+#
+# So this cell does two things differently: it deletes in a batch large enough
+# to clear the 100-tombstone floor within a few rounds, and it uses an
+# artificially low threshold so the ratio condition is reachable at all.
+#
+# WHAT IT MEASURES: whether the vacuum path, once entered, is expensive enough
+# to explain a delete gap. That is the open question.
+# WHAT IT DOES NOT MEASURE: the cost of the DEFAULT configuration. At
+# threshold=0.3 a real application vacuums rarely, and this cell says nothing
+# about how rarely. Do not quote it as "auto-vacuum costs X per delete".
+
+#: Comments removed per round — comfortably over the 100-tombstone floor, so
+#: the ratio condition is the only thing left gating the vacuum.
+BULK_DELETE_BATCH = 150
+
+#: Low enough that the ratio condition is satisfiable within a bounded run.
+#: The default is 0.3; see the caveat above before comparing the two.
+PROBE_VACUUM_THRESHOLD = 0.001
+
+#: Few rounds: each round deletes BULK_DELETE_BATCH nodes and a fired vacuum
+#: rebuilds column stores and reindexes the whole graph.
+BULK_ROUNDS = 6
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("auto_vacuum", [None, PROBE_VACUUM_THRESHOLD], ids=["vacuum_off", "vacuum_on"])
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_bulk_delete_by_auto_vacuum(benchmark, size, auto_vacuum):
+    """A batched delete with auto-vacuum reachable, versus disabled.
+
+    The discriminating pair for the standing hypothesis, run without asserting
+    it. Builds its own graph rather than sharing `delete_graphs`, because a
+    fired vacuum remaps every `NodeIndex` and rebuilds the column stores — it
+    would leave a shared fixture in a different state for whichever cell ran
+    next, making results depend on collection order.
+
+    Read `vacuum_on` against `vacuum_off` at the same size — **only against
+    each other, never against the single-delete cells above.** The `WHERE c.id
+    IN $ids` predicate is a label scan, so each round carries an O(V) term that
+    the point-lookup cells do not. Both arms pay it identically, so it cancels
+    in the comparison this cell exists to make, but it makes the absolute
+    number meaningless on its own. (The scan is deliberate: an `UNWIND` +
+    id-match spelling would be cheaper, and is also the exact shape of a fixed
+    0.11.2 bug where a bare point lookup silently returned nothing once the
+    list passed ~64 entries. A cell that quietly deleted zero nodes would be a
+    very fast delete benchmark and a completely false one.)
+
+    A large gap means the vacuum path is worth investigating as the delete
+    cost; a small one retires the hypothesis and points elsewhere. Either way
+    the answer is recorded rather than assumed.
+    """
+    graph = _issue_comment_graph(size)
+    graph.set_auto_vacuum(auto_vacuum)
+    total = BULK_DELETE_BATCH * (BULK_ROUNDS + 2)
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(BULK_BASE, BULK_BASE + total),
+                "body": [f"bulk body {i}" for i in range(total)],
+            }
+        ),
+        "Comment",
+        "id",
+        "body",
+    )
+    batches = iter(
+        [
+            list(range(BULK_BASE + n * BULK_DELETE_BATCH, BULK_BASE + (n + 1) * BULK_DELETE_BATCH))
+            for n in range(BULK_ROUNDS + 2)
+        ]
+    )
+
+    def delete_batch():
+        graph.cypher(
+            "MATCH (c:Comment) WHERE c.id IN $ids DETACH DELETE c",
+            params={"ids": next(batches)},
+        )
+
+    benchmark.pedantic(delete_batch, rounds=BULK_ROUNDS, iterations=1, warmup_rounds=1)

--- a/tests/benchmarks/test_bench_fast_write_path.py
+++ b/tests/benchmarks/test_bench_fast_write_path.py
@@ -1,0 +1,503 @@
+"""Does an ordinary user action silently move every later write onto a
+whole-graph clone?
+
+Two independent defects live here. Both make a single write O(V+E) instead of
+O(changes), both are invisible at small scale, and both were found by an
+external competitive benchmark rather than by this suite — because nothing in
+this suite was shaped to see them.
+
+────────────────────────────────────────────────────────────────────────────
+Defect A — the ``journal_covers`` vetoes (fixed in PR #86, ``59478b43``)
+────────────────────────────────────────────────────────────────────────────
+
+Until that fix, ``journal_covers`` had two independent veto terms, each
+permanently tripped by an ordinary user action, each sending every subsequent
+mutating statement through ``fork_transaction()`` — a full copy of the node
+and edge stores — for the rest of the session:
+
+* **``save()``** calls ``enable_columnar()``, which permanently populates
+  ``DirGraph.column_stores``. The old gate required that field to be *empty*.
+  Measured at 100k (2026-07-27): a single insert went **0.0062 ms → 3.0931 ms
+  and stayed there** — a ~500× permanent degradation from one ``save()``. A
+  second ``save()`` did not clear it. ``min ≈ mean``, so *every* write paid.
+* **any user index** vetoed the same path. Measured at 100k, ``durable=False``,
+  no ``save()``: **0.0127 ms → 15.22 ms**, reported as a 6–10× range rather
+  than a point estimate because the indexed cells were 17% noisy (two takes of
+  identical code gave 21.18 and 37.77 ms).
+
+With neither trigger, the same 100k insert costs **3.668 ms against SQLite's
+3.666 ms — exact parity**. So this was not an architectural deficit; it was a
+gate that excluded every realistic application graph.
+
+After PR #86 ``journal_covers`` (``rollback.rs:195-198``) has **exactly one**
+term left — ``graph.graph.supports_undo_journal()``. Neither ``save()`` nor any
+index family vetoes it any more. The only remaining way to force the clone is
+the *backend*: ``Memory`` journals, ``Recording`` forwards to its inner
+backend, and ``Mapped`` / ``Disk`` return ``false``
+(``storage/backend.rs:110-116``). A reintroduced veto is therefore a new
+conjunct in a one-conjunct predicate — cheap to add by accident, and these
+cells are what would notice.
+
+⚠ **The statement shape is load-bearing — see the STATEMENT SHAPE comment
+below.** A bare single-node ``CREATE`` cannot see this defect at all, in
+either direction, because it never opens a checkpoint in the first place.
+
+**Why the existing suite could not see it.** The Rust guard
+(``rollback_tests.rs::journalled_statements_copy_zero_nodes``) ran only on
+``seeded()`` — a graph with no column stores and no indexes, which cannot take
+the clone path *no matter what the gate says*. PR #86 added ``seeded_columnar``
+and ``seeded_indexed`` arms, and those are the authoritative, deterministic
+guard: they assert ``backend_clone_nodes() == 0``, an exact oracle for *which
+path ran*. This file cannot do that — ``backend_clone_nodes`` is ``#[cfg(test)]
+pub(crate)`` on a thread-local (``storage/backend.rs:42``) and is not reachable
+from Python by any route. **These benchmarks are the cost/scaling complement,
+not a replacement**: they measure that the fast path is still *cheap* and still
+*flat*, and they cover the one combination the Rust arms do not — saved **and**
+indexed at once, through a real ``save()`` rather than a bare
+``enable_columnar()``.
+
+────────────────────────────────────────────────────────────────────────────
+Defect B — ``Arc::make_mut`` deep clone on a merely-held reference
+────────────────────────────────────────────────────────────────────────────
+
+Holding a returned result view across a write triggers one full graph clone.
+Measured at 100k (2026-07-27): mean 0.0561 ms, p50 0.0044 ms, **max 5.17 ms**,
+with full recovery once the reference is released; ``freeze()`` held behaves
+the same (max 5.83 ms); ~28 ms at 1M. No threading, no snapshot API, no
+explicit copy — merely keeping the ``ResultView`` a query returned.
+
+See the measurement-trap comment above that section. It is the reason this
+defect survived a benchmark suite that already had a cell pointed at it.
+
+────────────────────────────────────────────────────────────────────────────
+How to read these, and the scale rule that governs the sizes
+────────────────────────────────────────────────────────────────────────────
+
+Like ``test_bench_write_scaling.py``, this file asserts no timing threshold —
+the signal is a **ratio**, and there are two of them:
+
+1. **Across variants at one size.** ``saved`` / ``indexed`` / ``saved_indexed``
+   must each stay close to ``fresh``. A variant that is orders of magnitude
+   worse has had its fast path vetoed.
+2. **Across sizes within one variant.** Every variant must be flat from 1k to
+   100k. A reintroduced O(V+E) term shows up as *divergence between the sizes*,
+   which is a far more robust detector than any absolute number: it survives a
+   change of machine, and it cannot be explained away as thermal noise.
+
+Nothing here is in the ``make bench-check`` tracked set. That gate runs
+``tests/benchmarks/test_bench_core.py`` only (see ``Makefile:85``), so a new
+file cannot perturb it — and, for defect B specifically, that gate compares on
+``--metric min``, which is structurally blind to it (again, see the trap
+comment).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_fast_write_path.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from kglite import KnowledgeGraph
+
+# ⚠ THE 100k CELL IS THE ONLY ONE THAT CAN SEE DEFECT A. DO NOT "SIMPLIFY"
+# THIS DOWN TO 1k.
+#
+# A fixed per-operation cost masks any multiplicative defect below the scale at
+# which the defect exceeds it. In the 2026-07-27 competitive run the index
+# penalty was *completely invisible* at 1k — 3.597 ms with no index vs 3.759 ms
+# with one, well inside noise — because the 3.4 ms F_FULLFSYNC floor swamped a
+# defect that is unmissable two decades up. A suite run only at small scale
+# would have certified this write path as healthy, which is exactly what
+# happened.
+#
+# 1k is kept as the *control*, not as the measurement: its job is to be the
+# denominator that makes the 100k divergence legible. Deleting it is as wrong
+# as deleting 100k.
+#
+# 1M is deliberately omitted. The defect is already unambiguous at two decades,
+# and four variants x 1M nodes is minutes of fixture build for no added signal.
+SIZES = [1_000, 100_000]
+
+#: The four corners of the ``journal_covers`` gate. ``saved_indexed`` is the
+#: one a real application actually is, and the one combination the Rust-side
+#: arms never build.
+VARIANTS = ["fresh", "saved", "indexed", "saved_indexed"]
+
+# Every cell here drives `benchmark.pedantic` with an explicit round count
+# rather than plain `benchmark(fn)`.
+#
+# This is a termination requirement, not a style choice. `pytest-benchmark`
+# auto-calibration times the first call to size the round count, and this file
+# exists precisely to compare a world where a write costs ~6 us against a world
+# where it costs ~15-38 ms. Calibration performed in the cheap world and then
+# applied in the expensive one schedules thousands of rounds of a
+# multi-millisecond call; `test_bench_write_scaling.py` records a real instance
+# of that pattern costing 5 minutes from a single test. A `-m benchmark` run is
+# exempt from the 120 s pytest hang ceiling (`tests/conftest.py`), so nothing
+# would interrupt it.
+#
+# `pedantic` skips calibration entirely, so runtime is bounded in BOTH worlds:
+# ~2 ms per cell when healthy, ~2 s per cell when the defect is back.
+ROUNDS = 50
+WARMUP_ROUNDS = 5
+
+#: Rounds for the reference-held cells (defect B). Lower, because each round
+#: forces a whole-graph copy by construction when the defect is present, and
+#: because a pinned reference keeps the pre-clone copy alive.
+REF_ROUNDS = 20
+REF_WARMUP_ROUNDS = 2
+
+
+# ⚠ STATEMENT SHAPE — THE SINGLE EASIEST WAY TO SILENTLY DISABLE THIS FILE.
+#
+# `session/execute.rs:390-394` opens a `StatementCheckpoint` only when
+# `can_skip_rollback_checkpoint(...)` is false. That whitelist
+# (`execute.rs:309-337`) returns true — meaning NO CHECKPOINT IS OPENED AT ALL,
+# `StatementCheckpoint::None` — for a query that is exactly one `Clause::Create`
+# with a single-node pattern, on a backend with
+# `supports_checkpoint_free_mutation()` (`backend.rs:94-96`: `Memory` only).
+#
+# So `CREATE (:Item {id: 1})` on an in-memory graph takes the same free path
+# before and after PR #86, on every variant. A benchmark built on it reads
+# identical everywhere and certifies health unconditionally — the exact
+# failure this file was written to end.
+#
+# `MERGE` is used instead: still a one-node insert, but not on the whitelist,
+# so it opens a real checkpoint and is therefore sensitive to which one opens.
+# The other non-whitelisted shapes are `SET`, a multi-element `CREATE`, and an
+# edge `CREATE` (they are what makes `rollback_tests.rs::ZERO_COPY_QUERIES`
+# non-vacuous — note its first entry, a bare `CREATE`, satisfies the assertion
+# trivially for this same reason).
+#
+# `test_bench_checkpoint_free_create_control` below pins the whitelist itself,
+# so that if it ever narrows, the cost shows up somewhere rather than nowhere.
+INSERT_STATEMENT = "MERGE (n:Item {id: $i}) ON CREATE SET n.name = 'x', n.code = 'c', n.qty = 1"
+
+
+def _base_graph(size: int) -> KnowledgeGraph:
+    """`size` nodes of one type, with a primary key and an indexable property.
+
+    The declared primary key is load-bearing and is not incidental tidiness.
+    Without one, `CREATE` invalidates the whole type's id index, so the next
+    lookup by id rebuilds it — an O(V) cost per statement that has nothing to
+    do with the rollback checkpoint but is large enough to swamp it entirely
+    (34,486 us vs 4.1 us at 1M, per `test_bench_write_scaling.py`). Measuring
+    the checkpoint through that noise would be measuring the wrong thing.
+
+    The string property matters too: a `Compact` `NodeData` clone allocates per
+    `Value::String`, so strings are what make a whole-graph clone expensive in
+    bytes rather than merely in node count.
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "name": [f"item-{i}" for i in range(size)],
+                "code": [f"code-{i}" for i in range(size)],
+                "qty": [i % 977 for i in range(size)],
+            }
+        ),
+        "Item",
+        "id",
+        "name",
+        columns=["code", "qty"],
+    )
+    # Warm the id index so the measurement is the write, not a first-touch
+    # index build landing in an arbitrary sample.
+    graph.cypher("MATCH (n:Item {id: 0}) RETURN n.id")
+    return graph
+
+
+def _variant_graph(size: int, variant: str, tmp_dir) -> KnowledgeGraph:
+    """A `_base_graph` pushed into one corner of the `journal_covers` gate.
+
+    ⚠ The save here is a **plain `KnowledgeGraph().save()`, never
+    `kglite.open()`**, and that is the single most important decision in this
+    file. `kglite.open()` defaults to `durable="full"`, which puts an
+    F_FULLFSYNC barrier — measured at 3.37 ms on this machine — on every commit.
+    The clone this file is trying to detect costs ~3.06 ms at 100k. Opening the
+    graph durably would therefore bury the entire signal underneath a fixed
+    cost of the same magnitude, and the cell would read "healthy" in both
+    worlds. Durability cost is measured in `test_bench_write_scaling.py`, on
+    purpose, separately.
+
+    `fsync=False` for the same reason: this save exists to flip
+    `column_stores` from empty to populated, not to benchmark a disk flush.
+    """
+    graph = _base_graph(size)
+    if variant in ("indexed", "saved_indexed"):
+        # A secondary property index — a lookup structure, not a constraint.
+        # Two of them, matching the shape the competitive run measured.
+        graph.create_index("Item", "code")
+        graph.create_index("Item", "qty")
+    if variant in ("saved", "saved_indexed"):
+        graph.save(str(tmp_dir / f"veto-{variant}-{size}.kgl"), fsync=False)
+
+    # Vacuity guards. The 2026-07-27 run's own methodology note earned this:
+    # every harness defect it caught was found because a number was
+    # inconsistent with the configuration it *claimed* to represent, never
+    # because a number looked implausible. A `saved` cell that silently isn't
+    # columnar, or an `indexed` cell whose index didn't take, would report a
+    # healthy fast path under a label promising otherwise — indistinguishable
+    # from the fix working. These are cheap and they fail loudly.
+    expect_columnar = variant in ("saved", "saved_indexed")
+    assert graph.is_columnar is expect_columnar, (
+        f"{variant} must{'' if expect_columnar else ' not'} own column stores; "
+        "save() populates DirGraph.column_stores via enable_columnar() "
+        "(io/file.rs:1495) and that is what the old gate vetoed on"
+    )
+    expect_indexed = variant in ("indexed", "saved_indexed")
+    assert graph.has_index("Item", "code") is expect_indexed
+    assert graph.has_index("Item", "qty") is expect_indexed
+    return graph
+
+
+@pytest.fixture(scope="module")
+def veto_graphs(tmp_path_factory) -> dict[tuple[int, str], KnowledgeGraph]:
+    """One graph per (size, variant) corner.
+
+    Module-scoped: eight fixtures, two of them 100k nodes, are seconds of build
+    time that must not be repeated per cell. `tmp_path_factory` rather than
+    `tmp_path` because the latter is function-scoped and cannot be reached from
+    here — and because nothing in this file may write outside a pytest-managed
+    temporary directory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("veto")
+    return {(size, variant): _variant_graph(size, variant, tmp_dir) for size in SIZES for variant in VARIANTS}
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_insert_after_veto_trigger(benchmark, veto_graphs, size, variant):
+    """One node inserted, on a graph in each corner of the `journal_covers` gate.
+
+    The headline cell. Defends: 100k insert **3.668 ms with neither trigger**
+    vs **21–38 ms with two secondary indexes**, and **0.0062 → 3.0931 ms
+    permanently after a single `save()`** (measured 2026-07-27).
+
+    Read `saved` / `indexed` / `saved_indexed` against `fresh` at the same
+    size, and each variant's 100k against its own 1k. Both ratios flat means
+    the journal path still covers real application graphs.
+
+    Uses `MERGE`, not `CREATE` — see the STATEMENT SHAPE comment above. This is
+    not interchangeable.
+    """
+    graph = veto_graphs[(size, variant)]
+    ids = iter(range(10_000_000, 1 << 30))
+
+    def write():
+        graph.cypher(INSERT_STATEMENT, params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_checkpoint_free_create_control(benchmark, veto_graphs, size, variant):
+    """A bare single-node `CREATE` — the statement that opens no checkpoint.
+
+    This cell is **expected to be flat and fast in every variant**, including
+    the ones where the defect would be present, because
+    `can_skip_rollback_checkpoint` gives it `StatementCheckpoint::None`
+    outright. It is here for two reasons, neither of them regression-gating:
+
+    1. It documents, executably, why the obvious insert benchmark cannot see
+       defect A — the next person to reach for `CREATE` here finds the answer
+       next to the code rather than re-deriving it from a null result.
+    2. It is the tripwire for the whitelist *narrowing*. If the checkpoint-free
+       path stops covering single-node `CREATE`, this cell moves and
+       `test_bench_insert_after_veto_trigger` does not, which localises the
+       change immediately.
+
+    A divergence between this cell and the `MERGE` cell in the `fresh` variant
+    is the cost of opening a journal checkpoint at all — worth knowing, and
+    currently unmeasured anywhere else.
+    """
+    graph = veto_graphs[(size, variant)]
+    ids = iter(range(40_000_000, 1 << 30))
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x', code: 'c', qty: 1})", params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_update_after_veto_trigger(benchmark, veto_graphs, size, variant):
+    """One `SET` by primary key, in each corner of the gate.
+
+    The update half of the same defect: `update_by_id` measured **3.986 ms with
+    no index vs 43.6 ms with indexes** at 100k (2026-07-27). `SET` is the
+    shape most exposed to the columnar veto, because a columnar graph routes
+    the write through the master column store and the journal has to be able to
+    reverse that sweep.
+
+    `qty` is written rather than `name` deliberately: `execute_set`'s columnar
+    fast path only fires for a property that is neither `title` nor `name`, so
+    writing `name` would quietly exercise the per-node fallback — the write
+    path that was never at risk. `rollback_tests.rs::
+    the_columnar_fixture_writes_through_the_master_store` pins the same
+    precondition on the Rust side.
+    """
+    graph = veto_graphs[(size, variant)]
+    counter = iter(range(1, 1 << 30))
+
+    def write():
+        graph.cypher("MATCH (n:Item {id: 7}) SET n.qty = $v", params={"v": next(counter)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    assert graph.cypher("MATCH (n:Item {id: 7}) RETURN n.qty AS q").to_list()[0]["q"] > 0
+
+
+# ── defect B: the whole-graph clone a held reference forces ──────────
+#
+# ⚠⚠ THIS SECTION DELIBERATELY DEPARTS FROM THIS PROJECT'S `min` CONVENTION.
+# DO NOT "FIX" IT BACK. READ THIS FIRST.
+#
+# CLAUDE.md's performance protocol says to trust `min` over `median` for
+# sub-millisecond benchmarks, because median pulls upward with system load.
+# That guidance is correct in general and WRONG HERE, and this comment exists
+# because the obvious "cleanup" silently disables the benchmark.
+#
+# The clone fires on the FIRST write after a second `Arc<DirGraph>` appears,
+# and once only — afterwards the graph is uniquely owned again and every
+# subsequent write is back to normal speed. The measured 100k signature is
+# exactly that: mean 0.0561 ms, p50 0.0044 ms, max 5.17 ms. So over N rounds
+# with a single reference taken once:
+#
+#   * `min`  sees round 2..N  -> healthy. Blind by construction.
+#   * `p50`  sees round N/2   -> healthy. Blind by construction.
+#   * `p95`  is healthy for any N > 20. Blind by construction.
+#   * only `max` sees it, and `max` is the one statistic nobody gates on
+#     because it is where genuine noise lands.
+#
+# `test_bench_write_scaling.py` already had a cell aimed at this defect
+# (`test_bench_create_with_lazy_result_alive`) and it reported NO DIFFERENCE —
+# doubly blinded, by the averaging above and by running only at 1k where the
+# clone is ~1000x too small to see. It has been removed and consolidated here;
+# a cell that cannot see the defect it was written for is worse than no cell,
+# because it certifies health.
+#
+# The fix is structural rather than statistical: `pedantic(setup=...)` runs
+# `setup` before EVERY round and does not time it, so each round takes a fresh
+# reference and each timed call is therefore a genuine first-write-after-a-
+# reference. Every round pays the clone, which makes mean, min and p50 all
+# meaningful again and needs no special-casing downstream.
+#
+# The invariant to preserve if you ever touch this: **the reference must be
+# acquired inside `setup`, never once outside the measurement.** Hoisting it
+# out is the one edit that turns this back into a benchmark that always passes.
+
+
+def _wide_result(graph: KnowledgeGraph):
+    """A lazy `ResultView` that keeps its own `Arc<DirGraph>` alive.
+
+    Every clause of this query is chosen against the laziness rules in
+    `planner/fusion/aggregate.rs:1733-1819` and `result_view.rs:112,203-217`,
+    because a view that materialises eagerly drops its `Arc` and silently
+    becomes the `holder="none"` case under a name claiming otherwise:
+
+    * **>32 cells.** `EAGER_MATERIALISE_MAX_CELLS = 32`, applied as
+      `rows * columns`. Two columns x `LIMIT 100` = 200 cells, comfortably past
+      it while staying cheap to build.
+    * **No standalone `WHERE`, no `WITH` / `UNWIND` / `CALL` / `ORDER BY`, one
+      `RETURN`, not `DISTINCT`.** Any of those disqualifies laziness outright.
+    * **Every `RETURN` item is a `PropertyAccess`.** Bare `RETURN n` is not one
+      and would force eager materialisation; `n.name` and `n.qty` are.
+    * **`streaming=True`** (the default) — `streaming=False` guarantees no pin.
+
+    Sessions, transactions and frozen views set `lazy_eligible: false`
+    explicitly, so they never produce a lazy view; `freeze()` pins the `Arc`
+    directly instead, which is the `holder="frozen"` arm.
+    """
+    return graph.cypher("MATCH (n:Item) RETURN n.name, n.qty LIMIT 100")
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("holder", ["none", "result_view", "frozen"])
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_first_write_after_reference(benchmark, veto_graphs, size, holder):
+    """The first write after a reference to the graph appears.
+
+    Defends (measured 2026-07-27, 100k): holding a returned `ResultView` across
+    a write costs **max 5.17 ms** against a 0.0044 ms p50, with full recovery
+    on release; `freeze()` held is the same at **max 5.83 ms**; ~28 ms at 1M.
+    `holder="none"` is the control and must stay at the ordinary write cost.
+
+    Read this as `result_view` / `frozen` against `none` at the same size, and
+    each against itself across sizes — the clone is O(V+E), so a present defect
+    shows a ~100x gap between 1k and 100k while the control stays flat.
+
+    Every round re-acquires the reference in an untimed `setup`; see the long
+    comment above for why that is load-bearing and not refactorable.
+
+    A bare single-node `CREATE` is deliberately correct here, unlike in the
+    defect-A cells. `Arc::make_mut` fires in `get_graph_mut`
+    (`kg_core.rs:1569` -> `handle.rs:630`) *before* the checkpoint whitelist is
+    ever consulted, so the cheapest possible statement still triggers the
+    clone — which isolates defect B from checkpoint cost rather than summing
+    the two.
+    """
+    graph = veto_graphs[(size, "fresh")]
+    ids = iter(range(20_000_000, 1 << 30))
+
+    def setup():
+        if holder == "result_view":
+            reference = _wide_result(graph)
+        elif holder == "frozen":
+            reference = graph.freeze()
+        else:
+            reference = None
+        return (reference,), {}
+
+    def write(reference):
+        graph.cypher("CREATE (:Item {id: $i, name: 'y', code: 'c', qty: 1})", params={"i": next(ids)})
+        # Returned, not merely closed over, so the reference is unambiguously
+        # live for the whole timed call and cannot be collected early — which
+        # would quietly turn this into the `none` case.
+        return reference
+
+    benchmark.pedantic(
+        write,
+        setup=setup,
+        rounds=REF_ROUNDS,
+        iterations=1,
+        warmup_rounds=REF_WARMUP_ROUNDS,
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_write_recovers_after_reference_released(benchmark, veto_graphs, size):
+    """Steady-state writes with no reference held — the recovery control.
+
+    The competitive run's key attribution: after the reference is released,
+    write cost returns fully to baseline. That is what separates defect B (one
+    write, then recovery) from defect A (every write, forever). Without this
+    cell a future reader cannot tell which of the two a regression in
+    `test_bench_first_write_after_reference` represents.
+
+    Expect this to match `test_bench_insert_after_veto_trigger[*-fresh]`.
+    """
+    graph = veto_graphs[(size, "fresh")]
+    ids = iter(range(30_000_000, 1 << 30))
+    # Taken and dropped before the measurement, so the graph has definitely
+    # been through the clone-and-recover cycle by the time timing starts.
+    _wide_result(graph)
+    graph.cypher("CREATE (:Item {id: 29999999, name: 'settle', code: 'c', qty: 1})")
+
+    def write():
+        graph.cypher("CREATE (:Item {id: $i, name: 'z', code: 'c', qty: 1})", params={"i": next(ids)})
+
+    benchmark.pedantic(write, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)

--- a/tests/benchmarks/test_bench_fast_write_path.py
+++ b/tests/benchmarks/test_bench_fast_write_path.py
@@ -99,6 +99,8 @@ Run with::
 
 from __future__ import annotations
 
+import itertools
+
 import pandas as pd
 import pytest
 
@@ -151,6 +153,14 @@ WARMUP_ROUNDS = 5
 #: because a pinned reference keeps the pre-clone copy alive.
 REF_ROUNDS = 20
 REF_WARMUP_ROUNDS = 2
+
+# Module-level, NOT per-test. The defect-B cells are parametrized over `holder`
+# but every parametrization writes to the SAME shared `(size, "fresh")` graph,
+# so a per-test `iter(range(BASE, ...))` hands the second parametrization ids
+# the first one already inserted -- a `duplicate primary key` failure that only
+# appears when the cells run together, never in isolation. A shared counter is
+# immune to that however these cells are parametrized in future.
+_FRESH_GRAPH_IDS = itertools.count(20_000_000)
 
 
 # ⚠ STATEMENT SHAPE — THE SINGLE EASIEST WAY TO SILENTLY DISABLE THIS FILE.
@@ -450,7 +460,7 @@ def test_bench_first_write_after_reference(benchmark, veto_graphs, size, holder)
     the two.
     """
     graph = veto_graphs[(size, "fresh")]
-    ids = iter(range(20_000_000, 1 << 30))
+    ids = _FRESH_GRAPH_IDS
 
     def setup():
         if holder == "result_view":
@@ -491,7 +501,7 @@ def test_bench_write_recovers_after_reference_released(benchmark, veto_graphs, s
     Expect this to match `test_bench_insert_after_veto_trigger[*-fresh]`.
     """
     graph = veto_graphs[(size, "fresh")]
-    ids = iter(range(30_000_000, 1 << 30))
+    ids = _FRESH_GRAPH_IDS
     # Taken and dropped before the measurement, so the graph has definitely
     # been through the clone-and-recover cycle by the time timing starts.
     _wide_result(graph)

--- a/tests/benchmarks/test_bench_startup.py
+++ b/tests/benchmarks/test_bench_startup.py
@@ -1,0 +1,231 @@
+"""How long until an embedded database can answer its first question?
+
+For a library that starts with the process, this is a cost paid on every cold
+request, every CLI invocation, every worker respawn — and it is the one number
+where the 2026-07-27 competitive benchmark found the largest structural gap:
+
+| graph  | kglite open -> first query | SQLite `wal_normal` |
+|--------|---------------------------:|--------------------:|
+| 100k   |                   113.5 ms |             1.44 ms |
+
+**79x**, and unlike a per-query gap it cannot be amortised by doing more work
+per process. SQLite opens a file handle and reads a page; kglite deserializes
+the entire graph.
+
+Nothing in this suite measured it. The nearest existing cell,
+`test_bench_phase19.py::test_bench_disk_reopen_query_mutate_promote`, covers
+**disk** mode only and bundles a query, a write and a `save()` into one number.
+There was no benchmark timing `kglite.open()` or `kglite.load()` of a `.kgl`
+file in memory mode at all.
+
+────────────────────────────────────────────────────────────────────────────
+⚠ The `storage="mapped"` reading from that run is void. Do not repeat it.
+────────────────────────────────────────────────────────────────────────────
+
+The competitive run recorded `storage="mapped"` at **116.5 ms against Default's
+113.5 ms** and concluded "mapped does not help — so this is not a Default-mode
+artifact". The conclusion is right; the evidence is not evidence. Reading the
+source (2026-07-27), those two cells ran **identical code**, for two
+independent reasons:
+
+1. `storage=` is **ignored when opening an existing file**. `kglite.open`
+   passes it to the constructor only on the file-does-not-exist branch
+   (`lib.rs:397-403`), and both the docstring (`__init__.pyi:757-759`) and
+   `lib.rs:264-265` say so.
+2. Even if it were honoured, it could not matter: `impl Deserialize for
+   GraphBackend` (`storage/backend.rs:494-499`) **always** yields
+   `GraphBackend::Memory`, and `io/file.rs` contains no occurrence of `Mapped`.
+   Mapped-ness is not a property of a loaded `.kgl`. The only mmap decision on
+   load is per-column and size-driven — a column spills to a temp file at
+   `MMAP_THRESHOLD` = 256 KB (`column_store.rs:137,2294-2306`) — identically
+   for both "modes".
+
+So 3 ms out of 115 ms was noise between two runs of the same code path, and no
+mapped cell appears in this file. A future mapped-vs-default startup comparison
+would have to build the graph mapped *and* teach the loader to preserve the
+mode; until then such a cell can only mislead. `graph_info()["columnar_is_
+mapped"]` is the field that would actually tell you whether mapped did
+anything.
+
+────────────────────────────────────────────────────────────────────────────
+What the three arms separate
+────────────────────────────────────────────────────────────────────────────
+
+The load is fully eager — `open()` does not return before the work is done, so
+timing `open()` *is* timing the load. Four O(graph) passes run in sequence
+(`io/file.rs:2395-2422`): a full Postcard deserialize of the `StableDiGraph`
+plus `rebuild_type_indices_and_compact()`; per-type column decompress; a
+per-node sweep in `attach_portable_column_stores` plus
+`rebuild_indices_from_keys()`; then embeddings, timeseries, secondary labels
+and the vector index. Nothing is deferred.
+
+* **`load`** — `kglite.load()`. The deserialize alone: no writer lease, no WAL
+  recovery, no header barriers.
+* **`open_off`** — `kglite.open(durable="off")`. Adds the cross-process writer
+  lease. `load` -> `open_off` is the lease cost.
+* **`open_full`** — the default. Adds WAL creation, which pays a `sync_all()`
+  **and** a `sync_parent_dir()` (`wal.rs:598-606`), plus recovery/replay of any
+  existing frames. `open_off` -> `open_full` is the cost of durability at
+  startup, and on macOS those barriers are `F_FULLFSYNC` — measured on this
+  machine at 3.37 ms each.
+
+Read every arm across sizes. All three are expected to be O(graph) today; the
+cells exist so that the *constant* is tracked and so that any future lazy-load
+work has a before number to point at.
+
+Nothing here is in the `make bench-check` tracked set (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_startup.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+# Three decades, because the finding IS the slope. A single size would report a
+# large constant and say nothing about whether it is O(graph) — which is the
+# whole claim being defended. 1M is omitted: at ~1.1 s per open it would
+# dominate the file's runtime while only confirming a line already drawn by
+# three points.
+SIZES = [1_000, 10_000, 100_000]
+
+# Explicit rounds. At 100k an open is ~113 ms, so auto-calibration would
+# schedule a round count from a first call that is not representative (cold
+# page cache) and could run for minutes; `-m benchmark` is exempt from the
+# 120 s hang ceiling, so nothing would stop it.
+#
+# 20 rounds x 113 ms x 9 cells is ~25 s for the file, which is the right budget
+# for a number quoted this often.
+ROUNDS = 20
+WARMUP_ROUNDS = 2
+
+#: `open()` variants under test. See the module docstring for what each adds.
+OPEN_MODES = ["load", "open_off", "open_full"]
+
+
+def _saved_graph_path(tmp_dir, size: int) -> str:
+    """Write a `size`-node `.kgl` once and return its path.
+
+    A primary key is declared because a real application graph has one, and
+    because `rebuild_indices_from_keys()` is one of the O(graph) load passes
+    being measured — a keyless graph would skip work that every real open pays.
+    """
+    graph = KnowledgeGraph()
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "id": range(size),
+                "name": [f"item-{i}" for i in range(size)],
+                "code": [f"code-{i}" for i in range(size)],
+                "qty": [i % 977 for i in range(size)],
+            }
+        ),
+        "Item",
+        "id",
+        "name",
+        columns=["code", "qty"],
+    )
+    graph.add_connections(
+        pd.DataFrame({"src": range(size), "dst": [(i * 7 + 13) % size for i in range(size)]}),
+        "LINKS",
+        "Item",
+        "src",
+        "Item",
+        "dst",
+    )
+    path = str(tmp_dir / f"startup-{size}.kgl")
+    graph.save(path)
+    return path
+
+
+@pytest.fixture(scope="module")
+def startup_paths(tmp_path_factory) -> dict[int, str]:
+    """One saved `.kgl` per size, under a pytest-managed temp dir.
+
+    `tmp_path_factory` rather than `tmp_path`: this is module-scoped, and
+    nothing in this file may write outside a temp directory pytest owns and
+    cleans.
+    """
+    tmp_dir = tmp_path_factory.mktemp("startup")
+    return {size: _saved_graph_path(tmp_dir, size) for size in SIZES}
+
+
+def _open_graph(mode: str, path: str) -> KnowledgeGraph:
+    """Open `path` under one of the three arms.
+
+    `lock=False` on both `open` arms is a measurement decision, not a
+    convenience. The writer lease is held until `close()`, and `close()`
+    *persists the graph to its origin path* — a full O(graph) serialize. A
+    benchmark that opened with the lease would therefore have to choose between
+    leaking a lock per round and paying a whole save inside the loop, and the
+    save is far larger than the open being measured. Opting out of the lease
+    keeps the timed region to the load.
+
+    The lease cost is consequently **not measured anywhere in this file**. It
+    is a file creation plus an advisory lock — small next to a 113 ms load, but
+    unquantified, and that should be stated rather than assumed.
+    """
+    if mode == "load":
+        return kglite.load(path)
+    if mode == "open_off":
+        return kglite.open(path, durable="off", lock=False)
+    return kglite.open(path, lock=False)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("mode", OPEN_MODES)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_open_to_first_query(benchmark, startup_paths, size, mode):
+    """Open a saved graph and answer one point query — time to first answer.
+
+    The headline cell. Defends **113.5 ms at 100k against SQLite's 1.44 ms**
+    (2026-07-27), a cost paid on every process start.
+
+    The query is included because "open to first query" is the number a caller
+    actually experiences, and excluded from interpretation because it is
+    negligible: a cold plan-cache miss is tens of microseconds against a
+    hundred-plus milliseconds of load.
+    `test_bench_first_query_on_open_graph` measures it alone so that claim is
+    checked rather than asserted.
+
+    The returned graph is handed back to pytest-benchmark rather than dropped,
+    so deallocation of a 100k-node graph cannot land inside the next round's
+    timing.
+    """
+    path = startup_paths[size]
+
+    def open_and_query():
+        graph = _open_graph(mode, path)
+        graph.cypher("MATCH (n:Item {id: 7}) RETURN n.name").to_list()
+        return graph
+
+    benchmark.pedantic(open_and_query, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_first_query_on_open_graph(benchmark, startup_paths, size):
+    """The first point query on an already-open graph — the control.
+
+    Exists to keep `test_bench_open_to_first_query` honest. If this is ever a
+    meaningful fraction of the open cell, then "startup is O(graph)" has become
+    the wrong description of that number and the attribution above needs
+    revisiting. Expect microseconds, flat across sizes.
+    """
+    graph = kglite.load(startup_paths[size])
+    counter = iter(range(1 << 30))
+
+    def query():
+        node_id = next(counter) % 1000
+        return graph.cypher("MATCH (n:Item {id: $i}) RETURN n.name", params={"i": node_id}).to_list()
+
+    benchmark.pedantic(query, rounds=ROUNDS * 5, iterations=1, warmup_rounds=WARMUP_ROUNDS)

--- a/tests/benchmarks/test_bench_wal_payload.py
+++ b/tests/benchmarks/test_bench_wal_payload.py
@@ -1,0 +1,298 @@
+"""Does one `add_nodes` call write a write-ahead-log frame quadratic in its
+own row count?
+
+Measured 2026-07-27 against mapped mode: **payload ~= 0.1496 * n^2 bytes** at
+116-byte strings, fitted exponent **2.00 twice**, three points to 0.1%. Because
+the 4 GiB ceiling is **per call** (`MAX_WAL_FRAME_BYTES = u32::MAX`,
+`wal.rs:115`), a large bulk load fails with `payload is 4920896785 bytes` and
+chunking the same rows into smaller calls is a complete workaround — the shape
+of a bug, not of a limit.
+
+────────────────────────────────────────────────────────────────────────────
+The attribution in the original report is probably wrong, and these cells
+are built to settle it rather than to inherit it
+────────────────────────────────────────────────────────────────────────────
+
+It was recorded as a **mapped-mode** defect, because that is where it was hit.
+Reading the source says the storage mode is incidental and the real ingredient
+is the **WAL**:
+
+* `add_nodes` -> `apply_node_batch` -> `commit_wal` (`kg_mutation.rs:1123`) ->
+  `flush_wal` (`kglite-py/src/graph/mod.rs:404-437`), which drains the capture
+  buffer, resolves it, and appends **one** `WalFrame`.
+* The op count is inflated by two loops in the columnar bulk-append path:
+  `Batch::detach_columnar_stores` (`batch.rs:354-390`, the iteration at
+  **`batch.rs:367`**) and `Batch::reattach_columnar_stores` (`batch.rs:396-437`,
+  at **`batch.rs:417`**). Both iterate *every existing node of the affected
+  type* calling `GraphWrite::node_weight_mut`, and `RecordingGraph::
+  node_weight_mut` (`recording.rs:568-579`) pushes a `RawOp::UpsertNode` on
+  every call. Each resolved op then carries the node's whole property map
+  (`recording.rs:195-200`).
+* With `LARGE_BATCH_CHUNK_SIZE = 1000` (`batch.rs:24`), an `n`-row call records
+  roughly `2 * sum_k 1000k ~= n^2/1000` ops. At ~150 bytes per op with
+  116-byte strings that is **0.15 * n^2 bytes** — which is the measured
+  0.1496 * n^2, including the constant.
+
+Two ingredients are therefore required, and **neither of them is "mapped"**:
+the type must already own a column store (so the detach/reattach loops run at
+all), and the WAL must be on (so the ops are recorded rather than discarded).
+The competitive run had both without intending either — `kglite.open(path,
+storage="mapped")` resolves `durable=None` to **`Full`** (`lib.rs:422-431`),
+silently turning the log on, whereas `KnowledgeGraph(storage="mapped")` has no
+WAL at all.
+
+The three arms below are chosen to decide this. If `default_normal` matches
+`mapped_normal`, the mapped attribution is refuted and the bug belongs to the
+WAL path, where an ordinary `kglite.open(...)` application after a `save()`
+would hit it too. If `default_off` stays linear while both logged arms go
+quadratic, the WAL is confirmed as the carrier.
+
+**This looks like a defect with a fix already sitting in the codebase.**
+`GraphWrite::node_weight_mut_silent` exists for exactly this
+(`storage/mod.rs:448`, impl `recording.rs:582-586`) and its doc reads *"Bypass
+recording — internal bookkeeping (columnar handle refresh), not a logical
+mutation."* Both loops are precisely that: the detach writes a temporary empty
+map that reattach restores before the flush, and genuinely-new nodes already
+got their op from `RecordingGraph::add_node` (`recording.rs:597-601`). Since
+`resolve_ops` reads *final* state, switching both call sites to the silent
+variant should collapse the payload to O(n). Not attempted here — this branch
+only adds benchmarks. Filed as a finding.
+
+────────────────────────────────────────────────────────────────────────────
+Why payload bytes, and not just wall time
+────────────────────────────────────────────────────────────────────────────
+
+The WAL sidecar is `<path>-wal` (`wal.rs:520-524`), so
+`os.path.getsize(path + "-wal")` is a **deterministic, noise-free** measurement
+of the thing that is actually broken. An exponent fitted from byte counts needs
+no idle machine, no warmup, no `min`-vs-`mean` argument and no thermal settle —
+it is either 1.0 or 2.0. Wall time is reported too, because that is what a user
+feels, but the byte count is the evidence.
+
+Each cell records `wal_bytes` and `wal_bytes_per_row` into
+`benchmark.extra_info`, so both land in `--benchmark-json` output. Read
+`wal_bytes_per_row` across the row counts: **flat = linear = fixed; growing
+proportionally to `rows` = the quadratic is still there.**
+
+⚠ This file asserts nothing about the exponent, because at the time of writing
+**the defect is live** and a guard would fail on `main`. It is a marker for a
+known open issue in the sense `test_bench_write_scaling.py::test_bench_id_
+index_invalidation_on_create` is one. Once the two `batch.rs` call sites are
+switched to the silent accessor, `wal_bytes_per_row` becomes flat and a real
+assertion can be added here — that is the follow-up this file is setting up.
+
+Row counts stop at 32k on purpose: `postcard::to_stdvec` materialises the whole
+payload before the limit is checked (`postcard_v1.rs:27-31`), so approaching
+the 4 GiB ceiling means a multi-gigabyte allocation and then an error. 32k rows
+is ~150 MB — enough to fit the curve to several decimal places, nowhere near
+enough to reproduce the crash. **Do not raise this to "see the failure"**; the
+failure is arithmetic, and the curve already predicts it.
+
+Nothing here is in the `make bench-check` tracked set (`Makefile:85`).
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_wal_payload.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+# Six geometric points. A quadratic is a straight line of slope 2 on a log-log
+# plot, and six points make the fit obvious by eye without any curve-fitting
+# machinery — the original finding needed only three to reach 0.1%.
+#
+# The top of the range is bounded by the payload it produces, not by runtime:
+# 32k rows is ~0.1496 * 32000^2 ~= 153 MB. See the module docstring before
+# raising it.
+ROW_COUNTS = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000]
+
+#: Seed rows written and checkpointed before the measured call, so the type
+#: already owns a column store when `add_nodes` runs. Without a pre-existing
+#: column store the detach/reattach loops never execute (`batch.rs:402-404`
+#: early-returns when nothing was detached) and the cell would measure a code
+#: path the defect does not live on.
+SEED_ROWS = 1_000
+
+#: 116-byte strings, matching the payload constant quoted in the report. The
+#: property payload is what each amplified op carries, so string width is a
+#: direct multiplier on the measured bytes — a narrower fixture would show the
+#: same exponent with a different constant and would not be comparable to the
+#: 0.1496 figure.
+FILLER = "x" * 116
+
+# The three arms that decide storage-mode versus WAL. `normal` rather than
+# `full`: the amplification is in the frame's *size*, and `full` would add one
+# F_FULLFSYNC per commit (3.37 ms on this machine) to a wall-time number
+# without changing a single payload byte.
+ARMS = ["default_off", "default_normal", "mapped_normal"]
+
+# Few rounds, and deliberately so. Each round rebuilds the fixture graph from
+# scratch in an untimed setup, and at the top row count each round writes
+# ~150 MB of WAL. The payload measurement — the part that matters — is exact
+# and needs no repetition at all; the rounds exist only to give the wall-time
+# figure a little stability.
+ROUNDS = 3
+WARMUP_ROUNDS = 1
+
+
+def _frame(rows: int, offset: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "id": range(offset, offset + rows),
+            "name": [f"item-{i}" for i in range(rows)],
+            "body": [FILLER] * rows,
+        }
+    )
+
+
+def _wal_bytes(path: str) -> int:
+    """Size of the `<path>-wal` sidecar, or 0 when there is no log.
+
+    At `durable="off"` the file is never created, which is why the control arm
+    reports 0 rather than a small number — that is the correct reading, not a
+    missing measurement.
+    """
+    try:
+        return os.path.getsize(path + "-wal")
+    except FileNotFoundError:
+        return 0
+
+
+def _reset(path: str) -> None:
+    """Remove a previous round's graph and its sidecars.
+
+    Called before every rebuild so that at most one graph's files exist at a
+    time. Without this, a cell at the top row count would leave ~150 MB per
+    round behind, and the file as a whole would leave gigabytes in the pytest
+    temp directory — the kind of ungated accumulation CLAUDE.md requires an
+    owner for.
+    """
+    for suffix in ("", "-wal", ".lock"):
+        try:
+            os.unlink(path + suffix)
+        except FileNotFoundError:
+            pass
+
+
+def _seeded_columnar_graph(path: str, arm: str) -> KnowledgeGraph:
+    """A file-backed graph whose `Item` type already owns a column store.
+
+    `save()` is what populates `DirGraph.column_stores`, via `enable_columnar()`
+    (`io/file.rs:1495`) — and it also truncates the WAL back to its 5-byte
+    header (`wal.rs:557-566`), which is what makes the post-save sidecar size a
+    clean zero point for the delta the cells measure.
+    """
+    _reset(path)
+    if arm == "default_off":
+        graph = kglite.open(path, durable="off", lock=False)
+    elif arm == "default_normal":
+        graph = kglite.open(path, durable="normal", lock=False)
+    else:
+        graph = kglite.open(path, storage="mapped", durable="normal", lock=False)
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(_frame(SEED_ROWS, 0), "Item", "id", "name")
+    graph.save()
+    return graph
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("arm", ARMS)
+@pytest.mark.parametrize("rows", ROW_COUNTS)
+def test_bench_add_nodes_wal_payload(benchmark, tmp_path, rows, arm):
+    """One `add_nodes` call of `rows` rows — wall time, and the bytes it logged.
+
+    Defends the measured **0.1496 * n^2** payload with exponent **2.00**
+    (2026-07-27) and the per-call 4 GiB ceiling it eventually overflows.
+
+    Read `wal_bytes_per_row` from `extra_info` across the `rows` parameter, at
+    a fixed `arm`. Flat means the amplification is gone; proportional to `rows`
+    means it is still there. Then read the same row count across arms to decide
+    whether this belongs to mapped mode or to the WAL — see the module
+    docstring for what each answer implies.
+    """
+    path = str(tmp_path / "ingest.kgl")
+
+    # The payload measurement is exact, so it is taken once and untimed rather
+    # than averaged over rounds. Taking it inside the timed callable would put
+    # two `stat` calls inside the measurement for no gain.
+    probe = _seeded_columnar_graph(path, arm)
+    before = _wal_bytes(path)
+    probe.add_nodes(_frame(rows, SEED_ROWS), "Item", "id", "name")
+    logged = _wal_bytes(path) - before
+    benchmark.extra_info["arm"] = arm
+    benchmark.extra_info["rows"] = rows
+    benchmark.extra_info["wal_bytes"] = logged
+    benchmark.extra_info["wal_bytes_per_row"] = logged / rows
+    del probe
+
+    offsets = iter(range(SEED_ROWS, 1 << 30, rows))
+
+    def setup():
+        graph = _seeded_columnar_graph(path, arm)
+        return (graph, _frame(rows, next(offsets))), {}
+
+    def ingest(graph, frame):
+        graph.add_nodes(frame, "Item", "id", "name")
+        # Returned so the graph is unambiguously alive for the whole timed
+        # call and its deallocation cannot land inside the next round.
+        return graph
+
+    benchmark.pedantic(ingest, setup=setup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    _reset(path)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("arm", ARMS)
+def test_bench_add_nodes_chunked_workaround(benchmark, tmp_path, arm):
+    """The same rows ingested in 1k-row calls instead of one large call.
+
+    The ceiling is **per call**, so chunking is the documented workaround — and
+    if the amplification is real, chunking is not merely a way to stay under
+    4 GiB but a large throughput win, because it caps the quadratic term at the
+    chunk size. That makes this cell the measurement of what the workaround is
+    worth, and the natural before/after for a fix: once the two `batch.rs` call
+    sites stop recording bookkeeping writes, this cell and the 32k row of
+    `test_bench_add_nodes_wal_payload` should converge.
+
+    Same total rows as the largest cell above, so the two are directly
+    comparable.
+    """
+    path = str(tmp_path / "chunked.kgl")
+    total = ROW_COUNTS[-1]
+    chunk = 1_000
+
+    probe = _seeded_columnar_graph(path, arm)
+    before = _wal_bytes(path)
+    for start in range(SEED_ROWS, SEED_ROWS + total, chunk):
+        probe.add_nodes(_frame(chunk, start), "Item", "id", "name")
+    logged = _wal_bytes(path) - before
+    benchmark.extra_info["arm"] = arm
+    benchmark.extra_info["rows"] = total
+    benchmark.extra_info["chunk"] = chunk
+    benchmark.extra_info["wal_bytes"] = logged
+    benchmark.extra_info["wal_bytes_per_row"] = logged / total
+    del probe
+
+    offsets = iter(range(SEED_ROWS, 1 << 30, total))
+
+    def setup():
+        graph = _seeded_columnar_graph(path, arm)
+        return (graph, next(offsets)), {}
+
+    def ingest(graph, offset):
+        for start in range(offset, offset + total, chunk):
+            graph.add_nodes(_frame(chunk, start), "Item", "id", "name")
+        return graph
+
+    benchmark.pedantic(ingest, setup=setup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+    _reset(path)

--- a/tests/benchmarks/test_bench_write_scaling.py
+++ b/tests/benchmarks/test_bench_write_scaling.py
@@ -28,6 +28,8 @@ Run with:
 
 from __future__ import annotations
 
+import os
+
 import pandas as pd
 import pytest
 
@@ -235,6 +237,43 @@ def test_bench_id_index_invalidation_on_create(benchmark, scaled_graphs_no_pk, s
 # true cost of the barrier. Both are per-commit and neither should scale with
 # graph size, which is why one fixed size is enough here.
 #
+# ── correction, 2026-07-27: what `off` is, and what it is not ────────
+#
+# A competitive benchmark read the `off` cell at 1.8 us and called it
+# impossible, on the grounds that it beat the tracked `cypher_match` READ
+# baseline of 6.2 us and a write must do strictly more work than a read.
+# Both halves of that are wrong, and the correction is worth keeping because
+# the cell invites the mistake:
+#
+#   * The comparison is not like-for-like. `test_bench_cypher_match` is
+#     `MATCH (n:Item) RETURN n.title, n.value LIMIT 100` *without* `.to_list()`
+#     — a lazy 100-row scan, tracked at 5.42 us min / 6.22 us mean. Its
+#     materialized sibling is 19.08 us min. A single-node insert with a warm
+#     plan cache producing no rows is simply less work than planning and
+#     scanning 100 rows. 1.8 us (a min) against 6.2 us (a mean) compares two
+#     different statistics of two different workloads.
+#   * Nothing is being skipped. At `off`, `logs()` is false, so `setup_durable`
+#     never runs (`lib.rs:416-418`), the backend is never wrapped in
+#     `RecordingGraph`, and `flush_wal` returns immediately on
+#     `durable.is_none()` (`graph/mod.rs:405-407`). The mutation itself is
+#     applied in place and synchronously at every level; there is no write
+#     buffer, no deferred commit, no background thread, and no coalescing
+#     anywhere in `wal.rs`. At `off` the write is a petgraph insert and index
+#     bookkeeping, full stop.
+#
+# So the number is real. What was unsound is the FRAMING: `off` is not a
+# cheaper commit, it is **no commit at all**, and there is no per-commit
+# durable work at `off` to measure. Its durability boundary is `save()`.
+# Labelling it a "durability level" alongside two levels that do write to disk
+# invites reading 1.8 us as "what a commit costs at off".
+#
+# Two cells below now hold that framing in place rather than leaving it to a
+# comment: `test_bench_unlogged_write_control` shows a plain in-memory graph
+# produces the same number (so file-backing buys nothing at `off`), and
+# `test_durable_off_loses_unsaved_writes` is the ordinary test proving what the
+# 1.8 us did *not* buy. The `wal_bytes` guard on the headline cell pins each
+# level to the configuration it claims.
+#
 # Not in `test_bench_core.py` on purpose: everything in this file is outside
 # the `make bench-check` tracked set, so adding cells here cannot break the
 # gate. Absolute numbers are machine- and device-specific — a barrier is
@@ -277,11 +316,38 @@ def _persisted_graph(path, level: str) -> KnowledgeGraph:
     return graph
 
 
+def _wal_bytes(path) -> int:
+    """Size of the `<path>-wal` sidecar, or 0 when no log exists.
+
+    `wal_path` is `<checkpoint>-wal` (`wal.rs:520-524`). This is the only
+    Python-visible window onto the WAL — `DurableState` exposes no getter for
+    `wal`, `next_lsn` or `level` — and it is enough to prove which level a cell
+    actually ran at.
+    """
+    try:
+        return os.path.getsize(str(path) + "-wal")
+    except FileNotFoundError:
+        return 0
+
+
 @pytest.mark.benchmark
 @pytest.mark.parametrize("level", DURABILITY_LEVELS)
 def test_bench_single_create_by_durability_level(benchmark, tmp_path, level):
-    """One `CREATE` of one node, per durability level. The headline cell."""
-    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    """One `CREATE` of one node, per durability level. The headline cell.
+
+    The trailing assertion is a vacuity guard, not a correctness test. A cell
+    that silently ran at the wrong level would report a plausible number under
+    a wrong label, and the 2026-07-27 methodology note is emphatic that this is
+    how benchmark harness defects actually present — every one caught in that
+    run was found because a number contradicted the configuration it claimed,
+    never because it looked implausible. A config-key collision there nearly
+    erased the headline finding while the table looked entirely normal.
+
+    At `off` the sidecar is never created, so a non-zero reading means the log
+    is on and the number is not an `off` number.
+    """
+    path = tmp_path / "bench.kgl"
+    graph = _persisted_graph(path, level)
     ids = iter(range(10_000_000, 1 << 30))
 
     def write():
@@ -289,66 +355,144 @@ def test_bench_single_create_by_durability_level(benchmark, tmp_path, level):
 
     benchmark(write)
 
+    logged = _wal_bytes(path)
+    if level == "off":
+        assert logged == 0, f"durable='off' must write no WAL; found {logged} bytes"
+    else:
+        assert logged > 0, f"durable='{level}' must write a WAL; sidecar is empty or absent"
+
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("level", ["full", "normal"])
-def test_bench_explicit_sync(benchmark, tmp_path, level):
-    """`sync()` — the on-demand barrier.
+def test_bench_unlogged_write_control(benchmark):
+    """The same `CREATE` on a plain in-memory graph — the control for `off`.
 
-    Under `"normal"` this is a real barrier and should cost about what
-    `full`'s per-commit barrier costs; under `"full"` it returns immediately
-    because every commit was already barriered. That gap is the number a
-    caller needs to decide how often to call it.
+    `durable="off"` opens no log and never wraps the backend, so a file-backed
+    graph at `off` should be indistinguishable from one that was never given a
+    path. This cell is what turns that from a claim into a reading: if it
+    differs materially from `test_bench_single_create_by_durability_level
+    [off]`, then something about file-backing costs per-write time and the
+    `off` row means something other than what it says.
+
+    It also gives the `off` number a name that cannot be misread. There is no
+    per-commit durable work at `off` to measure — the honest cost of durability
+    there is `save()` amortised over N writes, and `save()` is O(graph)
+    (tracked separately as `test_bench_columnar_save_kgl`, 300 us min at 1k and
+    `fsync=False`).
     """
-    graph = _persisted_graph(tmp_path / "bench.kgl", level)
-    ids = iter(range(60_000_000, 1 << 30))
-
-    def commit_then_sync():
-        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
-        graph.sync()
-
-    benchmark(commit_then_sync)
-
-
-# ── diagnostic: what is the non-durable commit actually spending? ────
-#
-# `durable="off"` is the engine's own per-commit cost with no durability
-# excuse, and reading the commit path turns up three candidate explanations
-# that reading alone cannot rank:
-#
-#   1. The Cypher plan cache is keyed on graph `version`, which is bumped
-#      before the lookup — so a write can never hit it and re-runs the full
-#      parse + optimizer pipeline every time.
-#   2. `Arc::make_mut` deep-clones the whole graph when a second
-#      `Arc<DirGraph>` is alive; a lazy `ResultView` above the 32-cell
-#      materialisation budget holds one.
-#   3. The statement rollback checkpoint, when it falls off its skip
-#      whitelist.
-#
-# The pair below discriminates (2) from the rest without changing a line of
-# engine code: same statement, once with the result dropped immediately and
-# once with it held across the next write. If `result_held` is dramatically
-# worse, it is the Arc clone; if the two are close, the cost is elsewhere and
-# (1) is the next suspect.
-#
-# This is a diagnostic, not a regression guard — it exists to attribute a
-# cost, and its conclusion belongs in an issue rather than in a threshold.
-
-
-@pytest.mark.benchmark
-@pytest.mark.parametrize("held", [False, True], ids=["result_dropped", "result_held"])
-def test_bench_create_with_lazy_result_alive(benchmark, held):
-    """One `CREATE`, with and without a lazy `ResultView` pinning the graph."""
     graph = _graph(DURABILITY_BENCH_SIZE)
-    ids = iter(range(50_000_000, 1 << 30))
-    # Wide enough to exceed the eager-materialisation budget, so the view
-    # stays lazy and keeps its own `Arc<DirGraph>` alive.
-    pinned = graph.cypher("MATCH (n:Item) RETURN n.id AS i, n.name AS nm") if held else None
+    ids = iter(range(70_000_000, 1 << 30))
 
     def write():
         graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
 
     benchmark(write)
-    # Keep `pinned` referenced past the measurement, or the interpreter is
-    # free to collect it early and quietly turn this into the other case.
-    assert pinned is None or pinned is not None
+
+
+def test_durable_off_loses_unsaved_writes(tmp_path):
+    """What the 1.8 us at `durable="off"` did not buy.
+
+    Not a benchmark — an ordinary test, and deliberately so. The `off` cell's
+    speed is only interpretable next to the guarantee it declines, and a
+    comment saying "off loses your data" is worth less than a test that
+    demonstrates it. Reopening is the closest in-process stand-in for the
+    process dying: no `save()`, so no checkpoint, so nothing to recover from.
+    """
+    path = tmp_path / "off.kgl"
+    graph = _persisted_graph(path, "off")
+    graph.cypher("CREATE (:Item {id: 999000, name: 'lost'})")
+    assert graph.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar() == 1
+
+    # The first handle is deliberately NOT closed. `close()` performs a full
+    # save, which would persist the very write this test exists to lose — and
+    # an assertion taken after it would be vacuous. Read the file as it stands
+    # on disk instead: the last checkpoint is `_persisted_graph`'s `seed.save()`
+    # from before the write. `lock=False` because the live handle still holds
+    # the writer lease.
+    on_disk = kglite.open(str(path), durable="off", lock=False)
+    survived = on_disk.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar()
+
+    assert survived == 0, (
+        "durable='off' wrote to a checkpoint it should not have; the speed of "
+        "the 'off' benchmark cell is only meaningful because this write is lost"
+    )
+    assert graph.cypher("MATCH (n:Item {id: 999000}) RETURN count(n) AS c").scalar() == 1
+
+
+# ── repaired 2026-07-27: `sync()` is timed alone, not after a create ──
+#
+# This cell used to time `CREATE` + `sync()` together, and at `full` it read
+# **1439 us — below the same file's create-only cost at `full`**. Create+sync
+# cannot be cheaper than create, so the pair was reported as an impossible
+# measurement. Reading the source says the cell was not measuring an ordering
+# at all:
+#
+#   * `sync()` at `full` is a **hard early return** (`kg_core.rs:711-713`). It
+#     touches no state — no flush, no barrier, no flag — because every commit
+#     was already barriered. `SyncMode` is fixed at `Wal::open` and never
+#     mutated afterwards, and nothing anywhere caches, batches or amortises
+#     across commits.
+#   * `Wal::append` is unconditional (`wal.rs:704-711`): no size threshold, no
+#     timer, no coalescing window. So at `full`, `CREATE` + `sync()` performs
+#     *exactly* the same work as `CREATE` alone.
+#
+# The old cell therefore duplicated `test_bench_single_create_by_durability_
+# level[full]` by construction and could never carry information — and 1439 vs
+# ~3400 us is F_FULLFSYNC variance between two runs of identical work, not an
+# ordering. A device-level barrier is the noisiest thing this suite measures.
+#
+# The repair is to move the `CREATE` into an untimed `pedantic` setup so the
+# timed region is the barrier and nothing else. `full` should now read ~0
+# (pinning the early return) and `normal` should read one barrier — which is
+# the number a caller actually needs to decide how often to call it, and was
+# previously buried under a create.
+#
+# `off` is absent from the parametrisation because `sync()` raises `ValueError`
+# there (`kg_core.rs:693-701`) rather than silently doing nothing.
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("level", ["full", "normal"])
+def test_bench_explicit_sync(benchmark, tmp_path, level):
+    """`sync()` alone — the on-demand barrier, with the commit untimed.
+
+    Under `"normal"` this is one real `F_FULLFSYNC`; under `"full"` it is an
+    early return. The gap between the two arms is the cost of taking a
+    power-safe point on demand, and it is what makes `"normal"` adoptable
+    rather than merely fast.
+
+    See the comment above before changing the shape of this cell — folding the
+    `CREATE` back into the timed region is what made its predecessor
+    uninterpretable.
+    """
+    graph = _persisted_graph(tmp_path / "bench.kgl", level)
+    ids = iter(range(60_000_000, 1 << 30))
+
+    def setup():
+        graph.cypher("CREATE (:Item {id: $i, name: 'x'})", params={"i": next(ids)})
+        return (), {}
+
+    benchmark.pedantic(graph.sync, setup=setup, rounds=OV_ROUNDS, iterations=1, warmup_rounds=OV_WARMUP_ROUNDS)
+
+
+# ── the lazy-`ResultView` diagnostic moved, 2026-07-27 ───────────────
+#
+# A `test_bench_create_with_lazy_result_alive` pair used to sit here, aimed at
+# the `Arc::make_mut` whole-graph clone that a held `ResultView` forces. It
+# reported **no difference**, and that null was wrong twice over:
+#
+#   1. **Under-powered.** It ran only at `DURABILITY_BENCH_SIZE` (1k), where
+#      the clone is ~1000x too small to separate from a write. The clone is
+#      O(V+E); at 100k it is ~5 ms, at 1M ~28 ms.
+#   2. **Structurally blind.** The reference was taken ONCE, outside the
+#      measurement. The clone fires on the first write after a second
+#      `Arc<DirGraph>` appears and once only — so `min`, `p50` and `p95` all
+#      saw post-clone rounds and read healthy. Only `max` could see it.
+#
+# It has been rewritten and moved to `test_bench_fast_write_path.py::
+# test_bench_first_write_after_reference`, which takes the reference in an
+# untimed per-round `setup` and runs at 1k and 100k. Consolidated rather than
+# duplicated: that file also owns the `journal_covers` cells, and both defects
+# are answers to "why did this one write cost milliseconds".
+#
+# Left here as a signpost because a null result that was believed for a while
+# is worth being able to trace.

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -61,19 +61,43 @@ requires_sigkill = pytest.mark.skipif(
 )
 
 
-def _open_kwargs(storage: str, durable: object = True) -> str:
-    """``kglite.open`` kwargs, as source text for a child script."""
-    parts = [f"durable={durable!r}"]
-    if storage != "memory":
-        parts.insert(0, f"storage={storage!r}")
-    return ", ".join(parts)
+# `storage=` selects a backend for a graph being *created*; an existing path is
+# loaded, and the load decides the backend. A `.kgl` checkpoint records no
+# storage mode, so a reopened one always comes back as memory — passing the mode
+# again is now an `ArgumentError` rather than being silently ignored.
+#
+# So the `[mapped]` parametrisation below means **"created mapped, recovered as
+# memory"**, and cannot mean anything else while `.kgl` carries no mode. That is
+# still a real durability test — the WAL frames under replay were written by a
+# mapped graph — but it does not exercise recovery *into* the mapped backend,
+# and before the kwarg was gated it silently claimed to.
+
+
+def _open_body(storage: str, durable: object = True) -> str:
+    """Source text for a child script's `open_durable()`.
+
+    Emitted as a runtime check rather than a fixed kwarg string because a child
+    may call `open_durable()` more than once — creating the graph on the first
+    call and reopening it after a checkpoint on later ones.
+    """
+    mode = "None" if storage == "memory" else repr(storage)
+    return textwrap.dedent(
+        f"""
+        def open_durable():
+            kwargs = {{"durable": {durable!r}}}
+            storage = {mode}
+            if storage is not None and not os.path.exists(path):
+                kwargs["storage"] = storage
+            return kglite.open(path, **kwargs)
+        """
+    ).strip()
 
 
 def _open(path, storage: str = "memory", durable: object = True):
     """Open *path* in *storage* mode at durability level *durable*
     (parent-side counterpart)."""
     kwargs = {"durable": durable}
-    if storage != "memory":
+    if storage != "memory" and not os.path.exists(str(path)):
         kwargs["storage"] = storage
     return kglite.open(str(path), **kwargs)
 
@@ -84,8 +108,7 @@ def _child_script(tmp_path, body: str, storage: str, ending: str, durable: objec
         import kglite, os, signal
         path = {str(tmp_path / "app.kgl")!r}
 
-        def open_durable():
-            return kglite.open(path, {_open_kwargs(storage, durable)})
+        {textwrap.indent(_open_body(storage, durable), "        ").strip()}
 
         {textwrap.indent(textwrap.dedent(body), "        ").strip()}
         {ending}

--- a/tests/test_encoding_hygiene.py
+++ b/tests/test_encoding_hygiene.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -96,10 +97,37 @@ def _missing_encoding(call: ast.Call) -> str | None:
 
 
 def _python_files() -> list[Path]:
-    files: list[Path] = []
-    for root in SCANNED_ROOTS:
-        files.extend((REPO_ROOT / root).rglob("*.py"))
-    return sorted(files)
+    """Every *tracked* Python file under the scanned roots.
+
+    Enumerated via `git ls-files`, not `rglob`, and that distinction is the
+    whole point: this gate exists to protect files the repo ships, and several
+    scanned roots have gitignored siblings holding local scratch work
+    (`.gitignore` ignores `/benchmarks/competitive/*`, for one). Walking the
+    filesystem made the gate fail on a developer's untracked scratch file
+    while CI — which only ever checks out tracked files — stayed green. A
+    hygiene check that depends on what happens to be lying around is worse
+    than no check: it trains people to ignore it.
+
+    Falls back to the filesystem walk outside a git checkout (a source
+    tarball, say), where there are no untracked files to confuse it anyway.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--", *SCANNED_ROOTS],
+            capture_output=True,
+            check=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        files: list[Path] = []
+        for root in SCANNED_ROOTS:
+            files.extend((REPO_ROOT / root).rglob("*.py"))
+        return sorted(files)
+
+    tracked = [REPO_ROOT / name for name in out.split("\0") if name.endswith(".py")]
+    # A tracked-but-deleted file still lists; skip rather than raise.
+    return sorted(p for p in tracked if p.is_file())
 
 
 def test_text_io_pins_utf8():

--- a/tests/test_open_storage_kwarg.py
+++ b/tests/test_open_storage_kwarg.py
@@ -1,0 +1,117 @@
+"""`kglite.open(..., storage=...)` must never be silently ignored.
+
+`storage=` picks a backend for a graph being *created*. An existing path is
+loaded instead, and the load decides the backend: a `.kgl` checkpoint records
+no storage mode, so it always comes back as memory. Before this was gated, the
+argument was simply dropped on the existing-file branch — so a
+create-then-reopen script asking for ``storage="mapped"`` got a mapped graph on
+run 1 and a memory graph on every run after, with nothing said. That silently
+invalidated a published mapped-vs-memory comparison in which both arms were
+unknowingly measuring the memory backend.
+
+These tests pin the contract that replaced the silence: agreeing modes pass,
+disagreeing modes raise, and an unknown mode is rejected on both branches.
+"""
+
+import pytest
+
+import kglite
+from kglite import KnowledgeGraph
+
+
+def _seed(path):
+    """Create a graph at ``path`` in mapped mode and leave it on disk."""
+    with kglite.open(str(path), storage="mapped") as g:
+        g.cypher("CREATE (:Person {name: 'Alice'})")
+    return path
+
+
+class TestStorageKwargOnExistingPath:
+    def test_creating_call_accepts_mapped(self, tmp_path):
+        """The call that *creates* the file honours the mode, as documented."""
+        target = tmp_path / "fresh.kgl"
+        with kglite.open(str(target), storage="mapped") as g:
+            g.cypher("CREATE (:Person {name: 'Alice'})")
+        assert target.exists()
+
+    def test_reopen_with_mapped_raises_instead_of_downgrading(self, tmp_path):
+        """The regression: reopening used to hand back memory in silence."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError) as excinfo:
+            kglite.open(str(target), storage="mapped")
+
+        message = str(excinfo.value)
+        # The error must name what was asked for, what actually happened, and
+        # a way forward — a bare "invalid argument" would not have prevented
+        # the benchmark mix-up this guards against.
+        assert "mapped" in message
+        assert "memory" in message
+        assert "KnowledgeGraph(storage=" in message
+
+    def test_reopen_without_storage_still_works(self, tmp_path):
+        """No new failure mode for callers who never passed `storage=`."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target)) as g:
+            assert g.cypher("MATCH (n:Person) RETURN n.name").to_list() == [{"n.name": "Alice"}]
+
+    def test_reopen_with_agreeing_mode_is_accepted(self, tmp_path):
+        """`storage="memory"` matches what a `.kgl` load produces, so it passes."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target), storage="memory") as g:
+            assert g.select("Person").len() == 1
+
+    def test_default_alias_agrees_with_a_loaded_kgl(self, tmp_path):
+        """`"default"` is a documented alias of `"memory"` and must behave alike."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with kglite.open(str(target), storage="default") as g:
+            assert g.select("Person").len() == 1
+
+    def test_unknown_mode_rejected_on_the_existing_path_too(self, tmp_path):
+        """Validation used to happen only inside the create branch."""
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError, match="Unknown storage mode"):
+            kglite.open(str(target), storage="banana")
+
+    def test_unknown_mode_still_rejected_on_the_creating_path(self, tmp_path):
+        with pytest.raises(kglite.ArgumentError, match="Unknown storage mode"):
+            kglite.open(str(tmp_path / "nope.kgl"), storage="banana")
+
+    def test_refusal_does_not_strand_the_writer_lease(self, tmp_path):
+        """A refused open must release the lock it took before loading.
+
+        `open()` acquires the single-writer lease *before* reading a byte, so
+        an error raised after the load has to leave the path openable. If it
+        did not, one typo would lock the graph out for the process lifetime.
+        """
+        target = _seed(tmp_path / "graph.kgl")
+
+        with pytest.raises(kglite.ArgumentError):
+            kglite.open(str(target), storage="mapped")
+
+        with kglite.open(str(target)) as g:
+            assert g.select("Person").len() == 1
+
+
+class TestConstructorIsUnaffected:
+    """The constructor always creates, so it always honours the mode."""
+
+    def test_mapped_constructor_still_works(self):
+        g = KnowledgeGraph(storage="mapped")
+        g.cypher("CREATE (:Person {name: 'Bob'})")
+        assert g.select("Person").len() == 1
+
+    def test_constructor_takes_no_durable_argument(self):
+        """Pins the documented asymmetry: only `open()` is durable.
+
+        `KnowledgeGraph(...)` returns a detached graph with no `source_path`,
+        so there is nowhere for a write-ahead log to live. This is structural,
+        not an oversight, and both docstrings say so — a `durable=` here must
+        stay a `TypeError` rather than quietly doing nothing.
+        """
+        with pytest.raises(TypeError):
+            KnowledgeGraph(storage="mapped", durable=True)

--- a/tests/test_schema_lock.py
+++ b/tests/test_schema_lock.py
@@ -182,10 +182,11 @@ class TestUnlock:
         # Should succeed now — schema unlocked
         g.cypher("CREATE (x:NewType {name: 'anything'})")
 
-    def test_reads_always_allowed(self):
+    def test_valid_reads_always_allowed(self):
         g = _make_graph()
         g.lock_schema()
-        # MATCH should always work regardless of lock
+        # A read against a *known* label is never blocked by the lock — the
+        # lock rejects typos, it does not gate reading.
         result = g.cypher("MATCH (p:Person) RETURN p.name")
         assert len(result) == 2
 
@@ -194,6 +195,122 @@ class TestUnlock:
         g.lock_schema()
         # DELETE should work even when schema locked
         g.cypher("MATCH (p:Person {name: 'Bob'}) DETACH DELETE p")
+
+
+# ── Read-side label validation ───────────────────────────────────────────────
+#
+# `lock_schema()` is the opt-in "catch my typos" mechanism. It has always
+# rejected an unknown *property* and an unknown *node type* on writes, but a
+# typo'd label in a MATCH used to return `[]` with no error — and an empty
+# result set reads as "no matching data" rather than "you made a mistake", so
+# it survives review and reaches production. These lock the symmetry in.
+
+
+class TestMatchLabelValidation:
+    def test_unknown_label_in_match_raises(self):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match="Unknown node type 'Persom'"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_enumerates_the_valid_labels(self):
+        # Mirrors the unknown-property message, which lists valid properties.
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match=r"Valid types: Paper, Person"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_suggests_the_near_miss(self):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError, match="Did you mean 'Person'"):
+            g.cypher("MATCH (p:Persom) RETURN p")
+
+    def test_error_carries_the_schema_code(self):
+        # Applications branch on `.code`, not on message prose.
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.SchemaError) as exc:
+            g.cypher("MATCH (p:Persom) RETURN p")
+        assert exc.value.code == "Schema"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # Every clause that can carry a label — covering only MATCH would
+            # recreate the same asymmetry one level down.
+            "MATCH (p:Persom) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Persom) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Persom) } RETURN p",
+            "CALL { MATCH (q:Persom) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Persom) RETURN q.name AS n",
+            "MATCH (n:Person:Persom) RETURN n",
+            "MERGE (q:Persom {name: 'x'})",
+        ],
+    )
+    def test_every_label_carrying_clause_is_covered(self, query):
+        g = _make_graph()
+        g.lock_schema()
+        with pytest.raises(kglite.KgError, match="Unknown node type 'Persom'"):
+            g.cypher(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "MATCH (p:Person) RETURN p",
+            "MATCH (p:Person) OPTIONAL MATCH (q:Paper) RETURN p, q",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (q:Paper) } RETURN p",
+            "CALL { MATCH (q:Paper) RETURN q } RETURN q",
+            "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Paper) RETURN q.title AS n",
+            "MATCH (n) RETURN n",
+            "MATCH (p:Person)-[:AUTHORED]->(q:Paper) RETURN p, q",
+        ],
+    )
+    def test_known_labels_are_never_rejected(self, query):
+        g = _make_graph()
+        g.lock_schema()
+        g.cypher(query)  # must not raise
+
+    def test_unlocking_restores_the_zero_row_idiom(self):
+        g = _make_graph()
+        g.lock_schema()
+        g.unlock_schema()
+        assert len(g.cypher("MATCH (p:Persom) RETURN p")) == 0
+
+
+class TestOpenSchemaUnchanged:
+    """The schemaless default is the product — it must be untouched."""
+
+    @pytest.mark.parametrize(
+        ("query", "rows"),
+        [
+            ("MATCH (p:Nonexistent) RETURN p", 0),
+            ("CALL { MATCH (q:Nonexistent) RETURN q } RETURN q", 0),
+            (
+                "MATCH (p:Person) RETURN p.name AS n UNION MATCH (q:Nonexistent) RETURN q.name AS n",
+                2,
+            ),
+            # OPTIONAL MATCH keeps the left rows with a null right side —
+            # still no error, which is the point.
+            ("MATCH (p:Person) OPTIONAL MATCH (q:Nonexistent) RETURN p, q", 2),
+        ],
+    )
+    def test_unknown_label_does_not_error(self, query, rows):
+        # The existence-check idiom: an unknown label is legal Cypher on an
+        # open schema and simply matches nothing.
+        g = _make_graph()
+        assert g.schema_locked is False
+        assert len(g.cypher(query)) == rows
+
+    def test_create_of_a_brand_new_label_still_works(self):
+        g = _make_graph()
+        g.cypher("CREATE (x:BrandNewType {name: 'anything'})")
+        assert len(g.cypher("MATCH (x:BrandNewType) RETURN x")) == 1
+
+    def test_merge_of_a_brand_new_label_still_works(self):
+        g = _make_graph()
+        g.cypher("MERGE (x:AnotherNewType {name: 'anything'})")
+        assert len(g.cypher("MATCH (x:AnotherNewType) RETURN x")) == 1
 
 
 # ── Introspection ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Combines four independently-green branches so the merged tree gets one CI run before release staging.

| PR | what |
|---|---|
| **#90** | columnar `SET` fix (5.51 → 1.08 ms), 84 blind-spot benchmarks, encoding-gate fix |
| **#91** | locked-schema rejection of unknown node labels |
| **#92** | delete no longer drops the type's id index; **columnar `REMOVE` data-resurrection fix** |
| **#93** | linear WAL payload for columnar bulk load; `open(storage=)` refuses a mode it cannot honour |

## The one that matters most is a correctness fix

`REMOVE` wrote only the node's `Arc` fork while the master column store kept the value, so the next unrelated `SET`'s handle-refresh resurrected the removed property. **A write to one property silently restored a deleted one.** Found while investigating a performance cost.

## Merge resolutions, all deliberate

- **CHANGELOG** conflicted three times — both sides were additive bullets under the same headings, so both were kept. Verified one heading of each section afterwards (the duplicate-heading trap from an earlier merge).
- **`source-quality.json`** conflicted on `execute_set`'s ceilings (two branches shrank it differently). Resolved provisionally to the max, then **tightened by hand to the measured 479 lines / 64 branches** — never `--refresh-functions`, which launders unrelated regressions into the baseline.
- **`write.rs` hit 2545 lines**, past its 2500 ceiling. Per project doctrine the file was **split, not the allowlist raised**: the three items reaching the per-type master `Arc<ColumnStore>` moved to `columnar_write.rs`. That is a real seam — `execute_set` and `execute_remove` must agree on all three, which is exactly the invariant the resurrection bug violated.
- **#91's Rust API baselines** were refreshed with the manifest-pinned nightly + `cargo-public-api` 0.49.0. Delta is exactly the two intended lines × 5 profiles (`SchemaErrorKind::UnknownNodeType` and its wire repr), 10 insertions and 0 deletions.

## Verification on the merged tree

`cargo test -p kglite` **1330 passed / 0 failed**; Python suite **4942 passed / 108 skipped**; parity oracles **109 passed**; `make gate`, workspace clippy `-D warnings`, `make source-quality`, `cargo fmt --check` all clean.

A first Python run showed 13 label-validation failures — **stale extension**, not a defect: the debug `.so` predated these merges. Rebuilding and re-running gave 0 failures. Worth noting because it is a trap: a Python suite silently tests whatever `.so` is installed, not the tree you are looking at.

All correctness testing ran against a **debug** build, per the rule that a release build disables the parser stack-depth and disk arena-guard assertions.

No version bump — workspace stays 0.14.5, entries under `[Unreleased]`.