### PR TITLE
fix: release-constants completeness, CI-poller reachability, CLAUDE.md trim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,12 +153,13 @@ reproduce them locally.
 
 ## Architecture
 
-- **Rust core** (`crates/kglite/src/`): the engine — `petgraph` storage; `KnowledgeGraph` is exposed to Python via PyO3 from the wrapper crate (`crates/kglite-py/src/`).
-- **Cypher engine** (`crates/kglite/src/graph/languages/cypher/`): parser → AST → planner → executor.
-- **Shared query primitives** (`crates/kglite/src/graph/core/`): pattern matching, filtering, traversal — used by both Cypher and the fluent API.
-- **Python package** (`kglite/`): thin wrapper. (Code-graph building lives in the sibling codingest project; kglite serves/queries its graphs.)
-- **Type stubs** (`kglite/__init__.pyi`): source of truth for API docs.
-- **Introspection** (`crates/kglite/src/graph/introspection/`): `describe()` XML schema for agents.
+Crate and module layout is derivable from `ls crates/` and the manifests; the
+two things it does *not* tell you:
+
+- **`kglite/__init__.pyi` is the source of truth for API docs** — not the Rust
+  docstrings, not the `.md` files.
+- **Code-graph building lives in the sibling codingest project**, not here.
+  kglite serves and queries those graphs; it does not build them.
 
 ### The boundary principle (wrappers vs core) — summary
 
@@ -393,6 +394,15 @@ is often false. `make gate` fails if any of the five drifts apart. The bump
 *size* stays a human decision (see `make semver-check`); the target only
 applies the version you hand it.
 
+Release-run procedure — captured-constant refresh, preflight and CI polling,
+ecosystem version consistency, and PyPI capacity — lives in the `release`
+skill, which loads when you invoke it. It is not repeated here.
+
+**One prohibition from it stays resident, because it is irreversible and
+must not depend on a skill being loaded: never delete published files from
+PyPI or crates.io.** Published artifacts are never removed automatically, and
+any manual deletion permanently breaks every pinned install that depends on
+them — it requires a downstream-impact audit and explicit approval first.
 ### One version bump per push
 
 A version isn't "released" until the user pushes. If a `release(x.y.z): ...` commit is already local, fold any follow-up work into the same `[x.y.z]` CHANGELOG block — amend or extend the release commit, don't add a new `release(x.y.z+1): ...` on top.
@@ -404,141 +414,6 @@ git log origin/main..HEAD --oneline | grep -E "^\w+ release\("
 ```
 
 If that returns a commit, keep the version it picked. Only mint a new version after a clean push to origin.
-
-### Captured-constant refresh at release time
-
-Three captured values drift across releases and need a version-paired refresh as part of the release commit. The gates that check them are otherwise reliable — see Test infrastructure → Phase 4 / Phase 5 / perf-regression — but they go stale silently when nobody updates the captured constants. `make refresh-release-constants` does all three in one pass and prints a `git diff --stat` so the maintainer can stage them into the release commit.
-
-- `tests/test_phase4_parity.py::GOLDEN_V3_DIGEST` (and demote the prior value into `ACCEPTABLE_DIGESTS`). The version string lives in the `.kgl` header, so every release shifts the digest.
-- `tests/test_phase5_parity.py::test_binary_size_regression` baseline. Update the docstring's "what grew" note with each bump — the script adds a `TODO: describe what grew since the prior baseline` line for the maintainer to fill in. **`make gate` fails while that marker survives** (`scripts/check_release_hygiene.py`), so the release can't ship with the placeholder in it.
-- `tests/benchmarks/baselines/<version>.json` and `current.json`. Captured by re-running the 11 tracked core benchmarks. The script is idempotent — if `<version>.json` already exists, recapture is skipped (delete the file to force a fresh capture; benchmark numbers are inherently noisy so we don't want to overwrite on every script run).
-
-The script requires one fresh release artifact (`uv run --no-sync maturin
-develop --release`) for steps 2 and 3. Build it once, after the completed PR's
-full CI is green; it is release-data generation, not a reason to rerun tests in
-release mode.
-
-**No step in that script is best-effort.** A step that cannot do its job —
-missing release artifact, missing *or wrong-version* `cargo-public-api`, a
-rewrite anchor that moved, a failed benchmark run, a fixture lock that won't
-re-resolve — exits non-zero with the remediation command. It never prints a
-line and lets the release continue: in 0.15.0 the public-API step found
-cargo-public-api 0.52.0 against a 0.49.0 pin, reported a no-op, and only a
-human reading the output stopped stale baselines from shipping. The only
-intentional skips are the idempotent per-version benchmark re-capture and an
-explicit `--skip-benchmarks`. Do what the error says and re-run; never route
-around it.
-
-Two release-time companions (both wired into the release skill):
-`make bench-anchor` gates cumulative perf drift (newest baseline vs ~3
-releases back, +30%), and `make semver-check` reports mechanically-detected
-API changes vs the last published kglite to ground the bump-size decision
-(informational — this project deliberately ships documented breaking changes
-in patch bumps).
-
-### Release preflight and CI polling
-
-Two release-time instruments, both **checkers** — neither performs a release
-step, and neither has a `--fix`:
-
-- `make release-preflight` reports whether the tree is ready for the release
-  commit, and **refuses** (exit 1) if not. It asserts workspace coherence —
-  every member inherits `[workspace.package] version`, the workspace
-  *resolves* (a resolving `cargo metadata`, since `--no-deps` skips
-  resolution and passes on exactly the broken tree), and all five publishable
-  crates sit at one version — plus workspace version vs. the top CHANGELOG
-  section, internal pin sync, captured constants present for this version,
-  server binaries newer than the manifest, `cargo fmt` + `ruff format` clean
-  (the constants refresh dirties formatting), and `origin/main` an ancestor of
-  HEAD. It prints the command for each unmet precondition and stops there.
-  Run it after promoting the CHANGELOG, before writing the release commit.
-
-  The coherence assertions are **not** redundant with `make bump-version`.
-  The bump tool fixes the forward path; nothing stops the state drifting some
-  other way (a merge, a hand-edit, a rebase resolving a manifest conflict
-  wrongly). And a member carrying its own stale explicit `version = "..."`
-  resolves perfectly well — resolution cannot see that class at all, only
-  reading the manifests can. Preflight **names the offending files and tells
-  you to run `make bump-version`; it never repairs them.** A divergence might
-  be someone's deliberate in-progress change, and quietly overwriting it
-  would be worse than the drift.
-- `python scripts/wait_for_release_ci.py` waits for the four push-triggered
-  workflows. It queries **by branch** with a client-side `head_sha` filter —
-  `gh run list --commit <sha>` returned `runs=0` for an hour during 0.15.0
-  while all four were green on that SHA — **requires all four runs to be
-  present** before concluding anything (a zero-incomplete loop exits instantly
-  green on an empty array), and reports **`conclusion`, not `status`**. A
-  timeout is a non-zero exit, never a pass.
-
-Do not grow either into a driver. A tool that reports "these four things are
-not ready" makes the maintainer faster; a tool that quietly performs the steps
-it checks is how gates stop gating. The bump size, the semver-check reading,
-and the push stay human decisions.
-
-### Ecosystem version consistency + downstream notification
-
-`scripts/check_version_consistency.py` audits every place a dependency
-version is declared across KGLite and its siblings (`codingest`,
-`kglite-datasets`, `sonagram`, `sonara`, `mcp-methods`) — not just
-`Cargo.toml`/`pyproject.toml`, but CI YAML, Makefiles, Dockerfiles, shell and
-Python scripts, install hints baked into source strings, committed lockfiles,
-and docs.
-
-**The class of bug it exists for:** a version requirement that *understates
-its real minimum*, or that is declared *outside package metadata*, is
-structurally invisible to the repo that declares it. `kglite-mcp-server`
-declared `mcp-methods = "0.4"` while calling 0.4.1 APIs — our lock held 0.4.1,
-so every local build and every CI run here resolved fine, and only a sibling
-with an older lock ever saw it. Same shape: `fastembed = "5"` selecting a
-5.9.0+ feature, `mimalloc = "0.1"` selecting `v2` (0.1.49+), and codingest's
-`ci.yml` pinning a version its own wheel metadata excluded.
-
-- `make check-ecosystem-versions` — run **before the version bump** at release
-  time, and any time you touch a dependency requirement. Exits non-zero on
-  *contradictions* (two binding sites in one resolution unit that no single
-  version satisfies); staleness, understated floors, and stale documented
-  versions are reported but do not fail unless you pass `--fail-on stale`.
-- `make check-ecosystem-versions-verbose` — adds the full inventory of
-  declaration sites outside package metadata, i.e. everything that can drift
-  with nothing watching it.
-- `make notify-downstream-dry-run` / `make notify-downstream` — run **after
-  publish is verified**. Writes a release note into `inbox/unread/` of each
-  *affected* downstream only.
-
-**Deliberately not in `make gate` or CI.** Its subject is disagreement
-*between* repos; CI checks out one repo, so every sibling would be absent and
-the check would pass vacuously or need five extra clones per run. It degrades
-with a skip-and-message when siblings are missing (`--require-siblings`
-inverts that), and it resolves the ecosystem root through a worktree's `.git`
-file, so it works from `/Users/Shared/kglite-wt/<branch>` too.
-
-**The notifier notifies only the affected.** A "we released, nothing changes
-for you" note is noise that trains people to ignore the inbox, and it degrades
-a mechanism that currently works (CLAUDE.md → "Route to the party who can
-act"). A downstream is notified only when its declared range excludes the new
-version, it pins us at a superseded exact version, it states a superseded
-version in published prose, or it references a symbol in this release's
-breaking set (`DEFAULT_BREAKING_SYMBOLS` in the script — refresh it with the
-other captured constants). Otherwise the run prints `SKIP <repo>: <reason>`
-and writes nothing. Notes are local files, never commits: `inbox/` is
-gitignored working state in every repo.
-
-Prose cannot be classified mechanically — "use kglite 0.13.4 to convert
-pre-0.14 artifacts" is correct forever, "a thin KGLite 0.14.3 frontend" is
-rot. Adjudicated cases live in the script's `ACKNOWLEDGED` table with a
-reason, or carry an inline `version-check: ignore` marker; changelogs,
-migration guides and dated ledger rows are skipped wholesale.
-
-### PyPI project capacity
-
-PyPI's default project limit is 10.0 GB. The wheel release workflow sums the
-published file sizes from PyPI's project JSON API, reserves 250 MB for the next
-release, and blocks before builds when projected use reaches 80% of that limit.
-When it blocks, request a project-limit increase before publishing. Published
-files are never deleted automatically; any manual deletion requires a separate
-downstream-impact audit and explicit approval because it permanently breaks
-pinned installs. Update the configured limit only after PyPI confirms a new
-project-specific allowance.
 
 ### Multi-phase plans
 

--- a/scripts/refresh_release_constants.py
+++ b/scripts/refresh_release_constants.py
@@ -201,6 +201,7 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
         )
     cur_baseline = int(bl_match.group(2).replace("_", ""))
 
+    original_text = text
     unchanged = cur_baseline == current_size
     if unchanged:
         # An unchanged SIZE is not an unchanged RELEASE. The history is a
@@ -216,8 +217,11 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
     # Re-stamp the baseline line so its comment names the version being cut,
     # even when the number itself did not move.
     formatted = f"{current_size:_}".replace("_", "_")  # "12_345_678" style
-    suffix = " (unchanged)" if unchanged else ""
-    new_line = f"{bl_match.group(1)}{formatted},  # {version} {platform_key} baseline{suffix}\n"
+    # No "(unchanged)" marker here: the comment must be a pure function of
+    # (size, version, platform) or re-stamping it is not idempotent, and the
+    # second refresh of a release would report a change that did not happen.
+    # The unchanged-ness is recorded in the history row's prose instead.
+    new_line = f"{bl_match.group(1)}{formatted},  # {version} {platform_key} baseline\n"
     text = text[: bl_match.start()] + new_line + text[bl_match.end() :]
 
     # Best-effort: drop a marker into the docstring's "Baseline history:"
@@ -240,8 +244,15 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
         )
     existing_history = re.search(rf"^      - {re.escape(version)}:.*$", text, re.MULTILINE)
     if existing_history is not None:
-        replacement = todo_marker.strip("\n")
-        text = text[: existing_history.start()] + replacement + text[existing_history.end() :]
+        # A row for this version already exists — leave it exactly as it is.
+        #
+        # Rewriting it was both wrong and unstable. Wrong: the maintainer
+        # replaces the generated TODO with real prose describing what grew,
+        # and regenerating would delete that. Unstable: `unchanged` compares
+        # the size against the baseline *in the file*, which the first run
+        # just updated, so a second run reclassifies the same release as
+        # "unchanged" and rewrites the row it had written moments earlier.
+        pass
     else:
         history_anchor = "    Raising the baseline is a deliberate act"
         if history_anchor in text:
@@ -254,6 +265,13 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
         f"(+10% over {version} {{platform_key}} baseline {{baseline:,}})",
         text,
     )
+
+    if text == original_text:
+        # Re-running after a completed refresh must be a no-op, or the caller
+        # cannot tell "I just recorded this" from "this was already recorded".
+        # The unchanged-size path still falls through to here, so idempotency
+        # is decided by whether the FILE moved, never by whether the size did.
+        return False, f"binary-size baseline and history already current ({current_size:,} bytes)"
 
     PHASE5_TEST.write_text(text, encoding="utf-8", newline="\n")
     if unchanged:

--- a/scripts/refresh_release_constants.py
+++ b/scripts/refresh_release_constants.py
@@ -201,23 +201,43 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
         )
     cur_baseline = int(bl_match.group(2).replace("_", ""))
 
-    if cur_baseline == current_size:
-        return False, f"binary-size baseline already current ({current_size:,} bytes)"
+    unchanged = cur_baseline == current_size
+    if unchanged:
+        # An unchanged SIZE is not an unchanged RELEASE. The history is a
+        # per-release ledger, and `release_preflight` requires a row for the
+        # version being cut -- an absent row reads as an *unmeasured* release,
+        # not an unchanged one. Returning early here made the two tools
+        # disagree: this one reported "already current" while preflight
+        # reported "no entry", which is exactly what happened cutting 0.15.1.
+        # So fall through and write the row (and re-stamp the version comment
+        # on the baseline line), just with the value left alone.
+        pass
 
-    # Replace the baseline line.
+    # Re-stamp the baseline line so its comment names the version being cut,
+    # even when the number itself did not move.
     formatted = f"{current_size:_}".replace("_", "_")  # "12_345_678" style
-    new_line = f"{bl_match.group(1)}{formatted},  # {version} {platform_key} baseline\n"
+    suffix = " (unchanged)" if unchanged else ""
+    new_line = f"{bl_match.group(1)}{formatted},  # {version} {platform_key} baseline{suffix}\n"
     text = text[: bl_match.start()] + new_line + text[bl_match.end() :]
 
     # Best-effort: drop a marker into the docstring's "Baseline history:"
     # block so the growth narrative gains an entry. We don't try to
     # rewrite the whole prose — that's the maintainer's job; we just
     # leave a TODO so they don't forget.
-    todo_marker = (
-        f"\n      - {version}:       {current_size:,} bytes "
-        f"(≈{current_size / (1024 * 1024):.1f} MB). "
-        "TODO: describe what grew since the prior baseline.\n"
-    )
+    if unchanged:
+        # Nothing grew, so there is nothing for a human to describe -- emitting
+        # a TODO here would be a marker that can never be resolved, and the
+        # hygiene lint would (correctly) block the release on it.
+        todo_marker = (
+            f"\n      - {version}:       {current_size:,} bytes — **unchanged** from the "
+            "prior baseline; this release moved no code size.\n"
+        )
+    else:
+        todo_marker = (
+            f"\n      - {version}:       {current_size:,} bytes "
+            f"(≈{current_size / (1024 * 1024):.1f} MB). "
+            "TODO: describe what grew since the prior baseline.\n"
+        )
     existing_history = re.search(rf"^      - {re.escape(version)}:.*$", text, re.MULTILINE)
     if existing_history is not None:
         replacement = todo_marker.strip("\n")
@@ -236,6 +256,8 @@ def refresh_binary_size(version: str, current_size: int) -> tuple[bool, str]:
     )
 
     PHASE5_TEST.write_text(text, encoding="utf-8", newline="\n")
+    if unchanged:
+        return True, f"binary-size unchanged at {current_size:,} bytes — history row recorded"
     return True, f"binary-size baseline {cur_baseline:,} -> {current_size:,} bytes"
 
 
@@ -413,6 +435,31 @@ def run() -> None:
     print(f"   {'CHANGED' if before != after else 'no-op '}: tests/fixtures/rust-embed-consumer/Cargo.lock\n")
 
     # Pretty diff summary.
+    # ── 6. Generated docs facts ────────────────────────────────────────
+    # `docs/_generated/project-facts.md` embeds the version, so every bump
+    # staled it. Nothing in this script regenerated it, and the only thing
+    # that noticed was `make gate` -- *if* someone happened to run it after
+    # the bump. Cutting 0.15.1 hit exactly that: a clean refresh, then a
+    # red gate from a file the refresh should have owned.
+    print("6. generated docs facts")
+    facts = REPO_ROOT / "docs/_generated/project-facts.md"
+    before_facts = facts.read_bytes() if facts.exists() else b""
+    proc = subprocess.run(
+        [sys.executable, "scripts/render_docs_facts.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no diagnostic output"
+        raise RefreshError(f"render_docs_facts.py failed:\n{detail}")
+    after_facts = facts.read_bytes() if facts.exists() else b""
+    if after_facts != before_facts:
+        print(f"   CHANGED: {facts.relative_to(REPO_ROOT)}")
+    else:
+        print("   no-op : generated docs facts already current")
+    print()
+
     diff = subprocess.run(
         [
             "git",
@@ -423,6 +470,7 @@ def run() -> None:
             "tests/test_phase5_parity.py",
             "tests/benchmarks/baselines/",
             "tests/api-baselines/",
+            "docs/_generated/project-facts.md",
         ],
         cwd=REPO_ROOT,
         capture_output=True,
@@ -434,7 +482,8 @@ def run() -> None:
             print(f"  {line}")
         print("\nIf the deltas are expected, stage the files and amend into the release commit:")
         print("  git add tests/test_phase4_parity.py tests/test_phase5_parity.py \\")
-        print("          tests/benchmarks/baselines/ tests/api-baselines/")
+        print("          tests/benchmarks/baselines/ tests/api-baselines/ \\")
+        print("          docs/_generated/project-facts.md")
         print("  git commit --amend --no-edit")
     else:
         print("All constants already current — no changes to stage.")

--- a/scripts/wait_for_release_ci.py
+++ b/scripts/wait_for_release_ci.py
@@ -60,6 +60,10 @@ RELEASE_WORKFLOWS = (
 TERMINAL_STATUS = "completed"
 
 
+#: Empty polls tolerated before probing whether the API is reachable at all.
+EMPTY_POLLS_BEFORE_PROBE = 3
+
+
 class PollError(RuntimeError):
     """The poll cannot proceed, or finished unsuccessfully."""
 
@@ -96,6 +100,25 @@ def fetch_runs(repo: str, branch: str, sha: str) -> tuple[list[dict], str]:
     merged.update({run["id"]: run for run in by_branch})
     source = f"branch={branch} matched {len(by_branch)}, head_sha matched {len(by_sha)}"
     return list(merged.values()), source
+
+
+def api_is_reachable(repo: str) -> tuple[bool, str]:
+    """Whether the Actions API answers at all, independent of this SHA.
+
+    `fetch_runs` returning nothing is ambiguous: the workflows may not have
+    registered yet, or we may be unable to see them. Those want opposite
+    responses -- keep waiting versus stop and say so -- and a poll loop that
+    cannot tell them apart will report "no runs" right up to its timeout
+    while the real problem is that nothing can reach GitHub.
+
+    Observed 2026-07-27: local ephemeral-port exhaustion made every outbound
+    connection fail with EADDRNOTAVAIL while a release was in flight.
+    """
+    try:
+        gh_api(f"repos/{repo}/actions/runs?per_page=1")
+    except PollError as exc:
+        return False, str(exc)
+    return True, "reachable"
 
 
 def latest_per_workflow(runs: list[dict], expected: tuple[str, ...]) -> dict[str, dict]:
@@ -166,11 +189,32 @@ def main() -> int:
         print(f"timeout {args.timeout}s, poll every {args.interval}s\n")
 
         deadline = time.monotonic() + args.timeout
+        empty_polls = 0
         while True:
             runs, source = fetch_runs(repo, args.branch, sha)
             all_terminal, missing, pending, failed = evaluate(runs, expected)
             print(f"[{time.strftime('%H:%M:%S')}] {source}")
             print(describe(runs, expected))
+
+            # Zero runs is ambiguous -- not registered yet, or not visible.
+            # Those want opposite responses, so after a few empty polls stop
+            # guessing and ask the API a question whose answer does not
+            # depend on this SHA.
+            if not runs:
+                empty_polls += 1
+                if empty_polls == EMPTY_POLLS_BEFORE_PROBE:
+                    ok, detail = api_is_reachable(repo)
+                    if not ok:
+                        raise PollError(
+                            "cannot see any workflow runs, and the Actions API is "
+                            f"unreachable:\n  {detail}\n"
+                            "This is NOT evidence that the release failed to trigger -- "
+                            "it is evidence that this machine cannot observe it. Resolve "
+                            "connectivity, then re-run; the push already happened."
+                        )
+                    print("   (API reachable — runs genuinely have not registered yet)")
+            else:
+                empty_polls = 0
 
             if all_terminal:
                 if failed:


### PR DESCRIPTION
Three follow-ups from cutting 0.15.1 — each closes a gap that release exposed.

**1. Release constants must record every release.** `refresh_binary_size` returned early when the size was unchanged, so no history row was written and the baseline comment kept naming the prior version. `release_preflight` then reported *"no 0.15.1 entry"* while the refresh reported *"already current"* — two tools disagreeing about whether a step was done. An absent row reads as an **unmeasured** release, not an unchanged one, so the row is now always written: value left alone, comment re-stamped, and no `TODO:` marker (nothing grew, and an unresolvable TODO would block the hygiene lint forever).

**2. The refresh now owns the generated docs facts.** `docs/_generated/project-facts.md` embeds the version and staled on every bump, but nothing in the refresh regenerated it — the only thing that noticed was `make gate`, and only if run after the bump. That is exactly how 0.15.1 got a clean refresh followed by a red gate. Now step 6, and in the stage hint.

**3. The CI poller can tell "no runs yet" from "cannot see runs".** Zero runs is ambiguous and the two want opposite responses. After three empty polls it now asks the API a question whose answer doesn't depend on the SHA; if that fails it stops and says the release is **unobserved, not untriggered** — the push already happened. (The poller already errored correctly when the API was unreachable at *startup*; verified during a live ephemeral-port exhaustion. This closes the mid-poll case.)

**4. `CLAUDE.md` 39,746 → 30,965 chars** (~9.9k → ~7.7k est. tokens every session), clear of the 40,000-char large-memory warning floor. Cut the crate/module layout from `## Architecture` — derivable from `ls crates/` and the manifests — keeping the two things they don't say. Moved four release-**run** subsections into the `release` skill, which loads only when invoked. Kept resident: commit format, push-approval rules, one-version-bump-per-push, multi-phase plans.

⚠ One prohibition was pulled back out of that move and left resident: **never delete published files from PyPI or crates.io**. It is irreversible, so it must not depend on a skill happening to be loaded.

Verified: `make gate` clean, `cargo test -p kglite` 1333, and the size-history fix tested against the exact failing state (row removed, comment reverted → refresh rewrites both, hygiene lint stays clean).