### PR TITLE
Release tooling: bump automation, MSRV, minimal-versions, version consistency, disk fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,71 @@ jobs:
       - name: Validate temporary RustSec exception policy
         run: python scripts/check_rustsec_advisories.py --policy-only
 
+  msrv-matrix:
+    # Derives the MSRV job's matrix from the manifests themselves. A
+    # hard-coded matrix would let the declared `rust-version` and the job
+    # that verifies it drift apart — which is the exact failure a declared-
+    # but-unchecked MSRV creates, just moved one level up. The script also
+    # fails when a workspace member declares no `rust-version` at all, so a
+    # new crate cannot join without picking a floor.
+    name: Derive MSRV matrix from manifests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.derive.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Show the declared floors
+        run: python scripts/msrv_matrix.py
+      - id: derive
+        run: python scripts/msrv_matrix.py --github >> "$GITHUB_OUTPUT"
+
+  msrv:
+    # Builds every published crate on exactly the Rust version it declares.
+    # We publish five crates to crates.io; before 0.15 none of them declared
+    # a `rust-version`, so a consumer on an older toolchain got a confusing
+    # compile error from somewhere inside the dep tree instead of a clear
+    # "package X requires rustc 1.88" from cargo.
+    #
+    # The floors are NOT uniform and deliberately so: `kglite-cli` needs
+    # 1.89 (rustyline 18 calls `File::lock_shared` while declaring no
+    # `rust-version` of its own) and `kglite-bolt-server` needs 1.91 (boltr).
+    # Forcing one number would have raised the engine's floor to 1.91 for no
+    # reason.
+    #
+    # Default features only. Optional `okf`/`rdf` are checked on the engine
+    # group; `fastembed` is excluded because it pulls a ~200 MB ONNX runtime
+    # (the `kglite-c` job skips it for the same reason).
+    name: MSRV ${{ matrix.toolchain }} (${{ matrix.label }})
+    needs: msrv-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.msrv-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv-${{ matrix.toolchain }}
+          workspaces: ". -> target"
+
+      - name: Build on the declared MSRV
+        run: cargo check ${{ matrix.packages }}
+
+      - name: Build the engine's optional format loaders on the same floor
+        if: matrix.core == 'true'
+        run: cargo check -p kglite --features okf,rdf
+
   rustsec-audit:
     name: Required RustSec audit
     runs-on: ubuntu-latest
@@ -899,6 +964,8 @@ jobs:
       - rust-checks
       - rust-core-coverage
       - source-quality
+      - msrv-matrix
+      - msrv
       - rustsec-audit
       - kglite-c
       - python-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,104 @@ jobs:
         if: matrix.core == 'true'
         run: cargo check -p kglite --features okf,rdf
 
+  minimal-versions:
+    # WHAT THIS CATCHES
+    # -----------------
+    # A dependency requirement that understates the version our own code
+    # actually needs. `mcp-methods = "0.4"` while calling APIs added in
+    # 0.4.1 (fixed in 3114caab) is the reference case. This class is
+    # STRUCTURALLY INVISIBLE to the repo that declares it: our committed
+    # lockfile already held 0.4.1 and a fresh resolve picks the newest
+    # match, so every local build and every other CI job resolved the
+    # working version. Only a consumer whose lock pinned 0.4.0 ever saw it,
+    # and only as a compile error in their repo.
+    #
+    # This job removes that blindness by resolving our DIRECT dependencies
+    # DOWN to their declared minimums and building the result.
+    #
+    # WHAT THIS DOES NOT CATCH
+    # ------------------------
+    # `-Z direct-minimal-versions` lowers only the direct dependencies of
+    # workspace members; transitive dependencies still resolve normally.
+    # A third-party crate that understates ITS floor is not detected here.
+    # Full `-Z minimal-versions` would cover that, but it fails across the
+    # ecosystem on crates that never declared accurate floors, so its
+    # output would be noise rather than signal.
+    #
+    # It also does not check that a floor is TIGHT — a needlessly high
+    # declared minimum resolves and builds fine. Overstating is the benign
+    # direction (the consumer gets a clear resolution error, not a
+    # mysterious compile failure), so that asymmetry is acceptable.
+    #
+    # WHY IT IS NON-BLOCKING TODAY
+    # ----------------------------
+    # It currently fails at the RESOLUTION step, before it can build
+    # anything. Roughly twenty of our direct dependencies are declared as
+    # bare `"1"` / `"0.x"` floors; lowered simultaneously, several conflict
+    # with each other's transitive requirements (e.g. `regex = "1"` resolves
+    # 1.0.0, which lacks the `std` feature `tracing-subscriber` needs).
+    # Reaching green requires giving each direct dependency a real, compiled
+    # floor — a separate piece of work, tracked in
+    # dev-docs/plans/publishing-contract-2026-07-27.md.
+    #
+    # So the job runs, prints its finding, and does NOT block the release
+    # gate. It is deliberately still listed in `ci-success`'s `needs` so it
+    # stays visible in every run rather than becoming a job nobody looks at.
+    # The `cargo check` step below is already wired up: the day the floors
+    # are tightened, this job starts delivering the real signal — and the
+    # `continue-on-error` flags come off — without further edits.
+    #
+    # Non-vacuity is verified, not assumed: with `3114caab` temporarily
+    # reverted (`mcp-methods = "0.4"`), resolution selects mcp-methods 0.4.0
+    # and the build fails on the missing `ActivationBuild` / `ActivationRequest`
+    # / `PreparedActivation` symbols. See the plan doc for the transcript.
+    name: Minimal versions (declared dependency floors)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust nightly (for -Z direct-minimal-versions)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install Rust stable (builds the lowered lockfile)
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: minimal-versions
+          workspaces: ". -> target"
+
+      - name: Resolve direct dependencies down to their declared minimums
+        id: resolve
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo +nightly -Z direct-minimal-versions generate-lockfile 2>&1 | tee resolve.log
+
+      - name: Build against the lowered lockfile
+        if: steps.resolve.outcome == 'success'
+        continue-on-error: true
+        run: cargo check --workspace --locked
+
+      - name: Report
+        if: always()
+        run: |
+          {
+            echo "## Minimal versions"
+            if [ "${{ steps.resolve.outcome }}" = "success" ]; then
+              echo "Resolution to declared minimums succeeded; see the build step."
+            else
+              echo "Resolution to declared minimums FAILED — a declared floor is"
+              echo "unreachable or understated. First conflict:"
+              echo ''
+              echo '```'
+              tail -n 25 resolve.log || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   rustsec-audit:
     name: Required RustSec audit
     runs-on: ubuntu-latest
@@ -966,6 +1064,11 @@ jobs:
       - source-quality
       - msrv-matrix
       - msrv
+      # `minimal-versions` is `continue-on-error: true`, so it reports
+      # `success` here even when it finds something. It is listed anyway so
+      # it stays visible in every run instead of quietly rotting; see the
+      # job's own comment for what it catches and why it cannot block yet.
+      - minimal-versions
       - rustsec-audit
       - kglite-c
       - python-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on exactly the version it declares, with the matrix derived from the
   manifests, so the contract cannot drift away from its check.
 
+### Fixed
+
+- **Two dependency requirements that understated their real minimum.**
+  `fastembed = "5"` selects the `ort-download-binaries-native-tls` feature,
+  which did not exist until **5.9.0**; `mimalloc = "0.1"` selects the `v2`
+  feature, which did not exist until **0.1.49**. Both now declare those
+  minimums. Neither could fail for us — our lockfile has held newer versions
+  throughout — but either would fail at resolution for a consumer whose lock
+  pinned an older version, with "package does not have that feature". This is
+  the same class as the `mcp-methods = "0.4"` fix that shipped just before it,
+  and it was found by the new minimal-versions CI job rather than by a
+  downstream report. `serde`, `serde_json` and `chrono` requirements that
+  differed between our own workspace members were aligned to the tightest
+  floor any member already declares.
+
 ## [0.15.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   could resolve. The writers now resolve, so the directory they emit is always
   one the same build can read back. The same failure could be triggered on any
   disk graph by a read-only query that merely mentions an unknown label
-  (`MATCH (n:Ghost {id: 1})`) before the next `save()`.
+  (`MATCH (n:Ghost {id: 1})`) before the next `save()`. Directories already
+  written that way load again without a rebuild: the stale entry is empty, and
+  an id index is a cache the read path rebuilds on demand, so it is dropped at
+  load. A *populated* entry under an unresolvable key is still rejected — that
+  is a damaged sidecar, not this bug.
 
 ## [0.15.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A declared minimum supported Rust version on every published crate.** All
+  five crates we publish to crates.io shipped without a `rust-version`, so a
+  consumer on an older toolchain got a compile error from somewhere inside the
+  dependency tree instead of cargo's clear "package X requires rustc 1.88".
+  The floors are now declared, and they are not uniform because the
+  dependencies are not: `kglite`, `kglite-c` and `kglite-mcp-server` require
+  **1.88.0** (the workspace default, inherited via `[workspace.package]`),
+  `kglite-cli` requires **1.89.0**, and `kglite-bolt-server` requires
+  **1.91.0**. Each number was determined by taking the maximum `rust-version`
+  across that crate's resolved dependency tree and then confirming the crate
+  actually builds on it — not by reading metadata alone, which understates the
+  answer: `rustyline 18` declares no `rust-version` at all yet calls
+  `File::lock_shared`, stabilized in 1.89, which is the whole reason
+  `kglite-cli` sits above the workspace floor. A new CI job builds every crate
+  on exactly the version it declares, with the matrix derived from the
+  manifests, so the contract cannot drift away from its check.
+
 ## [0.15.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `storage="disk"` graph containing a node type with no rows saved a
+  directory that could not be loaded**, failing with `File format error:
+  invalid id_indices.bin: directory contains an unresolved type key`. Declaring
+  a type that a given data slice leaves empty is ordinary — a blueprint with 26
+  node types legitimately populates a handful — and the build, the queries, and
+  `save()` all succeeded, so the failure only surfaced on the next `load()`.
+  Disk index sidecars address types by interner hash, and the writer derived
+  those hashes from the type name alone instead of resolving them against the
+  interner it persists alongside; a type whose name the interner never carried
+  (nothing interns a type that has no nodes) therefore got a key that nothing
+  could resolve. The writers now resolve, so the directory they emit is always
+  one the same build can read back. The same failure could be triggered on any
+  disk graph by a read-only query that merely mentions an unknown label
+  (`MATCH (n:Ghost {id: 1})`) before the next `save()`.
+
 ## [0.15.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,31 @@ API changes vs the last published kglite to ground the bump-size decision
 (informational — this project deliberately ships documented breaking changes
 in patch bumps).
 
+### Release preflight and CI polling
+
+Two release-time instruments, both **checkers** — neither performs a release
+step, and neither has a `--fix`:
+
+- `make release-preflight` reports whether the tree is ready for the release
+  commit: workspace version vs. the top CHANGELOG section, internal pin sync,
+  captured constants present for this version, server binaries newer than the
+  manifest, `cargo fmt` + `ruff format` clean (the constants refresh dirties
+  formatting), and `origin/main` an ancestor of HEAD. It prints the command
+  for each unmet precondition and stops there. Run it after promoting the
+  CHANGELOG, before writing the release commit.
+- `python scripts/wait_for_release_ci.py` waits for the four push-triggered
+  workflows. It queries **by branch** with a client-side `head_sha` filter —
+  `gh run list --commit <sha>` returned `runs=0` for an hour during 0.15.0
+  while all four were green on that SHA — **requires all four runs to be
+  present** before concluding anything (a zero-incomplete loop exits instantly
+  green on an empty array), and reports **`conclusion`, not `status`**. A
+  timeout is a non-zero exit, never a pass.
+
+Do not grow either into a driver. A tool that reports "these four things are
+not ready" makes the maintainer faster; a tool that quietly performs the steps
+it checks is how gates stop gating. The bump size, the semver-check reading,
+and the push stay human decisions.
+
 ### PyPI project capacity
 
 PyPI's default project limit is 10.0 GB. The wheel release workflow sums the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,60 @@ API changes vs the last published kglite to ground the bump-size decision
 (informational — this project deliberately ships documented breaking changes
 in patch bumps).
 
+### Ecosystem version consistency + downstream notification
+
+`scripts/check_version_consistency.py` audits every place a dependency
+version is declared across KGLite and its siblings (`codingest`,
+`kglite-datasets`, `sonagram`, `sonara`, `mcp-methods`) — not just
+`Cargo.toml`/`pyproject.toml`, but CI YAML, Makefiles, Dockerfiles, shell and
+Python scripts, install hints baked into source strings, committed lockfiles,
+and docs.
+
+**The class of bug it exists for:** a version requirement that *understates
+its real minimum*, or that is declared *outside package metadata*, is
+structurally invisible to the repo that declares it. `kglite-mcp-server`
+declared `mcp-methods = "0.4"` while calling 0.4.1 APIs — our lock held 0.4.1,
+so every local build and every CI run here resolved fine, and only a sibling
+with an older lock ever saw it. Same shape: `fastembed = "5"` selecting a
+5.9.0+ feature, `mimalloc = "0.1"` selecting `v2` (0.1.49+), and codingest's
+`ci.yml` pinning a version its own wheel metadata excluded.
+
+- `make check-ecosystem-versions` — run **before the version bump** at release
+  time, and any time you touch a dependency requirement. Exits non-zero on
+  *contradictions* (two binding sites in one resolution unit that no single
+  version satisfies); staleness, understated floors, and stale documented
+  versions are reported but do not fail unless you pass `--fail-on stale`.
+- `make check-ecosystem-versions-verbose` — adds the full inventory of
+  declaration sites outside package metadata, i.e. everything that can drift
+  with nothing watching it.
+- `make notify-downstream-dry-run` / `make notify-downstream` — run **after
+  publish is verified**. Writes a release note into `inbox/unread/` of each
+  *affected* downstream only.
+
+**Deliberately not in `make gate` or CI.** Its subject is disagreement
+*between* repos; CI checks out one repo, so every sibling would be absent and
+the check would pass vacuously or need five extra clones per run. It degrades
+with a skip-and-message when siblings are missing (`--require-siblings`
+inverts that), and it resolves the ecosystem root through a worktree's `.git`
+file, so it works from `/Users/Shared/kglite-wt/<branch>` too.
+
+**The notifier notifies only the affected.** A "we released, nothing changes
+for you" note is noise that trains people to ignore the inbox, and it degrades
+a mechanism that currently works (CLAUDE.md → "Route to the party who can
+act"). A downstream is notified only when its declared range excludes the new
+version, it pins us at a superseded exact version, it states a superseded
+version in published prose, or it references a symbol in this release's
+breaking set (`DEFAULT_BREAKING_SYMBOLS` in the script — refresh it with the
+other captured constants). Otherwise the run prints `SKIP <repo>: <reason>`
+and writes nothing. Notes are local files, never commits: `inbox/` is
+gitignored working state in every repo.
+
+Prose cannot be classified mechanically — "use kglite 0.13.4 to convert
+pre-0.14 artifacts" is correct forever, "a thin KGLite 0.14.3 frontend" is
+rot. Adjudicated cases live in the script's `ACKNOWLEDGED` table with a
+reason, or carry an inline `version-check: ignore` marker; changelogs,
+migration guides and dated ledger rows are skipped wholesale.
+
 ### PyPI project capacity
 
 PyPI's default project limit is 10.0 GB. The wheel release workflow sums the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,12 +442,26 @@ Two release-time instruments, both **checkers** — neither performs a release
 step, and neither has a `--fix`:
 
 - `make release-preflight` reports whether the tree is ready for the release
-  commit: workspace version vs. the top CHANGELOG section, internal pin sync,
-  captured constants present for this version, server binaries newer than the
-  manifest, `cargo fmt` + `ruff format` clean (the constants refresh dirties
-  formatting), and `origin/main` an ancestor of HEAD. It prints the command
-  for each unmet precondition and stops there. Run it after promoting the
-  CHANGELOG, before writing the release commit.
+  commit, and **refuses** (exit 1) if not. It asserts workspace coherence —
+  every member inherits `[workspace.package] version`, the workspace
+  *resolves* (a resolving `cargo metadata`, since `--no-deps` skips
+  resolution and passes on exactly the broken tree), and all five publishable
+  crates sit at one version — plus workspace version vs. the top CHANGELOG
+  section, internal pin sync, captured constants present for this version,
+  server binaries newer than the manifest, `cargo fmt` + `ruff format` clean
+  (the constants refresh dirties formatting), and `origin/main` an ancestor of
+  HEAD. It prints the command for each unmet precondition and stops there.
+  Run it after promoting the CHANGELOG, before writing the release commit.
+
+  The coherence assertions are **not** redundant with `make bump-version`.
+  The bump tool fixes the forward path; nothing stops the state drifting some
+  other way (a merge, a hand-edit, a rebase resolving a manifest conflict
+  wrongly). And a member carrying its own stale explicit `version = "..."`
+  resolves perfectly well — resolution cannot see that class at all, only
+  reading the manifests can. Preflight **names the offending files and tells
+  you to run `make bump-version`; it never repairs them.** A divergence might
+  be someone's deliberate in-progress change, and quietly overwriting it
+  would be worse than the drift.
 - `python scripts/wait_for_release_ci.py` waits for the four push-triggered
   workflows. It queries **by branch** with a client-side `head_sha` filter —
   `gh run list --commit <sha>` returned `runs=0` for an hour during 0.15.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,33 @@ The loop's pushes are still subject to the same rigor as any release push (lint 
 
 Conversational phrasing from earlier in the session ("ship it", "looks good", "you may push", "we're ready") **does not** carry over to a later moment outside the fix-and-push loop, even within the same turn if other actions intervene. When in doubt, prepare the commit, stop, and ask. The cost of a re-prompt is small; an unapproved push to `main` is not.
 
-Version source of truth: **`[workspace.package] version` in the root `Cargo.toml`**. Every member crate (engine, wheel, `kglite-c`, servers, cli) sets `version.workspace = true` and inherits it, so a release bumps this one line and all published crates ship in lockstep.
+Version source of truth: **`[workspace.package] version` in the root
+`Cargo.toml`**. Every member crate (engine, wheel, `kglite-c`, servers, cli)
+sets `version.workspace = true` and inherits it, so all published crates ship
+in lockstep.
+
+**But the version lives in five files, not one.** `[workspace.package]` covers
+each crate's *own* `package.version`; it does not cover the internal
+dependency requirements. Four member manifests — `kglite-bolt-server`,
+`kglite-c`, `kglite-cli`, `kglite-mcp-server` — declare
+`kglite = { version = "X.Y.Z", path = "../kglite", … }`, because `cargo
+publish` rejects a `path`-only dependency. Bumping only the workspace table
+leaves the workspace unresolvable as soon as the bump crosses a minor
+(`cargo metadata`: *failed to select a version for the requirement
+`kglite = ^0.14`*), and every release step that shells out to cargo dies on
+its first call — that is exactly what broke `make refresh-release-constants`
+during the 0.15.0 release.
+
+So: **never hand-edit the version. Run `make bump-version VERSION=X.Y.Z`.**
+It rewrites all five places and verifies with a resolving `cargo metadata`
+that every member resolved (`--no-deps` skips resolution entirely and passes
+on exactly the broken tree). The internal requirement carries the full `X.Y.Z`
+rather than the `X.Y` series, because these crates ship in lockstep and this
+project deliberately ships breaking engine changes in patch bumps — `^0.15`
+would advertise that `kglite-cli 0.15.3` builds against `kglite 0.15.0`, which
+is often false. `make gate` fails if any of the five drifts apart. The bump
+*size* stays a human decision (see `make semver-check`); the target only
+applies the version you hand it.
 
 ### One version bump per push
 
@@ -384,13 +410,24 @@ If that returns a commit, keep the version it picked. Only mint a new version af
 Three captured values drift across releases and need a version-paired refresh as part of the release commit. The gates that check them are otherwise reliable — see Test infrastructure → Phase 4 / Phase 5 / perf-regression — but they go stale silently when nobody updates the captured constants. `make refresh-release-constants` does all three in one pass and prints a `git diff --stat` so the maintainer can stage them into the release commit.
 
 - `tests/test_phase4_parity.py::GOLDEN_V3_DIGEST` (and demote the prior value into `ACCEPTABLE_DIGESTS`). The version string lives in the `.kgl` header, so every release shifts the digest.
-- `tests/test_phase5_parity.py::test_binary_size_regression` baseline. Update the docstring's "what grew" note with each bump — the script adds a `TODO: describe what grew since the prior baseline` line for the maintainer to fill in.
+- `tests/test_phase5_parity.py::test_binary_size_regression` baseline. Update the docstring's "what grew" note with each bump — the script adds a `TODO: describe what grew since the prior baseline` line for the maintainer to fill in. **`make gate` fails while that marker survives** (`scripts/check_release_hygiene.py`), so the release can't ship with the placeholder in it.
 - `tests/benchmarks/baselines/<version>.json` and `current.json`. Captured by re-running the 11 tracked core benchmarks. The script is idempotent — if `<version>.json` already exists, recapture is skipped (delete the file to force a fresh capture; benchmark numbers are inherently noisy so we don't want to overwrite on every script run).
 
 The script requires one fresh release artifact (`uv run --no-sync maturin
 develop --release`) for steps 2 and 3. Build it once, after the completed PR's
 full CI is green; it is release-data generation, not a reason to rerun tests in
 release mode.
+
+**No step in that script is best-effort.** A step that cannot do its job —
+missing release artifact, missing *or wrong-version* `cargo-public-api`, a
+rewrite anchor that moved, a failed benchmark run, a fixture lock that won't
+re-resolve — exits non-zero with the remediation command. It never prints a
+line and lets the release continue: in 0.15.0 the public-API step found
+cargo-public-api 0.52.0 against a 0.49.0 pin, reported a no-op, and only a
+human reading the output stopped stale baselines from shipping. The only
+intentional skips are the idempotent per-version benchmark re-capture and an
+explicit `--skip-benchmarks`. Do what the error says and re-run; never route
+around it.
 
 Two release-time companions (both wired into the release skill):
 `make bench-anchor` gates cumulative perf drift (newest baseline vs ~3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,31 @@ resolver = "2"
 [workspace.package]
 version = "0.15.0"
 
+# Minimum supported Rust version — the DEFAULT for members that inherit it
+# with `rust-version.workspace = true`. Two members legitimately need more
+# and declare their own (see below); the rest sit on this floor.
+#
+# 1.88.0 is not a guess. It is the maximum `rust-version` across the whole
+# resolved dependency tree of `kglite` / `kglite-c` / `kglite-mcp-server`
+# (`ort`, `geo`, `time`, `cookie_store`, `darling` all declare 1.88), and
+# `cargo +1.88.0 check` on those three members passes.
+#
+# The two members that need more, and why:
+#   - kglite-cli  → 1.89.0. `rustyline 18` declares NO `rust-version` at all
+#     but calls `File::lock_shared`, stabilized in 1.89. Nothing in the
+#     metadata says so; only compiling on 1.88 does (it fails with E0658
+#     `use of unstable library feature 'file_lock'`).
+#   - kglite-bolt-server → 1.91.0. `boltr 0.2.0` declares `rust-version =
+#     "1.91.0"`.
+# kglite-py depends on kglite-cli, so it inherits the 1.89.0 floor.
+#
+# `.github/workflows/ci.yml`'s `msrv` job builds each member on exactly the
+# version declared here, with the matrix derived from these manifests by
+# `scripts/msrv_matrix.py` — so a bump here cannot silently outrun its check.
+# Raising any of these is a user-visible contract change: note it in
+# CHANGELOG.md.
+rust-version = "1.88.0"
+
 # Phase G.4 — workspace root is now virtual (no `[package]`).
 # Polars-style layout: each crate has its own home under
 # `crates/`. The `kglite` Python wheel is built by maturin from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,16 @@ members = [
 ]
 resolver = "2"
 
-# Single source of truth for the crate version. Every member crate sets
-# `version.workspace = true`, so a release bumps this one line instead of
-# six. All published crates ship in lockstep at the same version.
+# Single source of truth for each crate's own `package.version`: every
+# member sets `version.workspace = true` and inherits this value, so all
+# published crates ship in lockstep.
+#
+# It is NOT the only place the version is written. The four member
+# manifests that publish against the engine also pin it in their
+# `kglite = { version = "X.Y.Z", path = "../kglite" }` requirement, which
+# `cargo publish` needs and `[workspace.package]` does not reach. Bump via
+# `make bump-version VERSION=X.Y.Z` — hand-editing this line alone leaves
+# `cargo metadata` unable to resolve the workspace across a minor bump.
 [workspace.package]
 version = "0.15.0"
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 SHELL := /bin/bash
 ACTIVATE := unset CONDA_PREFIX && source .venv/bin/activate
 
-.PHONY: dev dev-with-bin bundle-bin build-bolt-server test test-full test-rust test-core test-mcp test-cli test-py bench bench-save bench-compare bench-check bump-version check-release-hygiene refresh-release-constants refresh-api-baseline docs-facts check-docs-facts neo4j-up neo4j-down neo4j-conformance bolt-conformance check clean fmt fmt-py clippy gate lint lint-policy lint-full lint-py source-quality rustsec-policy cov stubtest
+.PHONY: dev dev-with-bin bundle-bin build-bolt-server test test-full test-rust test-core test-mcp test-cli test-py bench bench-save bench-compare bench-check bump-version check-release-hygiene release-preflight refresh-release-constants refresh-api-baseline docs-facts check-docs-facts neo4j-up neo4j-down neo4j-conformance bolt-conformance check clean fmt fmt-py clippy gate lint lint-policy lint-full lint-py source-quality rustsec-policy cov stubtest
 
 ## Build and install the package into the local .venv
 dev:
@@ -192,6 +192,18 @@ check-lint-allowances:
 bump-version:
 	@test -n "$(VERSION)" || { echo "usage: make bump-version VERSION=X.Y.Z"; exit 1; }
 	python3 scripts/bump_version.py --set $(VERSION)
+
+## Report whether the tree is ready for the release commit: version/CHANGELOG
+## agreement, internal pins, captured constants, server-binary freshness,
+## formatting, and fast-forwardability. Run it after promoting the CHANGELOG
+## and before writing the release commit.
+##
+## CHECKER, NOT A DRIVER. It performs no release step and has no --fix: it
+## prints the command for each unmet precondition and leaves running it — and
+## deciding whether to release at all — to the maintainer. A tool that quietly
+## performs the steps it checks is how gates stop gating.
+release-preflight:
+	python3 scripts/release_preflight.py
 
 ## Release-paperwork gates. Both are pure file reads (no cargo, no imports)
 ## so they stay inside the fast-gate budget:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 SHELL := /bin/bash
 ACTIVATE := unset CONDA_PREFIX && source .venv/bin/activate
 
-.PHONY: dev dev-with-bin bundle-bin build-bolt-server test test-full test-rust test-core test-mcp test-cli test-py bench bench-save bench-compare bench-check refresh-release-constants refresh-api-baseline docs-facts check-docs-facts neo4j-up neo4j-down neo4j-conformance bolt-conformance check clean fmt fmt-py clippy gate lint lint-policy lint-full lint-py source-quality rustsec-policy cov stubtest
+.PHONY: dev dev-with-bin bundle-bin build-bolt-server test test-full test-rust test-core test-mcp test-cli test-py bench bench-save bench-compare bench-check bump-version check-release-hygiene refresh-release-constants refresh-api-baseline docs-facts check-docs-facts neo4j-up neo4j-down neo4j-conformance bolt-conformance check clean fmt fmt-py clippy gate lint lint-policy lint-full lint-py source-quality rustsec-policy cov stubtest
 
 ## Build and install the package into the local .venv
 dev:
@@ -179,10 +179,33 @@ check-api-chokepoint:
 check-lint-allowances:
 	python scripts/check_lint_allowances.py
 
+## Bump the workspace version everywhere it is written down: the
+## `[workspace.package] version` in the root Cargo.toml AND the internal
+## `kglite = { version = ... }` requirement in the four member manifests that
+## publish against the engine. Editing only the workspace table leaves the
+## workspace unresolvable across a minor bump (`cargo metadata`: "failed to
+## select a version for the requirement `kglite = ^0.14`"), which broke the
+## 0.15.0 release. Verifies with a RESOLVING `cargo metadata` afterwards --
+## `--no-deps` skips resolution and passes on exactly the broken tree.
+## The bump SIZE is a human decision — see the release skill's `make
+## semver-check` step; this target only applies the version you give it.
+bump-version:
+	@test -n "$(VERSION)" || { echo "usage: make bump-version VERSION=X.Y.Z"; exit 1; }
+	python3 scripts/bump_version.py --set $(VERSION)
+
+## Release-paperwork gates. Both are pure file reads (no cargo, no imports)
+## so they stay inside the fast-gate budget:
+##  - every internal kglite dependency requirement matches the workspace version
+##  - CHANGELOG [Unreleased] has no duplicate/bespoke `###` headings, and no
+##    `TODO:` marker written by refresh_release_constants.py survived
+check-release-hygiene:
+	python3 scripts/bump_version.py --check
+	python3 scripts/check_release_hygiene.py
+
 ## Fast local checkpoint. Pair this with the smallest package/test filter
 ## covering the change. Policy audits, workspace clippy, stubtest, packaged-
 ## consumer verification, and the broad test matrix run in CI.
-gate: lint check-docs-facts
+gate: lint check-docs-facts check-release-hygiene
 
 ## Fast formatting/static lint. Intentionally performs no Rust compilation,
 ## metadata walk, or runtime import.

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,35 @@ check-api-chokepoint:
 check-lint-allowances:
 	python scripts/check_lint_allowances.py
 
+## Cross-repo version-consistency audit over the sibling checkouts under
+## ../ (codingest, kglite-datasets, sonagram, sonara, mcp-methods).
+##
+## DELIBERATELY NOT IN `gate` OR CI. Its whole subject is disagreement
+## *between* repos, and CI checks out one repo — there, every sibling is
+## absent and the check would either pass vacuously or need five extra
+## clones per run. It is a release-time and on-demand target instead, and it
+## skips-with-a-message rather than failing when a sibling is missing, so it
+## stays usable from a partial checkout. Exits non-zero on contradictions.
+check-ecosystem-versions:
+	$(ACTIVATE) && python scripts/check_version_consistency.py
+
+## Same audit, plus the full inventory of declaration sites that live outside
+## package metadata — the places that can drift with nothing watching them.
+check-ecosystem-versions-verbose:
+	$(ACTIVATE) && python scripts/check_version_consistency.py --show-sites
+
+## Preview the downstream release notes for the current version without
+## writing anything. Run before `notify-downstream` at release time.
+notify-downstream-dry-run:
+	$(ACTIVATE) && python scripts/check_version_consistency.py --notify --dry-run
+
+## Write a release note into inbox/unread/ of every AFFECTED downstream —
+## and only those (see the affected-only rule in the script's docstring).
+## Run after publish is verified. inbox/ is gitignored working state; the
+## notes are never committed, here or there.
+notify-downstream:
+	$(ACTIVATE) && python scripts/check_version_consistency.py --notify
+
 ## Fast local checkpoint. Pair this with the smallest package/test filter
 ## covering the change. Policy audits, workspace clippy, stubtest, packaged-
 ## consumer verification, and the broad test matrix run in CI.

--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,19 @@ bump-version:
 	@test -n "$(VERSION)" || { echo "usage: make bump-version VERSION=X.Y.Z"; exit 1; }
 	python3 scripts/bump_version.py --set $(VERSION)
 
-## Report whether the tree is ready for the release commit: version/CHANGELOG
-## agreement, internal pins, captured constants, server-binary freshness,
+## Report whether the tree is ready for the release commit. Asserts workspace
+## coherence -- every member inherits [workspace.package] version, the
+## workspace RESOLVES (which is what a stale internal `kglite = ...` pin
+## breaks), and all five publishable crates are at one version -- plus
+## version/CHANGELOG agreement, captured constants, server-binary freshness,
 ## formatting, and fast-forwardability. Run it after promoting the CHANGELOG
 ## and before writing the release commit.
+##
+## The three coherence assertions are not redundant with `make bump-version`:
+## the bump tool fixes the forward path, but a merge, hand-edit, or a rebase
+## that resolves a manifest conflict wrongly can drift the state anyway. And
+## resolution alone cannot see a member carrying its own stale explicit
+## version -- that resolves fine and still ships a broken publish set.
 ##
 ## CHECKER, NOT A DRIVER. It performs no release step and has no --fix: it
 ## prints the command for each unmet precondition and leaves running it — and

--- a/crates/kglite-bolt-server/Cargo.toml
+++ b/crates/kglite-bolt-server/Cargo.toml
@@ -30,9 +30,10 @@ path = "src/main.rs"
 # pyo3` → empty).
 # Local dev uses the path dep; `cargo publish` strips path and falls
 # back to the version requirement (so this crate publishes against
-# the crates.io kglite). The version must be kept in sync with
-# `crates/kglite/Cargo.toml`'s package.version on each release.
-kglite = { version = "0.15", path = "../kglite", default-features = false }
+# the crates.io kglite). The requirement tracks the exact workspace
+# version; `make bump-version VERSION=X.Y.Z` moves it, and `make gate`
+# fails if it drifts.
+kglite = { version = "0.15.0", path = "../kglite", default-features = false }
 
 # Bolt v5.x protocol library. Implements PackStream framing, message
 # dispatch, session state machine, handshake. We implement BoltBackend

--- a/crates/kglite-bolt-server/Cargo.toml
+++ b/crates/kglite-bolt-server/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kglite-bolt-server"
 version.workspace = true
 edition = "2021"
+# Above the 1.88.0 workspace floor: `boltr 0.2.0` declares
+# `rust-version = "1.91.0"`. This was previously recorded only as a
+# comment further down this file; now it is the actual contract.
+rust-version = "1.91.0"
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 license = "MIT"
 description = "Pure-Rust Bolt v5.x protocol server for kglite knowledge graphs, with a regression-tested Neo4j Python driver path."
@@ -39,10 +43,11 @@ kglite = { version = "0.15", path = "../kglite", default-features = false }
 # (the 11-method seam in boltr::server::BoltBackend) and hand the
 # instance to BoltServer::builder(...).serve(addr).
 #
-# boltr v0.2.0 requires rust-version = "1.91.0". Local + CI toolchains
-# (rustc stable 1.95+) clear this comfortably. Phase B's plan calls out
-# the upstream-churn risk; we accept it because hand-rolling Bolt
-# framing for Phase B alone is not the right shape.
+# boltr v0.2.0 requires rust-version = "1.91.0" — which is why this crate
+# declares `rust-version = "1.91.0"` above instead of inheriting the
+# workspace 1.88.0 floor. Phase B's plan calls out the upstream-churn
+# risk; we accept it because hand-rolling Bolt framing for Phase B alone
+# is not the right shape.
 boltr = { version = "0.2", features = ["tls"] }
 
 # Phase F #6: rustls crypto provider for boltr's TLS support.

--- a/crates/kglite-c/Cargo.toml
+++ b/crates/kglite-c/Cargo.toml
@@ -38,7 +38,7 @@ kglite = { version = "0.15", path = "../kglite", default-features = false }
 # Serde stack — needed to serialize Value to JSON at the C
 # boundary (the design doc fixes JSON-at-boundary for nested
 # value types in §7).
-serde_json = "1"
+serde_json = "1.0.150"
 
 [build-dependencies]
 # cbindgen generates `include/kglite.h` at build time from this

--- a/crates/kglite-c/Cargo.toml
+++ b/crates/kglite-c/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kglite-c"
 version.workspace = true
 edition = "2021"
+rust-version.workspace = true
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 license = "MIT"
 description = "C ABI for kglite — stable extern \"C\" surface over the kglite engine so non-Rust bindings (Go via cgo, JavaScript via napi, JVM via JNI, .NET via P/Invoke, …) consume a single C header rather than re-implementing wrappers in their host language. The Rust types (DirGraph, Session, CypherResult, KgErrorCode) live in the sibling `kglite` crate; this crate is glue."

--- a/crates/kglite-c/Cargo.toml
+++ b/crates/kglite-c/Cargo.toml
@@ -31,8 +31,9 @@ rdf = ["kglite/rdf"]
 # kglite-bolt-server / kglite-mcp-server pattern — features are
 # opted into here per the [features] block above. Path dep for
 # workspace builds; `cargo publish` strips the path and falls back
-# to the version requirement.
-kglite = { version = "0.15", path = "../kglite", default-features = false }
+# to the version requirement, which tracks the exact workspace version
+# (`make bump-version VERSION=X.Y.Z`; `make gate` fails on drift).
+kglite = { version = "0.15.0", path = "../kglite", default-features = false }
 
 # Serde stack — needed to serialize Value to JSON at the C
 # boundary (the design doc fixes JSON-at-boundary for nested

--- a/crates/kglite-cli/Cargo.toml
+++ b/crates/kglite-cli/Cargo.toml
@@ -2,6 +2,11 @@
 name = "kglite-cli"
 version.workspace = true
 edition = "2021"
+# Above the 1.88.0 workspace floor: `rustyline 18` declares no
+# `rust-version` of its own but calls `File::lock_shared`, stabilized in
+# 1.89.0. On 1.88 it fails with E0658 `use of unstable library feature
+# 'file_lock'`, so the metadata floor understates the real one.
+rust-version = "1.89.0"
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 license = "MIT"
 description = "Pure-Rust KGLite CLI: Cypher shell and offline code-review skill installer"

--- a/crates/kglite-cli/Cargo.toml
+++ b/crates/kglite-cli/Cargo.toml
@@ -18,9 +18,10 @@ path = "src/main.rs"
 [dependencies]
 # Reuse kglite's pure-Rust surface (kglite::api::*) — no libpython link
 # in the resulting binary. Mirrors the kglite-bolt-server / kglite-mcp-server
-# pattern: path dep locally, version requirement on `cargo publish`. Version
-# kept in sync with crates/kglite/Cargo.toml's package.version each release.
-kglite = { version = "0.15", path = "../kglite", default-features = false, features = ["okf"] }
+# pattern: path dep locally, version requirement on `cargo publish`. The
+# requirement tracks the exact workspace version (`make bump-version
+# VERSION=X.Y.Z`; `make gate` fails on drift).
+kglite = { version = "0.15.0", path = "../kglite", default-features = false, features = ["okf"] }
 
 # Line editor: prompt, history, Emacs/Vi keybindings, Ctrl-C/Ctrl-D handling.
 # The standard Rust REPL choice; not otherwise a workspace dep.

--- a/crates/kglite-cli/Cargo.toml
+++ b/crates/kglite-cli/Cargo.toml
@@ -37,7 +37,7 @@ rustyline = "18"
 ctrlc = "3"
 
 # `.mode json` output via kglite::api::param::kglite_value_to_json.
-serde_json = "1"
+serde_json = "1.0.150"
 
 # `.import <file.csv> <Type>` — parse the CSV; rows are passed as a Cypher
 # `$rows` param (values parameterized, not interpolated). Already a `kglite` dep.

--- a/crates/kglite-mcp-server/Cargo.toml
+++ b/crates/kglite-mcp-server/Cargo.toml
@@ -62,14 +62,14 @@ rmcp = { version = "2.2", features = ["server", "macros", "transport-io", "schem
 # making fastembed optional in 0.10.1, declare net explicitly so the
 # default build still compiles.
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "fs", "sync", "time", "net"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.150"
 regex = "1"
 schemars = "1"
 # ISO-8601 formatting of the active-graph build timestamp surfaced in
 # graph_overview / cypher_query / set_root_dir output. Already in the
 # resolved dep graph via kglite core — direct dep, zero extra build cost.
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
 
 # Error handling + CLI
 anyhow = "1"

--- a/crates/kglite-mcp-server/Cargo.toml
+++ b/crates/kglite-mcp-server/Cargo.toml
@@ -47,10 +47,11 @@ mcp-methods = { version = "0.4.1", default-features = false, features = ["server
 # source_location into kglite::api so mcp-server no longer needs
 # to route through the kglite-py wheel crate (which would drag
 # pyo3 along). Local dev uses the path dep; `cargo publish`
-# strips path and falls back to the version requirement, keeping
-# this in lockstep with the kglite core version.
+# strips path and falls back to the version requirement, which tracks
+# the exact workspace version (`make bump-version VERSION=X.Y.Z`;
+# `make gate` fails on drift).
 # Verified: `cargo tree -p kglite-mcp-server | grep pyo3` → empty.
-kglite = { version = "0.15", path = "../kglite", default-features = false }
+kglite = { version = "0.15.0", path = "../kglite", default-features = false }
 
 # rmcp re-export for the dynamic tool registration path.
 rmcp = { version = "2.2", features = ["server", "macros", "transport-io", "schemars"] }

--- a/crates/kglite-mcp-server/Cargo.toml
+++ b/crates/kglite-mcp-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kglite-mcp-server"
 version.workspace = true
 edition = "2021"
+rust-version.workspace = true
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 license = "MIT"
 description = "MCP server for kglite knowledge graphs — pure-Rust single-binary frontend for cypher_query / graph_overview / save_graph / read_code_source plus the generic source / GitHub surface from mcp-methods. No libpython link."

--- a/crates/kglite-py/Cargo.toml
+++ b/crates/kglite-py/Cargo.toml
@@ -115,7 +115,11 @@ serde_json = "1.0.150"
 petgraph = { version = "0.8.3", features = ["serde-1"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 regex = "1"
-mimalloc = { version = "0.1", default-features = false, features = ["v2"] }
+# 0.1.49 is a real MINIMUM, not a floor-by-habit: the `v2` feature that
+# pins us to the mimalloc v2 line was added in 0.1.49. Declaring plain
+# "0.1" let a consumer resolve 0.1.9 and fail with "mimalloc does not
+# have that feature". Found by the minimal-versions CI job.
+mimalloc = { version = "0.1.49", default-features = false, features = ["v2"] }
 # Scoped SIGINT (Ctrl-C) handler so long Cypher queries are interruptible
 # from a REPL/notebook (src/util.rs::EnterKg). Unix-only; the handler just
 # flips an AtomicBool the engine polls.

--- a/crates/kglite-py/Cargo.toml
+++ b/crates/kglite-py/Cargo.toml
@@ -5,6 +5,10 @@
 name = "kglite-py"
 version.workspace = true
 edition = "2021"
+# Inherited from the `kglite-cli` path dependency below, which needs
+# 1.89.0 for rustyline. Not published to crates.io, but the wheel is
+# built from source, so the floor is real for anyone building it.
+rust-version = "1.89.0"
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 description = "PyO3 wrapper for kglite — Python bindings around the pure-Rust kglite knowledge graph engine."
 readme = "../../README.md"

--- a/crates/kglite/Cargo.toml
+++ b/crates/kglite/Cargo.toml
@@ -7,6 +7,7 @@
 name = "kglite"
 version.workspace = true
 edition = "2021"
+rust-version.workspace = true
 authors = ["Kristian dF Kollsgård <kkollsg@gmail.com>"]
 license = "MIT"
 description = "Pure-Rust embedded Cypher knowledge graph engine with in-memory, mmap, and disk storage, and agent-facing schema introspection"

--- a/crates/kglite/Cargo.toml
+++ b/crates/kglite/Cargo.toml
@@ -79,7 +79,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
 [dependencies]
 petgraph = { version = "0.8.3", features = ["serde-1"] }
-fastembed = { version = "5", optional = true, default-features = false, features = ["ort-download-binaries-native-tls", "hf-hub-native-tls"] }
+# 5.9 is a real MINIMUM, not a floor-by-habit: the
+# `ort-download-binaries-native-tls` feature selected below was added in
+# fastembed 5.9.0 (5.0.x has `ort-download-binaries` and
+# `hf-hub-native-tls`, but not the native-tls ort variant). Declaring
+# plain "5" let a consumer resolve 5.0.1 and fail with "fastembed does
+# not have that feature". Found by the minimal-versions CI job.
+fastembed = { version = "5.9", optional = true, default-features = false, features = ["ort-download-binaries-native-tls", "hf-hub-native-tls"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.150"
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }

--- a/crates/kglite/src/graph/dir_graph/disk_snapshot_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/disk_snapshot_tests.rs
@@ -1,0 +1,171 @@
+//! A saved disk directory must be one this build can read back.
+//!
+//! Disk snapshots address types by `InternedKey` hash in `id_indices.bin` and
+//! `type_indices.bin`, and the loader resolves every one of those hashes
+//! through the `interner.bin.zst` sidecar written beside them. Any type name
+//! that reaches an index without reaching the interner therefore produces a
+//! directory that `save()` writes happily and `load()` rejects with
+//! "invalid id_indices.bin: directory contains an unresolved type key".
+//!
+//! Two shapes used to do exactly that, both of them ordinary usage:
+//!
+//! * a node type declared with **zero data rows** — a real data slice
+//!   legitimately leaves declared types empty — because `add_nodes` built an
+//!   (empty) id index for the type while only node *creation* interned its
+//!   name; and
+//! * a **label a read-only query merely mentioned** (`MATCH (n:Ghost {id: 1})`),
+//!   because the read path caches a build-on-miss index under that name.
+//!
+//! The tests below pin the round trip for both, with the in-memory and
+//! one-row variants as controls.
+
+use crate::datatypes::{DataFrame, Value};
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::io::file::{load_file, save_graph};
+use crate::graph::mutation::maintain::add_nodes;
+use crate::graph::session::{execute_read, ExecuteOptions};
+use std::sync::Arc;
+
+/// `id,name` rows, matching the two-column CSV shape a blueprint declares.
+fn rows(count: usize) -> DataFrame {
+    let rows: Vec<Vec<Value>> = (0..count)
+        .map(|i| {
+            vec![
+                Value::Int64(i as i64 + 1),
+                Value::String(format!("row-{i}")),
+            ]
+        })
+        .collect();
+    DataFrame::from_cypher_rows(vec!["id".to_string(), "name".to_string()], rows).unwrap()
+}
+
+fn declare(graph: &mut DirGraph, node_type: &str, row_count: usize) {
+    add_nodes(
+        graph,
+        rows(row_count),
+        node_type.to_string(),
+        "id".to_string(),
+        Some("name".to_string()),
+        None,
+    )
+    .unwrap_or_else(|e| panic!("add_nodes({node_type}, {row_count} rows) failed: {e}"));
+}
+
+fn count_of_type(graph: &DirGraph, node_type: &str) -> i64 {
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::new(&params);
+    let query = format!("MATCH (n:{node_type}) RETURN count(n) AS c");
+    let outcome = execute_read(graph, &query, &opts).expect("count query");
+    match outcome.result.rows.first().and_then(|row| row.first()) {
+        Some(Value::Int64(n)) => *n,
+        other => panic!("unexpected count value: {other:?}"),
+    }
+}
+
+/// Save `graph` as a disk directory and read it back.
+fn disk_round_trip(mut graph: DirGraph, dir: &std::path::Path) -> Arc<DirGraph> {
+    graph.enable_disk_mode().expect("enable disk mode");
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, dir.to_str().unwrap()).expect("save disk graph");
+    load_file(dir.to_str().unwrap()).expect("a saved disk directory must load")
+}
+
+/// The reported bug: one populated type, one declared type with no rows.
+#[test]
+fn declared_type_with_zero_rows_survives_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Empty", 0);
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert!(
+        loaded.get_node_type_metadata("Empty").is_some(),
+        "the declared-but-unpopulated type must survive the round trip"
+    );
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Empty"), 0);
+}
+
+/// Consumers declare tens of types and populate a handful; every unpopulated
+/// one used to add another unresolvable key to the same directory.
+#[test]
+fn many_declared_types_with_zero_rows_survive_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 3);
+    for name in ["Filing", "Insider", "Holding", "Transaction", "Rating"] {
+        declare(&mut graph, name, 0);
+    }
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert_eq!(count_of_type(&loaded, "Full"), 3);
+    for name in ["Filing", "Insider", "Holding", "Transaction", "Rating"] {
+        assert!(
+            loaded.get_node_type_metadata(name).is_some(),
+            "declared type '{name}' must survive the round trip"
+        );
+        assert_eq!(count_of_type(&loaded, name), 0);
+    }
+}
+
+/// Control: the same shape in memory always worked, and must keep working.
+#[test]
+fn declared_type_with_zero_rows_survives_a_kgl_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.kgl");
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Empty", 0);
+
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, path.to_str().unwrap()).expect("save .kgl");
+    let loaded = load_file(path.to_str().unwrap()).expect("load .kgl");
+
+    assert!(loaded.get_node_type_metadata("Empty").is_some());
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Empty"), 0);
+}
+
+/// Control: one row is enough to intern the type name, so this shape was
+/// never broken — it guards against a fix that only moved the boundary.
+#[test]
+fn single_row_type_survives_a_disk_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    declare(&mut graph, "Sparse", 1);
+
+    let loaded = disk_round_trip(graph, &tmp.path().join("graph"));
+
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+    assert_eq!(count_of_type(&loaded, "Sparse"), 1);
+}
+
+/// A read-only query naming a type the graph does not have caches an empty id
+/// index under that name (`IdIndexStore::lookup_or_build`). Saving afterwards
+/// must not carry that name into the directory — it has no interned identity,
+/// so the snapshot could not resolve it back.
+#[test]
+fn a_label_only_mentioned_by_a_query_does_not_poison_the_next_save() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("graph");
+    let mut graph = DirGraph::new();
+    declare(&mut graph, "Full", 2);
+    graph.enable_disk_mode().expect("enable disk mode");
+
+    let params = std::collections::HashMap::new();
+    let opts = ExecuteOptions::new(&params);
+    execute_read(&graph, "MATCH (n:Ghost {id: 1}) RETURN n", &opts).expect("ghost query");
+    assert!(
+        graph.id_indices.contains_key("Ghost"),
+        "precondition: the read path caches an index for the mentioned label"
+    );
+
+    let mut handle = Arc::new(graph);
+    save_graph(&mut handle, dir.to_str().unwrap()).expect("save disk graph");
+    let loaded = load_file(dir.to_str().unwrap()).expect("a saved disk directory must load");
+    assert_eq!(count_of_type(&loaded, "Full"), 2);
+}

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -2003,3 +2003,6 @@ mod dir_graph_tests;
 
 #[cfg(test)]
 mod rollback_tests;
+
+#[cfg(test)]
+mod disk_snapshot_tests;

--- a/crates/kglite/src/graph/languages/cypher/parse_cache.rs
+++ b/crates/kglite/src/graph/languages/cypher/parse_cache.rs
@@ -169,7 +169,10 @@ mod tests {
         // happened to parse anything, which is not a property of this code.
         // It went red on CI when a new disk-snapshot suite started issuing
         // queries in the same binary.
-        assert!(is_cached_for_tests(q), "second parse should have hit the cache");
+        assert!(
+            is_cached_for_tests(q),
+            "second parse should have hit the cache"
+        );
     }
 
     #[test]

--- a/crates/kglite/src/graph/languages/cypher/parse_cache.rs
+++ b/crates/kglite/src/graph/languages/cypher/parse_cache.rs
@@ -113,6 +113,20 @@ pub fn clear_for_tests() {
 
 /// Current cache occupancy. Test-only.
 #[cfg(test)]
+/// Whether `query` currently has a cache entry.
+///
+/// Preferred over [`entry_count_for_tests`] for hit/miss assertions: the cache
+/// is process-global, so a total count couples a test to whatever else the
+/// binary happened to parse.
+#[cfg(test)]
+pub fn is_cached_for_tests(query: &str) -> bool {
+    let key = hash_query(query);
+    cache()
+        .read()
+        .map(|c| c.map.contains_key(&key))
+        .unwrap_or(false)
+}
+
 pub fn entry_count_for_tests() -> usize {
     cache()
         .read()
@@ -147,7 +161,15 @@ mod tests {
         // ASTs are independently owned — mutation of one doesn't affect
         // the cached entry or other consumers.
         assert_eq!(first.clauses.len(), second.clauses.len());
-        assert_eq!(entry_count_for_tests(), 1);
+        // Assert THIS query is cached, not that it is the ONLY thing cached.
+        // The cache is process-global while `TEST_LOCK` is respected only by
+        // this module, so any test elsewhere that runs Cypher can add entries
+        // between `clear_for_tests()` and here. An exact total was never
+        // testing cache-hit behaviour -- it was testing that no other test
+        // happened to parse anything, which is not a property of this code.
+        // It went red on CI when a new disk-snapshot suite started issuing
+        // queries in the same binary.
+        assert!(is_cached_for_tests(q), "second parse should have hit the cache");
     }
 
     #[test]

--- a/crates/kglite/src/graph/languages/cypher/parse_cache.rs
+++ b/crates/kglite/src/graph/languages/cypher/parse_cache.rs
@@ -111,8 +111,6 @@ pub fn clear_for_tests() {
     guard.order.clear();
 }
 
-/// Current cache occupancy. Test-only.
-#[cfg(test)]
 /// Whether `query` currently has a cache entry.
 ///
 /// Preferred over [`entry_count_for_tests`] for hit/miss assertions: the cache
@@ -127,6 +125,8 @@ pub fn is_cached_for_tests(query: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Current cache occupancy. Test-only.
+#[cfg(test)]
 pub fn entry_count_for_tests() -> usize {
     cache()
         .read()

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -584,9 +584,11 @@ pub struct EdgeSpecReport {
 /// Bulk-create edges from explicit specs, addressed by stable node id +
 /// type. The DataFrame-free sibling of [`add_connections`]: it drives the
 /// *same* engine (`CombinedTypeLookup` + `ConnectionBatchProcessor`) but
-/// takes a spec list instead of a polars `DataFrame` — the path the C ABI
-/// (and future Go / JS / JVM bindings, which can't cheaply build a
-/// DataFrame) use, plus any caller that already has edges as records.
+/// takes a spec list instead of a [`DataFrame`] — the path the C ABI (and
+/// future Go / JS / JVM bindings, which can't cheaply build a DataFrame)
+/// use, plus any caller that already has edges as records. (That
+/// `DataFrame` is kglite's own columnar container in
+/// `crate::datatypes::values`; kglite does not depend on polars.)
 ///
 /// Specs are grouped by `(source_type, target_type, edge_type)`; each
 /// group gets one type lookup and one batch, mirroring `add_connections`.

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -195,9 +195,21 @@ impl IdIndexBase {
                 return Err(invalid_index("general payload exceeds decode limit"));
             }
             expected_payload = payload_end;
-            let name = interner
-                .try_resolve(InternedKey::from_u64(type_key))
-                .ok_or_else(|| invalid_index("directory contains an unresolved type key"))?;
+            let Some(name) = interner.try_resolve(InternedKey::from_u64(type_key)) else {
+                // Directories written before the writer resolved its keys
+                // (through 0.15.0) carry entries for type names the interner
+                // sidecar never received — a type declared with no rows, or a
+                // label a query merely mentioned. Those entries are always
+                // empty, and an id index is a cache the read path rebuilds on
+                // demand, so dropping one recovers the graph at no cost rather
+                // than making the whole directory unreadable. A *populated*
+                // entry under an unresolvable key is not that: it is a
+                // mismatched or damaged sidecar, and still fails the load.
+                if num_entries == 0 {
+                    continue;
+                }
+                return Err(invalid_index("directory contains an unresolved type key"));
+            };
             if variant == 1 {
                 let blob = &mmap[payload_off_usize..payload_end];
                 let map: HashMap<Value, NodeIndex> = serde_codec::decode_exact_with(
@@ -984,6 +996,40 @@ mod validation_tests {
         );
     }
 
+    /// A directory saved before the writer resolved its keys carries an empty
+    /// index under a type key the interner sidecar never received. Both
+    /// variants of that entry are recovered rather than failing the load; a
+    /// populated entry under an unresolvable key still fails (asserted in
+    /// `rejects_unsupported_unresolved_and_trailing_data`).
+    #[test]
+    fn an_empty_entry_with_an_unresolved_type_key_is_recovered() {
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Person");
+        let stale = InternedKey::from_str("NeverInterned").as_u64();
+
+        let base = load(&integer_fixture(stale, &[]), &interner)
+            .expect("a stale empty entry must not fail the load")
+            .unwrap();
+        assert!(!base.contains("NeverInterned"));
+
+        // The General variant is what a type with no rows actually produced:
+        // `num_entries` is 0, but the Postcard payload of an empty map is not.
+        let blob = serde_codec::encode_versioned(
+            serde_codec::CURRENT_CODEC,
+            &HashMap::<Value, NodeIndex>::new(),
+            MAX_GENERAL_INDEX_DECODE_BYTES,
+        )
+        .unwrap();
+        let mut bytes = integer_fixture(stale, &[]);
+        bytes[40] = 1;
+        bytes[64..72].copy_from_slice(&(blob.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&blob);
+        let base = load(&bytes, &interner)
+            .expect("a stale empty General entry must not fail the load")
+            .unwrap();
+        assert!(!base.contains("NeverInterned"));
+    }
+
     /// The writer resolves names against the interner it is handed, so it can
     /// never emit a directory key that the matching `interner.bin.zst` fails
     /// to resolve. An unregistered name is dropped when its index is empty
@@ -1004,6 +1050,16 @@ mod validation_tests {
             ("Unregistered".to_string(), TypeIdIndex::default()),
         ]));
         write_id_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        // Asserted on the bytes, not through the loader: the loader also
+        // recovers such an entry (directories written before this fix carry
+        // them), so a round trip alone would not pin the writer.
+        let raw = std::fs::read(temp.path().join("id_indices.bin")).unwrap();
+        assert_eq!(
+            u32::from_le_bytes(raw[12..16].try_into().unwrap()),
+            1,
+            "the unregistered name must not reach the directory at all"
+        );
 
         let base = IdIndexBase::load_from(temp.path(), &interner)
             .expect("the written directory must load")

--- a/crates/kglite/src/graph/storage/disk/id_index.rs
+++ b/crates/kglite/src/graph/storage/disk/id_index.rs
@@ -685,24 +685,48 @@ fn coerce_to_u32(id: &Value) -> Option<u32> {
 /// Write `id_indices.bin` (raw mmap layout). Iterates the store's union view
 /// (overlay + base) so saves capture both fresh mutations and unchanged
 /// base entries.
+///
+/// Directory keys are `InternedKey` hashes and the loader turns each one back
+/// into a type name through the interner sidecar that ships with the same
+/// snapshot. Names are therefore *resolved*, never interned here: deriving a
+/// key from the name alone — the old `interner.clone().try_get_or_intern`,
+/// which registered the name in a throwaway clone — manufactured keys for
+/// names the persisted interner never carried, and a single such entry made
+/// the whole directory unloadable ("directory contains an unresolved type
+/// key").
+///
+/// Only an empty index can carry an unregistered name: creating a node interns
+/// its type (`mutation/batch.rs`), so any index holding ids names an interned
+/// type. Empty entries do reach the store — the read path caches a
+/// build-on-miss index for a label a query merely mentioned
+/// ([`IdIndexStore::lookup_or_build`]) — and they are pure cache, so dropping
+/// them loses nothing. A non-empty unregistered entry would be a broken
+/// invariant, so it fails the save rather than shipping a directory that
+/// cannot be read back.
 pub fn write_id_indices_bin(
     dir: &Path,
     store: &IdIndexStore,
     interner: &StringInterner,
 ) -> Result<(), String> {
-    // Collect (type_key, name, materialized) triples sorted by type_key.
+    // Collect (type_key, materialized) pairs sorted by type_key.
     // `store.iter()` already returns owned, fully-materialized indices
     // (overlay + unshadowed base).
-    let mut entries: Vec<(u64, String, TypeIdIndex)> = Vec::new();
-    let mut interner_clone = interner.clone();
+    let mut entries: Vec<(u64, TypeIdIndex)> = Vec::new();
     for (name, materialized) in store.iter() {
-        let key = interner_clone
-            .try_get_or_intern(&name)
-            .map_err(|e| e.to_string())?
-            .as_u64();
-        entries.push((key, name, materialized));
+        let Some(key) = interner.try_resolve_to_key(&name) else {
+            if materialized.is_empty() {
+                continue;
+            }
+            return Err(format!(
+                "id index for type '{name}' holds {} ids but the type name is \
+                 not in the graph's interner; refusing to write an \
+                 id_indices.bin that cannot be read back",
+                materialized.len()
+            ));
+        };
+        entries.push((key.as_u64(), materialized));
     }
-    entries.sort_by_key(|(k, _, _)| *k);
+    entries.sort_by_key(|(k, _)| *k);
 
     let num_types = entries.len();
     let header_size = HEADER_BYTES;
@@ -722,7 +746,7 @@ pub fn write_id_indices_bin(
     let mut plans: Vec<Plan> = Vec::with_capacity(num_types);
     let mut cursor = data_offset as u64;
 
-    for (type_key, _name, idx) in &entries {
+    for (type_key, idx) in &entries {
         match idx {
             TypeIdIndex::Integer(map) => {
                 let mut pairs: Vec<(u32, u32)> =
@@ -958,6 +982,45 @@ mod validation_tests {
             base.lookup(integer_name, &Value::UniqueId(7)),
             Some(NodeIndex::new(4))
         );
+    }
+
+    /// The writer resolves names against the interner it is handed, so it can
+    /// never emit a directory key that the matching `interner.bin.zst` fails
+    /// to resolve. An unregistered name is dropped when its index is empty
+    /// (pure cache, rebuilt on demand) and fails the save when it is not.
+    #[test]
+    fn writer_never_emits_a_key_the_interner_cannot_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Known");
+
+        let mut store = IdIndexStore::default();
+        store.replace_with(HashMap::from([
+            (
+                "Known".to_string(),
+                TypeIdIndex::Integer(HashMap::from([(7, NodeIndex::new(1))])),
+            ),
+            // Never interned: an id index cached for a type with no rows.
+            ("Unregistered".to_string(), TypeIdIndex::default()),
+        ]));
+        write_id_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        let base = IdIndexBase::load_from(temp.path(), &interner)
+            .expect("the written directory must load")
+            .unwrap();
+        assert_eq!(
+            base.lookup("Known", &Value::UniqueId(7)),
+            Some(NodeIndex::new(1))
+        );
+        assert!(!base.contains("Unregistered"));
+
+        store.insert(
+            "Unregistered".to_string(),
+            TypeIdIndex::Integer(HashMap::from([(1, NodeIndex::new(0))])),
+        );
+        let error = write_id_indices_bin(temp.path(), &store, &interner).unwrap_err();
+        assert!(error.contains("Unregistered"), "{error}");
+        assert!(error.contains("cannot be read back"), "{error}");
     }
 
     #[test]

--- a/crates/kglite/src/graph/storage/disk/type_index.rs
+++ b/crates/kglite/src/graph/storage/disk/type_index.rs
@@ -518,12 +518,20 @@ impl TypeIndexStore {
 // Writer
 // =============================================================================
 
+/// Write `type_indices.bin` (flat CSR layout).
+///
+/// Type names are *resolved* against the interner that ships with the same
+/// snapshot, never interned here — see the equivalent note on
+/// [`write_id_indices_bin`](super::id_index::write_id_indices_bin). An
+/// unregistered name has no persisted identity: an empty entry is dropped
+/// (nothing to record), and a populated one fails the save rather than
+/// shipping a directory whose type keys the loader cannot resolve.
 pub fn write_type_indices_bin(
     dir: &Path,
     store: &TypeIndexStore,
     interner: &StringInterner,
 ) -> Result<(), String> {
-    // Collect (type_key, name, slice-or-vec) sorted by type_key.
+    // Collect (type_key, slice-or-vec) sorted by type_key.
     enum Source<'a> {
         Slice(&'a [u8]),
         Vec(&'a [NodeIndex]),
@@ -547,18 +555,24 @@ pub fn write_type_indices_bin(
         }
     }
 
-    let mut interner_clone = interner.clone();
     let mut entries: Vec<(u64, Source<'_>)> = Vec::new();
     for (name, view) in store.iter() {
-        let key = interner_clone
-            .try_get_or_intern(name)
-            .map_err(|e| e.to_string())?
-            .as_u64();
         let src = match view {
             TypeNodesRef::Overlay(s) => Source::Vec(s),
             TypeNodesRef::Mmap(s) => Source::Slice(s),
         };
-        entries.push((key, src));
+        let Some(key) = interner.try_resolve_to_key(name) else {
+            if src.len() == 0 {
+                continue;
+            }
+            return Err(format!(
+                "type index for type '{name}' holds {} nodes but the type name \
+                 is not in the graph's interner; refusing to write a \
+                 type_indices.bin that cannot be read back",
+                src.len()
+            ));
+        };
+        entries.push((key.as_u64(), src));
     }
     entries.sort_by_key(|(k, _)| *k);
 
@@ -701,5 +715,38 @@ mod validation_tests {
             load(&duplicate, &interner).unwrap_err().kind(),
             std::io::ErrorKind::InvalidData
         );
+    }
+
+    /// The writer resolves names against the interner it is handed, so the
+    /// directory it emits is always readable by the snapshot's own interner
+    /// sidecar. An unregistered name is dropped when empty and fails the save
+    /// when populated (a type index is not a rebuildable cache — silently
+    /// dropping a populated one would hide every node of that type).
+    #[test]
+    fn writer_never_emits_a_key_the_interner_cannot_resolve() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut interner = StringInterner::new();
+        interner.get_or_intern("Known");
+
+        let mut store = TypeIndexStore::default();
+        store.replace_with(HashMap::from([
+            ("Known".to_string(), vec![NodeIndex::new(0)]),
+            ("Unregistered".to_string(), Vec::new()),
+        ]));
+        write_type_indices_bin(temp.path(), &store, &interner).unwrap();
+
+        let base = TypeIndexBase::load_from(temp.path(), &interner)
+            .expect("the written directory must load")
+            .unwrap();
+        assert_eq!(base.materialize("Known").unwrap(), vec![NodeIndex::new(0)]);
+        assert!(base.materialize("Unregistered").is_none());
+
+        store.replace_with(HashMap::from([(
+            "Unregistered".to_string(),
+            vec![NodeIndex::new(0)],
+        )]));
+        let error = write_type_indices_bin(temp.path(), &store, &interner).unwrap_err();
+        assert!(error.contains("Unregistered"), "{error}");
+        assert!(error.contains("cannot be read back"), "{error}");
     }
 }

--- a/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
+++ b/crates/kglite/src/graph/storage/mapped/mmap_vec.rs
@@ -644,7 +644,7 @@ impl<T: MmapPod> MmapOrVec<T> {
             MmapOrVec::Heap { data } => data.as_mut_slice(),
             // SAFETY: `&mut self` + `*len ≤ capacity`, and the mmap has
             // `capacity * size_of::<T>()` bytes. See module invariants.
-            MmapOrVec::Mapped { mmap, len, .. } if *len == 0 => &mut [],
+            MmapOrVec::Mapped { len, .. } if *len == 0 => &mut [],
             MmapOrVec::Mapped { mmap, len, .. } => unsafe {
                 let mmap = mmap.as_mut().expect("non-empty MmapOrVec must be mapped");
                 std::slice::from_raw_parts_mut(mmap.as_mut_ptr() as *mut T, *len)

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -139,8 +139,11 @@ pub mod api {
     /// the DataFrame-free edge-ingest path that non-Python bindings use
     /// (the C ABI's `create_edges_batch` wraps it); the DataFrame-based
     /// `add_nodes` / `add_connections` / `replace_connections` are the
-    /// Rust-side bulk-ingest path (polars `DataFrame` in, operation report
-    /// out). `update_node_properties`, `purge_provisional_nodes`, and
+    /// Rust-side bulk-ingest path (`DataFrame` in, operation report out).
+    /// That `DataFrame` is kglite's own columnar container
+    /// (`crate::datatypes::values::DataFrame`, built on `Value`) — kglite
+    /// does not depend on polars. `update_node_properties`,
+    /// `purge_provisional_nodes`, and
     /// `extend_graph` (merge one graph into another) round out the
     /// generic, non-Selection mutation surface. Lifted in roadmap Piece 2.
     /// `create_connections` (edge-create between the two ends of a

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -77,6 +77,10 @@ INLINE_DEP_RE = re.compile(r"^(?P<key>[A-Za-z0-9_-]+)\s*=\s*\{(?P<body>[^}]*)\}\
 BODY_VERSION_RE = re.compile(r'version\s*=\s*"(?P<version>[^"]*)"')
 BODY_PATH_RE = re.compile(r'path\s*=\s*"(?P<path>[^"]*)"')
 
+# The crates `publish_crates.yml` pushes to crates.io, in lockstep at one
+# version. A divergence here is a broken publish set, not a warning.
+PUBLISHED_CRATES = ("kglite", "kglite-bolt-server", "kglite-c", "kglite-cli", "kglite-mcp-server")
+
 
 class BumpError(RuntimeError):
     """A condition that must stop the release, not print and continue."""
@@ -188,8 +192,33 @@ def bump(new_version: str) -> list[Path]:
     return changed
 
 
-def verify_resolves(expected: str) -> None:
-    """`cargo metadata` must succeed and report every member at `expected`.
+def declared_member_version(manifest: Path) -> str | None:
+    """What the member's own ``[package]`` table says its version is.
+
+    ``"workspace"`` when it inherits via ``version.workspace = true``, the
+    literal string when it hard-codes one, ``None`` when it declares
+    neither. A hard-coded value still *resolves* — cargo is perfectly
+    happy with a member pinned to a stale version — so this is drift that
+    dependency resolution cannot see.
+    """
+    in_package = False
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+            continue
+        if not in_package:
+            continue
+        if re.match(r"^version\s*\.\s*workspace\s*=\s*true\s*$", stripped):
+            return "workspace"
+        literal = re.match(r'^version\s*=\s*"([^"]+)"', stripped)
+        if literal:
+            return literal.group(1)
+    return None
+
+
+def resolve_workspace_versions() -> dict[str, str]:
+    """Resolve the workspace and return ``{member_name: version}``.
 
     Note the *absence* of ``--no-deps``: that flag skips dependency
     resolution altogether, so it happily reports success on a workspace
@@ -207,11 +236,16 @@ def verify_resolves(expected: str) -> None:
     )
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or "no diagnostic output"
-        raise BumpError(f"cargo metadata failed after the bump:\n{detail}")
+        raise BumpError(f"cargo metadata could not resolve the workspace:\n{detail}")
     metadata = json.loads(proc.stdout)
     members = set(metadata["workspace_members"])
-    packages = [pkg for pkg in metadata["packages"] if pkg["id"] in members]
-    wrong = sorted(f"{pkg['name']} {pkg['version']}" for pkg in packages if pkg["version"] != expected)
+    return {pkg["name"]: pkg["version"] for pkg in metadata["packages"] if pkg["id"] in members}
+
+
+def verify_resolves(expected: str) -> None:
+    """The workspace must resolve and every member must be at `expected`."""
+    packages = resolve_workspace_versions()
+    wrong = sorted(f"{name} {version}" for name, version in packages.items() if version != expected)
     if wrong:
         raise BumpError(f"members did not resolve to {expected}: {', '.join(wrong)}")
     print(f"cargo metadata: all {len(packages)} workspace members resolved to {expected}")

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Bump the workspace version *everywhere it is written down*.
+
+The version is single-sourced for the crates' own `package.version`
+(`[workspace.package] version` in the root `Cargo.toml`, inherited via
+`version.workspace = true`) — but that is **not** the only place the
+version appears. Four member manifests also declare an internal
+dependency on the engine with an explicit `version` requirement, because
+`cargo publish` refuses a `path`-only dependency:
+
+    crates/kglite-bolt-server/Cargo.toml
+    crates/kglite-c/Cargo.toml
+    crates/kglite-cli/Cargo.toml
+    crates/kglite-mcp-server/Cargo.toml
+
+Editing only `[workspace.package]` therefore leaves the workspace
+*unresolvable* the moment the bump crosses a minor: `cargo metadata`
+fails with "failed to select a version for the requirement
+`kglite = ^0.14`" and every downstream release step that shells out to
+cargo dies on its first call. That happened during the 0.14.5 -> 0.15.0
+release and broke `make refresh-release-constants` on its first step.
+
+This script edits all five places at once and then *verifies* with
+`cargo metadata` that every member actually resolved.
+
+Why the internal requirement carries the full `X.Y.Z` and not the `X.Y`
+series it used to:
+
+1. **`^0.15` is a false claim.** The five published crates ship in
+   lockstep and this project deliberately ships documented breaking
+   engine changes in patch bumps. `kglite = "0.15"` tells cargo that
+   `kglite-cli 0.15.3` builds against `kglite 0.15.0`; it frequently
+   does not. `kglite = "0.15.3"` states the true floor and, being a
+   caret requirement, still admits 0.15.4+ — it constrains nothing a
+   lockstep release wants to do.
+2. **It makes the bump path load-bearing every release.** With the `X.Y`
+   form the requirement only had to change on a minor bump, so the
+   omission stayed invisible across a dozen patch releases and then
+   detonated on the first minor. With `X.Y.Z` the requirement changes
+   every single release, which is exactly what `--check` gates.
+3. **The publish order supports it.** `publish_crates.yml` publishes
+   `kglite` first and waits for the crates.io index to serve it before
+   publishing the four dependents, so `^X.Y.Z` is satisfiable by the
+   time any dependent is verified.
+
+Usage::
+
+    python scripts/bump_version.py --check      # gate: everything in sync?
+    python scripts/bump_version.py --set 0.15.1 # release: bump all five
+
+`--check` is pure file reading (no cargo invocation) so it is cheap
+enough for `make gate`. `--set` runs a resolving `cargo metadata` at the
+end and fails loudly if any member did not resolve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_MANIFEST = REPO_ROOT / "Cargo.toml"
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+WORKSPACE_VERSION_RE = re.compile(
+    r'(^\[workspace\.package\]\s*$.*?^\s*version\s*=\s*")([^"]+)(")',
+    re.MULTILINE | re.DOTALL,
+)
+MEMBERS_RE = re.compile(r"^\[workspace\]\s*$.*?^\s*members\s*=\s*\[(?P<members>[^\]]*)\]", re.MULTILINE | re.DOTALL)
+# A one-line inline-table dependency, e.g.
+#   kglite = { version = "0.15", path = "../kglite", default-features = false }
+INLINE_DEP_RE = re.compile(r"^(?P<key>[A-Za-z0-9_-]+)\s*=\s*\{(?P<body>[^}]*)\}\s*$")
+BODY_VERSION_RE = re.compile(r'version\s*=\s*"(?P<version>[^"]*)"')
+BODY_PATH_RE = re.compile(r'path\s*=\s*"(?P<path>[^"]*)"')
+
+
+class BumpError(RuntimeError):
+    """A condition that must stop the release, not print and continue."""
+
+
+def read_workspace_version(text: str | None = None) -> str:
+    text = ROOT_MANIFEST.read_text(encoding="utf-8") if text is None else text
+    match = WORKSPACE_VERSION_RE.search(text)
+    if match is None:
+        raise BumpError(f"{ROOT_MANIFEST}: no [workspace.package] version found")
+    return match.group(2)
+
+
+def member_manifests() -> list[Path]:
+    """Every `[workspace] members` manifest, in declaration order."""
+    text = ROOT_MANIFEST.read_text(encoding="utf-8")
+    match = MEMBERS_RE.search(text)
+    if match is None:
+        raise BumpError(f"{ROOT_MANIFEST}: no [workspace] members list found")
+    members = re.findall(r'"([^"]+)"', match.group("members"))
+    if not members:
+        raise BumpError(f"{ROOT_MANIFEST}: [workspace] members list is empty")
+    manifests = []
+    for member in members:
+        manifest = REPO_ROOT / member / "Cargo.toml"
+        if not manifest.is_file():
+            raise BumpError(f"workspace member {member!r} has no Cargo.toml")
+        manifests.append(manifest)
+    return manifests
+
+
+def internal_version_pins(manifest: Path) -> list[tuple[int, str, str]]:
+    """Dependencies on another workspace member that carry a `version`
+    requirement — the pins a version bump has to move.
+
+    Returns ``(line_number, dependency_key, version_requirement)``. A
+    `path`-only dependency (no `version =`) is not a pin: it is never
+    published, so nothing has to track the workspace version. A
+    dependency whose path escapes the repository is external vendoring
+    and is likewise left alone.
+    """
+    pins: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(manifest.read_text(encoding="utf-8").splitlines(), 1):
+        dep = INLINE_DEP_RE.match(line)
+        if dep is None:
+            continue
+        body = dep.group("body")
+        path_match = BODY_PATH_RE.search(body)
+        version_match = BODY_VERSION_RE.search(body)
+        if path_match is None or version_match is None:
+            continue
+        target = (manifest.parent / path_match.group("path")).resolve()
+        if not target.is_relative_to(REPO_ROOT):
+            continue
+        pins.append((lineno, dep.group("key"), version_match.group("version")))
+    return pins
+
+
+def check() -> list[str]:
+    """Report every internal pin that disagrees with the workspace version."""
+    workspace_version = read_workspace_version()
+    if not SEMVER_RE.match(workspace_version):
+        return [f"Cargo.toml: [workspace.package] version {workspace_version!r} is not X.Y.Z"]
+
+    problems: list[str] = []
+    for manifest in member_manifests():
+        rel = manifest.relative_to(REPO_ROOT)
+        for lineno, key, requirement in internal_version_pins(manifest):
+            if requirement != workspace_version:
+                problems.append(
+                    f"{rel}:{lineno}: internal dependency {key!r} requires "
+                    f"{requirement!r} but the workspace is at {workspace_version!r}"
+                )
+    return problems
+
+
+def bump(new_version: str) -> list[Path]:
+    """Rewrite the workspace version and every internal pin. Returns the
+    files that changed."""
+    if not SEMVER_RE.match(new_version):
+        raise BumpError(f"{new_version!r} is not a X.Y.Z version")
+
+    changed: list[Path] = []
+    root_text = ROOT_MANIFEST.read_text(encoding="utf-8")
+    old_version = read_workspace_version(root_text)
+    if old_version != new_version:
+        root_text = WORKSPACE_VERSION_RE.sub(rf"\g<1>{new_version}\g<3>", root_text, count=1)
+        ROOT_MANIFEST.write_text(root_text, encoding="utf-8", newline="\n")
+        changed.append(ROOT_MANIFEST)
+
+    for manifest in member_manifests():
+        pins = internal_version_pins(manifest)
+        if not pins:
+            continue
+        lines = manifest.read_text(encoding="utf-8").splitlines(keepends=True)
+        dirty = False
+        for lineno, key, requirement in pins:
+            if requirement == new_version:
+                continue
+            line = lines[lineno - 1]
+            replaced, count = BODY_VERSION_RE.subn(f'version = "{new_version}"', line, count=1)
+            if count != 1:
+                raise BumpError(f"{manifest.relative_to(REPO_ROOT)}:{lineno}: could not rewrite {key!r} version")
+            lines[lineno - 1] = replaced
+            dirty = True
+        if dirty:
+            manifest.write_text("".join(lines), encoding="utf-8", newline="\n")
+            changed.append(manifest)
+    return changed
+
+
+def verify_resolves(expected: str) -> None:
+    """`cargo metadata` must succeed and report every member at `expected`.
+
+    Note the *absence* of ``--no-deps``: that flag skips dependency
+    resolution altogether, so it happily reports success on a workspace
+    whose internal requirement can no longer be satisfied. Verified
+    directly — a tree with `[workspace.package] version = "0.16.0"` and
+    `kglite = "^0.15.0"` passes `cargo metadata --no-deps` and fails
+    plain `cargo metadata` with "failed to select a version for the
+    requirement `kglite = ^0.15.0`". Only the resolving form is a check.
+    """
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no diagnostic output"
+        raise BumpError(f"cargo metadata failed after the bump:\n{detail}")
+    metadata = json.loads(proc.stdout)
+    members = set(metadata["workspace_members"])
+    packages = [pkg for pkg in metadata["packages"] if pkg["id"] in members]
+    wrong = sorted(f"{pkg['name']} {pkg['version']}" for pkg in packages if pkg["version"] != expected)
+    if wrong:
+        raise BumpError(f"members did not resolve to {expected}: {', '.join(wrong)}")
+    print(f"cargo metadata: all {len(packages)} workspace members resolved to {expected}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="Verify every internal pin matches the workspace version.")
+    group.add_argument("--set", metavar="X.Y.Z", help="Bump the workspace version and every internal pin.")
+    args = parser.parse_args()
+
+    try:
+        if args.check:
+            problems = check()
+            if problems:
+                print("internal kglite dependency requirements are out of sync:", file=sys.stderr)
+                for problem in problems:
+                    print(f"  {problem}", file=sys.stderr)
+                print(
+                    "\nfix: python scripts/bump_version.py --set "
+                    f"{read_workspace_version()}   (or `make bump-version VERSION=X.Y.Z`)",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"internal dependency requirements in sync at {read_workspace_version()}")
+            return 0
+
+        changed = bump(args.set)
+        for path in changed:
+            print(f"bumped {path.relative_to(REPO_ROOT)}")
+        if not changed:
+            print(f"already at {args.set} — nothing to rewrite")
+        verify_resolves(args.set)
+        remaining = check()
+        if remaining:
+            raise BumpError("post-bump check still reports drift:\n  " + "\n  ".join(remaining))
+        return 0
+    except BumpError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_hygiene.py
+++ b/scripts/check_release_hygiene.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Structural gates on the paperwork a release edits by hand.
+
+Two failure modes have shipped past review because nothing checked for
+them:
+
+1. **Merge-mangled CHANGELOG sections.** Integrating two branches that
+   both appended to ``## [Unreleased]`` produces two ``### Changed``
+   blocks (and two ``### Fixed`` blocks) under the same heading. Both
+   0.15.0 integration merges did exactly this and both were hand-fixed
+   after a human noticed. ``## [Unreleased]`` is promoted verbatim into
+   the release section by the release skill, so a duplicate authored
+   here ships as a duplicate.
+
+2. **Surviving ``TODO:`` markers.** ``scripts/refresh_release_constants.py``
+   deliberately writes ``TODO: describe what grew since the prior
+   baseline`` into ``tests/test_phase5_parity.py`` for the maintainer to
+   fill in. Nothing verified that it was filled in, so the marker could
+   ride into a release commit unnoticed.
+
+Scope note — only ``## [Unreleased]`` is linted for structure. The
+released sections below it are a frozen historical record: they carry
+215 bespoke ``###`` headings accumulated over ~200 releases
+(``### Performance``, ``### Internal``, ``### Added — <topic>``, …), and
+retro-linting them would mean rewriting already-published release notes
+to satisfy a gate. Gating ``[Unreleased]`` gates every *future* release
+section at the only moment the text is still cheap to fix, because
+release sections are produced by promoting ``[Unreleased]`` verbatim.
+
+Wired into ``make gate`` — pure file reading, no subprocess, no imports
+of the project.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# https://keepachangelog.com/en/1.1.0/ — the six change groups. New
+# `[Unreleased]` content uses these and nothing else; a bespoke heading
+# is either a typo or a decision that belongs in the prose, not in the
+# document structure.
+KEEP_A_CHANGELOG_HEADINGS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+# Files `scripts/refresh_release_constants.py` rewrites in place and
+# hands back to the maintainer to finish. Keep this list in step with
+# that script's `PHASE4_TEST` / `PHASE5_TEST` constants; the generated
+# JSON baselines are excluded because they are machine-written end to
+# end and never carry a maintainer marker.
+REFRESH_WRITTEN_FILES = (
+    Path("tests/test_phase4_parity.py"),
+    Path("tests/test_phase5_parity.py"),
+)
+TODO_MARKER_RE = re.compile(r"TODO:")
+
+SECTION_RE = re.compile(r"^## ")
+SUBSECTION_RE = re.compile(r"^###\s+(?P<heading>.*?)\s*$")
+
+
+def check_changelog() -> list[str]:
+    """Lint the structure of the ``## [Unreleased]`` section."""
+    problems: list[str] = []
+    lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+
+    sections = [(i, line) for i, line in enumerate(lines) if SECTION_RE.match(line)]
+    if not sections:
+        return [f"{CHANGELOG.name}: no `## ` release sections found"]
+
+    first_index, first_heading = sections[0]
+    if first_heading.strip() != "## [Unreleased]":
+        problems.append(
+            f"{CHANGELOG.name}:{first_index + 1}: the first release section must be "
+            f"`## [Unreleased]`, found {first_heading.strip()!r} — a release promotion "
+            "removed it instead of emptying it"
+        )
+        return problems
+
+    end = sections[1][0] if len(sections) > 1 else len(lines)
+    seen: dict[str, int] = {}
+    for offset in range(first_index + 1, end):
+        match = SUBSECTION_RE.match(lines[offset])
+        if match is None:
+            continue
+        heading = match.group("heading")
+        lineno = offset + 1
+        if heading in seen:
+            problems.append(
+                f"{CHANGELOG.name}:{lineno}: duplicate `### {heading}` under "
+                f"[Unreleased] (first at line {seen[heading]}) — merge the two blocks"
+            )
+        else:
+            seen[heading] = lineno
+        if heading not in KEEP_A_CHANGELOG_HEADINGS:
+            problems.append(
+                f"{CHANGELOG.name}:{lineno}: `### {heading}` is not a Keep a Changelog "
+                f"group; use one of {', '.join(KEEP_A_CHANGELOG_HEADINGS)}"
+            )
+    return problems
+
+
+def check_refresh_todos() -> list[str]:
+    """Fail on a `TODO:` marker left behind in a release-constants file."""
+    problems: list[str] = []
+    for relative in REFRESH_WRITTEN_FILES:
+        path = REPO_ROOT / relative
+        if not path.is_file():
+            problems.append(f"{relative}: missing — scripts/refresh_release_constants.py writes it")
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if TODO_MARKER_RE.search(line):
+                problems.append(f"{relative}:{lineno}: unresolved release-constants marker — {line.strip()!r}")
+    return problems
+
+
+def main() -> int:
+    problems = check_changelog() + check_refresh_todos()
+    if problems:
+        print("release hygiene check failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print("release hygiene: CHANGELOG [Unreleased] structure and release-constant markers clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,1602 @@
+#!/usr/bin/env python3
+"""Ecosystem version-consistency checker and downstream release notifier.
+
+WHY THIS EXISTS
+---------------
+A version requirement that *understates its real minimum*, or that is declared
+*outside package metadata*, is structurally invisible to the repo that declares
+it. Only a consumer — or a second declaration site — ever sees the disagreement.
+Three real failures of that single class, all on 2026-07-27:
+
+1. ``kglite-mcp-server`` declared ``mcp-methods = "0.4"`` while calling APIs
+   added in 0.4.1. Our ``Cargo.lock`` held 0.4.1, so every local build and every
+   CI run here resolved fine; a sibling with an older lock hit a compile failure
+   against the published crate.
+2. ``fastembed = "5"`` selects a feature that first existed in 5.9.0;
+   ``mimalloc = "0.1"`` selects ``v2``, added in 0.1.49. Same shape.
+3. codingest's ``.github/workflows/ci.yml`` pinned ``kglite==0.14.5`` while its
+   wheel metadata required ``>=0.15.0,<0.16``. ``pip check`` fails on push, and
+   *no local gate could see it* because the Makefile provisions its own venv.
+
+So this script does two things:
+
+* **check** — enumerate every place a dependency version is declared across the
+  ecosystem (manifests, lockfiles, CI YAML, Dockerfiles, Makefiles, shell and
+  Python scripts, and docs), then report disagreements.
+* **notify** — write a release note into each *genuinely affected* downstream's
+  ``inbox/unread/``. Deliberately NOT into every downstream's: see
+  ``AFFECTED-ONLY`` below.
+
+FINDING CATEGORIES
+------------------
+``contradiction``
+    Two sites in the same repo name mutually exclusive requirements for the same
+    dependency (failure 3). Latent build break. Exits non-zero.
+``understated-floor``
+    A manifest floor sits *below* the version the committed lockfile actually
+    resolved (failure 1 and 2). Not provably wrong — plenty of floors float on
+    purpose — but it is precisely the shape that is invisible locally, because
+    the lock papers over it. Reported as a warning with the evidence.
+``stale-downstream``
+    A downstream's declared range on an ecosystem package *excludes* the current
+    published upstream version. That repo cannot install the latest engine.
+``exact-pin``
+    A site pins an ecosystem package at an exact version that has been
+    superseded. Not an error; it is the thing that silently rots.
+``site``
+    Inventory: a declaration living outside package metadata. Always listed,
+    even when consistent, because these are the sites that *can* drift with
+    nothing watching them.
+
+AFFECTED-ONLY (the notifier's core rule)
+----------------------------------------
+CLAUDE.md: *"Route to the party who can act. A note only belongs in another
+project's inbox if it carries an actionable task for them."* and *"unread/ must
+reflect only what still needs doing, so a stale 'you still have unread mail'
+never hides a genuinely open item among resolved ones."*
+
+A note that says "we released, nothing changes for you" is noise that trains a
+maintainer to ignore the inbox — it actively degrades a mechanism that
+currently works. So ``--notify`` writes a note only when the downstream is
+genuinely affected:
+
+* its declared range **excludes** the new version (blocked), or
+* it pins the upstream at a now-superseded exact version somewhere, or
+* a breaking change in this release touches a symbol the repo actually
+  references (approximated by scanning its sources for the symbols listed in
+  ``--breaking-symbol`` / the release config).
+
+When a downstream is unaffected the run prints ``SKIP <repo>: <reason>`` and
+writes nothing. The decision *not* to notify is as much a feature as the note.
+
+USAGE
+-----
+    python scripts/check_version_consistency.py                  # check
+    python scripts/check_version_consistency.py --json           # machine output
+    python scripts/check_version_consistency.py --notify --dry-run
+    python scripts/check_version_consistency.py --notify         # writes inboxes
+
+Exit codes: 0 clean, 1 contradictions found (or ``--fail-on stale`` tripped),
+2 bad invocation. Missing sibling repos are skipped with a message, never a
+crash — see ``--require-siblings`` to invert that for a release gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import os
+from pathlib import Path
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _default_ecosystem_root(repo_root: Path) -> Path:
+    """Where the sibling repos live.
+
+    Normally ``../``. But this repo is routinely worked from a git worktree
+    parked outside the ecosystem tree (``/Users/Shared/kglite-wt/<branch>``),
+    where ``../`` holds only other worktrees and every sibling looks absent. A
+    worktree's ``.git`` is a *file* pointing at the main checkout, so follow it
+    and use the main checkout's parent instead.
+    """
+    env = os.environ.get("KGLITE_ECOSYSTEM_ROOT")
+    if env:
+        return Path(env)
+    dotgit = repo_root / ".git"
+    if dotgit.is_file():
+        try:
+            text = dotgit.read_text(encoding="utf-8").strip()
+        except OSError:
+            return repo_root.parent
+        if text.startswith("gitdir:"):
+            gitdir = Path(text.split(":", 1)[1].strip())
+            # .../<main>/.git/worktrees/<name> -> <main>
+            for parent in gitdir.parents:
+                if parent.name == ".git":
+                    return parent.parent.parent
+    return repo_root.parent
+
+
+ECOSYSTEM_ROOT = _default_ecosystem_root(REPO_ROOT)
+
+# --------------------------------------------------------------------------
+# Ecosystem configuration
+# --------------------------------------------------------------------------
+
+#: Sibling repos, in dependency order. ``upstream`` is the release source.
+UPSTREAM_REPO = "KGLite"
+DOWNSTREAM_REPOS = ("codingest", "kglite-datasets", "sonagram", "sonara", "mcp-methods")
+
+#: Package names published by this ecosystem, grouped by the repo that owns
+#: them. Any declaration of one of these anywhere is cross-repo coupling.
+ECOSYSTEM_PACKAGES: dict[str, tuple[str, ...]] = {
+    "KGLite": (
+        "kglite",
+        "kglite-c",
+        "kglite-cli",
+        "kglite-mcp-server",
+        "kglite-bolt-server",
+    ),
+    "codingest": ("codingest", "codingest-py", "codingest-mcp"),
+    "kglite-datasets": ("kglite-datasets",),
+    "sonagram": ("sonagram",),
+    "sonara": ("sonara", "sonara-python"),
+    "mcp-methods": ("mcp-methods", "mcp-methods-macros"),
+}
+
+#: Third-party dependencies whose floors have burned us. These are watched for
+#: `understated-floor` across every repo. Add to this list when a new one bites;
+#: the value is the version at which the *feature we actually use* appeared, or
+#: None to just compare against the lockfile.
+WATCHED_THIRD_PARTY: dict[str, str | None] = {
+    "fastembed": "5.9.0",  # the feature selected by `fastembed = "5"` is 5.9.0+
+    "mimalloc": "0.1.49",  # the `v2` feature landed in 0.1.49
+    "rmcp": None,
+    "rmcp-macros": None,
+    "pyo3": None,
+}
+
+#: Files we never walk into.
+SKIP_DIRS = {
+    ".git",
+    "target",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".uv-cache",
+    ".hypothesis",
+    "dist",
+    "build",
+    "_build",
+    ".idea",
+    ".vscode",
+    "inbox",
+    "dev-docs",
+    ".agents",
+    "site-packages",
+    # Local working notes, not published surface. A stale version in someone's
+    # design scratchpad is not an ecosystem finding and must never justify a
+    # note in their inbox.
+    "dev-documentation",
+    "notes",
+    "scratch",
+}
+
+MAX_FILE_BYTES = 2_000_000
+
+
+# --------------------------------------------------------------------------
+# Version + requirement algebra
+# --------------------------------------------------------------------------
+
+INF = (1 << 30, 0, 0)
+
+
+def parse_version(text: str) -> tuple[int, int, int] | None:
+    """Parse a dotted version into a 3-tuple, ignoring pre-release/build tails."""
+    m = re.match(r"^\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?", text.strip())
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2) or 0), int(m.group(3) or 0))
+
+
+def _next_caret(v: tuple[int, int, int], parts: int) -> tuple[int, int, int]:
+    """Upper bound (exclusive) of a caret/compatible requirement.
+
+    Cargo semantics, which PEP 440's ``~=`` matches closely enough for our use:
+    the left-most non-zero component is the one held fixed.
+    ``^1.2.3`` -> 2.0.0, ``^0.14.4`` -> 0.15.0, ``^0.0.3`` -> 0.0.4.
+    A partial requirement widens: ``^0.14`` -> 0.15.0, ``^5`` -> 6.0.0.
+    """
+    major, minor, patch = v
+    if major != 0:
+        return (major + 1, 0, 0)
+    if minor != 0 or parts >= 2:
+        return (0, minor + 1, 0)
+    return (0, 0, patch + 1)
+
+
+@dataclasses.dataclass(frozen=True)
+class Interval:
+    """Half-open version interval ``[lo, hi)``."""
+
+    lo: tuple[int, int, int]
+    hi: tuple[int, int, int]
+
+    def __bool__(self) -> bool:
+        return self.lo < self.hi
+
+    def contains(self, v: tuple[int, int, int]) -> bool:
+        return self.lo <= v < self.hi
+
+    def intersect(self, other: Interval) -> Interval:
+        return Interval(max(self.lo, other.lo), min(self.hi, other.hi))
+
+
+FULL = Interval((0, 0, 0), INF)
+
+_CLAUSE_RE = re.compile(r"^\s*(\^|~=|~|>=|<=|==|=|>|<|!=)?\s*v?([0-9][0-9A-Za-z.\-+*]*)\s*$")
+
+
+def parse_requirement(spec: str) -> Interval | None:
+    """Turn a Cargo or PEP 440 requirement string into an interval.
+
+    Returns ``None`` when the spec is a wildcard, a URL, a git ref, or anything
+    else we deliberately decline to reason about — the caller treats that as
+    "no constraint" rather than guessing.
+    """
+    spec = spec.strip()
+    if not spec or spec in {"*", "any"}:
+        return None
+    if spec.startswith(("http", "git+", "file:", "./", "../")):
+        return None
+
+    result = FULL
+    saw_clause = False
+    for raw in re.split(r"[,;]", spec):
+        raw = raw.strip()
+        if not raw:
+            continue
+        # Drop PEP 440 environment markers and extras.
+        raw = re.sub(r"\s*\[[^\]]*\]", "", raw)
+        if raw.endswith(".*"):
+            raw = raw[:-2]
+            m = _CLAUSE_RE.match(raw)
+            if not m:
+                return None
+            base = parse_version(m.group(2))
+            if base is None:
+                return None
+            parts = len(m.group(2).split("."))
+            clause = Interval(base, _next_caret(base, parts + 1))
+            result = result.intersect(clause)
+            saw_clause = True
+            continue
+
+        m = _CLAUSE_RE.match(raw)
+        if not m:
+            return None
+        op = m.group(1) or "^"  # Cargo's bare `1.2` means `^1.2`
+        text = m.group(2)
+        base = parse_version(text)
+        if base is None:
+            return None
+        parts = len([p for p in text.split(".") if p and p[0].isdigit()])
+
+        if op in {"^", "~="}:
+            clause = Interval(base, _next_caret(base, parts))
+        elif op == "~":
+            # Cargo tilde: `~1.2.3` -> <1.3.0, `~1.2` -> <1.3.0, `~1` -> <2.0.0
+            if parts >= 2:
+                clause = Interval(base, (base[0], base[1] + 1, 0))
+            else:
+                clause = Interval(base, (base[0] + 1, 0, 0))
+        elif op in {"=", "=="}:
+            if parts >= 3:
+                clause = Interval(base, (base[0], base[1], base[2] + 1))
+            else:
+                clause = Interval(base, _next_caret(base, parts + 1))
+        elif op == ">=":
+            clause = Interval(base, INF)
+        elif op == ">":
+            clause = Interval((base[0], base[1], base[2] + 1), INF)
+        elif op == "<":
+            clause = Interval((0, 0, 0), base)
+        elif op == "<=":
+            clause = Interval((0, 0, 0), (base[0], base[1], base[2] + 1))
+        elif op == "!=":
+            continue  # recorded but not modelled; exclusions are rare here
+        else:
+            return None
+        result = result.intersect(clause)
+        saw_clause = True
+
+    return result if saw_clause else None
+
+
+def fmt_version(v: tuple[int, int, int]) -> str:
+    return "∞" if v >= INF else "{}.{}.{}".format(*v)
+
+
+# --------------------------------------------------------------------------
+# Declaration records
+# --------------------------------------------------------------------------
+
+
+#: Sites whose disagreement is a real build break. Prose (`docs`) is excluded
+#: deliberately: a migration guide or a README naming an old version is stale,
+#: not contradictory, and conflating the two makes the gate cry wolf.
+#: Sites that *execute* an install or are consumed by a resolver. Only these can
+#: contradict each other.
+#:
+#: `script` and `source-string` are deliberately excluded. A version literal in
+#: a Python script or a Rust string is usually advisory — a docstring, a help
+#: message, an error hint — and treating it as binding produces false
+#: contradictions that would block a release. (This script's own docstring cites
+#: `kglite==0.14.5` as an example and promptly reported itself.) They are still
+#: inventoried and still checked for staleness; they just cannot fail the gate.
+BINDING_SITES = {
+    "cargo-manifest",
+    "python-metadata",
+    "python-requirements",
+    "python-constraints",
+    "ci-yaml",
+    "dockerfile",
+    "makefile",
+    "shell",
+    "compose",
+}
+DOC_SITES = {"docs", "docs-install"}
+ADVISORY_SITES = {"script", "source-string"}
+
+
+@dataclasses.dataclass
+class Declaration:
+    repo: str
+    path: Path
+    line: int
+    package: str
+    spec: str
+    site: str  # cargo-manifest | cargo-lock | python-metadata | ...
+    raw: str
+    metadata: bool  # True when this is authoritative package metadata
+    unit: Path = dataclasses.field(default=Path("."))  # resolution unit root
+
+    @property
+    def rel(self) -> str:
+        try:
+            return str(self.path.relative_to(ECOSYSTEM_ROOT))
+        except ValueError:
+            return str(self.path)
+
+    @property
+    def binding(self) -> bool:
+        return self.site in BINDING_SITES
+
+    @property
+    def interval(self) -> Interval | None:
+        return parse_requirement(self.spec)
+
+    def as_dict(self) -> dict:
+        return {
+            "repo": self.repo,
+            "path": str(self.path),
+            "line": self.line,
+            "package": self.package,
+            "spec": self.spec,
+            "site": self.site,
+            "metadata": self.metadata,
+        }
+
+
+@dataclasses.dataclass
+class Finding:
+    kind: str
+    severity: str  # error | warn | info
+    repo: str
+    package: str
+    message: str
+    declarations: list[Declaration] = dataclasses.field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "severity": self.severity,
+            "repo": self.repo,
+            "package": self.package,
+            "message": self.message,
+            "declarations": [d.as_dict() for d in self.declarations],
+        }
+
+
+# --------------------------------------------------------------------------
+# Scanners — one per declaration-site type
+# --------------------------------------------------------------------------
+
+
+def _tracked(name: str, tracked: set[str]) -> bool:
+    return name.lower().replace("_", "-") in tracked
+
+
+def _iter_files(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".sonagram")]
+        for name in filenames:
+            path = Path(dirpath) / name
+            try:
+                if path.stat().st_size > MAX_FILE_BYTES and name != "Cargo.lock":
+                    continue
+            except OSError:
+                continue
+            yield path
+
+
+def _read(path: Path) -> list[str] | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+
+
+# ---- Cargo manifests ------------------------------------------------------
+
+_CARGO_TABLE_RE = re.compile(r"^\s*\[([^\]]+)\]")
+_CARGO_INLINE_RE = re.compile(r"^\s*(?P<name>[A-Za-z0-9_.-]+)\s*=\s*(?P<rhs>.+?)\s*$")
+_CARGO_VERSION_IN_TABLE = re.compile(r'\bversion\s*=\s*"([^"]+)"')
+_CARGO_PKG_RENAME = re.compile(r'\bpackage\s*=\s*"([^"]+)"')
+
+
+def scan_cargo_manifest(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
+    lines = _read(path)
+    if lines is None:
+        return []
+    out: list[Declaration] = []
+    table = ""
+    for i, line in enumerate(lines, 1):
+        m = _CARGO_TABLE_RE.match(line)
+        if m:
+            table = m.group(1).strip()
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # `[dependencies.foo]` style
+        dep_table = re.match(
+            r"^(?:workspace\.)?(?:dependencies|dev-dependencies|build-dependencies|"
+            r"target\..*\.dependencies)(?:\.([A-Za-z0-9_-]+))?$",
+            table,
+        )
+        if dep_table and dep_table.group(1):
+            vm = _CARGO_VERSION_IN_TABLE.search(line)
+            if vm and _tracked(dep_table.group(1), tracked):
+                out.append(
+                    Declaration(
+                        repo, path, i, dep_table.group(1), vm.group(1), "cargo-manifest", stripped, metadata=True
+                    )
+                )
+            continue
+        if not dep_table:
+            continue
+
+        im = _CARGO_INLINE_RE.match(line)
+        if not im:
+            continue
+        name, rhs = im.group("name"), im.group("rhs")
+        rename = _CARGO_PKG_RENAME.search(rhs)
+        if rename:
+            name = rename.group(1)
+        if not _tracked(name, tracked):
+            continue
+        if rhs.startswith('"'):
+            spec = rhs.strip('", ')
+        else:
+            vm = _CARGO_VERSION_IN_TABLE.search(rhs)
+            if not vm:
+                # path-only or git-only dependency: a real declaration site with
+                # *no* version — worth surfacing on ecosystem packages.
+                if "path" in rhs or "git" in rhs:
+                    out.append(Declaration(repo, path, i, name, "", "cargo-manifest-pathonly", stripped, metadata=True))
+                continue
+            spec = vm.group(1)
+        out.append(Declaration(repo, path, i, name, spec, "cargo-manifest", stripped, metadata=True))
+    return out
+
+
+def scan_cargo_lock(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
+    lines = _read(path)
+    if lines is None:
+        return []
+    out: list[Declaration] = []
+    name = None
+    name_line = 0
+    for i, line in enumerate(lines, 1):
+        s = line.strip()
+        if s.startswith('name = "'):
+            name = s[8:].rstrip('"')
+            name_line = i
+        elif s.startswith('version = "') and name and _tracked(name, tracked):
+            out.append(
+                Declaration(
+                    repo, path, name_line, name, "=" + s[11:].rstrip('"'), "cargo-lock", f"{name} {s}", metadata=False
+                )
+            )
+            name = None
+    return out
+
+
+# ---- Python metadata ------------------------------------------------------
+
+_PY_REQ_RE = re.compile(r'^\s*["\'](?P<name>[A-Za-z0-9._-]+)\s*(?P<extras>\[[^\]]*\])?\s*(?P<spec>[^"\']*)["\']')
+
+
+def scan_pyproject(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
+    lines = _read(path)
+    if lines is None:
+        return []
+    out: list[Declaration] = []
+    for i, line in enumerate(lines, 1):
+        s = line.strip()
+        if s.startswith("#"):
+            continue
+        m = _PY_REQ_RE.match(line)
+        if m and _tracked(m.group("name"), tracked):
+            out.append(
+                Declaration(
+                    repo, path, i, m.group("name"), m.group("spec").strip(), "python-metadata", s, metadata=True
+                )
+            )
+            continue
+        # `dependencies = ["kglite>=0.15,<0.16"]` on one line
+        for dm in re.finditer(r'["\']([A-Za-z0-9._-]+)(\[[^\]]*\])?\s*([<>=!~][^"\']*)["\']', line):
+            if _tracked(dm.group(1), tracked):
+                d = Declaration(repo, path, i, dm.group(1), dm.group(3).strip(), "python-metadata", s, metadata=True)
+                if not any(x.line == i and x.package == d.package for x in out):
+                    out.append(d)
+    return out
+
+
+_REQ_LINE_RE = re.compile(r"^\s*(?P<name>[A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*(?P<spec>(?:[<>=!~][^\s;#]*)?)")
+
+
+def scan_requirements(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
+    lines = _read(path)
+    if lines is None:
+        return []
+    site = "python-constraints" if "constraint" in path.name else "python-requirements"
+    out: list[Declaration] = []
+    for i, line in enumerate(lines, 1):
+        s = line.strip()
+        if not s or s.startswith(("#", "-", "http")):
+            continue
+        m = _REQ_LINE_RE.match(s)
+        if m and _tracked(m.group("name"), tracked):
+            out.append(Declaration(repo, path, i, m.group("name"), m.group("spec").strip(), site, s, metadata=False))
+    return out
+
+
+# ---- Free-text sites: CI YAML, Dockerfiles, Makefiles, scripts, docs ------
+
+#: `pip install kglite==0.14.5`, `uv pip install 'kglite>=0.15'`,
+#: `cargo install kglite-cli --version 0.15.0`, `kglite = "0.15"` in a doc, etc.
+_INSTALL_RE = re.compile(
+    r"""(?:pip\s+install|uv\s+pip\s+install|uv\s+add|pipx\s+install|poetry\s+add)
+        [^\n]*?['"]?\b(?P<name>[A-Za-z0-9._-]+)(?:\[[^\]]*\])?
+        (?P<spec>(?:[<>=!~]=?[0-9][0-9A-Za-z.*+-]*)(?:\s*,\s*[<>=!~]=?[0-9][0-9A-Za-z.*+-]*)*)""",
+    re.VERBOSE,
+)
+_CARGO_INSTALL_RE = re.compile(
+    r"cargo\s+install\s+(?:[^\n]*?\s)?(?P<name>[A-Za-z0-9._-]+)[^\n]*?--version\s+"
+    r"['\"]?(?P<spec>[0-9][0-9A-Za-z.*+,<>=~^-]*)"
+)
+#: A bare `name==1.2.3` / `name>=1.2` token anywhere (matrix entries, env vars,
+#: `KGLITE_VERSION: 0.15.0`, shell variables).
+_BARE_PIN_RE = re.compile(
+    r"(?<![A-Za-z0-9._-])(?P<name>[A-Za-z][A-Za-z0-9._-]{2,})"
+    r"(?P<spec>(?:[<>=!~]=|==|>=|<=|[<>])\s*[0-9][0-9A-Za-z.*+-]*"
+    r"(?:\s*,\s*(?:[<>=!~]=|==|>=|<=|[<>])\s*[0-9][0-9A-Za-z.*+-]*)*)"
+)
+#: `KGLITE_VERSION = "0.15.0"` / `kglite-version: 0.15.0`
+_NAMED_VERSION_RE = re.compile(
+    r"(?P<name>[A-Za-z][A-Za-z0-9._-]*)[_-]version\s*[:=]\s*['\"]?(?P<spec>[0-9][0-9A-Za-z.]*)",
+    re.IGNORECASE,
+)
+#: Docs prose: "KGLite 0.14.3", "kglite v0.14.3", "requires kglite 0.15".
+_DOC_VERSION_RE = re.compile(
+    r"(?<![A-Za-z0-9._/-])(?P<name>[A-Za-z][A-Za-z0-9_-]{2,})[\s=]+v?(?P<spec>\d+\.\d+(?:\.\d+)?)"
+    r"(?![0-9.]*[A-Za-z/])"
+)
+
+
+#: This file names example versions in its own docstring and tables; scanning
+#: itself is pure self-reference.
+SELF = Path(__file__).resolve()
+
+
+def _site_for(path: Path) -> str | None:
+    if path.resolve() == SELF:
+        return None
+    name = path.name
+    parts = {p.lower() for p in path.parts}
+    if ".github" in parts and path.suffix in {".yml", ".yaml"}:
+        return "ci-yaml"
+    if name.startswith("Dockerfile") or name.endswith(".dockerfile"):
+        return "dockerfile"
+    if name in {"Makefile", "makefile", "GNUmakefile"} or path.suffix == ".mk":
+        return "makefile"
+    if path.suffix in {".sh", ".bash", ".zsh"}:
+        return "shell"
+    if path.suffix == ".py" and "scripts" in parts:
+        return "script"
+    # An install instruction baked into a runtime error message is a real,
+    # load-bearing declaration that no packaging tool will ever reconcile —
+    # sonagram tells users `pip install kglite>=0.15` from Rust.
+    if path.suffix in {".rs", ".py", ".pyi"}:
+        return "source-string"
+    if path.suffix in {".yml", ".yaml"} and "docker" in name.lower():
+        return "compose"
+    return None
+
+
+def scan_freetext(repo: str, path: Path, tracked: set[str], site: str) -> list[Declaration]:
+    lines = _read(path)
+    if lines is None:
+        return []
+    out: list[Declaration] = []
+    seen: set[tuple[int, str, str]] = set()
+
+    def add(i: int, name: str, spec: str, raw: str) -> None:
+        if not _tracked(name, tracked):
+            return
+        key = (i, name.lower(), spec)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(Declaration(repo, path, i, name, spec, site, raw.strip()[:200], metadata=False))
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if not stripped or SUPPRESS_MARKER in stripped:
+            continue
+        for m in _INSTALL_RE.finditer(line):
+            add(i, m.group("name"), m.group("spec"), stripped)
+        if site == "source-string":
+            # Source files are scanned *only* for embedded install instructions.
+            # Anything broader turns every version-shaped literal in the tree
+            # into a finding.
+            continue
+        for m in _CARGO_INSTALL_RE.finditer(line):
+            add(i, m.group("name"), "=" + m.group("spec"), stripped)
+        for m in _BARE_PIN_RE.finditer(line):
+            add(i, m.group("name"), m.group("spec").replace(" ", ""), stripped)
+        for m in _NAMED_VERSION_RE.finditer(line):
+            add(i, m.group("name"), "=" + m.group("spec"), stripped)
+    return out
+
+
+#: Documents whose whole purpose is to name *old* versions. Flagging these
+#: would be wrong, not merely noisy: a changelog entry, a migration guide, or a
+#: recorded benchmark run is supposed to say 0.13.3 forever.
+HISTORICAL_DOCS = re.compile(
+    r"(CHANGELOG|BENCHMARKS|HISTORY|RELEASES)\.md$|migrat|/history/|\.kgl\.lock$",
+    re.IGNORECASE,
+)
+#: Per-line opt-out for a deliberately pinned version in otherwise-live prose.
+SUPPRESS_MARKER = "version-check: ignore"
+#: A markdown table row that opens with a date is a ledger entry — sonagram's
+#: GRAPH-GATE.md records "2026-07-17 | … sonara 0.2.3 sync" forever. Same class
+#: as a changelog line, so it is history rather than a stale claim.
+_LEDGER_ROW = re.compile(r"^\|\s*\d{4}-\d{2}-\d{2}\s*\|")
+
+
+def scan_docs(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
+    """Docs that state a concrete version in prose.
+
+    Prose is the noisiest site, so this is deliberately conservative: it only
+    matches ``<tracked-package> <x.y[.z]>`` with an optional ``v``, only for
+    ecosystem packages (a doc saying ``pyo3 0.27`` is not our problem), and
+    never inside a document that exists to record history.
+    """
+    if HISTORICAL_DOCS.search(str(path)):
+        return []
+    lines = _read(path)
+    if lines is None:
+        return []
+    out: list[Declaration] = []
+    seen: set[tuple[int, str]] = set()
+    for i, line in enumerate(lines, 1):
+        s = line.strip()
+        if not s or s.startswith(("[", "|--", "---")) or SUPPRESS_MARKER in s:
+            continue
+        if _LEDGER_ROW.match(s):
+            continue
+        # An install line is the more specific reading of the same text, so it
+        # wins; otherwise the two regexes double-report every `pip install X==Y`.
+        for m in _INSTALL_RE.finditer(line):
+            name = m.group("name")
+            if _tracked(name, tracked) and (i, name.lower()) not in seen:
+                seen.add((i, name.lower()))
+                out.append(Declaration(repo, path, i, name, m.group("spec"), "docs-install", s[:200], metadata=False))
+        for m in _DOC_VERSION_RE.finditer(line):
+            name = m.group("name")
+            if not _tracked(name, tracked) or (i, name.lower()) in seen:
+                continue
+            seen.add((i, name.lower()))
+            out.append(Declaration(repo, path, i, name, "=" + m.group("spec"), "docs", s[:200], metadata=False))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Repo walk
+# --------------------------------------------------------------------------
+
+
+def assign_units(decls: list[Declaration], root: Path, lock_dirs: set[Path]) -> None:
+    """Tag each declaration with the resolution unit that will resolve it.
+
+    Two declarations only *contradict* if something resolves them together. A
+    workspace and a standalone example with its own ``Cargo.lock`` are separate
+    resolution units — the example pinning an older published version of its own
+    parent crate is stale, not contradictory. The unit is the nearest ancestor
+    directory carrying a lockfile, falling back to the repo root.
+    """
+    for d in decls:
+        unit = root
+        for parent in d.path.parents:
+            if parent in lock_dirs:
+                unit = parent
+                break
+            if parent == root:
+                break
+        d.unit = unit
+
+
+def scan_repo(repo: str, root: Path, tracked: set[str], include_docs: bool) -> list[Declaration]:
+    decls: list[Declaration] = []
+    lock_dirs: set[Path] = set()
+    for path in _iter_files(root):
+        name = path.name
+        if name in {"Cargo.lock", "uv.lock", "poetry.lock"}:
+            lock_dirs.add(path.parent)
+        if name == "Cargo.toml":
+            decls += scan_cargo_manifest(repo, path, tracked)
+        elif name == "Cargo.lock":
+            decls += scan_cargo_lock(repo, path, tracked)
+        elif name == "pyproject.toml":
+            decls += scan_pyproject(repo, path, tracked)
+        elif re.match(r"^(requirements|constraints).*\.txt$", name):
+            decls += scan_requirements(repo, path, tracked)
+        elif name == "uv.lock":
+            decls += scan_cargo_lock(repo, path, tracked)  # same name/version shape
+        elif path.suffix in {".md", ".rst"} and include_docs:
+            decls += scan_docs(repo, path, tracked)
+        else:
+            site = _site_for(path)
+            if site:
+                decls += scan_freetext(repo, path, tracked, site)
+    assign_units(decls, root, lock_dirs)
+    return decls
+
+
+def repo_own_version(root: Path) -> tuple[int, int, int] | None:
+    """The repo's own declared version (workspace Cargo.toml, then pyproject)."""
+    for rel in ("Cargo.toml", "pyproject.toml"):
+        lines = _read(root / rel)
+        if not lines:
+            continue
+        table = ""
+        for line in lines:
+            m = _CARGO_TABLE_RE.match(line)
+            if m:
+                table = m.group(1).strip()
+                continue
+            if table in {"workspace.package", "package", "project", "tool.poetry"}:
+                vm = re.match(r'^\s*version\s*=\s*"([^"]+)"', line)
+                if vm:
+                    parsed = parse_version(vm.group(1))
+                    if parsed:
+                        return parsed
+    return None
+
+
+# --------------------------------------------------------------------------
+# Analysis
+# --------------------------------------------------------------------------
+
+
+def _nearest_lock(d: Declaration, locks: list[Declaration]) -> Declaration | None:
+    """The lock entry that actually governs ``d``, by resolution unit.
+
+    Matching a manifest against *any* lockfile in the repo is wrong: mcp-methods
+    carries a standalone ``examples/downstream_binary`` with its own lock pinned
+    a major behind the workspace, and pairing that manifest with the workspace
+    lock produces a nonsense verdict in both directions.
+    """
+    same_unit = [x for x in locks if x.unit == d.unit]
+    if not same_unit:
+        return None
+    return max(same_unit, key=lambda x: x.interval.lo)  # type: ignore[union-attr]
+
+
+def analyse(
+    decls: list[Declaration],
+    package_owner: dict[str, tuple[str, tuple[int, int, int]]],
+) -> list[Finding]:
+    """Turn raw declarations into findings.
+
+    ``package_owner`` maps each ecosystem package to ``(repo, current_version)``
+    so staleness is checked against the version its own repo currently declares
+    — not only against KGLite. That generalisation is what catches mcp-methods'
+    own stale example fixture as well as a downstream stuck below the engine.
+    """
+    findings: list[Finding] = []
+    by_repo_pkg: dict[tuple[str, str], list[Declaration]] = {}
+    for d in decls:
+        by_repo_pkg.setdefault((d.repo, d.package.lower().replace("_", "-")), []).append(d)
+
+    for (repo, pkg), group in sorted(by_repo_pkg.items()):
+        constrained = [d for d in group if d.interval is not None]
+        locks = [d for d in constrained if d.site == "cargo-lock"]
+        binding = [d for d in constrained if d.binding]
+        manifests = [d for d in binding if d.metadata]
+
+        owner = package_owner.get(pkg)
+        current = owner[1] if owner else None
+
+        # A repo that tests both ends of its own declared range (kglite-datasets
+        # runs a `kglite==0.13.0` CI matrix leg against a `>=0.13` floor) is
+        # doing the right thing. An exact pin equal to the metadata floor is
+        # that pattern, not rot.
+        floor_pins: set[int] = set()
+        metadata_floors = {d.interval.lo for d in manifests}  # type: ignore[union-attr]
+        for d in binding:
+            if _is_exact(d.spec) and d.interval.lo in metadata_floors:  # type: ignore[union-attr]
+                floor_pins.add(id(d))
+
+        # --- 1. contradictions, scoped to a resolution unit
+        for unit in {d.unit for d in binding}:
+            requirements = [d for d in binding if d.unit == unit]
+            if len(requirements) < 2:
+                continue
+            acc = FULL
+            for d in requirements:
+                acc = acc.intersect(d.interval)  # type: ignore[arg-type]
+            if acc:
+                continue
+            pair = _minimal_conflict(requirements) or requirements
+            findings.append(
+                Finding(
+                    kind="contradiction",
+                    severity="error",
+                    repo=repo,
+                    package=pkg,
+                    message=(
+                        f"{repo} declares mutually exclusive requirements for {pkg!r} "
+                        f"within one resolution unit: no single version satisfies all "
+                        f"{len(requirements)} binding site(s). This is a latent build break "
+                        f"— whichever site the installer honours, another is violated."
+                    ),
+                    declarations=pair,
+                )
+            )
+
+        # --- 2. understated floor vs. the lock that actually governs it
+        known_floor = parse_version(WATCHED_THIRD_PARTY[pkg]) if WATCHED_THIRD_PARTY.get(pkg) else None
+        for d in manifests:
+            iv = d.interval
+            assert iv is not None
+            if known_floor and iv.lo < known_floor:
+                findings.append(
+                    Finding(
+                        kind="understated-floor",
+                        severity="warn",
+                        repo=repo,
+                        package=pkg,
+                        message=(
+                            f"{repo} declares {pkg} {d.spec!r} (floor {fmt_version(iv.lo)}) but "
+                            f"the feature this ecosystem selects first exists in "
+                            f"{fmt_version(known_floor)}. Raise the floor — the lockfile hides "
+                            f"this from every build in this repo."
+                        ),
+                        declarations=[d],
+                    )
+                )
+                continue  # the explicit floor is the better message; don't double-report
+            lock = _nearest_lock(d, locks)
+            if lock is None:
+                continue
+            lock_v = lock.interval.lo  # type: ignore[union-attr]
+            if iv.lo < lock_v and iv.contains(lock_v):
+                findings.append(
+                    Finding(
+                        kind="understated-floor",
+                        severity="warn",
+                        repo=repo,
+                        package=pkg,
+                        message=(
+                            f"{repo} declares {pkg} {d.spec!r} (floor {fmt_version(iv.lo)}) but "
+                            f"the governing lockfile resolved {fmt_version(lock_v)}. Every build "
+                            f"here resolves fine; a consumer resolving fresh gets "
+                            f"{fmt_version(iv.lo)} and may not compile. If the floor is real, "
+                            f"say so; if it is not, this is invisible until someone else breaks."
+                        ),
+                        declarations=[d, lock],
+                    )
+                )
+
+        # --- 3. staleness against the package's own current version
+        if current is not None:
+            for d in constrained:
+                if d.site == "cargo-lock":
+                    continue
+                iv = d.interval
+                assert iv is not None
+                is_doc = d.site in DOC_SITES
+                if not iv.contains(current):
+                    if id(d) in floor_pins:
+                        findings.append(
+                            Finding(
+                                kind="floor-test",
+                                severity="info",
+                                repo=repo,
+                                package=pkg,
+                                message=(
+                                    f"{repo} pins {pkg} at {fmt_version(iv.lo)}, which equals its "
+                                    f"own declared floor — a deliberate floor-test leg, not rot."
+                                ),
+                                declarations=[d],
+                            )
+                        )
+                    elif is_doc:
+                        # An upper-bound-only doc constraint (`pip install
+                        # "kglite<0.14"`) is a deliberate pin-back instruction,
+                        # not a stale statement of the current version.
+                        if iv.lo == (0, 0, 0):
+                            continue
+                        if _acknowledged(d):
+                            findings.append(
+                                Finding(
+                                    kind="acknowledged",
+                                    severity="info",
+                                    repo=repo,
+                                    package=pkg,
+                                    message=f"documented {fmt_version(iv.lo)} — {_acknowledged(d)}",
+                                    declarations=[d],
+                                )
+                            )
+                            continue
+                        findings.append(
+                            Finding(
+                                kind="stale-docs",
+                                severity="warn",
+                                repo=repo,
+                                package=pkg,
+                                message=(
+                                    f"{repo} documentation states {pkg} "
+                                    f"{fmt_version(iv.lo)}; current is {fmt_version(current)}. "
+                                    f"No gate watches prose, so this drifts silently."
+                                ),
+                                declarations=[d],
+                            )
+                        )
+                    else:
+                        findings.append(
+                            Finding(
+                                kind="stale-downstream",
+                                severity="error",
+                                repo=repo,
+                                package=pkg,
+                                message=(
+                                    f"{repo} declares {pkg} {d.spec!r}, which EXCLUDES the current "
+                                    f"{fmt_version(current)} (admits "
+                                    f"{fmt_version(iv.lo)}..{fmt_version(iv.hi)}). This repo "
+                                    f"cannot install the current {pkg}."
+                                ),
+                                declarations=[d],
+                            )
+                        )
+                elif _is_exact(d.spec) and iv.lo < current and not is_doc:
+                    findings.append(
+                        Finding(
+                            kind="exact-pin",
+                            severity="warn",
+                            repo=repo,
+                            package=pkg,
+                            message=(
+                                f"{repo} pins {pkg} at exactly {fmt_version(iv.lo)}, superseded "
+                                f"by {fmt_version(current)}."
+                            ),
+                            declarations=[d],
+                        )
+                    )
+
+        # --- 4. inventory of declaration sites outside package metadata
+        for d in group:
+            if not d.metadata and d.site != "cargo-lock":
+                findings.append(
+                    Finding(
+                        kind="site",
+                        severity="info",
+                        repo=repo,
+                        package=pkg,
+                        message=f"{d.site}: {pkg} {d.spec or '(no version)'}",
+                        declarations=[d],
+                    )
+                )
+
+    return findings
+
+
+#: Documented versions that are *supposed* to name an older release, with the
+#: reason. Prose cannot be classified mechanically — "use kglite 0.13.4 to
+#: convert pre-0.14 artifacts" is correct forever, while "a thin KGLite 0.14.3
+#: frontend" is rot, and no regex separates them. So the checker surfaces every
+#: candidate and this table records the adjudicated ones, in the same spirit as
+#: `scripts/check_lint_allowances.py`. Key: ``(path suffix, package)``.
+#: A one-off can instead carry the inline `version-check: ignore` marker.
+_BRIDGE = "0.13.4 is the documented pre-0.14 artifact-conversion bridge"
+ACKNOWLEDGED: dict[tuple[str, str, str], str] = {
+    ("KGLite", "README.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/index.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/python/value-projection.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/python/guides/semantic-search.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/python/guides/import-export.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/rust/c-abi.md", "kglite"): _BRIDGE,
+    ("KGLite", "docs/rust/api-reference.md", "kglite"): _BRIDGE,
+    (
+        "KGLite",
+        "docs/rust/postcard-persistence-performance.md",
+        "kglite",
+    ): "a recorded benchmark A/B; the reference wheel is pinned by design",
+    (
+        "codingest",
+        "docs/python-api.md",
+        "kglite",
+    ): "states which kglite release removed the Python builder — history, not a pin",
+}
+
+
+def _acknowledged(d: Declaration) -> str | None:
+    """Reason this documented version is deliberate, or None.
+
+    Keyed by repo as well as path: several repos have a ``README.md`` and a
+    ``docs/index.md``, and an unscoped suffix match silently exonerated
+    sonagram's genuinely stale strings.
+    """
+    posix = d.path.as_posix()
+    pkg = d.package.lower().replace("_", "-")
+    for (repo, suffix, want_pkg), reason in ACKNOWLEDGED.items():
+        if repo == d.repo and want_pkg == pkg and posix.endswith(suffix):
+            return reason
+    return None
+
+
+def _is_exact(spec: str) -> bool:
+    return bool(re.match(r"^\s*(==|=)\s*\d+\.\d+\.\d+\s*$", spec))
+
+
+def _minimal_conflict(decls: list[Declaration]) -> list[Declaration] | None:
+    """Smallest pair of declarations that already contradict, for reporting."""
+    for i, a in enumerate(decls):
+        for b in decls[i + 1 :]:
+            if not a.interval.intersect(b.interval):  # type: ignore[union-attr]
+                return [a, b]
+    return None
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+SEV_ORDER = {"error": 0, "warn": 1, "info": 2}
+KIND_TITLE = {
+    "contradiction": "CONTRADICTIONS — incompatible versions inside one resolution unit",
+    "stale-downstream": "CROSS-REPO STALENESS — declared range excludes the current version",
+    "understated-floor": "UNDERSTATED FLOORS — declared minimum below what actually builds",
+    "exact-pin": "SUPERSEDED EXACT PINS",
+    "stale-docs": "STALE DOCUMENTED VERSIONS — prose naming a superseded version",
+    "floor-test": "DELIBERATE FLOOR-TEST PINS (not findings; shown for audit)",
+    "acknowledged": "ACKNOWLEDGED HISTORICAL REFERENCES (adjudicated, no action)",
+    "site": "DECLARATION SITES OUTSIDE PACKAGE METADATA (drift surface)",
+}
+KIND_ORDER = [
+    "contradiction",
+    "stale-downstream",
+    "understated-floor",
+    "exact-pin",
+    "stale-docs",
+    "floor-test",
+    "acknowledged",
+    "site",
+]
+
+
+def report(findings: list[Finding], upstream_version, show_sites: bool) -> None:
+    print(f"ecosystem root: {ECOSYSTEM_ROOT}")
+    print(f"upstream: {UPSTREAM_REPO} {fmt_version(upstream_version)}\n")
+    for kind in KIND_ORDER:
+        group = [f for f in findings if f.kind == kind]
+        if not group:
+            continue
+        if kind == "site" and not show_sites:
+            print(f"{KIND_TITLE[kind]}: {len(group)} (use --show-sites to list)\n")
+            continue
+        print(f"== {KIND_TITLE[kind]} ({len(group)}) ==")
+        if kind == "site":
+            for f in sorted(group, key=lambda f: (f.repo, f.declarations[0].site, f.package)):
+                d = f.declarations[0]
+                print(f"  [{d.site:<20}] {d.rel}:{d.line}  {d.package} {d.spec or '-'}")
+        else:
+            for f in sorted(group, key=lambda f: (f.repo, f.package)):
+                print(f"  [{f.severity.upper()}] {f.repo} :: {f.package}")
+                print(f"      {f.message}")
+                for d in f.declarations:
+                    print(f"      - {d.rel}:{d.line}  {d.raw}")
+        print()
+
+
+# --------------------------------------------------------------------------
+# Part 2 — the downstream notifier
+# --------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class NotifyDecision:
+    repo: str
+    notify: bool
+    reasons: list[str]
+    skip_reason: str = ""
+    blocked: bool = False
+    findings: list[Finding] = dataclasses.field(default_factory=list)
+    touched_symbols: list[tuple[str, str]] = dataclasses.field(default_factory=list)
+
+
+def find_symbol_uses(root: Path, symbols: list[str]) -> list[tuple[str, str]]:
+    """Which of ``symbols`` this repo's sources actually reference.
+
+    Approximates "a breaking change touches a surface it uses". Deliberately
+    source-only: docs and changelogs mentioning a symbol are not usage.
+    """
+    hits: list[tuple[str, str]] = []
+    if not symbols:
+        return hits
+    exts = {".rs", ".py", ".pyi", ".toml"}
+    found: dict[str, str] = {}
+    for path in _iter_files(root):
+        if path.suffix not in exts or path.name in {"Cargo.lock", "CHANGELOG.md"}:
+            continue
+        lines = _read(path)
+        if lines is None:
+            continue
+        text = "\n".join(lines)
+        for sym in symbols:
+            if sym in found:
+                continue
+            if sym in text:
+                try:
+                    rel = str(path.relative_to(root))
+                except ValueError:
+                    rel = str(path)
+                found[sym] = rel
+    for sym in symbols:
+        if sym in found:
+            hits.append((sym, found[sym]))
+    return hits
+
+
+def decide_notifications(
+    findings: list[Finding],
+    declarations: list[Declaration],
+    repos: dict[str, Path],
+    upstream_version: tuple[int, int, int],
+    breaking_symbols: list[str],
+) -> list[NotifyDecision]:
+    decisions: list[NotifyDecision] = []
+    for repo in DOWNSTREAM_REPOS:
+        root = repos.get(repo)
+        if root is None:
+            decisions.append(NotifyDecision(repo, False, [], skip_reason="repo not present on disk"))
+            continue
+
+        # Only findings *about an upstream package* are this release's business.
+        # mcp-methods' own stale example fixture is a real finding, but it is not
+        # caused by a kglite release and must not ride a kglite release note.
+        upstream_pkgs = set(ECOSYSTEM_PACKAGES[UPSTREAM_REPO])
+        mine = [f for f in findings if f.repo == repo and f.package in upstream_pkgs]
+        blocked = [f for f in mine if f.kind == "stale-downstream"]
+        pins = [f for f in mine if f.kind == "exact-pin"]
+        contradictions = [f for f in mine if f.kind == "contradiction"]
+        stale_docs = [f for f in mine if f.kind == "stale-docs"]
+        touched = find_symbol_uses(root, breaking_symbols)
+
+        reasons: list[str] = []
+        relevant: list[Finding] = []
+        if blocked:
+            reasons.append(
+                f"declared range excludes {fmt_version(upstream_version)} "
+                f"({len(blocked)} site{'s' if len(blocked) != 1 else ''}) — BLOCKED"
+            )
+            relevant += blocked
+        if contradictions:
+            reasons.append(f"{len(contradictions)} internal version contradiction(s)")
+            relevant += contradictions
+        if pins:
+            reasons.append(
+                f"pins upstream at a superseded exact version ({len(pins)} site{'s' if len(pins) != 1 else ''})"
+            )
+            relevant += pins
+        if stale_docs:
+            files = sorted({f.declarations[0].path.name for f in stale_docs})
+            reasons.append(
+                f"{len(stale_docs)} documented upstream version(s) now superseded, across {', '.join(files)}"
+            )
+            relevant += stale_docs
+        if touched:
+            reasons.append(
+                "references "
+                + ", ".join(f"`{s}`" for s, _ in touched)
+                + " — touched by a breaking change in this release"
+            )
+
+        if reasons:
+            decisions.append(
+                NotifyDecision(repo, True, reasons, blocked=bool(blocked), findings=relevant, touched_symbols=touched)
+            )
+            continue
+
+        # Why a repo is unaffected is worth stating precisely: "declares nothing
+        # from us" and "declares us correctly" are different facts, and only the
+        # second one means the next release needs re-checking.
+        declares = any(d.package.lower().replace("_", "-") in upstream_pkgs and d.repo == repo for d in declarations)
+        if not declares:
+            skip = f"declares no {UPSTREAM_REPO} package anywhere — not a consumer"
+        else:
+            skip = (
+                f"declares {fmt_version(upstream_version)} correctly everywhere: range "
+                f"admits it, no superseded pin, no stale documented version, and no "
+                f"reference to this release's breaking surface"
+            )
+        decisions.append(NotifyDecision(repo, False, [], skip_reason=skip))
+    return decisions
+
+
+def compose_note(
+    decision: NotifyDecision,
+    upstream_version: tuple[int, int, int],
+    date: str,
+    highlights: list[str],
+) -> tuple[str, str]:
+    """Return ``(filename, body)`` for a downstream release note.
+
+    Follows the established inbox schema exactly (see ``.claude/skills/notify``
+    and the existing notes in every sibling's ``inbox/read/``): H1 title, a
+    From/To/Date/Type/Re metadata block, 1–3 paragraphs of context, then
+    ``## Ask / action requested`` and ``## References``. The recipient appends
+    their own ``## Status`` footer; we never write one.
+    """
+    ver = fmt_version(upstream_version)
+    kinds = {f.kind for f in decision.findings}
+    docs_only = kinds <= {"stale-docs"} and not decision.touched_symbols
+
+    if decision.blocked:
+        slug, note_type = "blocked-upgrade", "coordination"
+        title = f"kglite {ver} published — your declared range excludes it"
+        opening = (
+            f"kglite {ver} is published. This note is going to {decision.repo} and not "
+            f"to the rest of the ecosystem because {decision.repo} **cannot resolve it "
+            f"as declared** — a version requirement here excludes {ver}, so the upgrade "
+            f"fails before any code compiles."
+        )
+    elif docs_only:
+        slug, note_type = "documented-version-drift", "heads-up"
+        title = f"kglite {ver} published — your public docs still say an older version"
+        opening = (
+            f"kglite {ver} is published. Your package metadata already admits it, so "
+            f"nothing is blocked. This note is going to {decision.repo} and not to the "
+            f"rest of the ecosystem for one narrow reason: {decision.repo} states a "
+            f"superseded kglite version in published prose, where no packaging tool, "
+            f"lockfile, or CI job will ever notice the drift."
+        )
+    else:
+        slug, note_type = "upgrade-required", "heads-up"
+        title = f"kglite {ver} published — an upgrade step is waiting on you"
+        opening = (
+            f"kglite {ver} is published. This note is going to {decision.repo} and not "
+            f"to the rest of the ecosystem because {decision.repo} carries at least one "
+            f"declaration that this release supersedes or invalidates."
+        )
+
+    filename = f"{date}-from-kglite-{ver.replace('.', '-')}-{slug}.md"
+
+    lines = [
+        f"# {title}",
+        "",
+        "- **From:** kglite",
+        f"- **To:** {decision.repo}",
+        f"- **Date:** {date}",
+        f"- **Type:** {note_type}",
+        f"- **Re:** kglite {ver} (crates.io + PyPI)",
+        "",
+        opening,
+        "",
+        "**What is affected:**",
+        "",
+    ]
+    lines += [f"- {reason}" for reason in decision.reasons]
+    lines.append("")
+
+    # Quoted source lines routinely contain backticks and pipes, so they go in a
+    # fenced block rather than inline code — an inline span breaks on the first
+    # backtick and silently mangles the evidence.
+    sites: list[str] = []
+    for f in decision.findings:
+        for d in f.declarations:
+            if d.site == "cargo-lock":
+                continue
+            entry = f"{d.rel}:{d.line}\n    {d.raw}"
+            if entry not in sites:
+                sites.append(entry)
+    if sites:
+        lines += ["**The exact sites:**", "", "```"]
+        lines += sites
+        lines += ["```", ""]
+
+    if decision.touched_symbols:
+        lines += ["**Breaking-change surface you actually reference:**", ""]
+        lines += [f"- `{sym}` — in `{where}`" for sym, where in decision.touched_symbols]
+        lines.append("")
+
+    if highlights and not docs_only:
+        lines += ["**What changed in this release that can reach you:**", ""]
+        lines += [f"- {h}" for h in highlights]
+        lines.append("")
+
+    lines += ["## Ask / action requested", ""]
+    if decision.blocked:
+        lines.append(
+            f"- Widen or bump every requirement above so it admits {ver}, refresh the "
+            f"lockfile, and run your gate. Until that lands this repo is held on a "
+            f"superseded engine."
+        )
+    elif docs_only:
+        lines.append(
+            f"- Update those strings to {ver} (or drop the version from the prose so it "
+            f"stops needing maintenance). Nothing else here needs to change — your "
+            f"manifests are already correct."
+        )
+    else:
+        lines.append(
+            f"- Move the sites above to {ver} and refresh the lockfile. They sit outside "
+            f"package metadata, so nothing in your own CI will notice they drifted."
+        )
+    if decision.touched_symbols:
+        lines.append(
+            f"- Check those call sites against the `[{ver}]` CHANGELOG before upgrading; "
+            f"they may need an edit, not just a version bump."
+        )
+    lines += [
+        "",
+        "## References",
+        "",
+        f"- kglite release: `{ver}` (crates.io + PyPI, tag `v{ver}`)",
+        f"- CHANGELOG: `../KGLite/CHANGELOG.md` → `[{ver}]`",
+        "- Detected by `../KGLite/scripts/check_version_consistency.py` "
+        "(`make check-ecosystem-versions`); this note was generated by its "
+        "`--notify` mode, which writes only to affected repos.",
+        "",
+    ]
+    return filename, "\n".join(lines)
+
+
+def run_notify(
+    decisions: list[NotifyDecision],
+    repos: dict[str, Path],
+    upstream_version: tuple[int, int, int],
+    date: str,
+    highlights: list[str],
+    dry_run: bool,
+) -> int:
+    ver = fmt_version(upstream_version)
+    print(f"== NOTIFIER — kglite {ver} ==")
+    print(f"{'DRY RUN — nothing will be written' if dry_run else 'writing to inbox/unread/'}\n")
+    written = 0
+    for d in sorted(decisions, key=lambda x: (not x.notify, x.repo)):
+        if not d.notify:
+            print(f"  SKIP   {d.repo:<16} — {d.skip_reason}")
+            continue
+        root = repos[d.repo]
+        filename, body = compose_note(d, upstream_version, date, highlights)
+        target = root / "inbox" / "unread" / filename
+        print(f"  NOTIFY {d.repo:<16} -> {target}")
+        for reason in d.reasons:
+            print(f"           · {reason}")
+        if dry_run:
+            print()
+            print("           ---8<--- note body ---8<---")
+            for line in body.splitlines():
+                print(f"           {line}")
+            print("           ---8<--- end ---8<---\n")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+            written += 1
+    notified = sum(1 for d in decisions if d.notify)
+    skipped = len(decisions) - notified
+    print(f"\n{notified} downstream(s) affected, {skipped} deliberately not notified.")
+    if not dry_run:
+        print(f"{written} note(s) written. inbox/ is gitignored working state — never commit them.")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------
+
+#: Symbols whose *breaking* change in the current release could reach a
+#: downstream. Kept here (rather than parsed from CHANGELOG prose, which is not
+#: a machine contract) and refreshed at release time alongside the other
+#: captured constants. Empty is a valid state: a release with no breaking
+#: surface notifies only on range/pin grounds.
+DEFAULT_BREAKING_SYMBOLS = [
+    "kglite::api::durable::Wal",  # 0.15.0: `Wal::open` gained a second argument
+]
+
+DEFAULT_HIGHLIGHTS = [
+    "`kglite.open()` is now crash-safe by default (`durable` defaults on) and "
+    "enforces one writer per graph instead of silently allowing two.",
+    "Every kglite exception now carries a wire-stable `.code`; "
+    "`TransactionConflictError` is a distinct type (was `ArgumentError`).",
+    "Breaking (Rust API): `kglite::api::durable::Wal::open` takes a second argument.",
+]
+
+
+def main(argv: list[str] | None = None) -> int:
+    global ECOSYSTEM_ROOT
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--root", type=Path, default=ECOSYSTEM_ROOT, help="parent directory holding the sibling repos")
+    p.add_argument(
+        "--upstream-version", default=None, help="override the upstream version (default: KGLite's workspace version)"
+    )
+    p.add_argument("--show-sites", action="store_true", help="list every non-metadata declaration site individually")
+    p.add_argument("--no-docs", action="store_true", help="skip prose version strings in .md/.rst")
+    p.add_argument(
+        "--fail-on",
+        choices=["contradiction", "stale", "none"],
+        default="contradiction",
+        help="which severity trips a non-zero exit (default: contradiction)",
+    )
+    p.add_argument(
+        "--require-siblings",
+        action="store_true",
+        help="error when a sibling repo is absent (release gate); default is skip",
+    )
+    p.add_argument("--json", action="store_true", help="emit findings as JSON")
+    p.add_argument("--notify", action="store_true", help="write release notes into affected downstreams' inbox/unread/")
+    p.add_argument("--dry-run", action="store_true", help="with --notify: print what would be written, write nothing")
+    p.add_argument(
+        "--breaking-symbol",
+        action="append",
+        default=None,
+        help="symbol broken by this release; repeatable (default: the current release's set)",
+    )
+    p.add_argument("--date", default=None, help="date stamp for notes (default: today)")
+    args = p.parse_args(argv)
+
+    ECOSYSTEM_ROOT = args.root.resolve()
+
+    # --- resolve repos, degrading cleanly when siblings are absent
+    repos: dict[str, Path] = {}
+    missing: list[str] = []
+    for repo in (UPSTREAM_REPO, *DOWNSTREAM_REPOS):
+        root = ECOSYSTEM_ROOT / repo
+        if root.is_dir():
+            repos[repo] = root
+        else:
+            missing.append(repo)
+
+    if UPSTREAM_REPO not in repos:
+        # Running from inside KGLite itself: use our own tree.
+        repos[UPSTREAM_REPO] = REPO_ROOT
+        if UPSTREAM_REPO in missing:
+            missing.remove(UPSTREAM_REPO)
+
+    if missing:
+        msg = f"note: {len(missing)} sibling repo(s) not present under {ECOSYSTEM_ROOT}: {', '.join(missing)}"
+        if args.require_siblings:
+            print(msg.replace("note:", "error:"), file=sys.stderr)
+            print("      --require-siblings was set; this run cannot be trusted.", file=sys.stderr)
+            return 1
+        print(f"{msg}\n      skipping them; cross-repo checks cover the rest.\n")
+
+    # --- upstream version
+    if args.upstream_version:
+        upstream_version = parse_version(args.upstream_version)
+        if upstream_version is None:
+            print(f"error: unparseable --upstream-version {args.upstream_version!r}", file=sys.stderr)
+            return 2
+    else:
+        upstream_version = repo_own_version(repos[UPSTREAM_REPO])
+        if upstream_version is None:
+            print(f"error: could not read the upstream version from {repos[UPSTREAM_REPO]}/Cargo.toml", file=sys.stderr)
+            return 2
+
+    # --- tracked package set
+    tracked = {p.lower() for pkgs in ECOSYSTEM_PACKAGES.values() for p in pkgs}
+    tracked |= set(WATCHED_THIRD_PARTY)
+
+    decls: list[Declaration] = []
+    for repo, root in repos.items():
+        decls += scan_repo(repo, root, tracked, include_docs=not args.no_docs)
+
+    # Each ecosystem package is checked against the version its *own* repo
+    # currently declares. The upstream override applies to KGLite's packages so
+    # a release can be validated before the bump lands.
+    package_owner: dict[str, tuple[str, tuple[int, int, int]]] = {}
+    for owner_repo, pkgs in ECOSYSTEM_PACKAGES.items():
+        if owner_repo == UPSTREAM_REPO:
+            own = upstream_version
+        elif owner_repo in repos:
+            own = repo_own_version(repos[owner_repo])
+        else:
+            own = None
+        if own is None:
+            continue
+        for pkg in pkgs:
+            package_owner[pkg] = (owner_repo, own)
+
+    findings = analyse(decls, package_owner)
+
+    if args.notify:
+        symbols = args.breaking_symbol if args.breaking_symbol is not None else DEFAULT_BREAKING_SYMBOLS
+        date = args.date or _dt.date.today().isoformat()
+        decisions = decide_notifications(findings, decls, repos, upstream_version, symbols)
+        return run_notify(decisions, repos, upstream_version, date, DEFAULT_HIGHLIGHTS, args.dry_run)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ecosystem_root": str(ECOSYSTEM_ROOT),
+                    "upstream": {"repo": UPSTREAM_REPO, "version": fmt_version(upstream_version)},
+                    "missing_repos": missing,
+                    "declaration_count": len(decls),
+                    "findings": [f.as_dict() for f in findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        report(findings, upstream_version, args.show_sites)
+
+    errors = [f for f in findings if f.kind == "contradiction"]
+    stale = [f for f in findings if f.kind == "stale-downstream"]
+    warns = [f for f in findings if f.severity == "warn"]
+    sites = [f for f in findings if f.kind == "site"]
+
+    if not args.json:
+        print(
+            f"summary: {len(decls)} declaration(s) scanned across {len(repos)} repo(s) — "
+            f"{len(errors)} contradiction(s), {len(stale)} stale downstream(s), "
+            f"{len(warns)} warning(s), {len(sites)} non-metadata site(s)."
+        )
+
+    if args.fail_on == "none":
+        return 0
+    if errors:
+        return 1
+    if args.fail_on == "stale" and stale:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/msrv_matrix.py
+++ b/scripts/msrv_matrix.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Derive the MSRV verification matrix from the workspace manifests.
+
+The `msrv` CI job builds every workspace member on the exact Rust version
+that member declares as its `rust-version`. The matrix is *computed here*
+rather than hard-coded in the workflow, so the declared contract and the
+job that verifies it cannot drift apart -- which is the whole failure mode
+a declared-but-unchecked MSRV creates.
+
+Two modes:
+
+    python scripts/msrv_matrix.py            # human-readable table
+    python scripts/msrv_matrix.py --github   # `matrix=<json>` for GITHUB_OUTPUT
+
+The script also *fails* if any member is missing a `rust-version`, so a new
+crate cannot join the workspace without declaring its floor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+# `tomllib` is stdlib from 3.11, but ruff's `target-version = "py310"`
+# classifies it as third-party, hence the separate import section. The CI
+# job that runs this script pins Python 3.12.
+import tomllib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def workspace_members(root: pathlib.Path) -> list[str]:
+    manifest = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    return list(manifest["workspace"]["members"])
+
+
+def workspace_rust_version(root: pathlib.Path) -> str | None:
+    manifest = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    return manifest.get("workspace", {}).get("package", {}).get("rust-version")
+
+
+def member_rust_version(member_dir: pathlib.Path, inherited: str | None) -> tuple[str, str | None]:
+    """Return `(package_name, effective_rust_version)` for one member."""
+    manifest = tomllib.loads((member_dir / "Cargo.toml").read_text(encoding="utf-8"))
+    package = manifest["package"]
+    declared = package.get("rust-version")
+    if isinstance(declared, dict):
+        # `rust-version.workspace = true`
+        declared = inherited if declared.get("workspace") else None
+    return package["name"], declared
+
+
+def collect(root: pathlib.Path) -> dict[str, list[str]]:
+    """Group member package names by their effective `rust-version`."""
+    inherited = workspace_rust_version(root)
+    groups: dict[str, list[str]] = {}
+    missing: list[str] = []
+    for member in workspace_members(root):
+        name, version = member_rust_version(root / member, inherited)
+        if version is None:
+            missing.append(name)
+            continue
+        groups.setdefault(version, []).append(name)
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise SystemExit(
+            f"error: workspace member(s) without a `rust-version`: {joined}\n"
+            "Every published crate must declare its minimum supported Rust "
+            "version, either directly or with `rust-version.workspace = true`."
+        )
+    return groups
+
+
+def as_matrix(groups: dict[str, list[str]]) -> dict[str, list[dict[str, str]]]:
+    include = [
+        {
+            "toolchain": version,
+            # `-p a -p b` -- one cargo invocation per toolchain group.
+            "packages": " ".join(f"-p {name}" for name in sorted(names)),
+            # Used only for a readable job name in the Actions UI.
+            "label": ", ".join(sorted(names)),
+            # The group that owns the engine also checks the engine's
+            # pure-Rust optional loaders (`okf`, `rdf`) on the same floor,
+            # since a consumer may enable them. `fastembed` is excluded on
+            # purpose -- it pulls a ~200 MB ONNX runtime, the same reason
+            # the `kglite-c` job skips it.
+            "core": "true" if "kglite" in names else "false",
+        }
+        for version, names in sorted(groups.items())
+    ]
+    return {"include": include}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--github",
+        action="store_true",
+        help="emit `matrix=<json>` suitable for appending to $GITHUB_OUTPUT",
+    )
+    args = parser.parse_args()
+
+    groups = collect(REPO_ROOT)
+    matrix = as_matrix(groups)
+
+    if args.github:
+        print(f"matrix={json.dumps(matrix, separators=(',', ':'))}")
+        return 0
+
+    for entry in matrix["include"]:
+        print(f"{entry['toolchain']:>10}  {entry['label']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refresh_release_constants.py
+++ b/scripts/refresh_release_constants.py
@@ -20,9 +20,24 @@ nobody updates them at release time:
      public-api gate fails until all exact baselines are refreshed and committed.
 
 This script reads ``Cargo.toml`` for the version, then refreshes all
-four. Idempotent: running it twice in a row produces no diff. Step 4
-is best-effort: it no-ops with a message if cargo-public-api / the
-pinned nightly aren't installed locally.
+four. Idempotent: running it twice in a row produces no diff.
+
+**No step is best-effort.** A step that cannot do its job — missing
+release artifact, missing or wrong-version tooling, an anchor the
+rewriter can no longer find, a failed benchmark run — exits non-zero
+with the command that fixes it. It never prints a line and lets the
+release continue: during the 0.15.0 release step 4 found
+``cargo-public-api 0.52.0`` on ``PATH`` against a manifest pin of
+``0.49.0``, reported a no-op, and the run carried on; only a human
+reading the output stopped stale public-API baselines from shipping,
+and those baselines gate downstream Rust embedders and the C ABI.
+
+The one intentional skip is step 3's benchmark re-capture, which is
+skipped when ``<version>.json`` already exists. That is idempotence, not
+a swallowed failure: benchmark numbers are inherently noisy, so the
+per-version file is written once and re-running must not churn it.
+``--skip-benchmarks`` is the other intentional skip — an explicit
+operator request, not a silent one.
 
 Usage:
     python scripts/refresh_release_constants.py [--skip-benchmarks]
@@ -51,6 +66,17 @@ PHASE4_TEST = REPO_ROOT / "tests" / "test_phase4_parity.py"
 PHASE5_TEST = REPO_ROOT / "tests" / "test_phase5_parity.py"
 BASELINES_DIR = REPO_ROOT / "tests" / "benchmarks" / "baselines"
 API_PROFILE_MANIFEST = REPO_ROOT / "tests" / "api-baselines" / "rust-api-profiles.json"
+
+
+class RefreshError(RuntimeError):
+    """A step could not do its job.
+
+    Raising this aborts the run with a non-zero exit and the remediation
+    command. Use it for *every* condition that leaves a captured
+    constant unrefreshed — a release must not proceed on the assumption
+    that a printed line was read. A genuine no-op (the value is already
+    current, or an operator asked for a skip) returns normally instead.
+    """
 
 
 def read_version() -> str:
@@ -117,16 +143,14 @@ def refresh_kgl_golden(version: str, new_digest: str) -> tuple[bool, str]:
 
     cur_match = re.search(r'^(GOLDEN_V3_DIGEST = )"([0-9a-f]{64})"', text, re.MULTILINE)
     if cur_match is None:
-        return False, "tests/test_phase4_parity.py: GOLDEN_V3_DIGEST line not found — refusing to edit"
+        raise RefreshError(
+            "tests/test_phase4_parity.py: GOLDEN_V3_DIGEST line not found. The test moved or "
+            "was renamed; update this script's rewriter before releasing."
+        )
 
     cur_digest = cur_match.group(2)
     if cur_digest == new_digest:
         return False, f"GOLDEN_V3_DIGEST already current ({new_digest[:12]}…)"
-
-    # Demote the current golden into ACCEPTABLE_DIGESTS if it isn't already there.
-    if cur_digest not in text:
-        # extremely defensive; this should always be true since we just matched it
-        return False, "GOLDEN_V3_DIGEST value vanished mid-edit — refusing to edit"
 
     if cur_digest in text.split("ACCEPTABLE_DIGESTS")[1] if "ACCEPTABLE_DIGESTS" in text else False:
         # Already in the allowlist; only need to update the primary.
@@ -136,7 +160,10 @@ def refresh_kgl_golden(version: str, new_digest: str) -> tuple[bool, str]:
         # last entry inside ACCEPTABLE_DIGESTS and insert after it.
         marker = re.search(r"(    )\}\s*\n\)\s*\n", text)
         if marker is None:
-            return False, "ACCEPTABLE_DIGESTS closing brace not found — refusing to edit"
+            raise RefreshError(
+                "tests/test_phase4_parity.py: ACCEPTABLE_DIGESTS closing brace not found, so the "
+                "outgoing golden digest cannot be demoted. Fix the rewriter or demote it by hand."
+            )
         indent = marker.group(1)
         insert = f'{indent}# Demoted from GOLDEN_V3_DIGEST when {version} took over.\n{indent}"{cur_digest}",\n'
         text = text[: marker.start()] + insert + text[marker.start() :]
@@ -168,7 +195,10 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
         re.MULTILINE,
     )
     if bl_match is None:
-        return False, f"tests/test_phase5_parity.py: {platform_key} baseline entry not found"
+        raise RefreshError(
+            f"tests/test_phase5_parity.py: no {platform_key!r} baseline entry to update. The "
+            "baseline table moved or was reformatted; fix the rewriter before releasing."
+        )
     cur_baseline = int(bl_match.group(2).replace("_", ""))
 
     if cur_baseline == current_size:
@@ -256,7 +286,7 @@ def refresh_perf_baseline(version: str) -> tuple[bool, str]:
         ]
         proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
         if proc.returncode != 0:
-            return False, f"benchmark run failed:\n{proc.stdout}\n{proc.stderr}"
+            raise RefreshError(f"benchmark run failed (no perf baseline captured):\n{proc.stdout}\n{proc.stderr}")
         data = json.loads(tmp_json.read_text(encoding="utf-8"))
 
     # Strip per-iteration `data` — gates need aggregates only; carrying
@@ -276,10 +306,25 @@ def refresh_perf_baseline(version: str) -> tuple[bool, str]:
 
 
 def refresh_api_baseline() -> tuple[bool, str]:
-    """Regenerate every manifest-declared cargo-public-api baseline."""
-    if shutil.which("cargo-public-api") is None:
-        return False, "cargo-public-api not installed — see rust-api-profiles.json for the pinned version (skipped)"
+    """Regenerate every manifest-declared cargo-public-api baseline.
+
+    Both the toolchain pin and the tool-version pin are hard
+    requirements. `rust_api_profiles.py` rejects a mismatched
+    cargo-public-api version outright — a *different* version emits a
+    different surface, so a baseline captured with the wrong one is not
+    a baseline. Neither the missing-tool nor the wrong-version case may
+    degrade to a skip: these baselines gate downstream Rust embedders
+    and the C ABI.
+    """
     manifest = json.loads(API_PROFILE_MANIFEST.read_text(encoding="utf-8"))
+    if shutil.which("cargo-public-api") is None:
+        raise RefreshError(
+            "cargo-public-api is not installed, so the public-API baselines cannot be "
+            "refreshed. Install the pinned toolchain + tool:\n"
+            '  rustup toolchain install "$(python scripts/rust_api_profiles.py value nightly)"\n'
+            "  cargo install cargo-public-api --locked --version "
+            '"$(python scripts/rust_api_profiles.py value cargo_public_api_version)"'
+        )
     paths = [REPO_ROOT / profile["baseline"] for profile in manifest["profiles"]]
     before = {path: path.read_text(encoding="utf-8") if path.exists() else None for path in paths}
     proc = subprocess.run(
@@ -289,15 +334,22 @@ def refresh_api_baseline() -> tuple[bool, str]:
         text=True,
     )
     if proc.returncode != 0:
-        last = proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "unknown error"
-        return False, f"cargo public-api profile refresh failed: {last}"
+        detail = (proc.stderr.strip() or proc.stdout.strip() or "unknown error").splitlines()[-1]
+        raise RefreshError(
+            f"cargo public-api profile refresh failed: {detail}\n"
+            "The pinned toolchain and tool version are single-sourced in "
+            "tests/api-baselines/rust-api-profiles.json:\n"
+            '  rustup toolchain install "$(python scripts/rust_api_profiles.py value nightly)"\n'
+            "  cargo install cargo-public-api --locked --version "
+            '"$(python scripts/rust_api_profiles.py value cargo_public_api_version)"'
+        )
     after = {path: path.read_text(encoding="utf-8") if path.exists() else None for path in paths}
     if before == after:
         return False, f"all {len(paths)} Rust API profile baselines already current"
     return True, f"refreshed {len(paths)} Rust API profile baselines"
 
 
-def main() -> int:
+def run() -> None:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--skip-benchmarks", action="store_true", help="Skip the perf-baseline capture (~15s wall-clock).")
     args = p.parse_args()
@@ -315,11 +367,14 @@ def main() -> int:
     print("2. binary-size baseline")
     dylib = find_release_dylib()
     if dylib is None:
-        print("   SKIP   : no target/release/libkglite.{dylib,so} — run `cargo build --release` first.\n")
-    else:
-        size = dylib.stat().st_size
-        changed, msg = refresh_binary_size(version, size)
-        print(f"   {'CHANGED' if changed else 'no-op '}: {msg}\n")
+        raise RefreshError(
+            "no target/release/libkglite_py.{dylib,so} or libkglite.{dylib,so} — the binary-size "
+            "baseline describes the release artifact and cannot be captured without one.\n"
+            "  uv run --no-sync maturin develop --release   (or: cargo build --release)"
+        )
+    size = dylib.stat().st_size
+    changed, msg = refresh_binary_size(version, size)
+    print(f"   {'CHANGED' if changed else 'no-op '}: {msg}\n")
 
     # 3. perf baseline
     if args.skip_benchmarks:
@@ -339,14 +394,22 @@ def main() -> int:
     # dependency) must re-resolve its lock or the packaged-feature CI jobs
     # fail on main (bit 0.14.4 and 0.14.5).
     print("5. packaged-consumer fixture lockfile")
-    before = (REPO_ROOT / "tests/fixtures/rust-embed-consumer/Cargo.lock").read_bytes()
-    subprocess.run(
+    fixture_lock = REPO_ROOT / "tests/fixtures/rust-embed-consumer/Cargo.lock"
+    before = fixture_lock.read_bytes()
+    proc = subprocess.run(
         ["cargo", "update", "--manifest-path", "tests/fixtures/rust-embed-consumer/Cargo.toml", "-p", "kglite"],
         cwd=REPO_ROOT,
-        check=True,
         capture_output=True,
+        text=True,
     )
-    after = (REPO_ROOT / "tests/fixtures/rust-embed-consumer/Cargo.lock").read_bytes()
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no diagnostic output"
+        raise RefreshError(
+            f"packaged-consumer fixture lock did not re-resolve:\n{detail}\n"
+            "The packaged-feature CI jobs consume kglite by version under --locked, so a stale "
+            "fixture lock fails on main."
+        )
+    after = fixture_lock.read_bytes()
     print(f"   {'CHANGED' if before != after else 'no-op '}: tests/fixtures/rust-embed-consumer/Cargo.lock\n")
 
     # Pretty diff summary.
@@ -376,6 +439,13 @@ def main() -> int:
     else:
         print("All constants already current — no changes to stage.")
 
+
+def main() -> int:
+    try:
+        run()
+    except RefreshError as exc:
+        print(f"\nrelease-constant refresh FAILED: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -106,6 +106,71 @@ def check_internal_pins() -> Check:
     return Check("internal version pins", True, "all internal kglite requirements match the workspace")
 
 
+def check_member_inheritance(version: str) -> Check:
+    """No member may silently carry its own version.
+
+    `make bump-version` fixes the forward path, but nothing stops the
+    state drifting some other way — a merge, a hand-edit, a rebase that
+    resolves a manifest conflict wrongly. A member with a stale explicit
+    `version = "..."` still *resolves*, so dependency resolution cannot
+    see this class at all; only reading the manifests can.
+    """
+    problems: list[str] = []
+    for manifest in bump_version.member_manifests():
+        declared = bump_version.declared_member_version(manifest)
+        rel = manifest.relative_to(REPO_ROOT)
+        if declared is None:
+            problems.append(f"{rel}: [package] declares no version at all")
+        elif declared != "workspace" and declared != version:
+            problems.append(f"{rel}: [package] version = {declared!r}, workspace is {version!r}")
+    if problems:
+        return Check(
+            "member inheritance",
+            False,
+            problems[0] if len(problems) == 1 else f"{len(problems)} members diverge",
+            "set `version.workspace = true` in the offending manifest(s) — do not hand-set a version",
+        )
+    return Check("member inheritance", True, "every member inherits [workspace.package] version")
+
+
+def check_workspace_resolves(resolved: dict[str, str] | None, failure: str) -> Check:
+    """Every internal `kglite*` requirement must be satisfiable by the
+    version in the tree — the exact condition that broke 0.15.0."""
+    if resolved is None:
+        reason = next(
+            (line for line in failure.splitlines() if "failed to select a version" in line),
+            failure.splitlines()[0] if failure else "cargo metadata failed",
+        )
+        return Check(
+            "workspace resolves",
+            False,
+            reason.strip(),
+            "make bump-version VERSION=%s   (do not hand-edit the manifests)" % bump_version.read_workspace_version(),
+        )
+    return Check("workspace resolves", True, f"cargo metadata resolved all {len(resolved)} members")
+
+
+def check_publish_lockstep(version: str, resolved: dict[str, str] | None) -> Check:
+    """All five published crates at one version — they publish as a set."""
+    if resolved is None:
+        return Check("publish lockstep", False, "workspace does not resolve; cannot check", "see `workspace resolves`")
+    problems: list[str] = []
+    for crate in bump_version.PUBLISHED_CRATES:
+        actual = resolved.get(crate)
+        if actual is None:
+            problems.append(f"{crate} is not a workspace member")
+        elif actual != version:
+            problems.append(f"{crate} resolved to {actual}, expected {version}")
+    if problems:
+        return Check(
+            "publish lockstep",
+            False,
+            "; ".join(problems),
+            "make bump-version VERSION=%s" % version,
+        )
+    return Check("publish lockstep", True, f"all {len(bump_version.PUBLISHED_CRATES)} published crates at {version}")
+
+
 def check_server_binaries() -> Check:
     """A prebuilt server binary older than the manifest is stale — its
     suite then fails on a contract mismatch that never mentions the
@@ -236,8 +301,20 @@ def main() -> int:
         return 1
 
     print(f"release preflight for {version} — reporting only, nothing is modified\n")
+
+    # One resolution pass feeds both workspace-coherence checks.
+    resolved: dict[str, str] | None
+    failure = ""
+    try:
+        resolved = bump_version.resolve_workspace_versions()
+    except bump_version.BumpError as exc:
+        resolved, failure = None, str(exc)
+
     checks = [
         check_internal_pins(),
+        check_member_inheritance(version),
+        check_workspace_resolves(resolved, failure),
+        check_publish_lockstep(version, resolved),
         check_changelog_version(version),
         check_hygiene(),
         check_captured_constants(version),

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Report whether the tree is ready for the release commit. Change nothing.
+
+The release skill encodes several ordering dependencies in prose, and
+each one fails in a way that does not name its own cause:
+
+* **Bump before refreshing constants.** The golden ``.kgl`` digest embeds
+  the version string, so refreshing first captures the outgoing version
+  and the phase-4 parity test fails later with a digest mismatch that
+  says nothing about ordering.
+* **Rebuild the server binaries after the bump.** A stale prebuilt
+  binary fails its suite with a contract error that never mentions the
+  version.
+* **Re-run ``ruff format`` after the refresh.** The refresh rewrites
+  ``tests/test_phase4_parity.py`` / ``tests/test_phase5_parity.py`` and
+  can leave them unformatted, so ``make gate`` goes red immediately
+  after a clean refresh.
+
+This script turns those into named checks. Run it after promoting the
+CHANGELOG and before writing the ``release(x.y.z)`` commit.
+
+**It is a checker, not a driver, and that is deliberate.** It never
+bumps, never refreshes, never builds, never formats, never commits.
+There is no ``--fix``. A tool that reports "these four things are not
+ready" makes the maintainer faster; a tool that quietly performs the
+steps it checks is how gates stop gating — which is the whole lesson of
+the 0.15.0 release. Every remediation is printed as the exact command to
+run, and running it stays the maintainer's decision.
+
+Nothing here judges *whether* to release, what size the bump should be,
+or how to read ``make semver-check``. Those are human calls.
+
+Usage:
+    python scripts/release_preflight.py            # exit 1 if anything is not ready
+    python scripts/release_preflight.py --base origin/main
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import bump_version  # noqa: E402
+import check_release_hygiene  # noqa: E402
+
+ROOT_MANIFEST = REPO_ROOT / "Cargo.toml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+PHASE5_TEST = REPO_ROOT / "tests" / "test_phase5_parity.py"
+BASELINES_DIR = REPO_ROOT / "tests" / "benchmarks" / "baselines"
+SERVER_BINARIES = ("kglite-mcp-server", "kglite-bolt-server")
+
+RELEASE_SECTION_RE = re.compile(r"^## \[(?P<version>\d+\.\d+\.\d+)\]")
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    ok: bool
+    detail: str
+    remedy: str = ""
+
+
+def _version_slug(version: str) -> str:
+    return version.replace(".", "_")
+
+
+def check_changelog_version(version: str) -> Check:
+    """The topmost released section must be the version being shipped."""
+    for line in CHANGELOG.read_text(encoding="utf-8").splitlines():
+        match = RELEASE_SECTION_RE.match(line)
+        if match is None:
+            continue
+        top = match.group("version")
+        if top == version:
+            return Check("changelog version", True, f"top release section is [{version}]")
+        return Check(
+            "changelog version",
+            False,
+            f"workspace is at {version} but the top release section is [{top}]",
+            "promote CHANGELOG [Unreleased] -> [%s] (release skill step 7)" % version,
+        )
+    return Check(
+        "changelog version",
+        False,
+        "no `## [x.y.z]` release section found",
+        "promote CHANGELOG [Unreleased] -> [%s] (release skill step 7)" % version,
+    )
+
+
+def check_internal_pins() -> Check:
+    problems = bump_version.check()
+    if problems:
+        return Check(
+            "internal version pins",
+            False,
+            problems[0] if len(problems) == 1 else f"{len(problems)} manifests out of sync",
+            "make bump-version VERSION=%s" % bump_version.read_workspace_version(),
+        )
+    return Check("internal version pins", True, "all internal kglite requirements match the workspace")
+
+
+def check_server_binaries() -> Check:
+    """A prebuilt server binary older than the manifest is stale — its
+    suite then fails on a contract mismatch that never mentions the
+    version."""
+    manifest_mtime = ROOT_MANIFEST.stat().st_mtime
+    stale: list[str] = []
+    missing: list[str] = []
+    for name in SERVER_BINARIES:
+        binary = REPO_ROOT / "target" / "release" / name
+        if not binary.exists():
+            missing.append(name)
+        elif binary.stat().st_mtime < manifest_mtime:
+            stale.append(name)
+    if missing or stale:
+        parts = []
+        if missing:
+            parts.append("missing: " + ", ".join(missing))
+        if stale:
+            parts.append("older than Cargo.toml: " + ", ".join(stale))
+        return Check(
+            "server binaries",
+            False,
+            "; ".join(parts),
+            "cargo build -p kglite-mcp-server -p kglite-bolt-server --release",
+        )
+    return Check("server binaries", True, "both release binaries are newer than Cargo.toml")
+
+
+def check_formatting() -> Check:
+    """`cargo fmt --check` + `ruff format --check` — the refresh dirties
+    formatting, so this is the check that catches a missed re-run."""
+    failures: list[str] = []
+    rust = subprocess.run(["cargo", "fmt", "--", "--check"], cwd=REPO_ROOT, capture_output=True, text=True)
+    if rust.returncode != 0:
+        failures.append("cargo fmt")
+    ruff = REPO_ROOT / ".venv" / "bin" / "ruff"
+    if not ruff.exists():
+        return Check(
+            "formatting",
+            False,
+            "no .venv/bin/ruff — cannot verify Python formatting",
+            "uv venv .venv && uv pip install --python .venv/bin/python ruff",
+        )
+    python = subprocess.run([str(ruff), "format", "--check", "."], cwd=REPO_ROOT, capture_output=True, text=True)
+    if python.returncode != 0:
+        failures.append("ruff format")
+    if failures:
+        return Check(
+            "formatting",
+            False,
+            ", ".join(failures) + " reports unformatted files",
+            "cargo fmt && make fmt-py",
+        )
+    return Check("formatting", True, "cargo fmt and ruff format are clean")
+
+
+def check_captured_constants(version: str) -> Check:
+    """The captured constants that are cheap to verify from files alone:
+    the per-version perf baseline and the phase-5 size-history entry.
+
+    The `.kgl` golden digest is deliberately not recomputed here — that
+    needs a built extension, and the phase-4 parity test is its gate.
+    """
+    problems: list[str] = []
+    suffix = ".linux" if sys.platform.startswith("linux") else ""
+    baseline = BASELINES_DIR / f"{_version_slug(version)}{suffix}.json"
+    if not baseline.exists():
+        problems.append(f"no perf baseline {baseline.name}")
+    history = re.search(rf"^\s+- {re.escape(version)}:", PHASE5_TEST.read_text(encoding="utf-8"), re.MULTILINE)
+    if history is None:
+        problems.append(f"no {version} entry in the phase-5 binary-size history")
+    if problems:
+        return Check("captured constants", False, "; ".join(problems), "make refresh-release-constants")
+    return Check("captured constants", True, f"perf baseline and size-history entry present for {version}")
+
+
+def check_hygiene() -> Check:
+    """Reuse the `make gate` lint so preflight and the gate cannot disagree."""
+    problems = check_release_hygiene.check_changelog() + check_release_hygiene.check_refresh_todos()
+    if problems:
+        return Check(
+            "release hygiene",
+            False,
+            problems[0] if len(problems) == 1 else f"{len(problems)} problems",
+            "make check-release-hygiene   (full list)",
+        )
+    return Check("release hygiene", True, "CHANGELOG structure and release-constant markers clean")
+
+
+def check_fast_forward(base: str) -> Check:
+    """`base` must be an ancestor of HEAD, or the release push is not a
+    fast-forward and step 9's `git push origin HEAD:main` will be
+    rejected."""
+    rev = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", base], cwd=REPO_ROOT, capture_output=True, text=True
+    )
+    if rev.returncode != 0:
+        return Check(
+            "fast-forward",
+            False,
+            f"{base} does not resolve — cannot verify the push would fast-forward",
+            f"git fetch origin {base.split('/')[-1]}",
+        )
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", base, "HEAD"], cwd=REPO_ROOT, capture_output=True, text=True
+    )
+    if ancestor.returncode != 0:
+        return Check(
+            "fast-forward",
+            False,
+            f"{base} is not an ancestor of HEAD — the release push would not fast-forward",
+            f"git fetch origin && git rebase {base}",
+        )
+    return Check("fast-forward", True, f"{base} is an ancestor of HEAD")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--base", default="origin/main", help="Ref the release push must fast-forward (default origin/main)."
+    )
+    args = parser.parse_args()
+
+    try:
+        version = bump_version.read_workspace_version()
+    except bump_version.BumpError as exc:
+        print(f"release preflight: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"release preflight for {version} — reporting only, nothing is modified\n")
+    checks = [
+        check_internal_pins(),
+        check_changelog_version(version),
+        check_hygiene(),
+        check_captured_constants(version),
+        check_server_binaries(),
+        check_formatting(),
+        check_fast_forward(args.base),
+    ]
+
+    width = max(len(check.name) for check in checks)
+    for check in checks:
+        mark = "PASS" if check.ok else "NOT READY"
+        print(f"  {mark:<9}  {check.name:<{width}}  {check.detail}")
+
+    failed = [check for check in checks if not check.ok]
+    if not failed:
+        print(f"\nall {len(checks)} preconditions satisfied — the release commit can be written.")
+        return 0
+
+    print(f"\n{len(failed)} of {len(checks)} preconditions not satisfied. Run these yourself:")
+    for check in failed:
+        if check.remedy:
+            print(f"  {check.name}: {check.remedy}")
+    print("\n(This script performs no release step. Deciding what to run, and whether to")
+    print(" release at all, stays yours.)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rust_api_profiles.py
+++ b/scripts/rust_api_profiles.py
@@ -192,22 +192,52 @@ def capture_profile(manifest: dict[str, Any], profile: dict[str, Any]) -> str:
     return proc.stdout
 
 
+#: Conventional install location for a pinned cargo-public-api that must not sit
+#: on PATH. The version is frozen deliberately (its output *is* the baseline
+#: format), so a newer one being first on PATH is the normal state on a machine
+#: that also uses cargo-public-api for anything else -- which is exactly what
+#: happened here on 2026-07-27 and silently no-op'd the release refresh.
+PINNED_TOOL_DIRS = ("/Users/Shared/cargo-tools",)
+
+
+def _resolve_pinned_tool(expected_version: str) -> str | None:
+    """Path to a `cargo-public-api` reporting `expected_version`, or None.
+
+    Prefers PATH, then the conventional pinned-tool directories. Returning the
+    binary rather than mutating PATH keeps the choice explicit at the call site.
+    """
+    candidates: list[str] = []
+    on_path = shutil.which("cargo-public-api")
+    if on_path:
+        candidates.append(on_path)
+    for base in PINNED_TOOL_DIRS:
+        candidates.extend(str(p) for p in Path(base).glob("*/bin/cargo-public-api"))
+    for cand in candidates:
+        try:
+            got = subprocess.run([cand, "--version"], check=True, capture_output=True, text=True).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        if got == expected_version:
+            return cand
+    return None
+
+
 def run_profiles(manifest: dict[str, Any], *, check: bool) -> int:
-    if shutil.which("cargo-public-api") is None:
-        raise RuntimeError(
-            "cargo-public-api is not installed; install the version printed by "
-            "`python scripts/rust_api_profiles.py value cargo_public_api_version`"
-        )
-    version = subprocess.run(
-        ["cargo", "public-api", "--version"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
     expected_version = f"cargo-public-api {manifest['cargo_public_api_version']}"
-    if version != expected_version:
-        raise RuntimeError(f"expected {expected_version!r}, found {version!r}")
+    resolved = _resolve_pinned_tool(expected_version)
+    if resolved is None:
+        on_path = shutil.which("cargo-public-api")
+        found = "not installed"
+        if on_path:
+            found = subprocess.run([on_path, "--version"], check=False, capture_output=True, text=True).stdout.strip()
+        raise RuntimeError(
+            f"expected {expected_version!r}, found {found!r} on PATH and no matching "
+            f"binary under {', '.join(PINNED_TOOL_DIRS)}. Install the pinned version "
+            "(`python scripts/rust_api_profiles.py value cargo_public_api_version`) or "
+            "bump the pin in tests/api-baselines/rust-api-profiles.json and refresh "
+            "the baselines."
+        )
+    os.environ["PATH"] = f"{Path(resolved).parent}{os.pathsep}{os.environ['PATH']}"
 
     failed = False
     captures: dict[str, str] = {}

--- a/scripts/wait_for_release_ci.py
+++ b/scripts/wait_for_release_ci.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Wait for the four push-triggered release workflows to finish, and say
+whether they PASSED — not merely that they completed.
+
+Two recorded failures shape this script:
+
+1. **The `--commit` query silently returns nothing.** During the 0.15.0
+   release `gh run list --commit <sha>` reported `runs=0` for a full
+   hour while all four workflows on that exact SHA were green;
+   `gh run list --branch main` showed them immediately. An earlier note
+   records the same filter returning `[]` for 5-10 s right after a push.
+   So the primary query here is **by branch**, with a client-side
+   `head_sha` filter, and the head_sha-filtered query is only a
+   secondary source unioned in. If the two disagree, the branch query
+   wins and the script says so.
+
+2. **A monitor that reports `status` is not a monitor.** A previous
+   poller announced "completed" without saying whether anything passed.
+   Every line this script prints carries the `conclusion`, and a
+   non-`success` conclusion is a non-zero exit.
+
+Two structural requirements follow from those:
+
+* **Require the expected run count before concluding anything.** A naive
+  "no incomplete runs left" loop exits instantly and green on an empty
+  array — which is exactly what the `runs=0` hour would have produced.
+  Nothing is decided until all `--expect` workflow names are present.
+* **A timeout is a failure.** Running out of wall-clock exits non-zero
+  and names what was still missing or pending. It never degrades to
+  success.
+
+The script is read-only: a single `gh api` GET per poll. It never
+reruns, cancels, approves, or comments.
+
+Usage:
+    python scripts/wait_for_release_ci.py                    # HEAD, on main
+    python scripts/wait_for_release_ci.py --sha <sha> --timeout 3600
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The four workflows a push to `main` triggers for a release. Names must
+# match `.github/workflows/*.yml` `name:` exactly.
+RELEASE_WORKFLOWS = (
+    "CI",
+    "Publish to crates.io",
+    "Build and Publish Python Wheels",
+    "Build & Publish kglite-cli wheels",
+)
+
+TERMINAL_STATUS = "completed"
+
+
+class PollError(RuntimeError):
+    """The poll cannot proceed, or finished unsuccessfully."""
+
+
+def git_output(*args: str) -> str:
+    proc = subprocess.run(["git", *args], cwd=REPO_ROOT, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise PollError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def gh_api(path: str) -> dict:
+    proc = subprocess.run(["gh", "api", path], cwd=REPO_ROOT, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise PollError(f"gh api {path} failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    return json.loads(proc.stdout)
+
+
+def fetch_runs(repo: str, branch: str, sha: str) -> tuple[list[dict], str]:
+    """Return the workflow runs for `sha`, and which query found them.
+
+    Branch-scoped first: it is the query that demonstrably works when the
+    head_sha filter goes blind. The head_sha query is unioned in so a run
+    on a SHA that is no longer branch-tip is still seen.
+    """
+    by_branch = [
+        run
+        for run in gh_api(f"repos/{repo}/actions/runs?branch={branch}&per_page=100").get("workflow_runs", [])
+        if run.get("head_sha") == sha
+    ]
+    by_sha = gh_api(f"repos/{repo}/actions/runs?head_sha={sha}&per_page=100").get("workflow_runs", [])
+
+    merged: dict[int, dict] = {run["id"]: run for run in by_sha}
+    merged.update({run["id"]: run for run in by_branch})
+    source = f"branch={branch} matched {len(by_branch)}, head_sha matched {len(by_sha)}"
+    return list(merged.values()), source
+
+
+def latest_per_workflow(runs: list[dict], expected: tuple[str, ...]) -> dict[str, dict]:
+    """Newest run per expected workflow name (a rerun supersedes)."""
+    newest: dict[str, dict] = {}
+    for run in runs:
+        name = run.get("name")
+        if name not in expected:
+            continue
+        current = newest.get(name)
+        if current is None or run.get("run_number", 0) >= current.get("run_number", 0):
+            newest[name] = run
+    return newest
+
+
+def evaluate(runs: list[dict], expected: tuple[str, ...]) -> tuple[bool, list[str], list[str], list[str]]:
+    """(all_terminal, missing, pending, failed).
+
+    `all_terminal` is False whenever any expected workflow is missing —
+    an absent run is *unknown*, never *fine*. This is the guard against
+    the empty-array instant-green bug.
+    """
+    newest = latest_per_workflow(runs, expected)
+    missing = [name for name in expected if name not in newest]
+    pending = [name for name, run in newest.items() if run.get("status") != TERMINAL_STATUS]
+    failed = [
+        f"{name}: {run.get('conclusion')}"
+        for name, run in newest.items()
+        if run.get("status") == TERMINAL_STATUS and run.get("conclusion") != "success"
+    ]
+    return (not missing and not pending), missing, pending, failed
+
+
+def describe(runs: list[dict], expected: tuple[str, ...]) -> str:
+    newest = latest_per_workflow(runs, expected)
+    lines = []
+    for name in expected:
+        run = newest.get(name)
+        if run is None:
+            lines.append(f"    {name:<34}  (no run seen)")
+        else:
+            status = run.get("status")
+            conclusion = run.get("conclusion") or "-"
+            lines.append(f"    {name:<34}  status={status} conclusion={conclusion}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--sha", help="Commit to wait on (default: HEAD).")
+    parser.add_argument("--branch", default="main", help="Branch the push landed on (default: main).")
+    parser.add_argument("--repo", help="owner/name (default: the `origin` remote).")
+    parser.add_argument("--timeout", type=int, default=3600, help="Seconds before giving up (default 3600).")
+    parser.add_argument("--interval", type=int, default=30, help="Seconds between polls (default 30).")
+    parser.add_argument(
+        "--expect",
+        action="append",
+        help="Workflow name that must be present. Repeatable; defaults to the four release workflows.",
+    )
+    args = parser.parse_args()
+
+    try:
+        sha = args.sha or git_output("rev-parse", "HEAD")
+        repo = args.repo or gh_api("repos/{owner}/{repo}")["full_name"]
+        expected = tuple(args.expect) if args.expect else RELEASE_WORKFLOWS
+
+        print(f"waiting on {len(expected)} workflows for {repo}@{sha[:12]} (branch {args.branch})")
+        print(f"timeout {args.timeout}s, poll every {args.interval}s\n")
+
+        deadline = time.monotonic() + args.timeout
+        while True:
+            runs, source = fetch_runs(repo, args.branch, sha)
+            all_terminal, missing, pending, failed = evaluate(runs, expected)
+            print(f"[{time.strftime('%H:%M:%S')}] {source}")
+            print(describe(runs, expected))
+
+            if all_terminal:
+                if failed:
+                    raise PollError("release CI FAILED:\n  " + "\n  ".join(failed))
+                print(f"\nall {len(expected)} workflows reached conclusion=success")
+                return 0
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                detail = []
+                if missing:
+                    detail.append("never appeared: " + ", ".join(missing))
+                if pending:
+                    detail.append("still running: " + ", ".join(pending))
+                raise PollError(
+                    f"timed out after {args.timeout}s without a verdict — " + "; ".join(detail) + "\n"
+                    "This is a FAILURE, not a pass. Check the runs by branch in the web UI; "
+                    "`gh run list --commit` has returned nothing for a green SHA before."
+                )
+            time.sleep(min(args.interval, remaining))
+    except PollError as exc:
+        print(f"\n{exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\ninterrupted — no verdict reached", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_mechanics.py
+++ b/tests/test_release_mechanics.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import re
 import sys
 
 import pytest
@@ -173,3 +174,22 @@ def test_expected_workflow_names_exist_in_the_repository(workflow):
                 names.add(line.split(":", 1)[1].strip().strip("\"'"))
                 break
     assert workflow in names
+
+
+# ── workspace coherence (what resolution alone cannot see) ─────────────
+
+
+def test_every_member_inherits_the_workspace_version():
+    """A member with its own explicit version still *resolves*, so
+    `cargo metadata` cannot detect this class at all."""
+    declared = {m.parent.name: bump_version.declared_member_version(m) for m in bump_version.member_manifests()}
+    assert set(declared.values()) == {"workspace"}, declared
+
+
+def test_published_crate_list_matches_the_publish_workflow():
+    """If a crate is added to (or dropped from) the crates.io publish set
+    without updating PUBLISHED_CRATES, the lockstep assertion silently
+    stops covering it."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "publish_crates.yml").read_text(encoding="utf-8")
+    published = set(re.findall(r"cargo publish -p ([\w-]+)", workflow))
+    assert published == set(bump_version.PUBLISHED_CRATES)

--- a/tests/test_release_mechanics.py
+++ b/tests/test_release_mechanics.py
@@ -1,0 +1,175 @@
+"""Guards on the release-mechanics tooling itself.
+
+Every check here exists because the corresponding gate was, or could
+silently become, vacuous. These are pure-Python and import no native
+extension, so they cost the suite nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+bump_version = _load("bump_version")
+check_release_hygiene = _load("check_release_hygiene")
+wait_for_release_ci = _load("wait_for_release_ci")
+
+
+# ── the version bump reaches every manifest ────────────────────────────
+
+
+def test_every_internal_pin_matches_the_workspace_version():
+    """The gate `make gate` runs. If this fails, `cargo metadata` is one
+    minor bump away from refusing to resolve the workspace."""
+    assert bump_version.check() == []
+
+
+def test_the_four_publishing_members_actually_pin_the_engine():
+    """Guards the *discovery*, not just the comparison: if the pins were
+    renamed or dropped, `check()` would trivially pass on an empty set.
+    """
+    pinned = {
+        manifest.parent.name
+        for manifest in bump_version.member_manifests()
+        if any(key == "kglite" for _, key, _ in bump_version.internal_version_pins(manifest))
+    }
+    assert pinned == {"kglite-bolt-server", "kglite-c", "kglite-cli", "kglite-mcp-server"}
+
+
+def test_pins_carry_the_full_x_y_z_not_the_series():
+    version = bump_version.read_workspace_version()
+    assert version.count(".") == 2
+    for manifest in bump_version.member_manifests():
+        for _, _, requirement in bump_version.internal_version_pins(manifest):
+            assert requirement == version
+
+
+# ── CHANGELOG structure ────────────────────────────────────────────────
+
+
+def test_changelog_unreleased_section_is_clean():
+    assert check_release_hygiene.check_changelog() == []
+
+
+def test_no_release_constant_todo_markers_survive():
+    assert check_release_hygiene.check_refresh_todos() == []
+
+
+def test_changelog_lint_rejects_a_duplicate_heading(tmp_path, monkeypatch):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Changed\n\n- a\n\n### Changed\n\n- b\n\n## [0.1.0] - 2020-01-01\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_release_hygiene, "CHANGELOG", changelog)
+    problems = check_release_hygiene.check_changelog()
+    assert len(problems) == 1
+    assert "duplicate `### Changed`" in problems[0]
+
+
+def test_changelog_lint_rejects_a_non_keep_a_changelog_heading(tmp_path, monkeypatch):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n\n### Perfomance\n\n- typo\n", encoding="utf-8")
+    monkeypatch.setattr(check_release_hygiene, "CHANGELOG", changelog)
+    problems = check_release_hygiene.check_changelog()
+    assert len(problems) == 1
+    assert "not a Keep a Changelog group" in problems[0]
+
+
+def test_changelog_lint_rejects_a_deleted_unreleased_section(tmp_path, monkeypatch):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [0.1.0] - 2020-01-01\n\n### Added\n\n- a\n", encoding="utf-8")
+    monkeypatch.setattr(check_release_hygiene, "CHANGELOG", changelog)
+    problems = check_release_hygiene.check_changelog()
+    assert len(problems) == 1
+    assert "must be `## [Unreleased]`" in problems[0]
+
+
+def test_todo_lint_rejects_a_surviving_marker(tmp_path, monkeypatch):
+    written = tmp_path / "tests" / "test_phase5_parity.py"
+    written.parent.mkdir(parents=True)
+    written.write_text("# TODO: describe what grew since the prior baseline.\n", encoding="utf-8")
+    monkeypatch.setattr(check_release_hygiene, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_release_hygiene, "REFRESH_WRITTEN_FILES", (Path("tests/test_phase5_parity.py"),))
+    problems = check_release_hygiene.check_refresh_todos()
+    assert len(problems) == 1
+    assert "unresolved release-constants marker" in problems[0]
+
+
+# ── the CI poller does not declare victory prematurely ─────────────────
+
+WORKFLOWS = ("CI", "Publish to crates.io")
+
+
+def _run(name, status, conclusion, number=1):
+    return {
+        "id": hash((name, number)) & 0xFFFF,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "run_number": number,
+    }
+
+
+def test_empty_run_list_is_never_a_pass():
+    """The recorded bug: a zero-incomplete loop exits instantly green on
+    an empty array. `runs=0` persisted for an hour during 0.15.0."""
+    all_terminal, missing, pending, failed = wait_for_release_ci.evaluate([], WORKFLOWS)
+    assert all_terminal is False
+    assert missing == list(WORKFLOWS)
+    assert failed == []
+
+
+def test_a_partial_workflow_set_is_never_a_pass():
+    runs = [_run("CI", "completed", "success")]
+    all_terminal, missing, pending, _ = wait_for_release_ci.evaluate(runs, WORKFLOWS)
+    assert all_terminal is False
+    assert missing == ["Publish to crates.io"]
+
+
+def test_completed_but_failed_is_reported_as_failed_not_completed():
+    runs = [_run("CI", "completed", "failure"), _run("Publish to crates.io", "completed", "success")]
+    all_terminal, _, _, failed = wait_for_release_ci.evaluate(runs, WORKFLOWS)
+    assert all_terminal is True
+    assert failed == ["CI: failure"]
+
+
+def test_all_success_is_the_only_pass():
+    runs = [_run(name, "completed", "success") for name in WORKFLOWS]
+    all_terminal, missing, pending, failed = wait_for_release_ci.evaluate(runs, WORKFLOWS)
+    assert (all_terminal, missing, pending, failed) == (True, [], [], [])
+
+
+def test_a_rerun_supersedes_the_earlier_attempt():
+    runs = [_run("CI", "completed", "failure", 1), _run("CI", "completed", "success", 2)]
+    _, _, _, failed = wait_for_release_ci.evaluate(runs, ("CI",))
+    assert failed == []
+
+
+@pytest.mark.parametrize("workflow", wait_for_release_ci.RELEASE_WORKFLOWS)
+def test_expected_workflow_names_exist_in_the_repository(workflow):
+    """A renamed workflow would make the poller wait forever on a name
+    nobody publishes — so pin the names to the actual `name:` fields."""
+    names = set()
+    for path in (REPO_ROOT / ".github" / "workflows").glob("*.yml"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("name:"):
+                names.add(line.split(":", 1)[1].strip().strip("\"'"))
+                break
+    assert workflow in names

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,456 @@
+"""Regression tests for the ecosystem version-consistency checker.
+
+The checker's whole value is that it fails when a version requirement
+disagrees with another declaration site. A checker that silently reports
+"clean" is worse than none at all — it converts an unnoticed problem into a
+*believed-absent* one. So every category it claims to detect is exercised here
+against a synthetic ecosystem, and every one is also shown NOT to fire on the
+consistent variant of the same shape.
+
+The fixtures are synthetic rather than the real sibling repos: the real ones
+are actively edited, and a test that depends on their contents fails for
+reasons that have nothing to do with the checker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_version_consistency.py"
+_spec = importlib.util.spec_from_file_location("check_version_consistency", SCRIPT)
+assert _spec and _spec.loader
+vc = importlib.util.module_from_spec(_spec)
+sys.modules["check_version_consistency"] = vc
+_spec.loader.exec_module(vc)
+
+
+# --------------------------------------------------------------------------
+# Requirement algebra
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "version", "admits"),
+    [
+        # Cargo caret semantics, including the 0.x special case that governs
+        # every version in this ecosystem.
+        ("0.15", "0.15.3", True),
+        ("0.15", "0.16.0", False),
+        ("^0.14.4", "0.15.0", False),
+        ("^0.14.4", "0.14.9", True),
+        ("1.2", "1.9.0", True),
+        ("1.2", "2.0.0", False),
+        ("5", "5.17.3", True),
+        ("5", "6.0.0", False),
+        # PEP 440 shapes seen in pyproject/CI.
+        (">=0.15.0,<0.16", "0.15.0", True),
+        (">=0.15.0,<0.16", "0.16.0", False),
+        (">=0.15.0,<0.16", "0.14.5", False),
+        (">=0.13", "0.15.0", True),
+        ("==0.14.5", "0.14.5", True),
+        ("==0.14.5", "0.15.0", False),
+        ("<0.14", "0.13.9", True),
+        ("<0.14", "0.15.0", False),
+        (">=0.3.4, <0.4", "0.3.9", True),
+        (">=0.3.4, <0.4", "0.4.0", False),
+    ],
+)
+def test_requirement_admission(spec: str, version: str, admits: bool) -> None:
+    interval = vc.parse_requirement(spec)
+    assert interval is not None, f"failed to parse {spec!r}"
+    assert interval.contains(vc.parse_version(version)) is admits
+
+
+def test_unparseable_requirements_are_declined_not_guessed() -> None:
+    """A shape we do not model must yield None, never a wrong interval."""
+    for spec in ["*", "", "git+https://example.invalid/x", "../local/path"]:
+        assert vc.parse_requirement(spec) is None
+
+
+# --------------------------------------------------------------------------
+# Synthetic ecosystem
+# --------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def ecosystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A minimal, fully consistent two-repo ecosystem at kglite 0.15.0."""
+    monkeypatch.setattr(vc, "DOWNSTREAM_REPOS", ("downstream",))
+    monkeypatch.setattr(
+        vc,
+        "ECOSYSTEM_PACKAGES",
+        {
+            "KGLite": ("kglite",),
+            "downstream": ("downstream",),
+        },
+    )
+
+    root = tmp_path / "eco"
+    _write(root / "KGLite" / "Cargo.toml", '[workspace.package]\nversion = "0.15.0"\n')
+    _write(
+        root / "downstream" / "Cargo.toml",
+        '[workspace.package]\nversion = "1.0.0"\n\n[workspace.dependencies]\nkglite = { version = "0.15.0" }\n',
+    )
+    _write(
+        root / "downstream" / "pyproject.toml",
+        '[project]\nversion = "1.0.0"\ndependencies = [\n  "kglite>=0.15.0,<0.16",\n]\n',
+    )
+    _write(
+        root / "downstream" / ".github" / "workflows" / "ci.yml",
+        "jobs:\n  test:\n    steps:\n      - run: pip install kglite==0.15.0\n",
+    )
+    return root
+
+
+def run(root: Path, *args: str) -> tuple[int, str]:
+    """Invoke the checker, returning ``(exit_code, stdout)``."""
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+        code = vc.main(["--root", str(root), *args])
+    return code, buf.getvalue()
+
+
+def test_consistent_ecosystem_passes(ecosystem: Path) -> None:
+    code, out = run(ecosystem)
+    assert code == 0, out
+    assert "0 contradiction(s)" in out
+
+
+# --------------------------------------------------------------------------
+# 1. Contradictions — the highest-severity category, and the exit-code contract
+# --------------------------------------------------------------------------
+
+
+def test_contradiction_is_detected_and_exits_non_zero(ecosystem: Path) -> None:
+    """The real codingest failure: CI pins a version its metadata excludes.
+
+    Neither site is wrong on its own, and no tool inside the repo compares
+    them, which is exactly why this shipped.
+    """
+    ci = ecosystem / "downstream" / ".github" / "workflows" / "ci.yml"
+    ci.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: pip install kglite==0.14.5\n",
+        encoding="utf-8",
+    )
+
+    code, out = run(ecosystem)
+    assert code == 1, out
+    assert "CONTRADICTIONS" in out
+    assert "kglite==0.14.5" in out
+    assert "ci.yml" in out
+
+
+def test_removing_the_contradiction_restores_a_clean_exit(ecosystem: Path) -> None:
+    """The other half of the same proof: the failure was caused by the defect."""
+    ci = ecosystem / "downstream" / ".github" / "workflows" / "ci.yml"
+    ci.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: pip install kglite==0.14.5\n",
+        encoding="utf-8",
+    )
+    assert run(ecosystem)[0] == 1
+
+    ci.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: pip install kglite==0.15.0\n",
+        encoding="utf-8",
+    )
+    code, out = run(ecosystem)
+    assert code == 0, out
+
+
+def test_separate_resolution_units_do_not_contradict(ecosystem: Path) -> None:
+    """A standalone example with its own lockfile resolves independently.
+
+    mcp-methods keeps `examples/downstream_binary` pinned to the last published
+    major on purpose. Flagging that as a contradiction with the workspace would
+    make the gate unusable.
+    """
+    ex = ecosystem / "downstream" / "examples" / "old_consumer"
+    _write(ex / "Cargo.toml", '[dependencies]\nkglite = { version = "0.14" }\n')
+    _write(ex / "Cargo.lock", '[[package]]\nname = "kglite"\nversion = "0.14.5"\n')
+
+    code, out = run(ecosystem)
+    assert "CONTRADICTIONS" not in out, out
+    assert code == 0, out
+
+
+# --------------------------------------------------------------------------
+# 2. Cross-repo staleness
+# --------------------------------------------------------------------------
+
+
+def test_downstream_excluding_current_upstream_is_reported(ecosystem: Path) -> None:
+    code, out = run(ecosystem, "--upstream-version", "0.16.0")
+    assert "CROSS-REPO STALENESS" in out
+    assert "cannot install the current kglite" in out
+    # Staleness alone is a report, not a gate failure, unless asked for.
+    assert code == 0, out
+    assert run(ecosystem, "--upstream-version", "0.16.0", "--fail-on", "stale")[0] == 1
+
+
+def test_permissive_floor_is_not_stale(ecosystem: Path) -> None:
+    """kglite-datasets' deliberate `>=0.13` must stay a measured null."""
+    _write(
+        ecosystem / "downstream" / "pyproject.toml", '[project]\nversion = "1.0.0"\ndependencies = ["kglite>=0.13"]\n'
+    )
+    (ecosystem / "downstream" / "Cargo.toml").write_text('[workspace.package]\nversion = "1.0.0"\n', encoding="utf-8")
+    (ecosystem / "downstream" / ".github" / "workflows" / "ci.yml").write_text(
+        "jobs:\n  t:\n    steps:\n      - run: pip install kglite>=0.13\n", encoding="utf-8"
+    )
+
+    code, out = run(ecosystem, "--upstream-version", "0.16.0")
+    assert "CROSS-REPO STALENESS" not in out, out
+    assert code == 0
+
+
+def test_floor_test_pin_is_classified_not_flagged(ecosystem: Path) -> None:
+    """An exact pin equal to the declared floor is a CI floor-test leg."""
+    _write(
+        ecosystem / "downstream" / "pyproject.toml", '[project]\nversion = "1.0.0"\ndependencies = ["kglite>=0.13"]\n'
+    )
+    (ecosystem / "downstream" / "Cargo.toml").write_text('[workspace.package]\nversion = "1.0.0"\n', encoding="utf-8")
+    (ecosystem / "downstream" / ".github" / "workflows" / "ci.yml").write_text(
+        "jobs:\n  t:\n    strategy:\n      matrix:\n        spec: ['kglite>=0.13', 'kglite==0.13.0']\n",
+        encoding="utf-8",
+    )
+
+    code, out = run(ecosystem)
+    assert "FLOOR-TEST" in out
+    assert "CROSS-REPO STALENESS" not in out, out
+    assert code == 0
+
+
+# --------------------------------------------------------------------------
+# 3. Understated floors — the invisible-locally class
+# --------------------------------------------------------------------------
+
+
+def test_manifest_floor_below_the_governing_lock_is_reported(ecosystem: Path) -> None:
+    """The mcp-methods 0.4-vs-0.4.1 shape, reproduced exactly."""
+    _write(
+        ecosystem / "downstream" / "Cargo.toml",
+        '[workspace.package]\nversion = "1.0.0"\n\n[workspace.dependencies]\nkglite = { version = "0.15" }\n',
+    )
+    _write(ecosystem / "downstream" / "Cargo.lock", '[[package]]\nname = "kglite"\nversion = "0.15.4"\n')
+
+    code, out = run(ecosystem)
+    assert "UNDERSTATED FLOORS" in out
+    assert "floor 0.15.0" in out
+    assert "resolved 0.15.4" in out
+    # A warning, not a gate failure: floors legitimately float.
+    assert code == 0, out
+
+
+def test_known_feature_floor_beats_the_lock_heuristic(ecosystem: Path) -> None:
+    """`fastembed = "5"` selects a feature that first exists in 5.9.0."""
+    _write(
+        ecosystem / "downstream" / "Cargo.toml",
+        '[workspace.package]\nversion = "1.0.0"\n\n[workspace.dependencies]\nfastembed = { version = "5" }\n',
+    )
+    _write(ecosystem / "downstream" / "Cargo.lock", '[[package]]\nname = "fastembed"\nversion = "5.17.3"\n')
+
+    _, out = run(ecosystem)
+    assert "first exists in 5.9.0" in out
+    assert out.count("fastembed") >= 1
+    # Exactly one finding, not one per detection route.
+    assert out.count("UNDERSTATED FLOORS — declared minimum below what actually builds (1)") == 1
+
+
+# --------------------------------------------------------------------------
+# 4. Declaration sites outside package metadata
+# --------------------------------------------------------------------------
+
+
+def test_non_metadata_sites_are_inventoried_even_when_consistent(ecosystem: Path) -> None:
+    _, out = run(ecosystem, "--show-sites")
+    assert "OUTSIDE PACKAGE METADATA" in out
+    assert "ci-yaml" in out
+
+
+def test_install_hint_inside_a_source_string_is_a_site(ecosystem: Path) -> None:
+    """sonagram tells users `pip install kglite>=0.15` from a Rust error path."""
+    _write(
+        ecosystem / "downstream" / "src" / "lib.rs", 'fn e() { panic!("install it: `pip install kglite>=0.15`"); }\n'
+    )
+    _, out = run(ecosystem, "--show-sites")
+    assert "source-string" in out
+    assert "lib.rs" in out
+
+
+def test_advisory_sites_cannot_cause_a_contradiction(ecosystem: Path) -> None:
+    """A version literal in prose-bearing code must not fail the gate.
+
+    The checker's own docstring cites `kglite==0.14.5` as an example; when
+    scripts counted as binding, running it in its own repo reported the script
+    as a contradiction against the manifests.
+    """
+    _write(
+        ecosystem / "downstream" / "scripts" / "helper.py",
+        '"""Historical note: we used to pin kglite==0.9.0 here."""\n',
+    )
+    code, out = run(ecosystem)
+    assert code == 0, out
+    assert "CONTRADICTIONS" not in out
+
+
+# --------------------------------------------------------------------------
+# 5. Documented versions
+# --------------------------------------------------------------------------
+
+
+def test_stale_documented_version_is_reported(ecosystem: Path) -> None:
+    _write(ecosystem / "downstream" / "README.md", "# downstream\n\nA thin KGLite 0.14.3 frontend.\n")
+    code, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" in out
+    assert "0.14.3" in out
+    assert code == 0, out
+
+
+def test_history_bearing_documents_are_not_flagged(ecosystem: Path) -> None:
+    """A changelog, a migration guide and a dated ledger row say old versions
+    forever; flagging them would be wrong, not merely noisy."""
+    d = ecosystem / "downstream"
+    _write(d / "CHANGELOG.md", "## [0.9]\n\n- Moved kglite 0.13.0 to 0.14.0.\n")
+    _write(d / "docs" / "migrating-to-2.md", "Convert with kglite 0.13.4 first.\n")
+    _write(d / "GATE.md", "| 2026-07-17 | abc123 | kglite 0.13.0 sync (intended) |\n")
+
+    code, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" not in out, out
+    assert code == 0
+
+
+def test_pin_back_instruction_is_not_stale(ecosystem: Path) -> None:
+    """`pip install "kglite<0.14"` is an upper bound, not a claim about now."""
+    _write(
+        ecosystem / "downstream" / "README.md", '# downstream\n\nPin back anytime with `pip install "kglite<0.14"`.\n'
+    )
+    code, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" not in out, out
+    assert code == 0
+
+
+def test_inline_suppression_marker_silences_a_line(ecosystem: Path) -> None:
+    _write(
+        ecosystem / "downstream" / "README.md",
+        "# downstream\n\nA thin KGLite 0.14.3 frontend. <!-- version-check: ignore -->\n",
+    )
+    _, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" not in out, out
+
+
+# --------------------------------------------------------------------------
+# 6. The notifier's affected-only rule
+# --------------------------------------------------------------------------
+
+
+def test_blocked_downstream_is_notified(ecosystem: Path) -> None:
+    code, out = run(ecosystem, "--upstream-version", "0.16.0", "--notify", "--dry-run")
+    assert code == 0
+    assert "NOTIFY downstream" in out
+    assert "BLOCKED" in out
+    assert "your declared range excludes it" in out
+    # Dry run writes nothing.
+    assert not (ecosystem / "downstream" / "inbox").exists()
+
+
+def test_unaffected_downstream_is_not_notified(ecosystem: Path) -> None:
+    """The core doctrine: a 'nothing changes for you' note is inbox noise."""
+    code, out = run(ecosystem, "--notify", "--dry-run")
+    assert code == 0
+    assert "NOTIFY" not in out
+    assert "SKIP   downstream" in out
+    assert "0 downstream(s) affected, 1 deliberately not notified." in out
+
+
+def test_non_consumer_skip_states_the_real_reason(ecosystem: Path) -> None:
+    (ecosystem / "downstream" / "Cargo.toml").write_text('[workspace.package]\nversion = "1.0.0"\n', encoding="utf-8")
+    (ecosystem / "downstream" / "pyproject.toml").write_text(
+        '[project]\nversion = "1.0.0"\ndependencies = []\n', encoding="utf-8"
+    )
+    (ecosystem / "downstream" / ".github" / "workflows" / "ci.yml").write_text(
+        "jobs:\n  t:\n    steps:\n      - run: echo hi\n", encoding="utf-8"
+    )
+
+    _, out = run(ecosystem, "--notify", "--dry-run")
+    assert "not a consumer" in out
+
+
+def test_breaking_symbol_use_triggers_a_notification(ecosystem: Path) -> None:
+    """A repo that references a broken symbol is affected even when its range
+    admits the new version."""
+    _write(
+        ecosystem / "downstream" / "src" / "main.rs",
+        "use kglite::api::durable::Wal;\nfn main() { let _ = Wal::open(); }\n",
+    )
+
+    code, out = run(ecosystem, "--notify", "--dry-run", "--breaking-symbol", "kglite::api::durable::Wal")
+    assert code == 0
+    assert "NOTIFY downstream" in out
+    assert "touched by a breaking change" in out
+    assert "main.rs" in out
+
+
+def test_notify_writes_only_to_affected_inboxes(ecosystem: Path) -> None:
+    code, out = run(ecosystem, "--upstream-version", "0.16.0", "--notify")
+    assert code == 0
+    unread = ecosystem / "downstream" / "inbox" / "unread"
+    notes = list(unread.glob("*.md"))
+    assert len(notes) == 1
+    body = notes[0].read_text(encoding="utf-8")
+    # Matches the established inbox schema.
+    assert body.startswith("# ")
+    assert "- **From:** kglite" in body
+    assert "- **To:** downstream" in body
+    assert "## Ask / action requested" in body
+    assert "## References" in body
+    # The recipient owns the Status footer; the sender never writes one.
+    assert "## Status" not in body
+    assert notes[0].name.startswith("2026-") or notes[0].name[:4].isdigit()
+    assert "-from-kglite-" in notes[0].name
+
+
+def test_notify_is_idempotent_for_a_given_release(ecosystem: Path) -> None:
+    """Re-running a release's notification must not pile up duplicates."""
+    run(ecosystem, "--upstream-version", "0.16.0", "--notify", "--date", "2026-07-27")
+    run(ecosystem, "--upstream-version", "0.16.0", "--notify", "--date", "2026-07-27")
+    notes = list((ecosystem / "downstream" / "inbox" / "unread").glob("*.md"))
+    assert len(notes) == 1
+
+
+# --------------------------------------------------------------------------
+# 7. Degradation when siblings are absent
+# --------------------------------------------------------------------------
+
+
+def test_missing_siblings_skip_with_a_message(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vc, "DOWNSTREAM_REPOS", ("nowhere",))
+    monkeypatch.setattr(vc, "ECOSYSTEM_PACKAGES", {"KGLite": ("kglite",), "nowhere": ("nowhere",)})
+    root = tmp_path / "eco"
+    _write(root / "KGLite" / "Cargo.toml", '[workspace.package]\nversion = "0.15.0"\n')
+
+    code, out = run(root)
+    assert code == 0, out
+    assert "not present" in out
+    assert "nowhere" in out
+
+
+def test_require_siblings_turns_absence_into_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vc, "DOWNSTREAM_REPOS", ("nowhere",))
+    monkeypatch.setattr(vc, "ECOSYSTEM_PACKAGES", {"KGLite": ("kglite",), "nowhere": ("nowhere",)})
+    root = tmp_path / "eco"
+    _write(root / "KGLite" / "Cargo.toml", '[workspace.package]\nversion = "0.15.0"\n')
+
+    code, out = run(root, "--require-siblings")
+    assert code == 1
+    assert "cannot be trusted" in out


### PR DESCRIPTION
Six branches merged for one CI run. Everything here exists because it failed during today's 0.15.0 release.

| branch | what |
|---|---|
| `fix/disk-empty-node-type` | disk `save()` wrote an id-index key the interner couldn't resolve |
| `fix/parse-cache-test-isolation` | a global-cache test asserting an exact count |
| `chore/release-mechanics` | `make bump-version`, preflight, hygiene lint, CI poller, doc corrections |
| `chore/publishing-contract` | MSRV (3 tiers), `direct-minimal-versions` gate, seam analysis |
| `chore/version-consistency-checker` | 118-declaration ecosystem scanner + downstream notifier |
| `fix/pinned-api-tool-resolution` | find the pinned `cargo-public-api` past a newer one on `PATH` |

## The releases this prevents

**The version bump was never one line.** `CLAUDE.md` and the release skill both claimed bumping `[workspace.package] version` was sufficient. Four member manifests *also* pin the engine, and `cargo metadata` failed mid-release today. `make bump-version` now moves both together; `--check` runs in `make gate`; preflight refuses a release when they disagree. Both documents corrected.

**Six release steps could silently no-op.** `refresh_release_constants.py` returned `(False, msg)` and continued on: missing artifact, missing `cargo-public-api`, failed profile refresh, both rewrite anchors, failed benchmark. Today `PATH` held `cargo-public-api` 0.52.0 against a 0.49.0 pin — step 4 printed a no-op and the release continued, nearly shipping stale baselines that gate downstream Rust embedders and the C ABI. All now exit non-zero with a remediation command; the pinned tool is also *found* rather than merely required.

**Understated minimums are invisible to the repo that declares them.** `kglite-mcp-server` needed `mcp-methods` 0.4.1 while declaring `"0.4"` — every build here resolved fine; a sibling with an older lock hit a compile failure against the published crate. The new gate found two more of the same: `fastembed = "5"` (needs 5.9.0) and `mimalloc = "0.1"` (needs 0.1.49).

**We published five crates with no MSRV.** Now declared in three tiers — 1.88.0 / 1.89.0 (`rustyline` calls `File::lock_shared` despite declaring no floor) / 1.91.0 (boltr) — with a CI job whose matrix is *derived* from the manifests rather than hard-coded.

## Verification

`cargo test -p kglite` **1333**, Python **5005**, parity **109**, `make gate` clean, `cargo fmt --check`, `make source-quality`, workspace clippy `-D warnings`.

Every new gate was broken, watched to fail, and restored — including this branch's own CHANGELOG, where a bad merge resolution produced a duplicate `### Fixed` and the new hygiene lint caught it before CI did.

Three of the fixes here were mistakes made *while assembling this branch*: a `cargo fmt` miss, a text edit that stole a `#[cfg(test)]` attribute from the function below it, and the duplicate heading. Each was caught by a gate in this PR.

No version bump — `[Unreleased]` only. The `.claude/` skill edits are gitignored and live in the working checkout; they need `../kglite-doctrine/sync.sh` to be captured.