### PR TITLE
fix: declare the real mcp-methods minimum (0.4.1, was 0.4)

### DIFF
--- a/crates/kglite-mcp-server/Cargo.toml
+++ b/crates/kglite-mcp-server/Cargo.toml
@@ -32,7 +32,15 @@ path = "src/main.rs"
 # pure-Rust crate only (no pyo3 in tree, no libpython link).
 # 0.3.42 required: serve_prompts injects skill `description` (## When to
 # use) + honors `references_tools`, which the cross-tool skills below need.
-mcp-methods = { version = "0.4", default-features = false, features = ["server"] }
+# 0.4.1 is a real MINIMUM, not a floor-by-habit: `lib.rs` uses
+# ActivationBuild / ActivationRequest / ActivationTransactionHook /
+# PreparedActivation and Workspace::with_activation_transaction, all of
+# which landed in 0.4.1. Declaring "0.4" let a consumer whose lockfile
+# already pinned 0.4.0 resolve it, satisfy ^0.4, and then fail to compile
+# on the missing symbols -- which is exactly what happened to a sibling
+# repo against the published 0.15.0. Our own lock held 0.4.1, so no local
+# build ever saw it.
+mcp-methods = { version = "0.4.1", default-features = false, features = ["server"] }
 
 # kglite (pure-Rust core) — no pyo3 in the resulting binary, no
 # libpython link. The 0.10.1 lift moved KnowledgeGraph +


### PR DESCRIPTION
**A defect in the published 0.15.0**, found by a sibling repo building against the released crate rather than by anything in this repo.

`kglite-mcp-server/src/lib.rs` uses `ActivationBuild`, `ActivationRequest`, `ActivationTransactionHook`, `PreparedActivation` and `Workspace::with_activation_transaction` — all added in **mcp-methods 0.4.1** — while `Cargo.toml` declared only `"0.4"`.

A consumer whose lockfile already pinned **0.4.0** resolves it, because it satisfies `^0.4`, and then fails to compile on the missing symbols. That is exactly what happened to sonagram against the published 0.15.0.

**Why no gate here could have caught it:** our own `Cargo.lock` holds 0.4.1, and a fresh resolve picks the newest 0.4.x. So every local build and every CI run in this repo resolves a version new enough to compile. **A version requirement that understates its real minimum is structurally invisible to the repo that declares it** — only a consumer with an older lock ever sees it.

**Verified by the resolution itself rather than by a build passing:** with the minimum declared, `cargo update -p mcp-methods --precise 0.4.0` is now *rejected* — the bad resolution is unreachable. Before the change it resolved happily and then failed to compile.

Local: `cargo build -p kglite-mcp-server` clean, `make gate` clean.

No version bump here — this wants a **0.15.1 patch** so the corrected requirement actually reaches crates.io consumers, which is the maintainer's call.