### PR TITLE
fix: from_blueprint's save flag no longer promises what it doesn't do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`from_blueprint(save=True)` no longer silently does nothing.** `save`
+  defaulted to `True`, but the save only ran when the blueprint declared an
+  `output` / `output_file` setting — so the common call, with the flag left at
+  its default, persisted nothing while reading as if it did. Two independent
+  reports landed on the same day. On a `storage="disk"` build the consequence
+  is worse than a missing file: the directory passed as `path` is the live
+  working directory, publication happens only at `save()`, and the skipped save
+  left behind `.kglite.lock`, a `.working-<pid>-<n>/` directory and a partial
+  `seg_000/` — a directory that looks like a graph and that `kglite.load()`
+  rejects with *"Directory does not contain a valid disk graph (missing
+  disk_graph_meta.json)"*. A downstream package's disk cache had been built on
+  that call and had therefore never once committed a graph.
+
+  A build now has a **save destination** when the blueprint declares one *or*
+  when `storage="disk"` was given a `path`; in disk mode the directory is the
+  graph, so that is what the flag has to mean, and
+  `from_blueprint(storage="disk", path=out)` → `kglite.load(out)` now
+  round-trips. The flag itself stops overpromising: `save` now defaults to
+  `None` — save if a destination exists, build in memory if not — while an
+  explicit `save=True` with nowhere to write raises `ValueError` naming both
+  ways to give it a destination, matching `KnowledgeGraph.save()`, which
+  already refuses rather than guesses when it has no path. `save=False` is
+  unchanged, and so is every build whose blueprint declares an output.
+
 ## [0.15.1] - 2026-07-27
 
 

--- a/docs/python/guides/blueprints.md
+++ b/docs/python/guides/blueprints.md
@@ -392,7 +392,7 @@ graph.select("Contract").valid_during("2024-01-01", "2024-12-31")
 | Key | Description |
 |-----|-------------|
 | `root` (or `input_root`) | Base directory for resolving CSV paths. Defaults to `"."`. |
-| `output` | Path to auto-save the graph after loading (when `save=True`). |
+| `output` | Path to auto-save the graph to after loading. |
 | `output_path` | Alternative: output directory (combined with `output_file`). |
 | `output_file` | Alternative: output filename (combined with `output_path`). |
 
@@ -408,6 +408,35 @@ graph = kglite.from_blueprint("blueprint.json", verbose=True)
 # Skip auto-save (just build in memory)
 graph = kglite.from_blueprint("blueprint.json", save=False)
 ```
+
+### Where the graph gets saved
+
+A build has a **save destination** when either of these is true:
+
+- the blueprint declares `output` (or `output_path` + `output_file`), or
+- `storage="disk"` was given a `path`.
+
+The disk case matters because in disk mode the directory *is* the graph, and
+building alone leaves it unpublished — a directory that looks like a graph but
+that `kglite.load()` refuses with *"missing disk_graph_meta.json"*. Saving is
+what publishes it:
+
+```python
+kglite.from_blueprint("blueprint.json", storage="disk", path="graph/")
+reopened = kglite.load("graph/")     # works — the build published the directory
+```
+
+The `save` argument then selects the policy:
+
+| `save` | Behaviour |
+|--------|-----------|
+| omitted (default) | Save if a destination exists; build in memory if not. |
+| `True` | Save; raise `ValueError` if there is no destination. |
+| `False` | Never save. |
+
+Passing `save=True` on a blueprint with no `output` and no disk `path` is an
+error rather than a silent no-op, so a pipeline that believes it is persisting
+its output finds out at the first run.
 
 ## How Loading Works
 

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -945,7 +945,7 @@ def from_blueprint(
     blueprint_path: Union[str, Path],
     *,
     verbose: bool = False,
-    save: bool = True,
+    save: Optional[bool] = None,
     lock_schema: bool = False,
     storage: str = "default",
     path: Optional[str] = None,
@@ -980,27 +980,45 @@ def from_blueprint(
         graph = kglite.from_blueprint("blueprint.json", verbose=True)
         # All warnings now in blueprint.log instead of stderr.
 
+    **Where the graph is saved.** A build has a save destination when the
+    blueprint declares ``settings.output`` (or ``output_path`` +
+    ``output_file``), or when ``storage="disk"`` was given a ``path`` — in
+    disk mode the directory *is* the graph, and the build alone leaves it
+    unpublished, so that directory is what saving means. ``save=None``
+    (the default) saves when a destination exists and skips otherwise;
+    ``save=True`` demands one and raises if there is none, so an explicit
+    request to persist never silently does nothing; ``save=False`` never
+    saves.
+
     Args:
         blueprint_path: Path to the blueprint JSON file.
         verbose: If True, print progress information during loading.
-        save: If True and the blueprint specifies an ``output`` path,
-            save the graph to that path after building.
+        save: ``None`` (default) saves if a destination exists, ``True``
+            requires one, ``False`` never saves. See above.
         lock_schema: If True, lock the schema after loading. Cypher
             mutations will be validated against the blueprint's types
             and properties.
+        storage: ``"default"`` (in-memory), ``"mapped"`` (mmap columns),
+            or ``"disk"`` (CSR + mmap). Disk requires ``path``.
+        path: Directory for disk storage (only with ``storage="disk"``).
 
     Returns:
         A new KnowledgeGraph populated from the blueprint.
 
     Raises:
         FileNotFoundError: If the blueprint file is missing.
-        ValueError: If the blueprint JSON is malformed.
+        ValueError: If the blueprint JSON is malformed, or ``save=True``
+            was passed with no destination to write to.
 
     Example::
 
         import kglite
 
         graph = kglite.from_blueprint("blueprint.json", verbose=True)
+
+        # Disk mode: the directory is the graph, and it is published here.
+        g = kglite.from_blueprint("blueprint.json", storage="disk", path="graph/")
+        reopened = kglite.load("graph/")
     """
     ...
 
@@ -1040,7 +1058,10 @@ def from_records(
 
     Args:
         spec: The records spec as a ``dict`` or a JSON string.
-        save: If set, save the built graph to this ``.kgl`` path.
+        save: If set, save the built graph to this ``.kgl`` path. With
+            ``storage="disk"`` pass ``path`` here too — the disk build
+            leaves an unpublished working directory until something calls
+            ``save()``, and ``kglite.load()`` rejects that directory.
         lock_schema: If True, lock the schema after building.
         storage: ``"default"`` (in-memory), ``"mapped"``, or ``"disk"``.
         path: Directory for disk storage (only with ``storage="disk"``).

--- a/kglite/blueprint/__init__.py
+++ b/kglite/blueprint/__init__.py
@@ -8,8 +8,8 @@ Usage::
 
 Implemented entirely in Rust; see ``src/graph/blueprint/`` and the
 ``from_blueprint_rust`` ``#[pyfunction]`` in ``src/graph/pyapi/blueprint.rs``.
-This module is a ~20-line shim that handles optional save + schema lock
-on top of the Rust build.
+This module is a thin shim that handles optional save + schema lock on
+top of the Rust build.
 """
 
 from __future__ import annotations
@@ -23,11 +23,35 @@ from kglite.kglite import from_blueprint_rust as _from_blueprint_rs
 from kglite.kglite import from_records_rust as _from_records_rs
 
 
+def _save_destination(output_path: Optional[str], storage: str, path: Optional[str]) -> Optional[str]:
+    """Where a built blueprint graph should be written, or None.
+
+    Two destinations, in precedence order:
+
+    1. The blueprint's own ``output`` / ``output_file`` setting, already
+       resolved to an absolute path by the Rust loader.
+    2. ``storage="disk"`` + ``path``. In disk mode the directory *is* the
+       graph, but the build only leaves a working directory there —
+       publication (the ``CURRENT`` marker plus ``disk_graph_meta.json``)
+       happens at ``save()``. Without it the caller is left with a
+       directory that looks like a graph and that ``kglite.load()``
+       rejects, so ``path`` is the destination the flag must mean.
+
+    ``storage="mapped"`` ignores ``path`` (mapped columns spill to
+    anonymous mmap), so it never yields a destination.
+    """
+    if output_path:
+        return output_path
+    if storage == "disk" and path:
+        return path
+    return None
+
+
 def from_blueprint(
     blueprint_path: Union[str, Path],
     *,
     verbose: bool = False,
-    save: bool = True,
+    save: Optional[bool] = None,
     lock_schema: bool = False,
     storage: str = "default",
     path: Optional[str] = None,
@@ -37,13 +61,21 @@ def from_blueprint(
     Args:
         blueprint_path: Path to the blueprint JSON file.
         verbose: Print a summary line after the build.
-        save: If True and the blueprint has an ``output_file`` key, save
-            the built graph to that path.
+        save: Whether to persist the built graph. ``None`` (the default)
+            saves when a destination exists and skips otherwise; ``True``
+            requires one and raises ``ValueError`` if there is none;
+            ``False`` never saves. The destination is the blueprint's
+            ``output`` / ``output_file`` setting, or — with
+            ``storage="disk"`` — ``path``.
         lock_schema: If True, lock the schema so subsequent Cypher
             mutations are validated against the blueprint types.
         storage: ``"default"`` (in-memory), ``"mapped"`` (mmap columns),
             or ``"disk"`` (CSR + mmap). Disk requires ``path``.
         path: Directory for disk storage (only used with ``storage="disk"``).
+
+    Raises:
+        ValueError: If ``save=True`` was passed explicitly and neither
+            destination exists.
     """
     if verbose:
         print(f"Loading blueprint from {blueprint_path}...")
@@ -57,10 +89,21 @@ def from_blueprint(
         counts = graph.node_type_counts()
         for node_type, n in sorted(counts.items()):
             print(f"  {node_type}: {n} nodes")
-    if save and output_path:
-        out = Path(output_path)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        graph.save(str(out))
+    if save is not False:
+        destination = _save_destination(output_path, storage, path)
+        if destination is not None:
+            out = Path(destination)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            graph.save(str(out))
+        elif save:
+            raise ValueError(
+                "from_blueprint(save=True) has nowhere to write the graph: the "
+                "blueprint declares no 'output' / 'output_file' setting, and this "
+                "is not a storage='disk' build with a path. Add \"output\": "
+                '"graph.kgl" to the blueprint\'s settings, or pass '
+                "storage='disk', path='graph_dir/'. Omit save entirely to build "
+                "without persisting."
+            )
     if lock_schema:
         graph.lock_schema()
     return graph
@@ -100,7 +143,10 @@ def from_records(
               ]
             }
 
-        save: If set, save the built graph to this ``.kgl`` path.
+        save: If set, save the built graph to this ``.kgl`` path. With
+            ``storage="disk"`` pass ``path`` here too: the disk build
+            leaves an unpublished working directory until something calls
+            ``save()``, and ``kglite.load()`` rejects that directory.
         lock_schema: If True, lock the schema after building.
         storage: ``"default"`` (in-memory), ``"mapped"``, or ``"disk"``.
         path: Directory for disk storage (only used with ``storage="disk"``).

--- a/tests/api-baselines/python-api.json
+++ b/tests/api-baselines/python-api.json
@@ -1481,7 +1481,7 @@
     },
     "from_blueprint": {
       "kind": "function",
-      "signature": "(blueprint_path: 'Union[str, Path]', *, verbose: 'bool' = False, save: 'bool' = True, lock_schema: 'bool' = False, storage: 'str' = 'default', path: 'Optional[str]' = None) -> 'KnowledgeGraph'"
+      "signature": "(blueprint_path: 'Union[str, Path]', *, verbose: 'bool' = False, save: 'Optional[bool]' = None, lock_schema: 'bool' = False, storage: 'str' = 'default', path: 'Optional[str]' = None) -> 'KnowledgeGraph'"
     },
     "from_bytes": {
       "kind": "function",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -518,6 +518,63 @@ class TestSaveOutput:
         from_blueprint(bp_path, save=False)
         assert not (tmp_path / "output" / "graph.kgl").exists()
 
+    def test_save_defaults_to_on_when_blueprint_declares_output(self, tmp_path):
+        """The default (``save`` omitted) still honours ``settings.output``."""
+        bp_path = _minimal_blueprint(tmp_path)
+        with open(bp_path, encoding="utf-8") as f:
+            bp = json.load(f)
+        bp["settings"]["output"] = "output/graph.kgl"
+        _write_blueprint(bp_path, bp)
+
+        from_blueprint(bp_path)
+        assert (tmp_path / "output" / "graph.kgl").exists()
+
+    def test_disk_mode_publishes_the_path_directory(self, tmp_path):
+        """``storage="disk"`` + ``path`` is a save destination.
+
+        The build leaves a working directory; publication happens at
+        ``save()``. Before this was wired up the directory held only
+        ``.kglite.lock`` / ``.working-*`` / a partial ``seg_000/`` and
+        ``kglite.load()`` rejected it.
+        """
+        bp_path = _minimal_blueprint(tmp_path)
+        out = tmp_path / "disk-graph"
+
+        from_blueprint(bp_path, storage="disk", path=str(out))
+
+        assert (out / "CURRENT").exists(), sorted(p.name for p in out.iterdir())
+        reopened = kglite.load(str(out))
+        result = reopened.cypher("MATCH (p:Person) RETURN count(p) AS n")
+        assert result[0]["n"] == 3
+
+    def test_disk_mode_save_false_leaves_it_unpublished(self, tmp_path):
+        """``save=False`` still means "do not write" — in disk mode too."""
+        bp_path = _minimal_blueprint(tmp_path)
+        out = tmp_path / "disk-graph"
+
+        from_blueprint(bp_path, save=False, storage="disk", path=str(out))
+
+        assert not (out / "CURRENT").exists()
+        with pytest.raises(Exception):
+            kglite.load(str(out))
+
+    def test_explicit_save_without_destination_raises(self, tmp_path):
+        """An explicit ``save=True`` that cannot be honoured must not pass."""
+        bp_path = _minimal_blueprint(tmp_path)
+
+        with pytest.raises(ValueError, match="nowhere to write"):
+            from_blueprint(bp_path, save=True)
+
+    def test_default_without_destination_builds_in_memory(self, tmp_path):
+        """The default is "save if there is somewhere to save" — not an error."""
+        bp_path = _minimal_blueprint(tmp_path)
+        before = sorted(p.name for p in tmp_path.iterdir())
+
+        graph = from_blueprint(bp_path)
+
+        assert graph.cypher("MATCH (p:Person) RETURN count(p) AS n")[0]["n"] == 3
+        assert sorted(p.name for p in tmp_path.iterdir()) == before
+
 
 class TestErrorHandling:
     def test_missing_blueprint_file(self):


### PR DESCRIPTION
`save: bool = True` was gated on `if save and output_path`, and `output_path` is `None` unless the blueprint carries `output`/`output_file`. So the **default** was a boolean claim that was false — the flag said "yes, save" and did nothing.

Found independently from two directions the same day. Engine-side: with `storage="disk"` and a `path=`, the no-op leaves a directory holding `.kglite.lock`, `.working-<pid>-<n>/` and `seg_000/*.bin` — it *looks* like a graph but `kglite.load()` rejects it. Consumer-side: kglite-datasets' disk cache had **never committed anything**, so fixing its cache probe alone would have found nothing to find.

## The fix makes the default honest rather than picking between silence and a warning

`save: bool = True` → `save: Optional[bool] = None`, with a `_save_destination()` helper: the blueprint's resolved `output`/`output_file`, else `path` when `storage="disk"`, else `None`.

| call | behaviour |
|---|---|
| `save=None` (default) | save if a destination exists, build in memory if not |
| `save=True` explicit, no destination | **`ValueError`** naming both ways to give it one |
| `save=False` | unchanged |
| destination present | unchanged — blueprint `output` still wins over disk `path` |

The default is no longer a boolean that is false; it is a stated conditional, so nothing defaults to doing nothing.

**Raise rather than warn on explicit `True`**, for two reasons: `KnowledgeGraph.save()` already raises `ValueError` for exactly this condition, so the two now agree; and the failure mode being fixed *is* silence — a `UserWarning` inside a library pipeline is close to the same thing, which is how a downstream disk cache ran for months on a warning-free no-op. Blast radius is only callers who explicitly typed `save=True`, and for the largest such case (`storage="disk"`) it now works instead of raising.

## Non-vacuity

Two of five new tests fail against unmodified `main`:
- `test_disk_mode_publishes_the_path_directory` → `AssertionError: ['.kglite.lock', 'seg_000']` — the reported symptom, exactly.
- `test_explicit_save_without_destination_raises` → `DID NOT RAISE ValueError`.

The other three assert behaviour the scope guard says must *not* change, so they pass pre-fix by design — each was proven to detect a break by mutating the fix (`if save is not False:` → `if True:` / → `if save:`, `elif save:` → `elif save is None or save:`, dropping the disk branch), with the failing test recorded per mutation.

## Verification

`cargo test -p kglite` 1338; `make gate`, `make source-quality`, clippy `-D warnings`, `cargo fmt --check` replayed per-commit via `rebase --exec`. Python 59 passed. Because `.pyi` and `docs/` changed, the surface-conditional extras ran too: `sphinx-build -W --keep-going` clean and `mypy.stubtest` reports no issues.

**The CHANGELOG hygiene lint added earlier today caught a real mistake in this very PR** — the first insert swallowed the `## [0.15.1]` heading, merging that release's sections into `[Unreleased]`.

## Found, deliberately not fixed

`from_records(storage="disk", path=out)` has the same trap, but its `save` is an `Optional[str]` **path**, not a flag — it makes no false promise, and omitting it is the only way to say "don't save". Auto-publishing would remove that opt-out. Documented in its docstring and `.pyi` instead; fixing it properly needs the same tri-state treatment and is a separate API decision.