### PR TITLE
fix: disk save no longer writes an id-index key the interner cannot resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could resolve. The writers now resolve, so the directory they emit is always
   one the same build can read back. The same failure could be triggered on any
   disk graph by a read-only query that merely mentions an unknown label
-  (`MATCH (n:Ghost {id: 1})`) before the next `save()`.
+  (`MATCH (n:Ghost {id: 1})`) before the next `save()`. Directories already
+  written that way load again without a rebuild: the stale entry is empty, and
+  an id index is a cache the read path rebuilds on demand, so it is dropped at
+  load. A *populated* entry under an unresolvable key is still rejected — that
+  is a damaged sidecar, not this bug.
 
 ## [0.15.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `storage="disk"` graph containing a node type with no rows saved a
+  directory that could not be loaded**, failing with `File format error:
+  invalid id_indices.bin: directory contains an unresolved type key`. Declaring
+  a type that a given data slice leaves empty is ordinary — a blueprint with 26
+  node types legitimately populates a handful — and the build, the queries, and
+  `save()` all succeeded, so the failure only surfaced on the next `load()`.
+  Disk index sidecars address types by interner hash, and the writer derived
+  those hashes from the type name alone instead of resolving them against the
+  interner it persists alongside; a type whose name the interner never carried
+  (nothing interns a type that has no nodes) therefore got a key that nothing
+  could resolve. The writers now resolve, so the directory they emit is always
+  one the same build can read back. The same failure could be triggered on any
+  disk graph by a read-only query that merely mentions an unknown label
+  (`MATCH (n:Ghost {id: 1})`) before the next `save()`.
+
 ## [0.15.0] - 2026-07-27
 
 ### Added

--- a/crates/kglite/src/graph/dir_graph/disk_snapshot_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/disk_snapshot_tests.rs
@@ -1,0 +1,171 @@
+//! A saved disk directory must be one this build can read back.
+//!
+//! Disk snapshots address types by `InternedKey` hash in `id_indices.bin` and
+//! `type_indices.bin`, and the loader resolves every one of those hashes
+//! through the `interner.bin.zst` sidecar written beside them. Any type name
+//! that reaches an index without reaching the interner therefore produces a
+//! directory that `save()` writes happily and `load()` rejects with
+//! "invalid id_indices.bin: directory contains an unresolved type key".
+//!
+//! Two shapes used to do exactly that, both of them ordinary usage:
+//!
+//! * a node type declared with **zero data rows** — a real data slice
+//!   legitimately leaves declared types empty — because `add_nodes` built an
+//!   (empty) id index for the type while only node *creation* interned its
+//!   name; and
+//! * a **label a read-only query merely mentioned** (`MATCH (n:Ghost {id: 1})`),
+//!   because the read path caches a build-on-miss index under that name.
+//!
+//! The tests below pin the round trip for both, with the in-memory and
+//! one-row variants as controls.
+
+use crate::datatypes::{DataFrame, Value};
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::io::file::{load_file, save_graph};
+use crate::graph::mutation::maintain::add_nodes;
+use crate::graph::session::{execute_read, ExecuteOptions};
+use std::sync::Arc;
+
+/// `id,name` rows, matching the two-column CSV shape a blueprint declares.
+fn rows(count: usize) -> DataFrame {
+    let rows: Vec<Vec<Value>> = (0..count)
+        .map(|i| {
+            vec![
+                Value::Int64(i as i64 + 1),
+                Value::String(format!("row-{i}")),
+            ]
+        })
+        .collect();
+    DataFrame::from_cypher_rows(vec!["id".to_string(), "name".to_string()], rows).unwrap()
+}
+
+fn declare(graph: &mut DirGraph, node_type: &str, row_count: usize) {
+    add_nodes(
+        graph,
+        rows(row_count),
+        node_type.to_string(),
+        "id".to_string(),
+        Some("name".to_string()),
+        None,
+    )
+    .unwrap_or_else(|e| panic!("add_nodes({node_type}, {row_count} rows) failed: {e}"));
+}
+
+fn count_of_type(graph: &DirGraph, node_type: &str) -> i64 {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::new(&params);
+    let query = format!("MATCH (n:{node_type}) RETURN count(n) AS c");
+    let outcome = execute_read(graph, &query, &opts).expect("count query");
+    match outcome.result.rows.first().and_then(|row| row.first()) {
+        Some(Value::Int64(n)) => *n,
+        other => panic!("unexpected count value: {other:?}"),
+    }
+}
+
+/// Save `graph` as a disk directory and read it back.
+fn disk_round_trip(mut graph: DirGraph, dir: &std::path::Path) -> Arc<DirGraph> {
+    graph.enable_disk_mode().expect("enable disk mode");
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, dir.to_str().unwrap()).expect("save disk graph");
+    load_file(dir.to_str().unwrap()).expect("a saved disk directory must load")
+}
+
+/// The reported bug: one populated type, one declared type with no rows.
+#[test]
+fn declared_type_with_zero_rows_survives_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Empty", 0);
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert!(
+        loaded.get_node_type_metadata("Empty").is_some(),
+        "the declared-but-unpopulated type must survive the round trip"
+    );
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Empty"), 0);
+}
+
+/// Consumers declare tens of types and populate a handful; every unpopulated
+/// one used to add another unresolvable key to the same directory.
+#[test]
+fn many_declared_types_with_zero_rows_survive_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 3);
+    for name in ["Filing", "Insider", "Holding", "Transaction", "Rating"] {
+        declare(&mut graph, name, 0);
+    }
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert_eq!(count_of_type(&loaded, "Full"), 3);
+    for name in ["Filing", "Insider", "Holding", "Transaction", "Rating"] {
+        assert!(
+            loaded.get_node_type_metadata(name).is_some(),
+            "declared type '{name}' must survive the round trip"
+        );
+        assert_eq!(count_of_type(&loaded, name), 0);
+    }
+}
+
+/// Control: the same shape in memory always worked, and must keep working.
+#[test]
+fn declared_type_with_zero_rows_survives_a_kgl_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.kgl");
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Empty", 0);
+
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, path.to_str().unwrap()).expect("save .kgl");
+    let loaded = load_file(path.to_str().unwrap()).expect("load .kgl");
+
+    assert!(loaded.get_node_type_metadata("Empty").is_some());
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Empty"), 0);
+}
+
+/// Control: one row is enough to intern the type name, so this shape was
+/// never broken — it guards against a fix that only moved the boundary.
+#[test]
+fn single_row_type_survives_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Sparse", 1);
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Sparse"), 1);
+}
+
+/// A read-only query naming a type the graph does not have caches an empty id
+/// index under that name (`IdIndexStore::lookup_or_build`). Saving afterwards
+/// must not carry that name into the directory — it has no interned identity,
+/// so the snapshot could not resolve it back.
+#[test]
+fn a_label_only_mentioned_by_a_query_does_not_poison_the_next_save() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("graph");
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    graph.enable_disk_mode().expect("enable disk mode");
+
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::new(&params);
+    execute_read(&graph, "MATCH (n:Ghost {id: 1}) RETURN n", &opts).expect("ghost query");
+    assert!(
+        graph.id_indices.contains_key("Ghost"),
+        "precondition: the read path caches an index for the mentioned label"
+    );
+
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, dir.to_str().unwrap()).expect("save disk graph");
+    let loaded = load_file(dir.to_str().unwrap()).expect("a saved disk directory must load");
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+}

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -2003,3 +2003,6 @@ mod dir_graph_tests;
 
 #[cfg(test)]
 mod rollback_tests;
+
+#[cfg(test)]
+mod disk_snapshot_tests;

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -195,9 +195,21 @@ impl IdIndexBase {
                 return Err(invalid_index("general payload exceeds decode limit"));
             }
             expected_payload = payload_end;
-            let name = interner
-                .try_resolve(InternedKey::from_u64(type_key))
-                .ok_or_else(|| invalid_index("directory contains an unresolved type key"))?;
+            let Some(name) = interner.try_resolve(InternedKey::from_u64(type_key)) else {
+                // Directories written before the writer resolved its keys
+                // (through 0.15.0) carry entries for type names the interner
+                // sidecar never received — a type declared with no rows, or a
+                // label a query merely mentioned. Those entries are always
+                // empty, and an id index is a cache the read path rebuilds on
+                // demand, so dropping one recovers the graph at no cost rather
+                // than making the whole directory unreadable. A *populated*
+                // entry under an unresolvable key is not that: it is a
+                // mismatched or damaged sidecar, and still fails the load.
+                if num_entries == 0 {
+                    continue;
+                }
+                return Err(invalid_index("directory contains an unresolved type key"));
+            };
             if variant == 1 {
                 let blob = &mmap[payload_off_usize..payload_end];
                 let map: HashMap<Value, NodeIndex> = serde_codec::decode_exact_with(
@@ -984,6 +996,40 @@ mod validation_tests {
         );
     }
 
+    /// A directory saved before the writer resolved its keys carries an empty
+    /// index under a type key the interner sidecar never received. Both
+    /// variants of that entry are recovered rather than failing the load; a
+    /// populated entry under an unresolvable key still fails (asserted in
+    /// `rejects_unsupported_unresolved_and_trailing_data`).
+    #[test]
+    fn an_empty_entry_with_an_unresolved_type_key_is_recovered() {
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Person");
+        let stale = InternedKey::from_str("NeverInterned").as_u64();
+
+        let base = load(&integer_fixture(stale, &[]), &interner)
+            .expect("a stale empty entry must not fail the load")
+            .unwrap();
+        assert!(!base.contains("NeverInterned"));
+
+        // The General variant is what a type with no rows actually produced:
+        // `num_entries` is 0, but the Postcard payload of an empty map is not.
+        let blob = serde_codec::encode_versioned(
+            serde_codec::CURRENT_CODEC,
+            &HashMap::<Value, NodeIndex>::new(),
+            MAX_GENERAL_INDEX_DECODE_BYTES,
+        )
+        .unwrap();
+        let mut bytes = integer_fixture(stale, &[]);
+        bytes[40] = 1;
+        bytes[64..72].copy_from_slice(&(blob.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&blob);
+        let base = load(&bytes, &interner)
+            .expect("a stale empty General entry must not fail the load")
+            .unwrap();
+        assert!(!base.contains("NeverInterned"));
+    }
+
     /// The writer resolves names against the interner it is handed, so it can
     /// never emit a directory key that the matching `interner.bin.zst` fails
     /// to resolve. An unregistered name is dropped when its index is empty
@@ -1004,6 +1050,16 @@ mod validation_tests {
             ("Unregistered".to_string(), TypeIdIndex::default()),
         ]));
         write_id_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        // Asserted on the bytes, not through the loader: the loader also
+        // recovers such an entry (directories written before this fix carry
+        // them), so a round trip alone would not pin the writer.
+        let raw = std::fs::read(temp.path().join("id_indices.bin")).unwrap();
+        assert_eq!(
+            u32::from_le_bytes(raw[12..16].try_into().unwrap()),
+            1,
+            "the unregistered name must not reach the directory at all"
+        );
 
         let base = IdIndexBase::load_from(temp.path(), &interner)
             .expect("the written directory must load")

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -685,24 +685,48 @@ fn coerce_to_u32(id: &Value) -> Option<u32> {
 /// Write `id_indices.bin` (raw mmap layout). Iterates the store's union view
 /// (overlay + base) so saves capture both fresh mutations and unchanged
 /// base entries.
+///
+/// Directory keys are `InternedKey` hashes and the loader turns each one back
+/// into a type name through the interner sidecar that ships with the same
+/// snapshot. Names are therefore *resolved*, never interned here: deriving a
+/// key from the name alone — the old `interner.clone().try_get_or_intern`,
+/// which registered the name in a throwaway clone — manufactured keys for
+/// names the persisted interner never carried, and a single such entry made
+/// the whole directory unloadable ("directory contains an unresolved type
+/// key").
+///
+/// Only an empty index can carry an unregistered name: creating a node interns
+/// its type (`mutation/batch.rs`), so any index holding ids names an interned
+/// type. Empty entries do reach the store — the read path caches a
+/// build-on-miss index for a label a query merely mentioned
+/// ([`IdIndexStore::lookup_or_build`]) — and they are pure cache, so dropping
+/// them loses nothing. A non-empty unregistered entry would be a broken
+/// invariant, so it fails the save rather than shipping a directory that
+/// cannot be read back.
 pub fn write_id_indices_bin(
     dir: &Path,
     store: &IdIndexStore,
     interner: &StringInterner,
 ) -> Result<(), String> {
-    // Collect (type_key, name, materialized) triples sorted by type_key.
+    // Collect (type_key, materialized) pairs sorted by type_key.
     // `store.iter()` already returns owned, fully-materialized indices
     // (overlay + unshadowed base).
-    let mut entries: Vec<(u64, String, TypeIdIndex)> = Vec::new();
-    let mut interner_clone = interner.clone();
+    let mut entries: Vec<(u64, TypeIdIndex)> = Vec::new();
     for (name, materialized) in store.iter() {
-        let key = interner_clone
-            .try_get_or_intern(&name)
-            .map_err(|e| e.to_string())?
-            .as_u64();
-        entries.push((key, name, materialized));
+        let Some(key) = interner.try_resolve_to_key(&name) else {
+            if materialized.is_empty() {
+                continue;
+            }
+            return Err(format!(
+                "id index for type '{name}' holds {} ids but the type name is \
+                 not in the graph's interner; refusing to write an \
+                 id_indices.bin that cannot be read back",
+                materialized.len()
+            ));
+        };
+        entries.push((key.as_u64(), materialized));
     }
-    entries.sort_by_key(|(k, _, _)| *k);
+    entries.sort_by_key(|(k, _)| *k);
 
     let num_types = entries.len();
     let header_size = HEADER_BYTES;
@@ -722,7 +746,7 @@ pub fn write_id_indices_bin(
     let mut plans: Vec<Plan> = Vec::with_capacity(num_types);
     let mut cursor = data_offset as u64;
 
-    for (type_key, _name, idx) in &entries {
+    for (type_key, idx) in &entries {
         match idx {
             TypeIdIndex::Integer(map) => {
                 let mut pairs: Vec<(u32, u32)> =
@@ -958,6 +982,45 @@ mod validation_tests {
             base.lookup(integer_name, &Value::UniqueId(7)),
             Some(NodeIndex::new(4))
         );
+    }
+
+    /// The writer resolves names against the interner it is handed, so it can
+    /// never emit a directory key that the matching `interner.bin.zst` fails
+    /// to resolve. An unregistered name is dropped when its index is empty
+    /// (pure cache, rebuilt on demand) and fails the save when it is not.
+    #[test]
+    fn writer_never_emits_a_key_the_interner_cannot_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Known");
+
+        let mut store = IdIndexStore::default();
+        store.replace_with(HashMap::from([
+            (
+                "Known".to_string(),
+                TypeIdIndex::Integer(HashMap::from([(7, NodeIndex::new(1))])),
+            ),
+            // Never interned: an id index cached for a type with no rows.
+            ("Unregistered".to_string(), TypeIdIndex::default()),
+        ]));
+        write_id_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        let base = IdIndexBase::load_from(temp.path(), &interner)
+            .expect("the written directory must load")
+            .unwrap();
+        assert_eq!(
+            base.lookup("Known", &Value::UniqueId(7)),
+            Some(NodeIndex::new(1))
+        );
+        assert!(!base.contains("Unregistered"));
+
+        store.insert(
+            "Unregistered".to_string(),
+            TypeIdIndex::Integer(HashMap::from([(1, NodeIndex::new(0))])),
+        );
+        let error = write_id_indices_bin(temp.path(), &store, &interner).unwrap_err();
+        assert!(error.contains("Unregistered"), "{error}");
+        assert!(error.contains("cannot be read back"), "{error}");
     }
 
     #[test]

--- a/crates/kglite/src/graph/storage/disk/type_index.rs
+++ b/crates/kglite/src/graph/storage/disk/type_index.rs
@@ -518,12 +518,20 @@ impl TypeIndexStore {
 // Writer
 // =============================================================================
 
+/// Write `type_indices.bin` (flat CSR layout).
+///
+/// Type names are *resolved* against the interner that ships with the same
+/// snapshot, never interned here — see the equivalent note on
+/// [`write_id_indices_bin`](super::id_index::write_id_indices_bin). An
+/// unregistered name has no persisted identity: an empty entry is dropped
+/// (nothing to record), and a populated one fails the save rather than
+/// shipping a directory whose type keys the loader cannot resolve.
 pub fn write_type_indices_bin(
     dir: &Path,
     store: &TypeIndexStore,
     interner: &StringInterner,
 ) -> Result<(), String> {
-    // Collect (type_key, name, slice-or-vec) sorted by type_key.
+    // Collect (type_key, slice-or-vec) sorted by type_key.
     enum Source<'a> {
         Slice(&'a [u8]),
         Vec(&'a [NodeIndex]),
@@ -547,18 +555,24 @@ pub fn write_type_indices_bin(
         }
     }
 
-    let mut interner_clone = interner.clone();
     let mut entries: Vec<(u64, Source<'_>)> = Vec::new();
     for (name, view) in store.iter() {
-        let key = interner_clone
-            .try_get_or_intern(name)
-            .map_err(|e| e.to_string())?
-            .as_u64();
         let src = match view {
             TypeNodesRef::Overlay(s) => Source::Vec(s),
             TypeNodesRef::Mmap(s) => Source::Slice(s),
         };
-        entries.push((key, src));
+        let Some(key) = interner.try_resolve_to_key(name) else {
+            if src.len() == 0 {
+                continue;
+            }
+            return Err(format!(
+                "type index for type '{name}' holds {} nodes but the type name \
+                 is not in the graph's interner; refusing to write a \
+                 type_indices.bin that cannot be read back",
+                src.len()
+            ));
+        };
+        entries.push((key.as_u64(), src));
     }
     entries.sort_by_key(|(k, _)| *k);
 
@@ -701,5 +715,38 @@ mod validation_tests {
             load(&duplicate, &interner).unwrap_err().kind(),
             std::io::ErrorKind::InvalidData
         );
+    }
+
+    /// The writer resolves names against the interner it is handed, so the
+    /// directory it emits is always readable by the snapshot's own interner
+    /// sidecar. An unregistered name is dropped when empty and fails the save
+    /// when populated (a type index is not a rebuildable cache — silently
+    /// dropping a populated one would hide every node of that type).
+    #[test]
+    fn writer_never_emits_a_key_the_interner_cannot_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Known");
+
+        let mut store = TypeIndexStore::default();
+        store.replace_with(HashMap::from([
+            ("Known".to_string(), vec![NodeIndex::new(0)]),
+            ("Unregistered".to_string(), Vec::new()),
+        ]));
+        write_type_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        let base = TypeIndexBase::load_from(temp.path(), &interner)
+            .expect("the written directory must load")
+            .unwrap();
+        assert_eq!(base.materialize("Known").unwrap(), vec![NodeIndex::new(0)]);
+        assert!(base.materialize("Unregistered").is_none());
+
+        store.replace_with(HashMap::from([(
+            "Unregistered".to_string(),
+            vec![NodeIndex::new(0)],
+        )]));
+        let error = write_type_indices_bin(temp.path(), &store, &interner).unwrap_err();
+        assert!(error.contains("Unregistered"), "{error}");
+        assert!(error.contains("cannot be read back"), "{error}");
     }
 }


### PR DESCRIPTION
A disk graph directory could be written in a state that kglite itself cannot read back. Reproduced independently three times; **pre-existing, not a 0.15.0 regression** — fails identically on 0.13.0, 0.14.5 and 0.15.0.

## Mechanism

`write_id_indices_bin` computed its directory key as `interner.clone().try_get_or_intern(name)` — **interning into a throwaway clone.** That manufactures the FNV hash while recording the name nowhere durable. `write_interner_bin` then persists the real interner, which lacks the name, and the loader's `try_resolve` returns `None` and rejects the entire directory:

```
invalid id_indices.bin: directory contains an unresolved type key
```

`.kgl` (memory/mapped) is unaffected because it does not persist id indices at all — it rebuilds them on load, which is why the memory control passes.

## The trigger is wider than empty node types

The reported case was a blueprint declaring a node type with zero rows. But `IdIndexStore::lookup_or_build` caches a build-on-miss index under **any** label a query names — so a **read-only** `MATCH (n:Ghost {id: 1})` against a disk graph poisons the *next* `save()` identically.

**A query that mutates nothing can render a disk graph unloadable.** That settled the design: an upstream "intern the declared type name" fix would not have covered it, so that change — already written — was deliberately dropped rather than shipped as code no test needed.

## Fix

**The writer.** `write_id_indices_bin` and `write_type_indices_bin` now *resolve* names against the interner they are handed instead of manufacturing keys. An entry whose name has no interned identity is **dropped when empty** and **fails the save when populated**. Only empty entries can reach that branch (creating a node interns its type), and an id index is a cache the read path rebuilds on demand — so dropping one loses nothing, while a populated one is a broken invariant where a loud save error beats an unreadable directory.

**The reader, narrowly.** The writer fix does nothing for directories already on disk, and consumers have those. `IdIndexBase::load_from` now skips an unresolvable directory entry **only when `num_entries == 0`**, still rejecting a populated one. That recovers exactly the artifacts this bug produced without weakening the corruption detector. `type_indices.bin` stays strict, because no writer ever produced a stale key there.

## Tests — each confirmed non-vacuous by reverting each half separately

New `disk_snapshot_tests.rs`: zero-row type on disk; five empty types alongside a populated one; the ghost-label query; plus **controls** — the same shape in memory, and a one-row type on disk. Reverting the writer fix: 3 fail with the exact production error, the 2 controls pass, which is their job.

The id-index writer unit test asserts on the **emitted bytes** (`num_types == 1`) rather than through a round trip — otherwise the loader recovery would absorb a writer regression and the test would be silently vacuous.

`cargo test -p kglite` 1333 pass; clippy `-D warnings`, `cargo fmt --check`, `make source-quality` clean per commit.

## Related, reported separately

`from_blueprint(save=True)` is a silent no-op when the blueprint has no `output` key — the second error shape (`missing disk_graph_meta.json`) comes from that, not from this bug. Found independently by a consumer-side agent the same afternoon; tracked separately since it changes user-visible Python semantics.