### PR TITLE
fix: engine-defect sprint — four stale, three real, three vacuous nets closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure matrix rather than a single shape; before this change no test in the
   suite executed the mapped rollback path at all.
 
+### Fixed
+
+- **WAL replay is now gated on the checkpoint, so a stale log cannot roll a
+  durable graph backwards.** A `.kgl` checkpoint records the highest
+  log-sequence number it already contains, and reopening a `durable=` graph
+  replays only the frames above it. Previously replay started from zero and
+  folded in *every* frame the sidecar held, so a `<graph>-wal` that predated
+  the checkpoint — restored from a backup, carried along in a half-copied
+  graph directory, or otherwise surviving the truncation — would overwrite
+  already-durable properties with their values as of an earlier commit.
+
+  0.15.0 added a log barrier before the checkpoint, which prevents a stale
+  prefix from *arising* under a clean crash; this makes recovery robust to one
+  that arrives any other way. The frame counter also no longer restarts at each
+  checkpoint, so a pre-checkpoint frame can never reuse a live frame's
+  sequence number.
+
+  The stamp is additive and written only by a durable save, so existing `.kgl`
+  files load unchanged (replaying everything, as before) and a graph that was
+  never durable serializes byte-for-byte as it did previously.
+
 ## [0.15.3] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DirGraph::checkpoint_lsn` (Rust API).** Public because the wheel crate sets
+  it across a crate boundary at `save()` and reads it at load to gate WAL
+  replay. Additive: the field defaults to 0, which is the pre-gate
+  replay-everything behaviour, so existing embedders are unaffected.
+
 ### Changed
 
 - **Mapped graphs no longer copy the whole graph before every mutating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Mapped graphs no longer copy the whole graph before every mutating
+  statement.** `MappedGraph` now carries a statement-scoped undo journal, so a
+  mutating statement records inverse operations instead of forking an
+  `O(V + E)` checkpoint. Previously the journal was vetoed for both mapped and
+  disk backends, which since the columnar-journal work was the only remaining
+  veto term — so mapped writes kept paying the pre-journal cost, scaling with
+  graph size in exactly the mode chosen for large graphs.
+
+  The veto's stated reason was wrong for mapped: `MappedGraph` holds the same
+  heap `StableDiGraph` as `MemoryGraph`, so it could always express an inverse
+  edit. **Disk is unchanged and still takes the checkpoint** — it has no
+  petgraph and no stable node identity to restore, so the reason holds there.
+
+  Rollback fidelity on mapped graphs is now covered by the full mid-statement
+  failure matrix rather than a single shape; before this change no test in the
+  suite executed the mapped rollback path at all.
+
 ## [0.15.3] - 2026-07-29
 
 ### Added

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -633,6 +633,27 @@ impl KnowledgeGraph {
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
         }
 
+        // Stamp how far this checkpoint has consumed the log, so a reopen can
+        // *gate* replay instead of trusting the log's extent.
+        //
+        // The barrier above stops a stale prefix from arising under a clean
+        // crash; it cannot make replay robust to one that arises any other way
+        // (an operator restoring an old sidecar from backup, a copied graph
+        // directory, a filesystem that resurrects a truncated file). The gate
+        // is anchored here, in the checkpoint, because the checkpoint is the
+        // only artifact that knows which frames it already contains.
+        //
+        // `next_lsn` is the LSN the *next* frame will carry, so the newest
+        // frame folded into this snapshot is `next_lsn - 1`; a session that has
+        // logged nothing leaves the stamp at 0 (replay everything, unchanged
+        // behaviour). Any ops still sitting in the capture buffer are folded in
+        // by the serialize below and then dropped un-logged, so they consume no
+        // LSN and the arithmetic stays exact.
+        if let Some(ds) = self.lifecycle.durable.as_ref() {
+            let checkpoint_lsn = ds.next_lsn.saturating_sub(1);
+            get_graph_mut(&mut self.inner).checkpoint_lsn = checkpoint_lsn;
+        }
+
         // Mode-aware durable save lives in core (`save_graph_with`): disk dir
         // vs in-memory `.kgl`, columnar consolidation (v3 requires columnar;
         // handles fresh / mixed / mapped), atomic temp+rename, and file +
@@ -658,7 +679,13 @@ impl KnowledgeGraph {
                 ds.wal
                     .reset()
                     .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-                ds.next_lsn = 1;
+                // `next_lsn` deliberately keeps climbing across the truncation.
+                // Restarting it at 1 would make every post-checkpoint frame
+                // reuse LSNs a pre-checkpoint frame already spent, so the
+                // checkpoint stamp above could never distinguish a stale frame
+                // from a fresh one — and, since the stamp is taken as
+                // `next_lsn - 1`, the very next checkpoint would record 0 and
+                // the replay gate would be vacuous.
             }
         }
         Ok(())

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -575,7 +575,14 @@ fn setup_durable(
     // mutations are captured. Replaying before wrapping keeps the replay's
     // own GraphWrite calls out of the capture buffer.
     let dir = crate::graph::get_graph_mut(&mut kg.inner);
-    let max_lsn = kglite_core::api::durable::apply_frames(dir, &frames, 0)
+    // Gate replay on what the checkpoint says it already contains. Frames at or
+    // below this LSN are a **stale prefix** — already folded into the `.kgl` we
+    // just loaded — and folding them again would roll properties back to their
+    // values as of an earlier commit. A graph with no durable history (or a
+    // `.kgl` written before the stamp existed) reports 0, i.e. replay
+    // everything, which is the pre-gate behaviour.
+    let checkpoint_lsn = dir.checkpoint_lsn;
+    let max_lsn = kglite_core::api::durable::apply_frames(dir, &frames, checkpoint_lsn)
         .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)?;
     KnowledgeGraph::wrap_backend_for_durability(dir);
 

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -176,6 +176,25 @@ pub struct DirGraph {
     /// files). Docs: `docs/python/guides/schema-migrations.md`.
     #[serde(default)]
     pub user_schema_version: u32,
+    /// Highest WAL log-sequence number already folded into this graph's last
+    /// checkpoint — the replay gate for a durable session.
+    ///
+    /// A durable `save()` stamps the LSN of the newest logged frame here before
+    /// serializing, so the `.kgl` records *how far* the snapshot has consumed
+    /// the log. On the next durable open, replay skips every frame at or below
+    /// it, which is what makes recovery robust to a **stale WAL prefix** — a log
+    /// whose surviving frames predate the checkpoint. Folding such a prefix over
+    /// a newer snapshot would roll properties back to an earlier commit and
+    /// destroy already-durable data.
+    ///
+    /// `0` = "no checkpoint has consumed the log", which is also what a `.kgl`
+    /// written before this field existed loads as: replay everything, the
+    /// pre-gate behaviour. The counter is monotonic for the life of the log and
+    /// is **not** reset by a checkpoint — a per-checkpoint reset would make
+    /// every stamped value 0 and the gate vacuous, and would let a stale frame
+    /// carry the same LSN as a fresh one.
+    #[serde(default)]
+    pub checkpoint_lsn: u64,
     /// Auto-vacuum threshold: if Some(t), vacuum() is triggered automatically after
     /// DELETE operations when fragmentation_ratio exceeds t and tombstones > 100.
     /// Default: Some(0.3). Set to None to disable.
@@ -524,6 +543,7 @@ impl DirGraph {
             parent_types: HashMap::new(),
             graph_instructions: HashMap::new(),
             user_schema_version: 0,
+            checkpoint_lsn: 0,
             auto_vacuum_threshold: default_auto_vacuum_threshold(),
             spatial_configs: HashMap::new(),
             wkt_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -581,6 +601,7 @@ impl DirGraph {
             parent_types: HashMap::new(),
             graph_instructions: HashMap::new(),
             user_schema_version: 0,
+            checkpoint_lsn: 0,
             auto_vacuum_threshold: default_auto_vacuum_threshold(),
             spatial_configs: HashMap::new(),
             wkt_cache: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/kglite/src/graph/dir_graph/rollback.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback.rs
@@ -201,7 +201,11 @@ fn undo_bucket_append(members: Option<&mut Vec<NodeIndex>>, idx: NodeIndex) {
 ///   worse than the journal plus a per-touched-type unique rebuild, which is
 ///   that field's undo story.
 fn journal_covers(graph: &DirGraph) -> bool {
-    // Only the heap backend can express an inverse petgraph edit.
+    // Only a petgraph-backed backend can express an inverse edit. That is
+    // Memory and Mapped — MappedGraph.inner is the same StableDiGraph, which
+    // is why it gained a journal in this sprint. Disk has no petgraph and no
+    // NodeIndex identity to restore, and every UndoEntry variant is keyed on
+    // one, so it still takes the whole-graph checkpoint.
     graph.graph.supports_undo_journal()
 }
 

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -1054,6 +1054,73 @@ fn a_plain_set_journals_one_pre_image_per_changed_node() {
     );
 }
 
+/// The fork-detection guard is a no-op *today*, and this is what proves it.
+///
+/// `set_via_column_master` now adds a type to `touched_columnar_types` only
+/// when `Arc::make_mut` actually forked the master, rather than
+/// unconditionally. That must change nothing while every node holds its own
+/// strong handle: the master's count is `1 (map) + N (nodes)` at the first
+/// write of a clause, so the fork is unavoidable and the type is registered
+/// exactly as before.
+///
+/// Two writes to the same type in one statement are the interesting case —
+/// the second finds the fresh allocation uniquely owned and mutates in place,
+/// so it does NOT fork. The sweep must still have happened, via the first
+/// write's registration. A regression here would surface as a stale per-node
+/// handle serving a pre-clause value, which is exactly what the assertions
+/// below read back.
+///
+/// When per-node handles become weak this test is expected to change meaning,
+/// not to be deleted: the fork count drops but the observable values must not.
+#[test]
+fn fork_detection_is_a_no_op_while_nodes_hold_strong_handles() {
+    let mut graph = wide_columnar();
+
+    // Locate the node up front: `id` is an inline canonical field, not a
+    // column-store property, so it cannot be used to read back through the
+    // per-node handle. `qty` is columnar and seeded to the node's index.
+    let idx = graph
+        .graph
+        .node_indices()
+        .find(|i| {
+            graph
+                .graph
+                .node_weight(*i)
+                .and_then(|n| n.get_property_value("qty"))
+                .map(|v| v == crate::datatypes::Value::Int64(1))
+                .unwrap_or(false)
+        })
+        .expect("fixture seeds qty = node index");
+
+    // Two SET clauses in one statement, same type and same property. The first
+    // forks (count is 1 + N); the second finds the fresh allocation uniquely
+    // owned and mutates IN PLACE, so it does not fork.
+    run(
+        &mut graph,
+        "MATCH (n:Item {id: 1}) SET n.qty = 111 SET n.qty = 222",
+    );
+
+    // Read back THROUGH the per-node handle, not through the master. If the
+    // first write had failed to register the type, no sweep would run and this
+    // handle would still point at the pre-clause allocation serving qty = 1.
+    let node = graph.graph.node_weight(idx).expect("node still present");
+    assert_eq!(
+        node.get_property_value("qty"),
+        Some(crate::datatypes::Value::Int64(222)),
+        "both writes must be visible through the per-node handle; reading 1 \
+         means the refresh sweep never ran, i.e. fork detection failed to \
+         register the type on the write that actually forked"
+    );
+
+    // The design pin still holds afterwards: the sweep re-pointed every node at
+    // the current master, so it is shared again.
+    let master = graph.column_stores.get("Item").expect("master");
+    assert!(
+        Arc::strong_count(master) > 1,
+        "the sweep must have re-pointed the per-node handles at the master"
+    );
+}
+
 /// Why the checkpoint's second `Arc` on the master is *not* what makes the
 /// columnar fast path fork the store.
 ///

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -326,27 +326,37 @@ fn assert_rolls_back(graph: &mut DirGraph, query: &str, scope: Option<&[&str]>) 
 /// property variety that a partial restore shows up in the fingerprint.
 fn seeded() -> DirGraph {
     let mut graph = DirGraph::new();
+    seed_into(&mut graph);
+    graph
+}
+
+/// The seeding itself, factored out so a fixture on a *different backend*
+/// is provably the same graph rather than a similar one written twice.
+///
+/// Every arm below compares behaviour across backends, so a drift between
+/// two hand-maintained copies of these queries would surface as a backend
+/// difference and be believed.
+fn seed_into(graph: &mut DirGraph) {
     run(
-        &mut graph,
+        graph,
         "CREATE (a:Item {id: 1, name: 'a', qty: 10}), \
                 (b:Item {id: 2, name: 'b', qty: 20}), \
                 (c:Item {id: 3, name: 'c', qty: 30})",
     );
-    run(&mut graph, "CREATE (t:Tag:Hot {id: 1, name: 'urgent'})");
-    run(&mut graph, "CREATE (t:Tag:Cold {id: 2, name: 'later'})");
+    run(graph, "CREATE (t:Tag:Hot {id: 1, name: 'urgent'})");
+    run(graph, "CREATE (t:Tag:Cold {id: 2, name: 'later'})");
     run(
-        &mut graph,
+        graph,
         "MATCH (a:Item {id: 1}), (b:Item {id: 2}) CREATE (a)-[:LINKS {weight: 5}]->(b)",
     );
     run(
-        &mut graph,
+        graph,
         "MATCH (b:Item {id: 2}), (c:Item {id: 3}) CREATE (b)-[:LINKS {weight: 7}]->(c)",
     );
     run(
-        &mut graph,
+        graph,
         "MATCH (a:Item {id: 1}), (t:Tag {id: 1}) CREATE (a)-[:TAGGED]->(t)",
     );
-    graph
 }
 
 /// `seeded()` after `enable_columnar()` — the shape every graph takes the
@@ -381,6 +391,33 @@ fn seeded_columnar() -> DirGraph {
         graph.graph.node_count(),
         "every seeded node must read its properties through a column store"
     );
+    graph
+}
+
+/// `seeded()` on the **Mapped** backend — the storage mode a large-graph
+/// application actually runs in.
+///
+/// This fixture exists because the whole file was memory-only until 2026-07-30:
+/// `seeded`, `seeded_columnar` and `seeded_indexed` all build a bare
+/// `DirGraph`, so nothing here had ever executed the mapped path. Rollback on a
+/// mapped graph was entirely unverified — not "verified and slow", unverified.
+///
+/// Mapped is not a larger-than-RAM backend in the way the name suggests:
+/// `MappedGraph.inner` is the same heap `StableDiGraph<NodeData, EdgeData>` as
+/// `MemoryGraph.inner`. What `StorageMode::Mapped` changes is the backend
+/// variant plus `memory_limit = Some(0)`, which forces the columnar property
+/// store to spill to mmap. That distinction is the whole reason the arms below
+/// can be written at all.
+fn seeded_mapped() -> DirGraph {
+    use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+
+    let mut graph = new_dir_graph_in_mode(StorageMode::Mapped, None).expect("mapped graph");
+    assert!(
+        graph.graph.is_mapped(),
+        "the mapped fixture must actually be on the Mapped backend, or every \
+         arm below is a second run of the plain fixture"
+    );
+    seed_into(&mut graph);
     graph
 }
 
@@ -680,6 +717,72 @@ fn journalled_statements_copy_zero_nodes_on_a_saved_graph() {
 #[test]
 fn journalled_statements_copy_zero_nodes_on_an_indexed_graph() {
     assert_statements_copy_zero_nodes(&mut seeded_indexed(), "indexed");
+}
+
+/// The mapped backend takes the **clone** path — measured, not assumed.
+///
+/// This is the inverse of every arm above, and it is deliberate. Mapped and
+/// Disk return `false` from `supports_undo_journal` (`storage/backend.rs`),
+/// which since PR #86 is the *only* remaining veto term in `journal_covers`
+/// (`rollback.rs`). So every mutating statement on a mapped graph still opens
+/// an `O(V+E)` `fork_transaction()` whole-graph checkpoint — the pre-journal
+/// behaviour, still live. Mapped also fails the only escape hatch,
+/// `can_skip_rollback_checkpoint`, whose gate is
+/// `matches!(self, GraphBackend::Memory(_))`.
+///
+/// Asserting the *cost* rather than asserting zero is the point. A gap that no
+/// test executes reads identically to a gap that does not exist: the previous
+/// state of this file was not "mapped is slow", it was silence. This arm makes
+/// the price an explicit number that changes visibly when someone changes it.
+///
+/// **When Mapped gets an undo journal, this test must be inverted, not
+/// deleted.** The counter should fall to 0 and this arm becomes another
+/// `assert_statements_copy_zero_nodes` call. Deleting it instead would remove
+/// the only mapped coverage in the file and restore the silence.
+#[test]
+fn mapped_statements_still_take_the_clone_path() {
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+
+    let mut graph = seeded_mapped();
+    let nodes = graph.graph.node_count();
+    assert!(
+        nodes > 0,
+        "fixture must have nodes or the counter proves nothing"
+    );
+
+    for &query in ZERO_COPY_QUERIES {
+        reset_backend_clone_count();
+        run(&mut graph, query);
+        let copied = backend_clone_nodes();
+        assert!(
+            copied > 0,
+            "mapped statements are expected to copy the graph today, but this \
+             one copied nothing: {query}. If Mapped gained an undo journal, \
+             invert this test rather than deleting it — it is the only mapped \
+             rollback coverage in this file."
+        );
+    }
+}
+
+/// Mapped rollback must be *correct*, whichever path it takes.
+///
+/// Separate from the cost arm above on purpose. The clone path and the journal
+/// path produce identical observable state by construction, which is exactly
+/// why the Python parity oracle cannot tell them apart — it compares outputs.
+/// So the cost is pinned by a counter and correctness is pinned by the
+/// fingerprint, and neither stands in for the other.
+///
+/// This is the arm that must keep passing unchanged when Mapped switches to
+/// the journal. If it ever fails, the journal restored something the clone
+/// used to restore, and the fingerprint says which field.
+#[test]
+fn mapped_rolls_back_completely() {
+    let mut graph = seeded_mapped();
+    assert_rolls_back(
+        &mut graph,
+        "MATCH (n:Item) DETACH DELETE n CREATE (:Blocked {id: 1})",
+        Some(&["Item"]),
+    );
 }
 
 /// Rollback is allowed to be the expensive direction, but it must still not

--- a/crates/kglite/src/graph/dir_graph/rollback_tests.rs
+++ b/crates/kglite/src/graph/dir_graph/rollback_tests.rs
@@ -496,6 +496,16 @@ macro_rules! rollback_shapes {
                 fn indexed() {
                     assert_rolls_back(&mut seeded_indexed(), $query, $scope);
                 }
+
+                /// The **mapped** shape — the storage mode a large-graph
+                /// application runs in, and a journal-path configuration
+                /// since 2026-07-30. Before that flip Mapped took the clone
+                /// checkpoint, so no shape here had ever been rolled back
+                /// through the journal on it.
+                #[test]
+                fn mapped() {
+                    assert_rolls_back(&mut seeded_mapped(), $query, $scope);
+                }
             }
         )*
     };
@@ -719,49 +729,28 @@ fn journalled_statements_copy_zero_nodes_on_an_indexed_graph() {
     assert_statements_copy_zero_nodes(&mut seeded_indexed(), "indexed");
 }
 
-/// The mapped backend takes the **clone** path — measured, not assumed.
+/// The mapped backend now takes the **journal** path too.
 ///
-/// This is the inverse of every arm above, and it is deliberate. Mapped and
-/// Disk return `false` from `supports_undo_journal` (`storage/backend.rs`),
-/// which since PR #86 is the *only* remaining veto term in `journal_covers`
-/// (`rollback.rs`). So every mutating statement on a mapped graph still opens
-/// an `O(V+E)` `fork_transaction()` whole-graph checkpoint — the pre-journal
-/// behaviour, still live. Mapped also fails the only escape hatch,
-/// `can_skip_rollback_checkpoint`, whose gate is
-/// `matches!(self, GraphBackend::Memory(_))`.
+/// This arm was the inverse until 2026-07-30: it asserted `copied > 0`,
+/// pinning the whole-graph clone every mapped statement used to open, with a
+/// note to invert rather than delete it when Mapped gained a journal. This is
+/// that inversion. `MappedGraph.inner` is the same heap `StableDiGraph` as
+/// `MemoryGraph.inner`, so the same capture seam applies; only `Disk`, which
+/// has no petgraph and no `NodeIndex` identity for an `UndoEntry` to name,
+/// still returns `false` from `supports_undo_journal`.
 ///
-/// Asserting the *cost* rather than asserting zero is the point. A gap that no
-/// test executes reads identically to a gap that does not exist: the previous
-/// state of this file was not "mapped is slow", it was silence. This arm makes
-/// the price an explicit number that changes visibly when someone changes it.
-///
-/// **When Mapped gets an undo journal, this test must be inverted, not
-/// deleted.** The counter should fall to 0 and this arm becomes another
-/// `assert_statements_copy_zero_nodes` call. Deleting it instead would remove
-/// the only mapped coverage in the file and restore the silence.
+/// Keeping the arm rather than folding it into the list above is deliberate:
+/// it is still the only place the *cost* of a mapped statement is measured,
+/// and a regression that quietly re-vetoes Mapped would otherwise be invisible
+/// again.
 #[test]
-fn mapped_statements_still_take_the_clone_path() {
-    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
-
+fn mapped_statements_copy_zero_nodes() {
     let mut graph = seeded_mapped();
-    let nodes = graph.graph.node_count();
     assert!(
-        nodes > 0,
+        graph.graph.node_count() > 0,
         "fixture must have nodes or the counter proves nothing"
     );
-
-    for &query in ZERO_COPY_QUERIES {
-        reset_backend_clone_count();
-        run(&mut graph, query);
-        let copied = backend_clone_nodes();
-        assert!(
-            copied > 0,
-            "mapped statements are expected to copy the graph today, but this \
-             one copied nothing: {query}. If Mapped gained an undo journal, \
-             invert this test rather than deleting it — it is the only mapped \
-             rollback coverage in this file."
-        );
-    }
+    assert_statements_copy_zero_nodes(&mut graph, "mapped");
 }
 
 /// Mapped rollback must be *correct*, whichever path it takes.
@@ -772,9 +761,9 @@ fn mapped_statements_still_take_the_clone_path() {
 /// So the cost is pinned by a counter and correctness is pinned by the
 /// fingerprint, and neither stands in for the other.
 ///
-/// This is the arm that must keep passing unchanged when Mapped switches to
-/// the journal. If it ever fails, the journal restored something the clone
-/// used to restore, and the fingerprint says which field.
+/// This is the arm that kept passing unchanged when Mapped switched to the
+/// journal. If it ever fails, the journal restored less than the clone used
+/// to, and the fingerprint says which field.
 #[test]
 fn mapped_rolls_back_completely() {
     let mut graph = seeded_mapped();
@@ -782,6 +771,72 @@ fn mapped_rolls_back_completely() {
         &mut graph,
         "MATCH (n:Item) DETACH DELETE n CREATE (:Blocked {id: 1})",
         Some(&["Item"]),
+    );
+}
+
+/// The mapped **silent** write path must record nothing in the undo journal.
+///
+/// [`GraphWrite::node_weight_mut_silent`] has a *trait default* that forwards
+/// to the recorded `node_weight_mut`. `MemoryGraph` overrides it to bypass
+/// capture; `MappedGraph` relying on the default was harmless only while
+/// Mapped had no journal to capture into. The moment it got one, the default
+/// makes every silent write clone a `NodeData` pre-image — and both silent
+/// callers are sweeps over *every node of a type*:
+/// `refresh_columnar_node_handles`, and `BatchProcessor::detach_columnar_stores`
+/// / `reattach_columnar_stores`, which run only under
+/// `is_mapped() || is_disk()` and so are exercised by no memory-backed test at
+/// all. That is exactly the O(type)-per-write amplification commit 3bf9ef00
+/// removed from the WAL, re-created inside the journal.
+///
+/// Nothing existing catches it. The WAL payload guard
+/// (`tests/benchmarks/test_bench_wal_payload.py`) measures WAL *bytes*, which
+/// this override does not change; every `BACKEND_CLONE_NODES` arm counts
+/// backend clones, and the journal path clones no backend by construction. So
+/// the assertion has to read the journal itself.
+///
+/// The recorded arm is the non-vacuity control: without it a test that
+/// silently failed to install a journal, or looked at the wrong node, would
+/// pass by reading zero from an empty buffer.
+#[test]
+fn the_mapped_silent_write_path_records_nothing() {
+    use crate::graph::storage::GraphWrite;
+
+    let mut graph = seeded_mapped();
+    let idx = graph
+        .graph
+        .node_indices()
+        .next()
+        .expect("the fixture must have a node");
+
+    // Control: the recorded seam does capture, so the journal is really live.
+    graph.graph.begin_undo();
+    GraphWrite::node_weight_mut(&mut graph.graph, idx).expect("node is live");
+    let recorded = graph
+        .graph
+        .take_undo()
+        .expect("begin_undo must install a journal on a mapped graph")
+        .into_replay_order()
+        .count();
+    assert_eq!(
+        recorded, 1,
+        "the recorded seam must capture a pre-image, or the silent arm below \
+         is comparing against an empty journal for the wrong reason"
+    );
+
+    // The claim: the silent seam captures nothing.
+    graph.graph.begin_undo();
+    GraphWrite::node_weight_mut_silent(&mut graph.graph, idx).expect("node is live");
+    let silent = graph
+        .graph
+        .take_undo()
+        .expect("begin_undo must install a journal on a mapped graph")
+        .into_replay_order()
+        .count();
+    assert_eq!(
+        silent, 0,
+        "the mapped silent write path journalled {silent} entries; it must \
+         journal none, or the columnar detach/reattach and handle-refresh \
+         sweeps cost one pre-image per node of the type per chunk"
     );
 }
 
@@ -816,6 +871,14 @@ fn journalled_rollback_copies_zero_nodes_on_a_saved_graph() {
 #[test]
 fn journalled_rollback_copies_zero_nodes_on_an_indexed_graph() {
     assert_rollback_copies_zero_nodes(&mut seeded_indexed(), "indexed");
+}
+
+/// The rollback half of the mapped switch. `mapped_rolls_back_completely`
+/// pins that the restore is faithful; this pins that it got there without a
+/// whole-graph copy.
+#[test]
+fn journalled_rollback_copies_zero_nodes_on_a_mapped_graph() {
+    assert_rollback_copies_zero_nodes(&mut seeded_mapped(), "mapped");
 }
 
 /// Pins that the `columnar` arms exercise the master side channel rather than
@@ -868,7 +931,27 @@ const WIDE_ITEMS: usize = 200;
 /// entries and any threshold that catches the difference is indistinguishable
 /// from noise.
 fn wide_columnar() -> DirGraph {
-    let mut graph = DirGraph::new();
+    wide_columnar_into(DirGraph::new())
+}
+
+/// [`wide_columnar`] on the **mapped** backend.
+///
+/// Not interchangeable with `seeded_mapped()`: a mapped graph built by Cypher
+/// `CREATE` has an *empty* `column_stores` (the mapped bulk-columnar path in
+/// `mutation::batch` is reached by `add_nodes`, not by the Cypher executor),
+/// so the master-store write path the cost guard below is about never fires on
+/// it. `enable_columnar()` — what `save()` calls — is what puts a mapped graph
+/// into the shape a real application graph is in, and the preconditions are
+/// asserted so the arm cannot go vacuous if that stops being true.
+fn wide_columnar_mapped() -> DirGraph {
+    use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+
+    let graph = new_dir_graph_in_mode(StorageMode::Mapped, None).expect("mapped graph");
+    assert!(graph.graph.is_mapped(), "fixture must be on Mapped");
+    wide_columnar_into(graph)
+}
+
+fn wide_columnar_into(mut graph: DirGraph) -> DirGraph {
     let rows: Vec<String> = (0..WIDE_ITEMS)
         .map(|i| format!("(:Item {{id: {i}, name: 'n{i}', qty: {i}}})"))
         .collect();
@@ -913,6 +996,39 @@ fn a_columnar_set_journals_one_pre_image_per_changed_node() {
         "a one-row columnar SET captured {captured} node pre-images across \
          {WIDE_ITEMS} nodes of the type; it must be O(nodes changed), not \
          O(nodes of the type) — the handle-refresh sweep is being journalled"
+    );
+}
+
+/// The same bound on the **mapped** backend, which is where it is easiest to
+/// lose and hardest to notice.
+///
+/// `node_weight_mut_silent` has a trait *default* that forwards to the recorded
+/// `node_weight_mut`. `MemoryGraph` overrides it, which is what the arm above
+/// pins; `MappedGraph` had no reason to until it gained a journal, and adding
+/// the journal without the override re-creates the O(type)-per-write cost
+/// exactly. Measured, not assumed: with the override removed this captured
+/// **200** pre-images for a one-row `SET`, against 0 with it.
+///
+/// This arm and `the_mapped_silent_write_path_records_nothing` guard the same
+/// override from opposite ends — one at the seam, one through the statement
+/// that actually reaches it — because the seam has a second caller
+/// (`mutation::batch`'s columnar detach/reattach, gated on
+/// `is_mapped() || is_disk()`) that no Cypher statement reaches today and so
+/// no end-to-end test can cover.
+#[test]
+fn a_mapped_columnar_set_journals_one_pre_image_per_changed_node() {
+    use crate::graph::storage::undo::{journal_node_pre_images, reset_journal_node_pre_images};
+
+    let mut graph = wide_columnar_mapped();
+    reset_journal_node_pre_images();
+    run(&mut graph, "MATCH (i:Item {id: 7}) SET i.priority = 3");
+    let captured = journal_node_pre_images();
+
+    assert!(
+        captured <= 2,
+        "a one-row columnar SET on a mapped graph captured {captured} node \
+         pre-images across {WIDE_ITEMS} nodes of the type; the mapped \
+         handle-refresh sweep is being journalled"
     );
 }
 

--- a/crates/kglite/src/graph/handle.rs
+++ b/crates/kglite/src/graph/handle.rs
@@ -787,3 +787,120 @@ mod boundary_lift_tests {
         assert!(!is_canonical_node_column("Title"));
     }
 }
+
+/// The cost of holding a reader across a write — pinned as a *count*, not a
+/// timing.
+///
+/// [`make_dir_graph_mut`] deep-clones the whole graph whenever a second
+/// `Arc<DirGraph>` is alive, which the doc on
+/// [`make_dir_graph_mut_preserving_lineage`] warns about. The reachable-from-
+/// ordinary-code shape is mundane: a request handler keeps a query result in a
+/// local, then writes. No snapshot API, no threading, no `freeze()`.
+///
+/// This is measured elsewhere as wall time — and that measurement is
+/// structurally hard to gate on. `min`-of-N and p95 both *hide* it, because
+/// only the first write after acquiring the reference pays; the Python
+/// benchmark that does see it (`test_bench_first_write_after_reference`) has to
+/// re-acquire the reference in an untimed `pedantic` setup before every round,
+/// and even then it asserts no threshold, and lives behind a marker the default
+/// suite deselects. Meanwhile `bench-check` and `bench-anchor` both run
+/// `--metric min`, so neither can ever see this.
+///
+/// `BACKEND_CLONE_NODES` sidesteps all of it. It counts nodes copied, so the
+/// intentional O(1) clone of an emptied backend registers zero while a real
+/// fork registers the node count. That turns a ~28 ms cliff at 1M nodes into an
+/// exact integer at ten — no idle machine, no statistics, no marker.
+///
+/// These tests pin **current** behaviour, including the cost. They are not
+/// asserting the cost is acceptable; they are making it impossible to change
+/// either direction silently. When the fork is fixed (structural sharing in
+/// `MemoryGraph` — its own sprint), `held_reader_forces_a_whole_graph_copy`
+/// is the test that must be inverted, and the diff will say so out loud.
+#[cfg(test)]
+mod held_reference_clone_tests {
+    use super::*;
+    use crate::graph::session::{execute_mut, ExecuteOptions};
+    use crate::graph::storage::backend::{backend_clone_nodes, reset_backend_clone_count};
+    use crate::graph::storage::GraphRead;
+    use std::collections::HashMap;
+
+    /// Small on purpose. The defect is O(V), so ten nodes prove the shape
+    /// exactly as well as a million and keep the test in the millisecond range.
+    const FIXTURE_NODES: usize = 10;
+
+    fn seeded_arc() -> Arc<DirGraph> {
+        let mut graph = DirGraph::new();
+        let params = HashMap::new();
+        for i in 0..FIXTURE_NODES {
+            execute_mut(
+                &mut graph,
+                &format!("CREATE (:Item {{id: {i}, name: 'item-{i}'}})"),
+                &ExecuteOptions::eager(&params),
+            )
+            .expect("fixture node");
+        }
+        Arc::new(graph)
+    }
+
+    /// The baseline: a uniquely-owned handle mutates in place.
+    ///
+    /// Without this arm the guard below would pass on a build where *every*
+    /// write copies the graph, and would still look like it was measuring
+    /// something specific to holding a reader.
+    #[test]
+    fn unique_handle_copies_nothing() {
+        let mut arc = seeded_arc();
+        reset_backend_clone_count();
+        let _ = make_dir_graph_mut(&mut arc);
+        assert_eq!(
+            backend_clone_nodes(),
+            0,
+            "a uniquely-owned Arc<DirGraph> must mutate in place"
+        );
+    }
+
+    /// The defect, as an exact integer.
+    ///
+    /// Holding one extra `Arc` — what a live `ResultView` or an open
+    /// transaction snapshot does — makes the next write copy every node.
+    #[test]
+    fn held_reader_forces_a_whole_graph_copy() {
+        let mut arc = seeded_arc();
+        let reader = Arc::clone(&arc);
+
+        reset_backend_clone_count();
+        let _ = make_dir_graph_mut(&mut arc);
+        let copied = backend_clone_nodes();
+
+        // Keep the reader alive across the write. Dropping it earlier would
+        // make `Arc::get_mut` succeed and the test would measure the baseline
+        // above while appearing to measure this.
+        assert_eq!(reader.graph.node_count(), FIXTURE_NODES);
+
+        assert_eq!(
+            copied, FIXTURE_NODES,
+            "a live second Arc<DirGraph> must (today) force a whole-graph copy; \
+             getting 0 here means the fork was fixed — invert this test and \
+             retire the backlog item rather than deleting the assertion"
+        );
+    }
+
+    /// Dropping the reader restores in-place mutation.
+    ///
+    /// This is what makes the guard above a statement about *sharing* rather
+    /// than about `make_dir_graph_mut` being unconditionally expensive.
+    #[test]
+    fn dropping_the_reader_restores_in_place_mutation() {
+        let mut arc = seeded_arc();
+        let reader = Arc::clone(&arc);
+        drop(reader);
+
+        reset_backend_clone_count();
+        let _ = make_dir_graph_mut(&mut arc);
+        assert_eq!(
+            backend_clone_nodes(),
+            0,
+            "once the extra Arc is gone the write must mutate in place again"
+        );
+    }
+}

--- a/crates/kglite/src/graph/io/file.rs
+++ b/crates/kglite/src/graph/io/file.rs
@@ -167,6 +167,25 @@ pub(crate) struct FileMetadata {
     /// files simply lack the key and default to 0.
     #[serde(default, skip_serializing_if = "is_zero")]
     user_schema_version: u32,
+    /// Highest WAL log-sequence number this checkpoint already contains (see
+    /// `DirGraph::checkpoint_lsn`). On a durable reopen, replay skips every
+    /// frame at or below it, so a **stale WAL prefix** — one whose frames
+    /// predate the checkpoint — cannot be folded back over a newer snapshot and
+    /// roll committed properties backwards.
+    ///
+    /// The gate is anchored in the checkpoint rather than in the log because the
+    /// failure is precisely that the log is stale *relative to* the checkpoint;
+    /// only the checkpoint is authoritative about how much of the log it
+    /// consumed.
+    ///
+    /// Additive and *invisible when unset*, exactly like `user_schema_version`
+    /// above: `skip_serializing_if` omits the key entirely at the baseline, so a
+    /// graph that was never durable serializes byte-for-byte as it did before
+    /// this field existed — which is what keeps the `test_phase4_parity` golden
+    /// digest stable. Older files simply lack the key and default to 0, i.e.
+    /// replay everything, the pre-gate behaviour.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    checkpoint_lsn: u64,
     /// Spatial configuration per node type.
     #[serde(default)]
     spatial_configs: HashMap<String, SpatialConfig>,
@@ -221,10 +240,12 @@ fn default_ts_data_version() -> u32 {
     2
 }
 
-/// `skip_serializing_if` predicate for the additive `user_schema_version` key:
-/// omitting it at the baseline keeps saves byte-identical to pre-field ones.
-fn is_zero(value: &u32) -> bool {
-    *value == 0
+/// `skip_serializing_if` predicate for the additive integer keys
+/// (`user_schema_version`, `checkpoint_lsn`): omitting them at the baseline
+/// keeps saves byte-identical to pre-field ones. Generic over the integer width
+/// so a second such key needs no near-duplicate predicate.
+fn is_zero<T: Default + PartialEq>(value: &T) -> bool {
+    *value == T::default()
 }
 
 // ─── Metadata transfer helpers ───────────────────────────────────────────────
@@ -250,6 +271,7 @@ impl FileMetadata {
             parent_types: graph.parent_types.clone(),
             graph_instructions: graph.graph_instructions.clone(),
             user_schema_version: graph.user_schema_version,
+            checkpoint_lsn: graph.checkpoint_lsn,
             spatial_configs: graph.spatial_configs.clone(),
             timeseries_configs: graph.timeseries_configs.clone(),
             temporal_node_configs: graph.temporal_node_configs.clone(),
@@ -307,6 +329,7 @@ impl FileMetadata {
         graph.parent_types = self.parent_types;
         graph.graph_instructions = self.graph_instructions;
         graph.user_schema_version = self.user_schema_version;
+        graph.checkpoint_lsn = self.checkpoint_lsn;
         graph.spatial_configs = self.spatial_configs;
         graph.timeseries_configs = self.timeseries_configs;
         graph.temporal_node_configs = self.temporal_node_configs;

--- a/crates/kglite/src/graph/languages/cypher/executor/columnar_write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/columnar_write.rs
@@ -95,8 +95,31 @@ pub(super) fn set_via_column_master(
     let Some(master) = graph.column_stores.get_mut(write.node_type) else {
         return false;
     };
+    // Did `make_mut` actually fork, or did it mutate in place?
+    //
+    // Only a fork leaves the per-node handles stale, and only stale handles
+    // need the O(N) end-of-clause sweep. Comparing the allocation address
+    // across the call is the exact question — `Arc::strong_count` is not, since
+    // it cannot distinguish "nobody else holds this" from "the clone already
+    // happened".
+    //
+    // TODAY THIS IS A PROVABLE NO-OP, and that is the point of landing it
+    // alone. Every node of a type holds its own strong handle, so the master's
+    // count is `1 (map) + N (nodes)` at the first write of a clause and
+    // `make_mut` always forks; the second and later writes in the same clause
+    // find the fresh allocation uniquely owned and mutate in place, but the
+    // type is already in the set by then. So the set ends up identical either
+    // way, which `fork_detection_is_a_no_op_while_nodes_hold_strong_handles`
+    // pins.
+    //
+    // It stops being a no-op the moment nodes stop holding strong handles: then
+    // most writes mutate in place, and an unconditional insert would keep
+    // paying a sweep that has nothing to re-point.
+    let before = Arc::as_ptr(master);
     Arc::make_mut(master).set(row_id, key, write.value, None);
-    touched_columnar_types.insert(write.node_type.to_string());
+    if !std::ptr::eq(before, Arc::as_ptr(master)) {
+        touched_columnar_types.insert(write.node_type.to_string());
+    }
     graph.graph.note_recorded_node_upsert(write.node_idx);
     true
 }

--- a/crates/kglite/src/graph/mutation/batch.rs
+++ b/crates/kglite/src/graph/mutation/batch.rs
@@ -370,11 +370,24 @@ impl BatchProcessor {
     /// flush time — so those ops still carry the columnar values that
     /// `reattach_columnar_stores` installs after `add_node` returns.
     ///
-    /// No undo obligation is dropped either: both columnar sweeps run only
-    /// when `is_mapped() || is_disk()`, and `GraphBackend::undo_journal_mut`
-    /// yields `None` for `Mapped` and `Disk` (see
-    /// `GraphBackend::supports_undo_journal`) — there is never a journal
-    /// installed on this path to capture into.
+    /// The undo journal is skipped here too, and since 2026-07-30 that is a
+    /// deliberate choice rather than a vacuous one. Both columnar sweeps run
+    /// only when `is_mapped() || is_disk()`; `Disk` still journals nothing, but
+    /// `Mapped` now does, so `node_weight_mut_silent` must bypass undo capture
+    /// on `MappedGraph` exactly as it does on `MemoryGraph` — otherwise the
+    /// per-node pre-image this sweep would clone reproduces, inside the
+    /// journal, the very `O(n²/chunk)` amplification the paragraph above
+    /// removed from the WAL.
+    ///
+    /// No undo obligation is dropped by that bypass: the pair is a logical
+    /// no-op for an existing node (same argument as above), the *created* rows
+    /// are captured structurally by [`GraphWrite::add_node`], and the master
+    /// store itself is restored from the rollback checkpoint's schema shell,
+    /// which does not park `column_stores`. No Cypher statement reaches this
+    /// funnel today in any case — the executor creates nodes through
+    /// `DirGraph::insert_node_routed` — so there is currently no journal
+    /// installed while it runs; the override is what keeps that safe if one
+    /// ever is.
     ///
     /// Returns `(rows awaiting reattachment, owned stores keyed by node type)`.
     fn detach_columnar_stores(

--- a/crates/kglite/src/graph/storage/backend.rs
+++ b/crates/kglite/src/graph/storage/backend.rs
@@ -99,44 +99,53 @@ impl GraphBackend {
     /// statement-scoped undo journal, i.e. whether rollback can avoid the
     /// whole-graph clone.
     ///
-    /// Only the heap backend can. `Mapped` maintains lazy mmap-columnar
-    /// indexes and `Disk` mutates through generation overlays whose inverse is
-    /// not expressible as a petgraph edit, so both keep the clone checkpoint
-    /// (see `dir_graph/rollback.rs`). `Recording` forwards to whatever it
-    /// wraps, so a durable graph participates exactly when its underlying
-    /// backend would: `Recording(Memory)` journals, `Recording(Mapped)` keeps
-    /// the clone. Durability and rollback strategy are independent concerns.
+    /// Every petgraph-backed backend can. `Memory` and `Mapped` both hold a
+    /// heap `StableDiGraph<NodeData, EdgeData>` as `inner`, and every
+    /// `UndoEntry` variant is keyed on the `NodeIndex`/`EdgeIndex` that graph
+    /// hands out, so the capture seam is the same one for both. "Larger than
+    /// RAM" is loose for `Mapped`: what `StorageMode::Mapped` changes is where
+    /// *properties* live (`memory_limit = Some(0)` spills the columnar store
+    /// to mmap), not the node/edge graph, which stays heap-resident.
     ///
-    /// **This is deliberate, and it is the only remaining veto term in
-    /// `journal_covers`** — every other term was retired as the journal grew
-    /// to cover saved, indexed and columnar graphs. The user-visible cost is
-    /// worth stating plainly, because nothing else surfaces it: every mutating
-    /// statement on a mapped or disk graph still opens an O(V+E)
-    /// `fork_transaction()` whole-graph checkpoint, which is the pre-journal
-    /// behaviour. Under the "in-memory wins" doctrine that is the right
-    /// trade — the journal exists to make the *core* product cheap, and
-    /// neither larger-than-RAM backend can express an inverse petgraph edit
-    /// today — but it does mean statement rollback cost scales with graph
-    /// size in exactly the modes chosen for large graphs. Mirrored in the
+    /// `Disk` cannot, and that is the whole of the remaining veto. It has no
+    /// petgraph at all — it mutates a CSR + mmap layout through generation
+    /// overlays and arena-staged writes, its slots carry no `NodeIndex`
+    /// identity for an entry to name, and it has no free list whose LIFO
+    /// ordering reverse replay could exploit to restore slot identity. So a
+    /// disk graph keeps the clone checkpoint (see `dir_graph/rollback.rs`):
+    /// every mutating statement on it still opens an O(V+E)
+    /// `fork_transaction()` whole-graph checkpoint, the pre-journal behaviour,
+    /// and its statement-rollback cost scales with graph size. Mirrored in the
     /// user-facing storage-mode guide (`docs/python/core-concepts.md`).
+    ///
+    /// `Recording` forwards to whatever it wraps, so a durable graph
+    /// participates exactly when its underlying backend would:
+    /// `Recording(Memory)` and `Recording(Mapped)` journal,
+    /// `Recording(Disk)` keeps the clone. Durability and rollback strategy are
+    /// independent concerns.
+    ///
+    /// **This is the only remaining veto term in `journal_covers`** — every
+    /// other term was retired as the journal grew to cover saved, indexed and
+    /// columnar graphs.
     #[inline]
     pub(crate) fn supports_undo_journal(&self) -> bool {
         match self {
-            GraphBackend::Memory(_) => true,
+            GraphBackend::Memory(_) | GraphBackend::Mapped(_) => true,
             GraphBackend::Recording(rg) => rg.inner().supports_undo_journal(),
-            GraphBackend::Mapped(_) | GraphBackend::Disk(_) => false,
+            GraphBackend::Disk(_) => false,
         }
     }
 
-    /// Install a fresh undo journal on the heap backend. No-op on backends
-    /// that do not support one — callers gate on
+    /// Install a fresh undo journal on a petgraph-backed backend. No-op on
+    /// backends that do not support one — callers gate on
     /// [`Self::supports_undo_journal`] first.
     #[inline]
     pub(crate) fn begin_undo(&mut self) {
         match self {
             GraphBackend::Memory(g) => g.begin_undo(),
+            GraphBackend::Mapped(g) => g.begin_undo(),
             GraphBackend::Recording(rg) => rg.inner_mut().begin_undo(),
-            GraphBackend::Mapped(_) | GraphBackend::Disk(_) => {}
+            GraphBackend::Disk(_) => {}
         }
     }
 
@@ -145,8 +154,9 @@ impl GraphBackend {
     pub(crate) fn take_undo(&mut self) -> Option<Box<UndoJournal>> {
         match self {
             GraphBackend::Memory(g) => g.take_undo(),
+            GraphBackend::Mapped(g) => g.take_undo(),
             GraphBackend::Recording(rg) => rg.inner_mut().take_undo(),
-            GraphBackend::Mapped(_) | GraphBackend::Disk(_) => None,
+            GraphBackend::Disk(_) => None,
         }
     }
 
@@ -157,8 +167,9 @@ impl GraphBackend {
     pub(crate) fn undo_journal_mut(&mut self) -> Option<&mut UndoJournal> {
         match self {
             GraphBackend::Memory(g) => g.undo_journal_mut(),
+            GraphBackend::Mapped(g) => g.undo_journal_mut(),
             GraphBackend::Recording(rg) => rg.inner_mut().undo_journal_mut(),
-            GraphBackend::Mapped(_) | GraphBackend::Disk(_) => None,
+            GraphBackend::Disk(_) => None,
         }
     }
 

--- a/crates/kglite/src/graph/storage/impls.rs
+++ b/crates/kglite/src/graph/storage/impls.rs
@@ -34,9 +34,10 @@ use std::time::Instant;
 // `MemoryGraph` and `MappedGraph` wrap identical `StableDiGraph` today but
 // carry distinct type identity for per-backend divergence. The
 // `impl_heap_graph_read!` macro emits the shared read body. The write side is
-// written out per backend: `MappedGraph` maintains its own lazy indexes and
-// `MemoryGraph` carries the statement-scoped undo journal, so the two have
-// nothing left in common to share.
+// written out per backend: both carry the statement-scoped undo journal, but
+// `MappedGraph` also maintains its own lazy type/property indexes and
+// `MemoryGraph` its peer counts, so the two have nothing left in common to
+// share.
 // ──────────────────────────────────────────────────────────────────────────
 
 macro_rules! impl_heap_graph_read {
@@ -762,46 +763,170 @@ impl GraphRead for MappedGraph {
     }
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// MappedGraph GraphWrite — lazy-index invalidation + undo-journal capture
+//
 // GraphWrite invalidates the type index on every edge mutation and the
 // property index on every node-property mutation. `add_node` and
 // `remove_node` also clear the property index since the set of
 // `(value, node_idx)` pairs has changed.
+//
+// On top of that, and since 2026-07-30, the same undo-capture seam
+// `MemoryGraph` carries above — for the same reason: `inner` is a heap
+// `StableDiGraph`, so every `UndoEntry` variant, all keyed on a petgraph
+// index, is expressible here. What `StorageMode::Mapped` changes is where
+// *properties* live (mmap-spilled column stores), not the node/edge graph, so
+// the journal transfers verbatim.
+//
+// Each method captures the inverse of the edit *if a journal is installed*,
+// then performs the edit — never at the cost of the invalidation it already
+// owed. With no journal (the steady state, and every read path) the added cost
+// is one `Option` discriminant check; the clone-the-pre-image work lives in
+// `#[cold]` helpers.
+// ──────────────────────────────────────────────────────────────────────────
+
+impl MappedGraph {
+    /// Clone `idx`'s current weight into the journal as its pre-statement
+    /// state, unless this statement already captured it.
+    #[cold]
+    fn capture_node_weight(&mut self, idx: NodeIndex) {
+        let inner = &self.inner;
+        if let Some(journal) = self.undo.as_deref_mut() {
+            journal.note_node_weight(idx, || inner.node_weight(idx).cloned());
+        }
+    }
+
+    /// Edge counterpart of [`Self::capture_node_weight`].
+    #[cold]
+    fn capture_edge_weight(&mut self, idx: EdgeIndex) {
+        let inner = &self.inner;
+        if let Some(journal) = self.undo.as_deref_mut() {
+            journal.note_edge_weight(idx, || inner.edge_weight(idx).cloned());
+        }
+    }
+
+    /// Any edge incident to `idx`, in either direction.
+    fn first_incident_edge(&self, idx: NodeIndex) -> Option<EdgeIndex> {
+        self.inner
+            .edges_directed(idx, Direction::Outgoing)
+            .next()
+            .or_else(|| self.inner.edges_directed(idx, Direction::Incoming).next())
+            .map(|edge| edge.id())
+    }
+
+    /// Detach `idx`'s edges one at a time, through the recorded
+    /// [`GraphWrite::remove_edge`], so each gets its own journal entry.
+    ///
+    /// petgraph's `remove_node` drops incident edges in one internal sweep
+    /// whose order we neither observe nor control, which would leave reverse
+    /// replay unable to hand each edge back its own free-list slot. Doing the
+    /// detach ourselves makes the removal order the recorded order. The end
+    /// state is identical either way; the Cypher delete path already detaches
+    /// explicitly (`mutation::maintain::detach_delete_nodes`), so in practice
+    /// this loop finds nothing to do and exists for every *other* caller of
+    /// `remove_node`.
+    #[cold]
+    fn detach_for_journal(&mut self, idx: NodeIndex) {
+        while let Some(edge) = self.first_incident_edge(idx) {
+            GraphWrite::remove_edge(self, edge);
+        }
+    }
+}
+
 impl GraphWrite for MappedGraph {
     #[inline]
     fn node_weight_mut(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
         // Caller may mutate properties — invalidate property index.
         self.invalidate_property_index();
+        if self.undo.is_some() {
+            self.capture_node_weight(idx);
+        }
         self.inner_mut().node_weight_mut(idx)
     }
+
+    /// Bypasses the undo journal as well as the WAL recorder.
+    ///
+    /// Two callers, both pure storage bookkeeping and both mapped-relevant:
+    /// the columnar handle-refresh sweep in
+    /// [`crate::graph::languages::cypher::executor`], and the
+    /// detach/reattach pair in [`crate::graph::mutation::batch`], which runs
+    /// *only* under `is_mapped() || is_disk()` and touches every existing node
+    /// of a type per chunk. Capturing a `NodeData` pre-image for each of them
+    /// would make one `SET`, or one bulk `CREATE`, cost a clone per node *of
+    /// the type* — the O(V+E)-per-write cost this journal exists to remove,
+    /// reintroduced at a smaller constant. Without this override `MappedGraph`
+    /// would inherit the trait default, which forwards to the *recorded*
+    /// `node_weight_mut`; that is precisely the quadratic amplification commit
+    /// 3bf9ef00 removed from the WAL, and no existing guard would see it in
+    /// the journal.
+    ///
+    /// Nothing else may use this method to skip capture: a caller that
+    /// changes a node's *content* silently is unrecoverable on rollback.
+    #[inline]
+    fn node_weight_mut_silent(&mut self, idx: NodeIndex) -> Option<&mut NodeData> {
+        self.invalidate_property_index();
+        self.inner_mut().node_weight_mut(idx)
+    }
+
     #[inline]
     fn edge_weight_mut(&mut self, idx: EdgeIndex) -> Option<&mut EdgeData> {
         // Mutating an edge weight can change its connection_type, which
         // would invalidate the per-conn-type index.
         self.invalidate_type_index();
+        if self.undo.is_some() {
+            self.capture_edge_weight(idx);
+        }
         self.inner_mut().edge_weight_mut(idx)
     }
+
     #[inline]
     fn add_node(&mut self, data: NodeData) -> NodeIndex {
         self.invalidate_property_index();
-        self.inner_mut().add_node(data)
+        let node_type = data.node_type;
+        let idx = self.inner_mut().add_node(data);
+        if let Some(journal) = self.undo.as_deref_mut() {
+            journal.note_node_added(idx, node_type);
+        }
+        idx
     }
+
     #[inline]
     fn remove_node(&mut self, idx: NodeIndex) -> Option<NodeData> {
         // Removing a node removes its incident edges and any property
         // entries pointing at it.
         self.invalidate_type_index();
         self.invalidate_property_index();
-        self.inner_mut().remove_node(idx)
+        if self.undo.is_some() {
+            self.detach_for_journal(idx);
+        }
+        let removed = self.inner_mut().remove_node(idx)?;
+        if let Some(journal) = self.undo.as_deref_mut() {
+            journal.note_node_removed(idx, removed.clone());
+        }
+        Some(removed)
     }
+
     #[inline]
     fn add_edge(&mut self, a: NodeIndex, b: NodeIndex, data: EdgeData) -> EdgeIndex {
         self.invalidate_type_index();
-        self.inner_mut().add_edge(a, b, data)
+        let idx = self.inner_mut().add_edge(a, b, data);
+        if let Some(journal) = self.undo.as_deref_mut() {
+            journal.note_edge_added(idx);
+        }
+        idx
     }
+
     #[inline]
     fn remove_edge(&mut self, idx: EdgeIndex) -> Option<EdgeData> {
         self.invalidate_type_index();
-        self.inner_mut().remove_edge(idx)
+        let endpoints = self.undo.is_some().then(|| self.inner.edge_endpoints(idx));
+        let removed = self.inner_mut().remove_edge(idx)?;
+        if let Some(journal) = self.undo.as_deref_mut() {
+            if let Some(Some((src, tgt))) = endpoints {
+                journal.note_edge_removed(idx, src, tgt, removed.clone());
+            }
+        }
+        Some(removed)
     }
 }
 

--- a/crates/kglite/src/graph/storage/mapped_graph_impl.rs
+++ b/crates/kglite/src/graph/storage/mapped_graph_impl.rs
@@ -1,11 +1,13 @@
-//! `impl MappedGraph` — type-index / property-index build helpers and
-//! the columnar-mode `flatten_to_csr` helper used by both index builds.
+//! `impl MappedGraph` — construction, `Clone`, the statement-scoped undo
+//! journal accessors, type-index / property-index build helpers, and the
+//! columnar-mode `flatten_to_csr` helper used by both index builds.
 //!
 //! Split out of `storage/mod.rs` to keep that file under its 800-line
 //! cap. Lives in a sibling `impl MappedGraph {}` block.
 
 use crate::datatypes::Value;
 use crate::graph::schema::{EdgeData, InternedKey, NodeData};
+use crate::graph::storage::undo::UndoJournal;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::stable_graph::StableDiGraph;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences};
@@ -13,6 +15,23 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use super::{flatten_to_csr, MappedGraph, MappedPropertyIndex, MappedTypeIndex};
+
+impl Clone for MappedGraph {
+    fn clone(&self) -> Self {
+        // All lazy indexes are derived state; drop them on clone and
+        // let the clone rebuild on demand. Avoids `RwLock` clone
+        // plumbing.
+        Self {
+            inner: self.inner.clone(),
+            type_index: RwLock::new(HashMap::new()),
+            property_index: RwLock::new(HashMap::new()),
+            global_property_index: RwLock::new(HashMap::new()),
+            // A journal belongs to the statement that opened it, never to a
+            // copy of the graph it was recorded against.
+            undo: None,
+        }
+    }
+}
 
 impl MappedGraph {
     #[inline]
@@ -22,7 +41,28 @@ impl MappedGraph {
             type_index: RwLock::new(HashMap::new()),
             property_index: RwLock::new(HashMap::new()),
             global_property_index: RwLock::new(HashMap::new()),
+            undo: None,
         }
+    }
+
+    /// Install a fresh statement-scoped undo journal, discarding any stale
+    /// one (defensive: a journal must never outlive its statement).
+    #[inline]
+    pub(crate) fn begin_undo(&mut self) {
+        self.undo = Some(Box::new(UndoJournal::new()));
+    }
+
+    /// Uninstall and return the journal, ending capture.
+    #[inline]
+    pub(crate) fn take_undo(&mut self) -> Option<Box<UndoJournal>> {
+        self.undo.take()
+    }
+
+    /// Mutable access to the active journal, for the `DirGraph`-level capture
+    /// seam (inverted-index and timeseries edits the backend cannot see).
+    #[inline]
+    pub(crate) fn undo_journal_mut(&mut self) -> Option<&mut UndoJournal> {
+        self.undo.as_deref_mut()
     }
 
     /// Wrap an existing petgraph, with every derived index empty.
@@ -40,6 +80,7 @@ impl MappedGraph {
             type_index: RwLock::new(HashMap::new()),
             property_index: RwLock::new(HashMap::new()),
             global_property_index: RwLock::new(HashMap::new()),
+            undo: None,
         }
     }
 

--- a/crates/kglite/src/graph/storage/mod.rs
+++ b/crates/kglite/src/graph/storage/mod.rs
@@ -546,6 +546,17 @@ pub struct MappedGraph {
     /// Backs `lookup_by_property_eq_any_type` / `_prefix_any_type`
     /// (used by untyped patterns like `MATCH (n {title: 'X'})`).
     pub(crate) global_property_index: RwLock<HashMap<String, Arc<MappedPropertyIndex>>>,
+    /// Statement-scoped inverse-op buffer. `Some` only while a mutating
+    /// Cypher statement holds a rollback checkpoint; `None` is the steady
+    /// state, so reads pay nothing and writes pay one discriminant check.
+    /// See [`crate::graph::storage::undo`].
+    ///
+    /// Mapped journals for exactly the same reason memory does: `inner` is a
+    /// heap `StableDiGraph`, so every `UndoEntry` variant — all of which are
+    /// keyed on a petgraph `NodeIndex`/`EdgeIndex` — is expressible here. The
+    /// mmap spilling that `StorageMode::Mapped` turns on lives in the
+    /// *columnar property store*, not in the node/edge graph.
+    pub(crate) undo: Option<Box<UndoJournal>>,
 }
 
 /// Per-conn-type edge index for `MappedGraph`. CSR-style layout
@@ -631,20 +642,6 @@ impl MappedPropertyIndex {
             i += 1;
         }
         out
-    }
-}
-
-impl Clone for MappedGraph {
-    fn clone(&self) -> Self {
-        // All lazy indexes are derived state; drop them on clone and
-        // let the clone rebuild on demand. Avoids `RwLock` clone
-        // plumbing.
-        Self {
-            inner: self.inner.clone(),
-            type_index: RwLock::new(HashMap::new()),
-            property_index: RwLock::new(HashMap::new()),
-            global_property_index: RwLock::new(HashMap::new()),
-        }
     }
 }
 
@@ -783,6 +780,7 @@ impl<'de> serde::Deserialize<'de> for MappedGraph {
             type_index: RwLock::new(HashMap::new()),
             property_index: RwLock::new(HashMap::new()),
             global_property_index: RwLock::new(HashMap::new()),
+            undo: None,
         })
     }
 }

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -5,12 +5,20 @@
 //!
 //! A `.kgl-wal` sidecar holds an append-only sequence of **logical**
 //! mutation frames. Each committed mutation operation appends one
-//! [`WalFrame`] — a batch of [`MutationOp`]s tagged with the post-commit
-//! graph `version` as its log-sequence number (LSN) — and `fsync`s. On
-//! open, the engine loads the `.kgl` checkpoint snapshot, then replays
-//! every WAL frame with `lsn > checkpoint.version` to recover work
-//! committed since the last checkpoint. A checkpoint (a full `.kgl`
-//! save) truncates the WAL.
+//! [`WalFrame`] — a batch of [`MutationOp`]s tagged with a log-sequence
+//! number (LSN) — and `fsync`s. On open, the engine loads the `.kgl`
+//! checkpoint snapshot, then replays every WAL frame with
+//! `lsn > DirGraph::checkpoint_lsn` to recover work committed since the
+//! last checkpoint. A checkpoint (a full `.kgl` save) truncates the WAL
+//! and stamps the LSN it consumed up to into the `.kgl`.
+//!
+//! The LSN is a **counter owned by the log**, not the graph `version`:
+//! the writing binding hands out `next_lsn` and increments it (see
+//! `KnowledgeGraph::flush_wal`). It is monotonic for the life of the log
+//! and survives checkpoint truncation, which is what lets the stamped
+//! `checkpoint_lsn` distinguish a frame the snapshot already contains
+//! from one committed after it. Graph `version` is a different quantity —
+//! it advances on work that is never logged — and is not a log position.
 //!
 //! This module owns only the **on-disk format**: the op schema, the
 //! frame envelope, and crash-safe read/write. Capture (translating
@@ -265,13 +273,18 @@ pub enum MutationOp {
     },
 }
 
-/// One committed mutation operation: the ops it produced, tagged with
-/// the post-commit graph version as the log-sequence number.
+/// One committed mutation operation: the ops it produced, tagged with a
+/// log-sequence number.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WalFrame {
-    /// Post-commit graph `version`. Frames replay in ascending `lsn`;
-    /// on recovery, frames with `lsn <= checkpoint_version` are already
+    /// Log-sequence number, issued by the writer's own monotonic counter —
+    /// **not** the graph `version`. Frames replay in ascending `lsn`; on
+    /// recovery, frames with `lsn <= DirGraph::checkpoint_lsn` are already
     /// folded into the snapshot and skipped.
+    ///
+    /// The counter must never restart at a checkpoint: a restarted LSN would
+    /// be reused by a post-checkpoint frame, making a stale pre-checkpoint
+    /// frame indistinguishable from a fresh one.
     pub lsn: u64,
     /// The logical ops this commit produced, in application order.
     pub ops: Vec<MutationOp>,

--- a/docs/python/core-concepts.md
+++ b/docs/python/core-concepts.md
@@ -98,17 +98,17 @@ re-ingest from the original source. This matters most for benchmarks — a
 create-then-reopen script that passed `storage="mapped"` on both runs was
 previously measuring the memory backend twice.
 
-**Statement rollback is cheap only in memory mode.** One mutating Cypher
-statement is atomic: if it fails partway through, the graph is restored to its
-pre-statement state. In-memory graphs do that with an undo journal costing
-O(changes). Mapped and disk graphs cannot — neither backend can express an
-inverse edit against its mmap-columnar indexes or generation overlays — so both
-fall back to taking a **whole-graph O(V+E) checkpoint before every mutating
-statement**. This is a deliberate consequence of "in-memory wins", but it means
-per-statement write overhead grows with graph size in precisely the two modes
-you would choose for a large graph. If a mapped graph's writes feel slow
-relative to its reads, this is why; batching more work into fewer statements is
-the lever that helps.
+**Statement rollback is cheap in memory and mapped mode, expensive on disk.**
+One mutating Cypher statement is atomic: if it fails partway through, the graph
+is restored to its pre-statement state. Memory and mapped graphs do that with
+an undo journal costing O(changes) — mapped spills *properties* to mmap, but
+its node/edge graph is the same heap structure the memory backend uses, so the
+journal applies unchanged. Disk graphs cannot: they hold no such structure to
+record an inverse edit against, so a disk graph falls back to taking a
+**whole-graph O(V+E) checkpoint before every mutating statement**. That means
+per-statement write overhead grows with graph size on disk. If a disk graph's
+writes feel slow relative to its reads, this is why; batching more work into
+fewer statements is the lever that helps.
 
 ## Return Types
 

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -2047,6 +2047,7 @@ impl core::default::Default for kglite::api::CurrentSelection
 pub fn kglite::api::CurrentSelection::default() -> kglite::api::CurrentSelection
 pub struct kglite::api::DirGraph
 pub kglite::api::DirGraph::auto_vacuum_threshold: core::option::Option<f64>
+pub kglite::api::DirGraph::checkpoint_lsn: u64
 pub kglite::api::DirGraph::column_stores: std::collections::hash::map::HashMap<alloc::string::String, alloc::sync::Arc<kglite::graph::storage::column_store::ColumnStore>>
 pub kglite::api::DirGraph::composite_index_keys: alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<alloc::string::String>)>
 pub kglite::api::DirGraph::composite_indices: std::collections::hash::map::HashMap<(alloc::string::String, alloc::vec::Vec<alloc::string::String>), std::collections::hash::map::HashMap<kglite::graph::schema::CompositeValue, alloc::vec::Vec<petgraph::graph_impl::NodeIndex>>>

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -2032,6 +2032,7 @@ impl core::default::Default for kglite::api::CurrentSelection
 pub fn kglite::api::CurrentSelection::default() -> kglite::api::CurrentSelection
 pub struct kglite::api::DirGraph
 pub kglite::api::DirGraph::auto_vacuum_threshold: core::option::Option<f64>
+pub kglite::api::DirGraph::checkpoint_lsn: u64
 pub kglite::api::DirGraph::column_stores: std::collections::hash::map::HashMap<alloc::string::String, alloc::sync::Arc<kglite::graph::storage::column_store::ColumnStore>>
 pub kglite::api::DirGraph::composite_index_keys: alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<alloc::string::String>)>
 pub kglite::api::DirGraph::composite_indices: std::collections::hash::map::HashMap<(alloc::string::String, alloc::vec::Vec<alloc::string::String>), std::collections::hash::map::HashMap<kglite::graph::schema::CompositeValue, alloc::vec::Vec<petgraph::graph_impl::NodeIndex>>>

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -2032,6 +2032,7 @@ impl core::default::Default for kglite::api::CurrentSelection
 pub fn kglite::api::CurrentSelection::default() -> kglite::api::CurrentSelection
 pub struct kglite::api::DirGraph
 pub kglite::api::DirGraph::auto_vacuum_threshold: core::option::Option<f64>
+pub kglite::api::DirGraph::checkpoint_lsn: u64
 pub kglite::api::DirGraph::column_stores: std::collections::hash::map::HashMap<alloc::string::String, alloc::sync::Arc<kglite::graph::storage::column_store::ColumnStore>>
 pub kglite::api::DirGraph::composite_index_keys: alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<alloc::string::String>)>
 pub kglite::api::DirGraph::composite_indices: std::collections::hash::map::HashMap<(alloc::string::String, alloc::vec::Vec<alloc::string::String>), std::collections::hash::map::HashMap<kglite::graph::schema::CompositeValue, alloc::vec::Vec<petgraph::graph_impl::NodeIndex>>>

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -2032,6 +2032,7 @@ impl core::default::Default for kglite::api::CurrentSelection
 pub fn kglite::api::CurrentSelection::default() -> kglite::api::CurrentSelection
 pub struct kglite::api::DirGraph
 pub kglite::api::DirGraph::auto_vacuum_threshold: core::option::Option<f64>
+pub kglite::api::DirGraph::checkpoint_lsn: u64
 pub kglite::api::DirGraph::column_stores: std::collections::hash::map::HashMap<alloc::string::String, alloc::sync::Arc<kglite::graph::storage::column_store::ColumnStore>>
 pub kglite::api::DirGraph::composite_index_keys: alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<alloc::string::String>)>
 pub kglite::api::DirGraph::composite_indices: std::collections::hash::map::HashMap<(alloc::string::String, alloc::vec::Vec<alloc::string::String>), std::collections::hash::map::HashMap<kglite::graph::schema::CompositeValue, alloc::vec::Vec<petgraph::graph_impl::NodeIndex>>>

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -2047,6 +2047,7 @@ impl core::default::Default for kglite::api::CurrentSelection
 pub fn kglite::api::CurrentSelection::default() -> kglite::api::CurrentSelection
 pub struct kglite::api::DirGraph
 pub kglite::api::DirGraph::auto_vacuum_threshold: core::option::Option<f64>
+pub kglite::api::DirGraph::checkpoint_lsn: u64
 pub kglite::api::DirGraph::column_stores: std::collections::hash::map::HashMap<alloc::string::String, alloc::sync::Arc<kglite::graph::storage::column_store::ColumnStore>>
 pub kglite::api::DirGraph::composite_index_keys: alloc::vec::Vec<(alloc::string::String, alloc::vec::Vec<alloc::string::String>)>
 pub kglite::api::DirGraph::composite_indices: std::collections::hash::map::HashMap<(alloc::string::String, alloc::vec::Vec<alloc::string::String>), std::collections::hash::map::HashMap<kglite::graph::schema::CompositeValue, alloc::vec::Vec<petgraph::graph_impl::NodeIndex>>>

--- a/tests/benchmarks/test_bench_merge_columnar.py
+++ b/tests/benchmarks/test_bench_merge_columnar.py
@@ -1,0 +1,174 @@
+"""What does one multi-row `MERGE` cost against a saved (columnar) type?
+
+The gap this file fills. `test_bench_fast_write_path.py` measures a **one-row**
+`MERGE` across the four corners of the `journal_covers` gate, and
+`test_bench_write_scaling.py` measures inserts as the graph grows. Neither
+measures the shape that carries the remaining columnar cost: **one statement
+merging R rows into a type that already has N nodes.**
+
+────────────────────────────────────────────────────────────────────────────
+The shape, and why it is worse than "R times a one-row MERGE"
+────────────────────────────────────────────────────────────────────────────
+
+`MERGE` issues one `SET` clause per row (`executor/write.rs`), and each clause
+calls `execute_set` with a single-row `ResultSet`. Two costs compound:
+
+* `touched_columnar_types` is **local to each `execute_set` call**, so the
+  end-of-clause handle-refresh sweep re-points every node of the type at the
+  fork. After the sweep the master's strong count is back to `1 + N`, which
+  means the **next** row's `Arc::make_mut` forks the whole `ColumnStore` again.
+* `ColumnStore::clone` is a genuine deep copy — `columns: self.columns.clone()`
+  over `Vec<TypedColumn>` whose heap arm is a `Vec<T>`.
+
+So the cost is **O(R x (N + |store|))**: R full column-store deep copies *plus*
+R O(N) sweeps — not the O(R x N) the backlog originally recorded. The store
+term is what makes wide types disproportionately expensive, and it is invisible
+in any cell that merges a single row.
+
+Every node holding its own strong `Arc<ColumnStore>` handle is the root, and it
+is pinned as intended design by
+`rollback_tests.rs::every_node_shares_the_master_column_store_handle`. Changing
+it to `Weak` is the bounded fix — the first write of a statement still forks
+(the journal's `prior` clone keeps the strong count at 2), while every
+subsequent write mutates in place, collapsing R forks + R sweeps to one each.
+
+────────────────────────────────────────────────────────────────────────────
+How to read it
+────────────────────────────────────────────────────────────────────────────
+
+Two axes, and the interesting number is a **ratio**, never an absolute:
+
+* **Across `MERGE_ROWS` at one `size`.** Linear in rows is the floor — R rows
+  is R rows of work. Growing *faster* than linearly is the compounding above.
+* **Across `SIZES` at one row count.** This is the diagnostic axis. Merging R
+  rows should not care how many nodes the type already has. If the 100k column
+  is materially slower than the 1k column at the same R, the per-row sweep and
+  fork are being paid, and that is exactly what the weak-handle change removes.
+
+`fresh` is the control. It has no column stores at all, so it cannot take the
+master-write path and should stay flat across `SIZES` no matter what happens to
+`saved`. If `fresh` ever tracks `saved`, the cost is not columnar and this
+file's premise is wrong — treat that as a finding, not as noise.
+
+⚠ This file asserts no timing threshold, deliberately: wall time here is
+sensitive to machine state, and the project's doctrine is that a timing gate on
+a shared runner flakes in both directions. It is a measurement harness for a
+change that has not landed yet, and the honest reading of a benchmark with no
+assertion is "read the numbers", not "this is guarded". The *correctness* of
+the columnar path is guarded in Rust
+(`rollback_tests.rs::a_columnar_set_journals_one_pre_image_per_changed_node`
+and the mapped arm beside it), which is where a deterministic assertion
+belongs.
+
+Nothing here is in the `make bench-check` tracked set.
+
+Run with::
+
+    uv run --no-sync maturin develop --release
+    .venv/bin/python -m pytest tests/benchmarks/test_bench_merge_columnar.py \\
+        -m benchmark -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from kglite import KnowledgeGraph
+
+#: Existing nodes in the merged type. The diagnostic axis: the cost of merging
+#: R rows must not depend on N, and two decades of N make a dependency obvious.
+SIZES = [1_000, 100_000]
+
+#: Rows merged by the single measured statement. 1 is the degenerate case the
+#: other files already cover, and is included so this file's own numbers can be
+#: compared against theirs; the rest is where the compounding shows.
+MERGE_ROWS = [1, 50, 500]
+
+#: `fresh` owns no column stores, so it cannot take the master-write path —
+#: the control that separates "columnar cost" from "MERGE is just slow".
+VARIANTS = ["fresh", "saved"]
+
+#: Wide enough that `|store|` is a visible term rather than a rounding error.
+#: The fork copies every column, so a narrow type would show the sweep cost and
+#: hide the deep-copy cost — and the deep copy is the half the backlog missed.
+EXTRA_COLUMNS = 12
+
+ROUNDS = 5
+WARMUP_ROUNDS = 1
+
+
+def _frame(rows: int, offset: int) -> pd.DataFrame:
+    data = {
+        "id": range(offset, offset + rows),
+        "name": [f"item-{i}" for i in range(rows)],
+    }
+    for c in range(EXTRA_COLUMNS):
+        data[f"c{c}"] = [f"v{c}-{i}" for i in range(rows)]
+    return pd.DataFrame(data)
+
+
+def _variant_graph(size: int, variant: str, tmp_dir) -> KnowledgeGraph:
+    graph = KnowledgeGraph()
+    graph.define_schema({"nodes": {"Item": {"primary_key": "id"}}})
+    graph.add_nodes(_frame(size, 0), "Item", "id", "name")
+    if variant == "saved":
+        # save() is what populates DirGraph.column_stores via enable_columnar().
+        # fsync=False: this save exists to flip the storage shape, not to
+        # benchmark a disk flush.
+        graph.save(str(tmp_dir / f"merge-{variant}-{size}.kgl"), fsync=False)
+
+    # Vacuity guard, in the spirit of the one in test_bench_fast_write_path.py:
+    # a `saved` cell that silently is not columnar would report a healthy number
+    # under a label promising the opposite — indistinguishable from a fix.
+    expect_columnar = variant == "saved"
+    assert graph.is_columnar is expect_columnar, (
+        f"{variant} must{'' if expect_columnar else ' not'} own column stores; "
+        "without them this cell measures a code path the cost does not live on"
+    )
+    return graph
+
+
+@pytest.fixture(scope="module")
+def merge_graphs(tmp_path_factory) -> dict[tuple[int, str], KnowledgeGraph]:
+    """One graph per (size, variant). Module-scoped — the 100k builds are
+    seconds each and must not be repeated per cell."""
+    tmp_dir = tmp_path_factory.mktemp("merge-columnar")
+    return {(size, variant): _variant_graph(size, variant, tmp_dir) for size in SIZES for variant in VARIANTS}
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("rows", MERGE_ROWS)
+@pytest.mark.parametrize("size", SIZES)
+def test_bench_merge_rows_into_columnar_type(benchmark, merge_graphs, size, rows, variant):
+    """One `MERGE` statement covering `rows` rows, against a type with `size`
+    existing nodes.
+
+    The cell the sprint's Phase 0 found missing. Read it two ways — across
+    `rows` at fixed `size` (linear is the floor), and across `size` at fixed
+    `rows` (flat is correct; growth is the per-row fork and sweep).
+
+    Every merged row is a genuine ON MATCH: the ids are drawn from the rows the
+    fixture already created, so the statement never inserts and the number is
+    the update path rather than a mix of insert and update.
+    """
+    graph = merge_graphs[(size, variant)]
+
+    # ON MATCH, not ON CREATE — ids in [0, rows) already exist in every fixture
+    # (all SIZES are >= max(MERGE_ROWS)). Merging new ids would measure inserts
+    # and grow the fixture between rounds, making later rounds a different
+    # experiment from earlier ones.
+    ids = list(range(rows))
+
+    statement = "UNWIND $ids AS i MERGE (n:Item {id: i}) ON MATCH SET n.name = 'merged'"
+
+    def merge():
+        return graph.cypher(statement, params={"ids": ids})
+
+    benchmark.pedantic(merge, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
+
+    benchmark.extra_info["variant"] = variant
+    benchmark.extra_info["existing_nodes"] = size
+    benchmark.extra_info["merged_rows"] = rows
+    benchmark.extra_info["columns"] = EXTRA_COLUMNS + 2

--- a/tests/benchmarks/test_bench_wal_payload.py
+++ b/tests/benchmarks/test_bench_wal_payload.py
@@ -33,30 +33,46 @@ is the **WAL**:
   116-byte strings that is **0.15 * n^2 bytes** — which is the measured
   0.1496 * n^2, including the constant.
 
-Two ingredients are therefore required, and **neither of them is "mapped"**:
-the type must already own a column store (so the detach/reattach loops run at
-all), and the WAL must be on (so the ops are recorded rather than discarded).
-The competitive run had both without intending either — `kglite.open(path,
-storage="mapped")` resolves `durable=None` to **`Full`** (`lib.rs:422-431`),
-silently turning the log on, whereas `KnowledgeGraph(storage="mapped")` has no
-WAL at all.
+Two ingredients are required: the type must already own a column store (so the
+detach/reattach loops run at all), and the WAL must be on (so the ops are
+recorded rather than discarded). The competitive run had both without intending
+either — `kglite.open(path, storage="mapped")` resolves `durable=None` to
+**`Full`**, silently turning the log on, whereas `KnowledgeGraph(storage=
+"mapped")` has no WAL at all.
 
-The three arms below are chosen to decide this. If `default_normal` matches
-`mapped_normal`, the mapped attribution is refuted and the bug belongs to the
-WAL path, where an ordinary `kglite.open(...)` application after a `save()`
-would hit it too. If `default_off` stays linear while both logged arms go
-quadratic, the WAL is confirmed as the carrier.
+**SETTLED 2026-07-30, and the guess above was wrong.** The paragraph that stood
+here argued "neither ingredient is mapped" and predicted that an ordinary
+`kglite.open(...)` application would hit this after any `save()`. It does not.
+The sweeps are storage-mode gated at `batch.rs:186`::
 
-**This looks like a defect with a fix already sitting in the codebase.**
-`GraphWrite::node_weight_mut_silent` exists for exactly this
-(`storage/mod.rs:448`, impl `recording.rs:582-586`) and its doc reads *"Bypass
-recording — internal bookkeeping (columnar handle refresh), not a logical
-mutation."* Both loops are precisely that: the detach writes a temporary empty
-map that reattach restores before the flush, and genuinely-new nodes already
-got their op from `RecordingGraph::add_node` (`recording.rs:597-601`). Since
-`resolve_ops` reads *final* state, switching both call sites to the silent
-variant should collapse the payload to O(n). Not attempted here — this branch
-only adds benchmarks. Filed as a finding.
+    let mapped = graph.graph.is_mapped() || graph.graph.is_disk();
+
+and the detach/reattach pair runs only under that flag, so a memory-backed
+durable graph never enters the amplifying path. Demonstrated rather than read:
+reverting the reattach call site to the recorded borrow turns `mapped_normal`
+red at ratio 2.18 while `default_normal` passes untouched.
+
+The correct scope is **mapped or disk, plus a WAL** — which is exactly how the
+shipped CHANGELOG entry phrases it. That mis-attribution propagated into the
+backlog, where it was recorded as "THIS IS NOT A MAPPED-MODE BUG"; it is not a
+*mapped-mode* bug in the narrow sense, because disk hits it too, but it is
+firmly a not-memory bug, and the difference matters when choosing which arm
+guards it.
+
+**RESOLVED — and the fix was exactly this.** `GraphWrite::node_weight_mut_silent`
+existed for the case already (`storage/mod.rs`, impl in `recording.rs`), doc
+reading *"Bypass recording — internal bookkeeping (columnar handle refresh),
+not a logical mutation."* Both loops were precisely that: the detach writes a
+temporary empty map that reattach restores before the flush, and genuinely-new
+nodes already got their op from `RecordingGraph::add_node`. Since `resolve_ops`
+reads *final* state, switching both call sites collapsed the payload to O(n).
+Shipped in v0.15.0 as `3bf9ef00`; measured 1k-row 2,000 ops / 84 B per row and
+4k-row 20,000 ops / 213 B per row, both now 1 op/row at flat byte cost.
+
+The file also moved: the two sweeps are now `graph/mutation/batch.rs:393`
+(detach) and `:449` (reattach), not the `batch.rs:367`/`:417` cited above. The
+remaining *recorded* `node_weight_mut` in that file is a genuine logical
+mutation and is correctly still recorded.
 
 ────────────────────────────────────────────────────────────────────────────
 Why payload bytes, and not just wall time
@@ -74,12 +90,24 @@ Each cell records `wal_bytes` and `wal_bytes_per_row` into
 `wal_bytes_per_row` across the row counts: **flat = linear = fixed; growing
 proportionally to `rows` = the quadratic is still there.**
 
-⚠ This file asserts nothing about the exponent, because at the time of writing
-**the defect is live** and a guard would fail on `main`. It is a marker for a
-known open issue in the sense `test_bench_write_scaling.py::test_bench_id_
-index_invalidation_on_create` is one. Once the two `batch.rs` call sites are
-switched to the silent accessor, `wal_bytes_per_row` becomes flat and a real
-assertion can be added here — that is the follow-up this file is setting up.
+The defect this file was built to measure was **fixed in v0.15.0** by
+`3bf9ef00`, which switched both `batch.rs` sweeps to the silent accessor. The
+follow-up that fix set up — a real assertion — is
+`test_wal_bytes_per_row_are_flat` below.
+
+That guard is deliberately **not** marked `benchmark`. Everything else here is,
+and `-m 'not benchmark'` is in the default `addopts`, so a guard living behind
+that marker would never run in the ordinary suite — a gate nobody executes. It
+needs no `benchmark` fixture either: the payload measurement is an untimed pair
+of `stat` calls, exact on the first try, with nothing to average.
+
+⚠ Historical note, kept because it cost real time: between 07:14 and 11:00 on
+2026-07-27 this docstring said "**the defect is live** and a guard would fail
+on `main`". The fix landed at 11:00 and the docstring was not updated. On
+2026-07-30 an investigating agent read it, trusted it over the code, and
+reported the bug as still live — while `batch.rs:393` and `:449` had been
+calling `node_weight_mut_silent` for three days. A file that asserts nothing
+cannot correct a stale claim about itself; only an assertion can.
 
 Row counts stop at 32k on purpose: `postcard::to_stdvec` materialises the whole
 payload before the limit is checked (`postcard_v1.rs:27-31`), so approaching
@@ -296,3 +324,120 @@ def test_bench_add_nodes_chunked_workaround(benchmark, tmp_path, arm):
 
     benchmark.pedantic(ingest, setup=setup, rounds=ROUNDS, iterations=1, warmup_rounds=WARMUP_ROUNDS)
     _reset(path)
+
+
+# ---------------------------------------------------------------------------
+# The guard. Unmarked on purpose — see the module docstring.
+# ---------------------------------------------------------------------------
+
+#: Two row counts an octave apart. The defect was `payload ~= 0.1496 * n^2`, so
+#: an 8x row count meant ~8x the bytes *per row*; linear means the ratio sits at
+#: 1.0. Anything between those is not a shape this code can produce, which is
+#: why a single loose threshold separates them cleanly.
+FLAT_ROW_COUNTS = (1_000, 8_000)
+
+#: Slack over 1.0. The per-row cost is not perfectly constant — the frame header
+#: and the postcard varint widths grow with row *count*, not row count squared —
+#: so a few percent of drift is real and expected. 1.25 sits far above that and
+#: far below the ~8x a reintroduced quadratic would produce.
+FLAT_TOLERANCE = 1.25
+
+#: 32k is used by the benchmark cells above but not here: it writes ~150 MB per
+#: measurement, and this guard runs in the DEFAULT suite under a 120 s timeout.
+#: 8k is enough to separate n from n^2 by 8x.
+#:
+#: ONLY the arms that actually execute the sweeps. `batch.rs:186` reads
+#: `let mapped = graph.graph.is_mapped() || graph.graph.is_disk();` and the
+#: detach/reattach pair runs only under that flag — so a memory-backed durable
+#: graph never enters the amplifying path at all. `default_normal` was in this
+#: tuple for one revision and is the reason it is now documented: with the
+#: reattach site deliberately reverted to the recorded borrow, `mapped_normal`
+#: went red at ratio 2.18 while `default_normal` sailed through. An arm that
+#: cannot fail is not a guard, whatever it is measuring.
+#:
+#: Disk shares the identical `is_disk()` branch. It is not covered here only
+#: because a disk fixture is materially heavier to stand up; the mapped arm
+#: exercises the same two call sites.
+SWEEP_ARMS = ("mapped_normal",)
+
+
+def _wal_bytes_per_row(tmp_path, arm: str, rows: int) -> float:
+    """Bytes the WAL grew by during one `add_nodes`, divided by rows written.
+
+    Mirrors the untimed measurement in `test_bench_add_nodes_wal_payload` — the
+    seeded graph gives the type a column store so the detach/reattach sweeps
+    actually execute, and the post-`save()` sidecar is a clean zero point.
+    """
+    path = str(tmp_path / f"flat-{arm}-{rows}.kgl")
+    probe = _seeded_columnar_graph(path, arm)
+    before = _wal_bytes(path)
+    probe.add_nodes(_frame(rows, SEED_ROWS), "Item", "id", "name")
+    logged = _wal_bytes(path) - before
+    del probe
+    _reset(path)
+    return logged / rows
+
+
+@pytest.mark.parametrize("arm", SWEEP_ARMS)
+def test_wal_bytes_per_row_are_flat(tmp_path, arm):
+    """One `add_nodes` must log a constant number of bytes per row.
+
+    Guards the v0.15.0 fix (`3bf9ef00`): the columnar detach/reattach sweeps in
+    `batch.rs` once iterated every existing node of the type through the
+    *recorded* `node_weight_mut`, pushing a `RawOp::UpsertNode` carrying the
+    whole property map per call — `~n^2/1000` ops at `LARGE_BATCH_CHUNK_SIZE`.
+
+    Byte counts are deterministic, so this needs no idle machine, no warmup and
+    no min-vs-mean argument. It is a correctness assertion that happens to live
+    in a benchmark file, not a performance gate.
+    """
+    small = _wal_bytes_per_row(tmp_path, arm, FLAT_ROW_COUNTS[0])
+    large = _wal_bytes_per_row(tmp_path, arm, FLAT_ROW_COUNTS[1])
+
+    # A zero here would make the ratio meaningless (0/0) and pass vacuously —
+    # exactly the failure this file spent three days demonstrating. These arms
+    # are the LOGGED ones; if nothing was logged, the measurement is broken,
+    # not the code under test.
+    assert small > 0, f"{arm}: no WAL bytes logged at {FLAT_ROW_COUNTS[0]} rows"
+    assert large > 0, f"{arm}: no WAL bytes logged at {FLAT_ROW_COUNTS[1]} rows"
+
+    ratio = large / small
+    assert ratio <= FLAT_TOLERANCE, (
+        f"{arm}: WAL payload is not linear in row count. "
+        f"{FLAT_ROW_COUNTS[0]} rows logged {small:.1f} B/row, "
+        f"{FLAT_ROW_COUNTS[1]} rows logged {large:.1f} B/row "
+        f"(ratio {ratio:.2f} > {FLAT_TOLERANCE}). "
+        f"An {FLAT_ROW_COUNTS[1] // FLAT_ROW_COUNTS[0]}x ratio means the "
+        f"quadratic amplification is back: check that both sweeps in "
+        f"graph/mutation/batch.rs still call node_weight_mut_silent."
+    )
+
+
+def test_durable_off_logs_nothing(tmp_path):
+    """Control. Without it, a broken measurement reads as a pass.
+
+    `durable="off"` never creates the sidecar, so `_wal_bytes` returns 0 by the
+    FileNotFoundError path. If this ever reports bytes, the arm above is
+    measuring something other than the WAL and its ratio proves nothing.
+    """
+    assert _wal_bytes_per_row(tmp_path, "default_off", FLAT_ROW_COUNTS[0]) == 0
+
+
+def test_memory_backed_durable_graph_never_runs_the_sweeps(tmp_path):
+    """Pins WHY `default_normal` is absent from `SWEEP_ARMS` — it cannot fail.
+
+    This is documentation with an assertion attached, not a regression guard.
+    The columnar detach/reattach pair is gated on
+    `graph.graph.is_mapped() || graph.graph.is_disk()` (`batch.rs:186`), so a
+    memory-backed durable graph never enters the path that once amplified the
+    payload. Its bytes-per-row is therefore flat by construction, and would
+    stay flat with the fix reverted — verified by doing exactly that.
+
+    If this ever goes red, the mode gate at `batch.rs:186` changed and
+    `SWEEP_ARMS` must grow to match, or the real guard silently stops covering
+    the ordinary durable path.
+    """
+    small = _wal_bytes_per_row(tmp_path, "default_normal", FLAT_ROW_COUNTS[0])
+    large = _wal_bytes_per_row(tmp_path, "default_normal", FLAT_ROW_COUNTS[1])
+    assert small > 0 and large > 0, "expected a memory-backed durable graph to log"
+    assert large / small <= FLAT_TOLERANCE

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -732,6 +732,63 @@ def test_normal_checkpoint_truncates_then_recovers_post_checkpoint(tmp_path, sto
     assert names == ["Alice3", "Bob"]
 
 
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_stale_wal_prefix_is_gated_by_the_checkpoint_lsn(tmp_path, storage):
+    """Replay is gated on the LSN the checkpoint says it already contains, so a
+    **stale WAL prefix cannot roll a newer checkpoint backwards**.
+
+    Why this test and not
+    ``test_normal_checkpoint_truncates_then_recovers_post_checkpoint``: that one
+    crashes the child *after* ``save()`` has already truncated, so the WAL it
+    recovers holds only post-checkpoint frames — the one input that separates a
+    gated replay from an ungated one is absent, and it passes identically with
+    the gate deleted. It pins the pre-checkpoint barrier, not the gate.
+
+    The barrier stops a stale prefix *arising* from a clean crash; nothing stops
+    one arriving another way — an operator restoring a sidecar from backup, a
+    half-copied graph directory, a filesystem that resurrects a truncated file.
+    So the hazard is constructed directly: a real log captured before a
+    checkpoint is written back over the sidecar afterwards, with a genuinely
+    post-checkpoint frame appended behind it. Recovery must skip the first and
+    apply the second — asserting both is what keeps this non-vacuous, since a
+    gate that skipped *everything* would satisfy the first assertion alone.
+    """
+    path = tmp_path / "app.kgl"
+    wal = tmp_path / "app.kgl-wal"
+
+    g = _open(path, storage, durable="full")
+    # The sidecar exists with a header and no frames the moment it is opened;
+    # reading it here derives the header length rather than hard-coding it, so
+    # the frame splice below survives a header-format change.
+    header = wal.read_bytes()
+    assert header, "the sidecar must exist before any commit for this splice"
+
+    g.cypher("CREATE (:Person {id: 1, name: 'Alice1'})")
+    stale = wal.read_bytes()
+    assert len(stale) > len(header), "the captured prefix must hold a real frame"
+
+    g.save()  # checkpoint 1 — folds 'Alice1' in, truncates the log
+    g.cypher("MATCH (p:Person {id: 1}) SET p.name = 'Alice2'")
+    g.save()  # checkpoint 2 — folds 'Alice2' in, truncates again
+
+    # Committed after the newest checkpoint, so it lives only in the log.
+    g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
+    fresh_frames = wal.read_bytes()[len(header) :]
+    assert fresh_frames, "the post-checkpoint frame must have been logged"
+
+    del g  # release the single-writer lease; no save(), so checkpoint 2 stands
+
+    # The hazard: the pre-checkpoint log, back in front of the frames that
+    # legitimately postdate it.
+    wal.write_bytes(stale + fresh_frames)
+
+    g = _open(path, storage, durable="full")
+    names = sorted(r["n"] for r in g.cypher("MATCH (p:Person) RETURN p.name AS n"))
+    # 'Alice1' here would mean the stale frame was folded over the newer
+    # checkpoint; a missing 'Bob' would mean the gate ate a live frame too.
+    assert names == ["Alice2", "Bob"]
+
+
 # ── level spellings and validation ───────────────────────────────────
 
 


### PR DESCRIPTION
Seven filed engine defects were handed to this sprint. **Four were already fixed and shipped** — plus four more stale items the audit turned up — and two of the filed *premises* turned out false. What remained was smaller and differently shaped than filed.

Plan: `dev-docs/plans/engine-defect-sprint.md`.

## Already fixed — closed with evidence, zero work

| Item | Fixed by |
|---|---|
| quadratic mapped `add_nodes` | duplicate, `3bf9ef00`, v0.15.0 |
| post-save SET regression | `6f0a8760`, v0.15.0 |
| quadratic WAL payload | `3bf9ef00`, v0.15.0 |
| `storage=` silently ignored on open | `973515b1`, v0.15.0 |
| durability asymmetry | not a defect — structural; `GraphLifecycle::detached()` has no file for a WAL |
| `execute_remove` per-node clone | `write.rs` ("**was** O(R x N)") |

## Two false premises

- **The `Arc<DirGraph>` clone and the columnar `Arc<ColumnStore>` fork do not share a root.** Different Arcs, different costs; fixing one moves none of the other's numbers. That framing is what made this look like an all-or-nothing design sprint.
- **LSN gating never needed a `.kgl` format bump.** The v5 metadata block is canonical JSON and `user_schema_version` is an exact additive precedent. It was deferred from a release for a reason that did not hold.

## Phases

- [x] **1** Arm the WAL-payload guard — 250 lines, **zero assertions**, and a docstring that had said "the defect is live" for three days after the fix landed. It misled a Phase-0 investigator into reporting a fixed bug as open.
- [x] **2** Pin the held-reader whole-graph copy as a **count, not a timing**. `min`/p95 hide it by construction and `bench-check`/`bench-anchor` both run `--metric min`, so a 28 ms cliff at 1M nodes is now an exact integer at ten.
- [x] **3** Cover mapped rollback — **nothing had ever executed it**.
- [x] **4** Give `MappedGraph` an undo journal. Mapped statements stop paying an `O(V+E)` fork per statement. The veto's stated reason was false for mapped (`MappedGraph.inner` is the same heap `StableDiGraph`); Disk is unchanged and the reason is genuinely correct there.
- [x] **5** Gate WAL replay on the checkpoint LSN. The skip mechanism already existed and was being passed a hardcoded `0`.
- [x] **6** Make the columnar refresh sweep fork-conditional — a provable no-op today, landed alone so the behaviour change belongs to its own diff.
- [x] **7** Benchmark the multi-row MERGE shape, which nothing measured.
- [x] **8** Weak columnar handles — **attempted, stopped, not landed.** See below.

## Phase 8 stopped deliberately, with evidence

`Arc<ColumnStore>` in `PropertyStorage::Columnar` does **two** jobs and `Weak` is correct for only one: a read handle onto the shared master, *and* an **owning** handle onto a node-private copy-on-write fork. Measured on the mainline query `MATCH (n:Item {id: 3}) SET n.name = 'renamed'`, the node's store has **`strong_count == 1`** — the node is its sole owner. Under `Weak` it would be freed instantly, and since `enable_columnar` nulls `id`/`title` to sentinels that read through the store, the node goes fully blank with a null id. `Serialize` would then write empty property maps to `.kgl`.

Everything the plan predicted about *rollback* held up. The design was refuted by a path the plan never listed — which is why the audit was step 1 with authority to stop. Decomposition for a future sprint is in the plan and task #35.

## Three vacuous nets, each closed by a phase

1. Zero-assertion benchmark file whose stale docstring actively misinformed.
2. The checkpoint-truncation durability test **cannot fail if the LSN gate is deleted** — its child crashes after truncation, so the WAL never holds a pre-checkpoint frame.
3. Mapped/disk clone guards ran memory-only.

## Testing discipline

Every gate added here was **observed failing before being trusted**, which caught four things reading the code did not: a vacuous arm in a guard just written, a red `make gate` committed over, **silent data loss** from flipping one flag, and a counter reset whose removal was load-bearing rather than cosmetic. Details in each commit message.

No version bump, no CHANGELOG promotion — shipping is the release skill's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)