### PR TITLE
fix: suggest only genuinely-close names, and warn on typos inside subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Did you mean?" suggested names that were not close.** The edit-distance
+  threshold behind every suggestion — unknown node label, unknown relationship
+  type, unknown property, and the mutation-path validators — was
+  `input.len().clamp(2, 4)`, so a four-character name admitted a distance of 4
+  and matched very nearly any word of similar length. Scored over 66 cases
+  drawn from kglite's own vocabularies, that rule produced 18 confidently
+  wrong suggestions, among them `Isue` → `Paper` against a `{Person, Paper}`
+  schema, `Line` → `File`, and `WROTE` → `KNOWS`. A confidently wrong
+  suggestion is worse than none: it names a real but irrelevant thing the
+  reader may act on. The threshold is now rustc's `max(len, 3) / 3` over
+  character count, and the distance is Damerau–Levenshtein, so an adjacent
+  transposition (`Persno`) costs one edit rather than two — swapped letters
+  are among the most common real typos, and charging them double forced any
+  threshold loose enough to catch them to also admit unrelated words. A
+  case-only typo now gets a suggestion as well (`person` → `Person`), which
+  the old filter discarded because its distance is 0. The
+  `text_edit_distance()` Cypher function is unaffected: it is a user-facing
+  string metric, not a typo heuristic.
+
+- **A typo'd label or relationship type inside a subquery produced no
+  warning.** kglite warns non-fatally — on stderr and in `result.diagnostics`
+  — when a read pattern names a node label or relationship type the graph has
+  never seen, the most common cause of a silently empty result. The collector
+  walked only top-level `MATCH` / `OPTIONAL MATCH`, so the identical typo
+  inside `CALL { }`, `WHERE EXISTS { }` or a `UNION` branch said nothing, and
+  the shape of the query decided whether you were told. The warning and the
+  locked-schema check now reach patterns through a single traversal, so every
+  place a read pattern can appear is covered by both and a newly-covered form
+  lands on both at once. Nothing became an error, and write patterns
+  (`CREATE`, `MERGE`) are still never warned about — on an open schema that
+  is how a node type comes into existence.
+
 ## [0.15.1] - 2026-07-27
 
 

--- a/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/schema_check.rs
@@ -55,6 +55,13 @@
 //! the same messages into `QueryDiagnostics` so MCP/agent callers see them
 //! structurally is the natural next step.
 //!
+//! Both surfaces — the fatal check and these warnings — reach patterns through
+//! the single traversal in [`walk_query_patterns`], so a typo warns wherever a
+//! read pattern can appear (`CALL {}` bodies, `WHERE EXISTS {}`, `UNION`
+//! branches) rather than only at the top level. The one exception is
+//! [`absent_property_warnings`], which needs a var → label map and so stays
+//! top-level-only for want of a scope model.
+//!
 //! ## Pipeline placement
 //!
 //! Called by three downstream Cypher consumers after `parse_cypher` and
@@ -70,6 +77,7 @@ use crate::graph::core::pattern_matching::{Pattern, PatternElement};
 use crate::graph::mutation::validation::did_you_mean;
 use crate::graph::schema::{DirGraph, InternedKey};
 use std::collections::{HashMap, HashSet};
+use std::convert::Infallible;
 
 /// Built-in fields valid on any node type — mirrors BUILTIN_FIELDS in
 /// `mutation/validation.rs`. Listed explicitly so it's obvious what's
@@ -117,8 +125,7 @@ pub fn validate_schema(query: &CypherQuery, graph: &DirGraph) -> Result<(), Sche
         return Ok(());
     }
 
-    let mut var_types: HashMap<String, String> = HashMap::new();
-    validate_query(query, graph, &mut var_types)
+    validate_query(query, graph)
 }
 
 fn undefined_variable(name: &str) -> SchemaError {
@@ -912,53 +919,56 @@ pub fn collect_unknown_pattern_warnings(query: &CypherQuery, graph: &DirGraph) -
         return Vec::new();
     }
 
-    // Walk MATCH / OPTIONAL MATCH patterns, checking each label/relationship
-    // against the schema directly. The all-valid path (the overwhelming common
-    // case) allocates nothing — only confirmed-unknown, not-yet-seen names are
+    // Walk every read pattern — top-level MATCH / OPTIONAL MATCH *and* the
+    // ones nested in `CALL {}`, `WHERE EXISTS {}` and `UNION` branches (see
+    // [`walk_query_patterns`]) — checking each label/relationship against the
+    // schema directly. The all-valid path (the overwhelming common case)
+    // allocates nothing: only confirmed-unknown, not-yet-seen names are
     // recorded, and the candidate lists for "did you mean?" are built lazily
     // only if there's at least one unknown.
     let mut seen: HashSet<String> = HashSet::new();
     let mut unknown_labels: Vec<String> = Vec::new();
     let mut unknown_rels: Vec<String> = Vec::new();
 
-    for clause in &query.clauses {
-        if let Clause::Match(m) | Clause::OptionalMatch(m) = clause {
-            for pattern in &m.patterns {
-                for element in &pattern.elements {
-                    match element {
-                        PatternElement::Node(np) if have_node_schema => {
-                            for label in np.node_type.iter().chain(np.extra_labels.iter()) {
-                                // A label is known if it's a declared primary
-                                // type OR a secondary label applied via
-                                // add_label (`MATCH (n:Reviewer)` is valid even
-                                // though `Reviewer` is no node's primary type).
-                                let known = graph.node_type_metadata.contains_key(label)
-                                    || graph.type_indices.contains_key(label)
-                                    || graph
-                                        .secondary_label_index
-                                        .contains_key(&InternedKey::from_str(label));
-                                if !known && seen.insert(format!("L:{label}")) {
-                                    unknown_labels.push(label.clone());
-                                }
-                            }
+    for_each_query_pattern(query, &mut |site| {
+        // Write patterns are deliberately skipped: on an open schema
+        // `CREATE (n:NewType)` is how a type comes into existence.
+        let PatternSite::Read(pattern) = site else {
+            return;
+        };
+        for element in &pattern.elements {
+            match element {
+                PatternElement::Node(np) if have_node_schema => {
+                    for label in np.node_type.iter().chain(np.extra_labels.iter()) {
+                        // A label is known if it's a declared primary
+                        // type OR a secondary label applied via
+                        // add_label (`MATCH (n:Reviewer)` is valid even
+                        // though `Reviewer` is no node's primary type).
+                        let known = graph.node_type_metadata.contains_key(label)
+                            || graph.type_indices.contains_key(label)
+                            || graph
+                                .secondary_label_index
+                                .contains_key(&InternedKey::from_str(label));
+                        if !known && seen.insert(format!("L:{label}")) {
+                            unknown_labels.push(label.clone());
                         }
-                        PatternElement::Edge(ep) if have_edge_schema => {
-                            let single = ep.connection_type.iter();
-                            let multi = ep.connection_types.iter().flatten();
-                            for rel in single.chain(multi) {
-                                if !graph.connection_type_metadata.contains_key(rel)
-                                    && seen.insert(format!("R:{rel}"))
-                                {
-                                    unknown_rels.push(rel.clone());
-                                }
-                            }
-                        }
-                        _ => {}
                     }
                 }
+                PatternElement::Edge(ep) if have_edge_schema => {
+                    let single = ep.connection_type.iter();
+                    let multi = ep.connection_types.iter().flatten();
+                    for rel in single.chain(multi) {
+                        if !graph.connection_type_metadata.contains_key(rel)
+                            && seen.insert(format!("R:{rel}"))
+                        {
+                            unknown_rels.push(rel.clone());
+                        }
+                    }
+                }
+                _ => {}
             }
         }
-    }
+    });
 
     // Seed with the absent-property warnings (A1b) so they're emitted alongside
     // the unknown-label/rel ones even when the labels/rels are all valid.
@@ -1009,100 +1019,142 @@ pub fn warn_unknown_pattern_refs(query: &CypherQuery, graph: &DirGraph) {
     }
 }
 
-fn validate_query(
+fn validate_query(query: &CypherQuery, graph: &DirGraph) -> Result<(), SchemaError> {
+    walk_query_patterns(query, &mut |site| match site {
+        PatternSite::Read(pattern) => validate_pattern(pattern, graph),
+        PatternSite::Write(pattern) => validate_create_pattern(pattern, graph),
+    })
+}
+
+/// A pattern the shared traversal hands to its visitor.
+///
+/// Read and write patterns are kept apart because the two consumers treat them
+/// differently: [`validate_schema`] checks pattern-literal property names in
+/// both, while [`collect_unknown_pattern_warnings`] must stay silent on writes
+/// — `CREATE (n:NewType)` on an open schema is how a type comes into
+/// existence, not a typo.
+enum PatternSite<'q> {
+    Read(&'q Pattern),
+    Write(&'q CreatePattern),
+}
+
+/// The one traversal that answers "where can a pattern appear in a query?".
+///
+/// Both schema surfaces route through it — [`validate_schema`] (fatal, locked
+/// schemas) and [`collect_unknown_pattern_warnings`] (non-fatal, open
+/// schemas) — and that is the point. The warning collector used to walk
+/// top-level `MATCH` / `OPTIONAL MATCH` itself, so a typo'd label inside
+/// `CALL {}`, `WHERE EXISTS {}` or a `UNION` branch produced no warning while
+/// the identical typo at top level did: exactly the incomplete-coverage bug
+/// the fatal path had already been extended to fix. Two walkers drift; there
+/// is now one, and a newly-covered nesting form lands on both surfaces at
+/// once.
+///
+/// Covers, recursively so nesting composes: `MATCH` / `OPTIONAL MATCH`,
+/// `EXISTS {}` at any `AND` / `OR` / `XOR` / `NOT` depth inside a `WHERE`
+/// (standalone or attached to a `WITH`), `CALL {}` bodies, `UNION` branches,
+/// and `CREATE` / `MERGE` write patterns.
+///
+/// Not covered — equally for both consumers, which is what keeps them in
+/// step: `COUNT {}` subqueries and `EXISTS {}` in expression position (both
+/// reach patterns through [`Expression`] rather than [`Predicate`]), and
+/// update clauses inside `FOREACH`.
+fn walk_query_patterns<E>(
     query: &CypherQuery,
-    graph: &DirGraph,
-    var_types: &mut HashMap<String, String>,
-) -> Result<(), SchemaError> {
+    visit: &mut impl FnMut(PatternSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
     for clause in &query.clauses {
-        validate_clause(clause, graph, var_types)?;
+        walk_clause_patterns(clause, visit)?;
     }
     Ok(())
 }
 
-fn validate_clause(
+fn walk_clause_patterns<E>(
     clause: &Clause,
-    graph: &DirGraph,
-    var_types: &mut HashMap<String, String>,
-) -> Result<(), SchemaError> {
+    visit: &mut impl FnMut(PatternSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
     match clause {
         Clause::Match(m) | Clause::OptionalMatch(m) => {
             for pattern in &m.patterns {
-                validate_pattern(pattern, graph, var_types)?;
+                visit(PatternSite::Read(pattern))?;
             }
         }
-        Clause::Where(w) => {
-            walk_predicate_for_nested_patterns(&w.predicate, graph, var_types)?;
-        }
+        Clause::Where(w) => walk_predicate_patterns(&w.predicate, visit)?,
         Clause::With(w) => {
-            for item in &w.items {
-                if let Some(alias) = &item.alias {
-                    var_types.remove(alias);
-                }
-            }
             if let Some(wc) = &w.where_clause {
-                walk_predicate_for_nested_patterns(&wc.predicate, graph, var_types)?;
+                walk_predicate_patterns(&wc.predicate, visit)?;
             }
         }
-        Clause::Union(u) => {
-            let mut inner_vars: HashMap<String, String> = HashMap::new();
-            validate_query(&u.query, graph, &mut inner_vars)?;
-        }
-        Clause::CallSubquery { import, body } => {
-            // Recurse into the body so pattern-literal property typos inside
-            // `CALL { MATCH (n:T {prp: v}) ... }` get the same "did you
-            // mean?" treatment as top-level patterns (mirrors the Union /
-            // EXISTS recursion).
-            //
-            // Imported variables are EXTERNALLY bound: the leading importing
-            // `WITH` was stripped at parse time, so the body re-binds them
-            // from the outer scope. Seed the body's `var_types` with the
-            // imported names' outer types so a body pattern that re-anchors
-            // on an import (`CALL { WITH p MATCH (p {prp: v}) }`) validates
-            // against the import's real type. Non-imported body variables
-            // start fresh (§1.2 rule 1 — a bare body name is a new variable).
-            let mut inner_vars: HashMap<String, String> = HashMap::new();
-            for name in import {
-                if let Some(ty) = var_types.get(name) {
-                    inner_vars.insert(name.clone(), ty.clone());
-                }
-            }
-            validate_query(body, graph, &mut inner_vars)?;
-        }
-        // LOAD CSV binds an untyped map/list, so there is no node type to
-        // validate properties against — same as UNWIND.
-        Clause::Return(_) | Clause::OrderBy(_) | Clause::Unwind(_) | Clause::LoadCsv(_) => {}
+        Clause::Union(u) => walk_query_patterns(&u.query, visit)?,
+        // The importing `WITH` was stripped at parse time, so the body is a
+        // self-contained sub-pipeline: recurse into it as into a UNION branch.
+        Clause::CallSubquery { body, .. } => walk_query_patterns(body, visit)?,
         Clause::Create(c) => {
             for pattern in &c.patterns {
-                validate_create_pattern(pattern, graph, var_types)?;
+                visit(PatternSite::Write(pattern))?;
             }
         }
-        Clause::Merge(m) => {
-            validate_create_pattern(&m.pattern, graph, var_types)?;
-            // MERGE's `ON CREATE SET` / `ON MATCH SET` use `SetItem`,
-            // which we intentionally skip — see the module doc-comment.
-        }
-        Clause::Set(_) | Clause::Delete(_) | Clause::Remove(_) | Clause::Call(_) => {}
+        // MERGE's `ON CREATE SET` / `ON MATCH SET` use `SetItem`, which the
+        // schema check intentionally skips — see the module doc-comment.
+        Clause::Merge(m) => visit(PatternSite::Write(&m.pattern))?,
+        // LOAD CSV binds an untyped map/list, so it carries no pattern —
+        // same as UNWIND.
         _ => {}
     }
     Ok(())
+}
+
+/// Descend a predicate to the `EXISTS { ... }` patterns nested inside it.
+fn walk_predicate_patterns<E>(
+    predicate: &Predicate,
+    visit: &mut impl FnMut(PatternSite<'_>) -> Result<(), E>,
+) -> Result<(), E> {
+    match predicate {
+        Predicate::And(a, b) | Predicate::Or(a, b) | Predicate::Xor(a, b) => {
+            walk_predicate_patterns(a, visit)?;
+            walk_predicate_patterns(b, visit)?;
+        }
+        Predicate::Not(p) => walk_predicate_patterns(p, visit)?,
+        Predicate::Exists {
+            patterns,
+            where_clause,
+            ..
+        } => {
+            for pattern in patterns {
+                visit(PatternSite::Read(pattern))?;
+            }
+            if let Some(w) = where_clause {
+                walk_predicate_patterns(w, visit)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Infallible companion to [`walk_query_patterns`] for visitors that only
+/// collect — the warning path never rejects, so it should not have to spell
+/// out an error type it cannot produce.
+fn for_each_query_pattern(query: &CypherQuery, visit: &mut impl FnMut(PatternSite<'_>)) {
+    let outcome = walk_query_patterns(query, &mut |site| -> Result<(), Infallible> {
+        visit(site);
+        Ok(())
+    });
+    match outcome {
+        Ok(()) => {}
+        // `Infallible` is uninhabited — this arm cannot be constructed.
+        Err(never) => match never {},
+    }
 }
 
 /// Validate a CREATE / MERGE pattern's node-pattern property names
 /// against the schema. Edge-pattern properties aren't validated —
 /// `connection_type_metadata` is keyed differently and edge schemas
 /// in kglite are looser; revisit if a real divergence shows up.
-fn validate_create_pattern(
-    pattern: &CreatePattern,
-    graph: &DirGraph,
-    var_types: &mut HashMap<String, String>,
-) -> Result<(), SchemaError> {
+fn validate_create_pattern(pattern: &CreatePattern, graph: &DirGraph) -> Result<(), SchemaError> {
     for element in &pattern.elements {
         if let CreateElement::Node(np) = element {
             if let Some(ref node_type) = np.label {
-                if let Some(ref var) = np.variable {
-                    var_types.insert(var.clone(), node_type.clone());
-                }
                 for (prop_name, _expr) in &np.properties {
                     validate_property(node_type, prop_name, graph)?;
                 }
@@ -1112,11 +1164,13 @@ fn validate_create_pattern(
     Ok(())
 }
 
-fn validate_pattern(
-    pattern: &Pattern,
-    graph: &DirGraph,
-    var_types: &mut HashMap<String, String>,
-) -> Result<(), SchemaError> {
+/// Validate a read pattern's labels (locked schemas only) and its
+/// pattern-literal property names.
+///
+/// A node pattern carrying no explicit label is skipped entirely: property
+/// validation needs a node type, and kglite does not infer one from an outer
+/// binding, so `CALL { WITH p MATCH (p {prp: v}) }` is not checked.
+fn validate_pattern(pattern: &Pattern, graph: &DirGraph) -> Result<(), SchemaError> {
     for element in &pattern.elements {
         if let PatternElement::Node(np) = element {
             // Label check first: on a locked schema an unknown label is a
@@ -1130,9 +1184,6 @@ fn validate_pattern(
                 }
             }
             if let Some(ref node_type) = np.node_type {
-                if let Some(ref var) = np.variable {
-                    var_types.insert(var.clone(), node_type.clone());
-                }
                 if let Some(ref props) = np.properties {
                     for prop_name in props.keys() {
                         validate_property(node_type, prop_name, graph)?;
@@ -1140,39 +1191,6 @@ fn validate_pattern(
                 }
             }
         }
-    }
-    Ok(())
-}
-
-/// Descend the predicate to find nested `EXISTS { MATCH ... }` patterns
-/// so their pattern-literal properties get validated too. Does not check
-/// expression-level property accesses or label checks — those are
-/// delivered as Phase 3 diagnostics instead.
-fn walk_predicate_for_nested_patterns(
-    predicate: &Predicate,
-    graph: &DirGraph,
-    var_types: &HashMap<String, String>,
-) -> Result<(), SchemaError> {
-    match predicate {
-        Predicate::And(a, b) | Predicate::Or(a, b) | Predicate::Xor(a, b) => {
-            walk_predicate_for_nested_patterns(a, graph, var_types)?;
-            walk_predicate_for_nested_patterns(b, graph, var_types)?;
-        }
-        Predicate::Not(p) => walk_predicate_for_nested_patterns(p, graph, var_types)?,
-        Predicate::Exists {
-            patterns,
-            where_clause,
-            ..
-        } => {
-            let mut inner_vars = var_types.clone();
-            for p in patterns {
-                validate_pattern(p, graph, &mut inner_vars)?;
-            }
-            if let Some(w) = where_clause {
-                walk_predicate_for_nested_patterns(w, graph, &inner_vars)?;
-            }
-        }
-        _ => {}
     }
     Ok(())
 }
@@ -1782,5 +1800,147 @@ mod tests {
             err.message,
             "Unknown node type 'Isue'. Did you mean 'Issue'?\n  Valid types: Issue, Paper, Person, Reviewer"
         );
+    }
+
+    // ── Open-schema warnings reach every nested clause ───────────────────
+    //
+    // The counterpart to the locked-schema block above. The warning
+    // collector once walked top-level MATCH / OPTIONAL MATCH only, so the
+    // same typo warned at top level and said nothing one level down —
+    // precisely the asymmetry the locked path had already been fixed for.
+    // Both now share [`walk_query_patterns`], so each clause form gets a
+    // case here and stays covered.
+
+    /// Open (unlocked) schema with an `Issue` type, so `Isue` has a real
+    /// near-miss to suggest — the locked block's scenario, unlocked.
+    fn open_graph_with_issue() -> DirGraph {
+        let mut g = graph_with_schema();
+        let mut issue_props = HashMap::new();
+        issue_props.insert("status".to_string(), "string".to_string());
+        g.upsert_node_type_metadata("Issue", issue_props);
+        assert!(!g.schema_locked, "this block is about the open-schema path");
+        g
+    }
+
+    /// Exactly one warning, naming the typo'd label and suggesting the real
+    /// one — and still no error, because a zero-row read stays legal.
+    fn assert_warns_isue(query: &str) {
+        let g = open_graph_with_issue();
+        let q = parse_cypher(query).unwrap();
+        let warnings = collect_unknown_pattern_warnings(&q, &g);
+        assert_eq!(warnings.len(), 1, "for `{query}`, got: {warnings:?}");
+        assert_eq!(
+            warnings[0],
+            "MATCH references unknown node label 'Isue' — the graph has no such type, so this \
+             pattern returns no rows. Did you mean 'Issue'?",
+            "for `{query}`"
+        );
+        assert!(
+            validate_schema(&q, &g).is_ok(),
+            "warning must stay non-fatal on an open schema: `{query}`"
+        );
+    }
+
+    #[test]
+    fn warns_unknown_label_in_top_level_match() {
+        // Control: the surface that already worked must keep working, with
+        // the identical message the nested cases assert.
+        assert_warns_isue("MATCH (i:Isue) RETURN i");
+        assert_warns_isue("MATCH (p:Person) OPTIONAL MATCH (i:Isue) RETURN p, i");
+    }
+
+    #[test]
+    fn warns_unknown_label_in_call_subquery() {
+        assert_warns_isue("CALL { MATCH (i:Isue) RETURN i } RETURN i");
+    }
+
+    #[test]
+    fn warns_unknown_label_in_where_exists() {
+        assert_warns_isue("MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p");
+        // …and behind boolean nesting, which the predicate walk descends.
+        assert_warns_isue(
+            "MATCH (p:Person) WHERE p.age > 1 AND NOT EXISTS { MATCH (i:Isue) } RETURN p",
+        );
+        // …and on a WITH's WHERE, not just a standalone one.
+        assert_warns_isue("MATCH (p:Person) WITH p WHERE EXISTS { MATCH (i:Isue) } RETURN p");
+    }
+
+    #[test]
+    fn warns_unknown_label_in_union_branch() {
+        assert_warns_isue("MATCH (p:Person) RETURN p UNION MATCH (i:Isue) RETURN i");
+    }
+
+    #[test]
+    fn warns_unknown_label_nested_two_deep() {
+        // Nesting composes: an EXISTS inside a CALL body is reached by the
+        // same recursion, so no clause form needs its own special case.
+        assert_warns_isue(
+            "CALL { MATCH (p:Person) WHERE EXISTS { MATCH (i:Isue) } RETURN p } RETURN p",
+        );
+    }
+
+    #[test]
+    fn warns_unknown_relationship_type_in_nested_clauses() {
+        // The relationship half of the same walk — one warning per query,
+        // wherever the pattern sits.
+        let g = open_graph_with_issue();
+        for query in [
+            "CALL { MATCH (a:Person)-[:KNOWZ]->(b:Person) RETURN a } RETURN a",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (a:Person)-[:KNOWZ]->(b:Person) } RETURN p",
+            "MATCH (p:Person) RETURN p UNION MATCH (a:Person)-[:KNOWZ]->(b:Person) RETURN a",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            let warnings = collect_unknown_pattern_warnings(&q, &g);
+            assert_eq!(warnings.len(), 1, "for `{query}`, got: {warnings:?}");
+            assert!(
+                warnings[0].contains("unknown relationship type 'KNOWZ'")
+                    && warnings[0].contains("Did you mean 'KNOWS'?"),
+                "for `{query}`, got: {}",
+                warnings[0]
+            );
+        }
+    }
+
+    #[test]
+    fn no_warning_for_known_labels_in_nested_clauses() {
+        // The other half of the coverage: descending must not invent
+        // warnings for valid nested patterns.
+        let g = open_graph_with_issue();
+        for query in [
+            "CALL { MATCH (i:Issue) RETURN i } RETURN i",
+            "MATCH (p:Person) WHERE EXISTS { MATCH (i:Issue) } RETURN p",
+            "MATCH (p:Person) RETURN p UNION MATCH (i:Issue) RETURN i",
+            "CALL { MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a } RETURN a",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                collect_unknown_pattern_warnings(&q, &g).is_empty(),
+                "spurious warning for `{query}`: {:?}",
+                collect_unknown_pattern_warnings(&q, &g)
+            );
+        }
+    }
+
+    #[test]
+    fn no_warning_for_new_label_in_nested_write() {
+        // Write patterns are how a type comes into existence on an open
+        // schema — warning "the graph has no such type" for a CREATE would
+        // be wrong. The shared walk visits them (the fatal check needs their
+        // property names), so the warning collector must skip them by kind.
+        // (A write inside `CALL { }` is rejected by the parser, so top-level
+        // CREATE / MERGE are the reachable cases.)
+        let g = open_graph_with_issue();
+        for query in [
+            "CREATE (i:Ticket {title: 'x'})",
+            "MERGE (i:Ticket {title: 'x'})",
+            "MATCH (p:Person) MERGE (p)-[:KNOWZ]->(t:Ticket {title: 'x'})",
+        ] {
+            let q = parse_cypher(query).unwrap();
+            assert!(
+                collect_unknown_pattern_warnings(&q, &g).is_empty(),
+                "write pattern wrongly warned for `{query}`: {:?}",
+                collect_unknown_pattern_warnings(&q, &g)
+            );
+        }
     }
 }

--- a/crates/kglite/src/graph/mutation/validation.rs
+++ b/crates/kglite/src/graph/mutation/validation.rs
@@ -264,37 +264,90 @@ pub fn get_value_type_name(value: &Value) -> String {
 }
 
 // ============================================================================
-// Edit distance (Levenshtein) for "did you mean?" suggestions
+// Edit distance for "did you mean?" suggestions
 // ============================================================================
 
-/// Compute Levenshtein edit distance between two strings (case-insensitive).
+/// Damerau–Levenshtein edit distance (optimal string alignment), computed
+/// case-insensitively.
+///
+/// Transpositions cost **one** edit, not two. Swapped adjacent letters
+/// (`Papre`/`Paper`, `Fucntion`/`Function`) are among the most common real
+/// typos, and plain Levenshtein charges them the same as two unrelated
+/// substitutions — which forces any threshold loose enough to catch them to
+/// also admit genuinely different words. Charging a swap 1 is what lets
+/// [`did_you_mean`] run a threshold tight enough to stay silent on an
+/// unrelated name.
+///
+/// Not to be confused with the `text_edit_distance()` Cypher function, which
+/// is plain, case-*sensitive* Levenshtein (`executor::helpers::levenshtein`)
+/// because it is a user-facing string metric rather than a typo heuristic.
 pub fn edit_distance(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().flat_map(|c| c.to_lowercase()).collect();
     let b: Vec<char> = b.chars().flat_map(|c| c.to_lowercase()).collect();
     let (m, n) = (a.len(), b.len());
+    // A transposition reads the row *before* the previous one, so three rows
+    // rotate here instead of two.
+    let mut prev2 = vec![0usize; n + 1];
     let mut prev = (0..=n).collect::<Vec<_>>();
-    let mut curr = vec![0; n + 1];
+    let mut curr = vec![0usize; n + 1];
     for i in 1..=m {
         curr[0] = i;
         for j in 1..=n {
             let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
-            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+            let mut best = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                best = best.min(prev2[j - 2] + cost);
+            }
+            curr[j] = best;
         }
+        // prev2 ← row i-1, then prev ← row i.
+        std::mem::swap(&mut prev2, &mut prev);
         std::mem::swap(&mut prev, &mut curr);
     }
     prev[n]
 }
 
-/// Format a "did you mean 'X'?" suffix, or empty string if no close match.
+/// Maximum edit distance at which `input` still counts as a typo of a
+/// candidate: `max(len, 3) / 3` over the input's **character** count.
+///
+/// The rule is rustc's (`rustc_span::edit_distance`), and it was picked on
+/// measurement rather than taste. Scored over 66 (typo, vocabulary, expected)
+/// cases drawn from this repo's real vocabularies — the `Person`/`Paper`/
+/// `Issue` schema in `schema_check.rs`, the graph-algorithm config keys in
+/// `call_clause.rs`, and a code-graph node/property schema — it is the only
+/// candidate rule that suggests on every genuine typo *and* stays silent on
+/// every unrelated word.
+///
+/// The rule it replaced, `input.len().clamp(2, 4)`, admitted **4** edits for a
+/// 4-character input, i.e. very nearly any word of similar length: it produced
+/// 18 confidently-wrong suggestions over the same corpus, among them `Isue` →
+/// `Paper` against a `{Person, Paper}` schema, `Line` → `File`, and `WROTE` →
+/// `KNOWS`. A confidently wrong suggestion is worse than none — it sends the
+/// reader to a real but irrelevant name they may then act on — so the bar is
+/// "genuinely close, or silent".
+fn suggestion_threshold(input: &str) -> usize {
+    input.chars().count().max(3) / 3
+}
+
+/// Format a " Did you mean 'X'?" suffix, or an empty string when no candidate
+/// is genuinely close (see [`suggestion_threshold`]).
 pub fn did_you_mean(input: &str, candidates: &[&str]) -> String {
     if candidates.is_empty() {
         return String::new();
     }
-    let threshold = input.len().clamp(2, 4);
+    let threshold = suggestion_threshold(input);
     let mut best: Option<(&str, usize)> = None;
     for &c in candidates {
+        // A candidate spelled exactly like the input is not a suggestion.
+        // Distance 0 with a *differing* spelling is a case-only typo
+        // (`person` → `Person`) — the most useful hint of all, since the
+        // reader cannot see what is wrong — so it must not be discarded
+        // along with it.
+        if c == input {
+            continue;
+        }
         let d = edit_distance(input, c);
-        if d > 0 && d <= threshold && (best.is_none() || d < best.unwrap().1) {
+        if d <= threshold && (best.is_none() || d < best.unwrap().1) {
             best = Some((c, d));
         }
     }
@@ -594,10 +647,108 @@ mod tests {
     }
 
     #[test]
+    fn edit_distance_charges_a_transposition_one_edit() {
+        // The whole reason the metric is Damerau rather than plain
+        // Levenshtein: a swap must not cost the same as two unrelated
+        // substitutions, or the threshold cannot be tight.
+        assert_eq!(edit_distance("Papre", "Paper"), 1);
+        assert_eq!(edit_distance("Fucntion", "Function"), 1);
+        assert_eq!(edit_distance("Isseu", "Issue"), 1);
+        assert_eq!(edit_distance("Pesron", "Person"), 1);
+        // …and a swap of *non*-adjacent letters is still two edits — the
+        // discount is for adjacent transposition only.
+        assert_eq!(edit_distance("ebcda", "abcde"), 2);
+    }
+
+    #[test]
     fn test_did_you_mean() {
         let candidates = vec!["Paper", "Person", "Software", "Grant"];
         assert!(did_you_mean("Papier", &candidates).contains("Paper"));
         assert!(did_you_mean("Persom", &candidates).contains("Person"));
         assert!(did_you_mean("ZZZZZZZZZ", &candidates).is_empty());
+    }
+
+    /// The reported defect, verbatim: `Isue` against a `{Person, Paper}`
+    /// schema used to suggest `Paper` (edit distance 4, admitted because the
+    /// old threshold was `len().clamp(2, 4)` and the input is 4 characters).
+    /// A real-but-irrelevant type is worse than no suggestion.
+    #[test]
+    fn did_you_mean_stays_silent_when_nothing_is_close() {
+        let schema = ["Person", "Paper"];
+        assert_eq!(did_you_mean("Isue", &schema), "");
+        // …and the same input still suggests once the near-miss exists.
+        let with_issue = ["Person", "Paper", "Issue"];
+        assert_eq!(did_you_mean("Isue", &with_issue), " Did you mean 'Issue'?");
+    }
+
+    #[test]
+    fn did_you_mean_rejects_unrelated_words_of_similar_length() {
+        // Every one of these was suggested by the old `clamp(2, 4)` rule.
+        for (input, vocabulary) in [
+            ("Node", &["Person", "Paper"][..]),
+            ("Task", &["Person", "Paper"][..]),
+            ("User", &["Person", "Paper"][..]),
+            ("Repo", &["Person", "Paper"][..]),
+            ("Topic", &["Person", "Paper", "Issue"][..]),
+            ("year", &["age", "email"][..]),
+            ("name", &["age", "email"][..]),
+            ("WROTE", &["KNOWS", "AUTHORED"][..]),
+            ("OWNS", &["KNOWS", "AUTHORED"][..]),
+            ("CITES", &["KNOWS", "AUTHORED"][..]),
+            ("Line", &["File", "Function", "Class", "Module"][..]),
+            ("Field", &["File", "Function", "Class", "Module"][..]),
+            ("bogus_key", &["where", "node_type", "timeout_ms"][..]),
+        ] {
+            assert_eq!(
+                did_you_mean(input, vocabulary),
+                "",
+                "{input:?} should get no suggestion from {vocabulary:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn did_you_mean_still_catches_real_typos() {
+        for (input, vocabulary, expected) in [
+            ("Persn", &["Person", "Paper"][..], "Person"),
+            ("Peson", &["Person", "Paper"][..], "Person"),
+            ("Pape", &["Person", "Paper"][..], "Paper"),
+            // Transpositions — the case plain Levenshtein scores as 2.
+            ("Papre", &["Person", "Paper"][..], "Paper"),
+            ("Preson", &["Person", "Paper"][..], "Person"),
+            ("agee", &["age", "email"][..], "age"),
+            ("emial", &["age", "email"][..], "email"),
+            ("KNOWZ", &["KNOWS", "AUTHORED"][..], "KNOWS"),
+            ("AUTHOR", &["KNOWS", "AUTHORED"][..], "AUTHORED"),
+            // Long identifiers: the threshold scales, so a one-edit slip in a
+            // 14-character config key is still caught.
+            (
+                "connection_typ",
+                &["where", "node_type", "connection_types"][..],
+                "connection_types",
+            ),
+            (
+                "maximum_iterations",
+                &["max_iterations", "tolerance"][..],
+                "max_iterations",
+            ),
+        ] {
+            assert_eq!(
+                did_you_mean(input, vocabulary),
+                format!(" Did you mean '{expected}'?"),
+                "{input:?} against {vocabulary:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn did_you_mean_suggests_on_a_case_only_typo() {
+        // Distance 0 under a case-insensitive metric, but a different
+        // spelling — and the hardest kind of typo to spot unaided.
+        let schema = ["Person", "Paper"];
+        assert_eq!(did_you_mean("person", &schema), " Did you mean 'Person'?");
+        assert_eq!(did_you_mean("PERSON", &schema), " Did you mean 'Person'?");
+        // An identical spelling is never echoed back as a suggestion.
+        assert_eq!(did_you_mean("Person", &schema), "");
     }
 }


### PR DESCRIPTION
Two developer-experience defects, both surfaced deliberately when the locked-schema label check shipped because both cross shared surfaces.

## 1. `did_you_mean` suggested unrelated words

The threshold was `input.len().clamp(2, 4)` — a 4-character input admitted edit distance **4**, i.e. nearly any word of similar length. Scored over 66 (typo, vocabulary, expected) cases drawn from this repo's own vocabularies, that produced **18 confidently-wrong suggestions**: `Isue → Paper` against a `{Person, Paper}` schema, `Line → File`, `WROTE → KNOWS`. A confidently wrong suggestion is worse than none — it names a real-but-irrelevant thing the reader may act on.

Two changes, the first making the second affordable:
- **`edit_distance` is now Damerau–Levenshtein**, so an adjacent transposition costs 1 edit rather than 2. Swapped letters are among the most common real typos; charging them 2 forces any threshold loose enough to catch them to also admit unrelated words.
- **Threshold is rustc's `max(len,3)/3`** over character count — the only candidate in the scoring that fired on every genuine typo and stayed silent on every unrelated one.

Also fixes a case the old filter discarded: `d > 0` rejected distance-0 matches, but distance 0 with a *differing spelling* is `person → Person` — the most useful hint of all, since the reader cannot see what is wrong. Exact spellings are skipped instead.

`text_edit_distance()` the Cypher function is untouched: it is plain case-*sensitive* Levenshtein by design, a user-facing string metric rather than a typo heuristic.

## 2. Typos inside subqueries produced no warning at all

`collect_unknown_pattern_warnings` walked only top-level `MATCH`/`OPTIONAL MATCH`, so on an open schema a typo'd label inside `CALL {}`, `WHERE EXISTS {}`, or a `UNION` branch warned about nothing — while the same typo at top level did.

**Fixed by unifying the traversal rather than adding a second walker.** A new `walk_query_patterns` is the single answer to "where can a pattern appear?", handing each site to a visitor tagged `Read` or `Write`. Both surfaces consume it — the fatal locked-schema check and the non-fatal open-schema warning — so they cannot drift apart again, which is exactly how this gap opened. Write sites are visited but tagged, because the consumers genuinely differ: the fatal check validates CREATE/MERGE property names, while the warning collector skips them, since on an open schema `CREATE (n:NewType)` is how a type comes into existence.

**Enabler:** the fatal path threaded a `var_types` map through every clause that nothing ever read to make a decision — write-only state, and the main reason the two walks looked unmergeable. Removed, with the limitation it nominally existed to lift now documented.

## Verification

**8 new tests, each confirmed non-vacuous by three separate probes.** Replacing the walk with the pre-fix top-level-only version failed exactly the 5 nested-coverage tests and no others, with the top-level control still passing as it must. Treating Write sites as reads failed the write guard; forcing `known = false` failed the known-labels guard.

`cargo test -p kglite` **1346 pass**, replayed per-commit via `rebase --exec` alongside clippy `-D warnings`, `make gate`, `make source-quality`, `cargo fmt --check`. Full-workspace clippy clean on HEAD.

**Differential corpus does not apply, confirmed rather than assumed:** `schema_check` runs pre-planner and is absent from `PASSES`, so it cannot be named in `disabled_passes` — and the corpus compares *row results*, while a warning changes zero rows.

## Found, not fixed

`COUNT {}` and `EXISTS {}` in expression position reach patterns through `Expression` rather than `Predicate`, so both surfaces are equally blind and stay in step; extending it would newly make locked schemas raise. `absent_property_warnings` is still top-level-only — it needs a var→label scope model, and flattening subquery scopes without one would invent false positives. Both documented in place.