### PR TITLE
Planner NDV alias fix, index maintenance divergence, describe-cost recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scanning the now-correctly-chosen type), so an index added as a workaround
   is still worth keeping.
 
+- **`.statistics()` on a type's own title or id field returned nothing.** For a
+  type loaded as `add_nodes(..., unique_id_field="term_id",
+  node_title_field="term_name")`, `select("Term").statistics("term_id")` —
+  and equally `"term_name"`, `"id"`, `"title"` — reported `count = N` with
+  `valid_count = 0`, no `min`/`max`/`avg`, and `value_type = "null"`: a silently
+  empty answer rather than an error, on a column every node carries. The
+  ungrouped path read the property map directly, where identity columns do not
+  live, while its `group_by=` sibling already resolved the alias. Both now read
+  through the same alias-resolving route as every other read, so the two entry
+  points cannot disagree about what a field name means. A genuinely absent
+  property still reports `valid_count = 0`.
+
 ## [0.15.12] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A join filtered on a type's title/id field is no longer planned as if the
+  filter matched everything.** The planner estimates a non-indexed equality
+  (and `IN`) filter as `type_count / distinct_values`, but the distinct-value
+  scan read the property map only — and a type's `node_title_field` /
+  `unique_id_field` (`add_nodes(..., unique_id_field="wlbWellboreName")`, and
+  the canonical `title` / `id`) do not live there. The scan therefore found
+  nothing, reported one distinct value, and the filter scored as excluding
+  nothing, so the join anchored on the *other*, larger end of the pattern and
+  drove every one of its rows through the filter. Present since 0.11.9, when
+  the distinct-value estimate was introduced. The statistic now resolves the
+  same field aliases the matcher does, and an empty scan reports *no
+  information* rather than "one distinct value" — no estimate can be
+  manufactured from an absent property again. Traversals filtered on a title
+  or id field over a large type get order-of-magnitude speedups. Measured
+  (release build, min-of-12, two agreeing runs, unchanged-path controls flat):
+  a 20k-node synthetic join filtered on the title field 1.09 ms → 0.039 ms
+  (28×) and on the id field 1.02 ms → 0.006 ms (168×), against 0.023 ms for
+  the same join filtered on an ordinary property; on a real 195 MB legal
+  graph `MATCH (d:CourtDecision)-[:HAS_KEYWORD]->(k:Keyword) WHERE k.name =
+  'Erstatning'` 5.79 ms → 0.92 ms, and on a 135 MB petroleum graph a
+  four-hop anchored on `w.wlbWellboreName` 2.41 ms → 0.22 ms. Results were
+  always correct — only the plan was wrong. `create_index` on the filtered
+  property remains faster still (it answers the lookup outright rather than
+  scanning the now-correctly-chosen type), so an index added as a workaround
+  is still worth keeping.
+
 ## [0.15.12] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scanning the now-correctly-chosen type), so an index added as a workaround
   is still worth keeping.
 
+- **An indexed `MATCH` could return phantom or duplicate rows after a Cypher
+  `CREATE` / `SET` on a type whose indexed property is an id/title alias
+  spelling.** For a type loaded as `add_nodes(..., unique_id_field="term_id",
+  node_title_field="term_name")` and indexed with `create_index("Term",
+  "term_name")` (or `CREATE INDEX FOR (t:Term) ON (t.term_name)`), the index is
+  built from the node's title — the value a `MATCH` on that name compares
+  against — but incremental maintenance read the node by the user-facing key
+  instead. A written node was filed under a bucket value no scan can produce:
+  `MATCH (t:Term {term_name: …})` returned rows that the same query without the
+  index did not, an inline-map predicate and its `WHERE` spelling disagreed with
+  each other, and a written value colliding with an existing node's title added
+  a bogus member to that node's bucket. Index updates now resolve field aliases
+  exactly like index rebuilds and scans do, so incremental maintenance and
+  `create_index` agree by construction. Two adjacent defects fixed with it: a
+  `SET` on `title` left an index registered under the title-alias spelling
+  stale, and a property carrying both a hash and a range index (Neo4j-style
+  `CREATE RANGE INDEX`) had newly created nodes appended to each bucket twice,
+  so an indexed lookup returned them twice.
+
 - **`.statistics()` on a type's own title or id field returned nothing.** For a
   type loaded as `add_nodes(..., unique_id_field="term_id",
   node_title_field="term_name")`, `select("Term").statistics("term_id")` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`describe()` / `describe(types=[...])` are ~2.3× faster on property-heavy
+  graphs, with byte-identical output.** 0.15.9 routed the property-stats scan
+  through the storage accessors so that saved (columnar) graphs stop reporting
+  empty stats — a real fix that stays — but it paid for every row twice over:
+  the per-node accumulator was keyed by `String`, so a 50k-node × 13-property
+  type allocated and hashed ~650k short-lived key strings per call, and every
+  columnar row enumeration allocated a `HashSet` for a merge step that only the
+  mmap-backed path performs. The scan now accumulates by interned key (a `Copy`
+  u64) and resolves names once at the end, and the row enumerator builds its
+  merge set only when there is an mmap store to merge with — which speeds up
+  every columnar row read, not just `describe`. Measured (release build,
+  min-of-12, two agreeing runs, unchanged-path controls flat within 4%):
+  synthetic law-like graph (50k nodes × 13 string properties + 5 smaller
+  types), saved and reloaded, `describe()` 49.4 ms → 21.9 ms and
+  `describe(types=["Decision"])` 48.7 ms → 21.4 ms; a 40-type narrow-numeric
+  graph's `describe(types=[...])` 3.19 ms → 0.88 ms (3.6×). Output is
+  unchanged — counts, distinct values, ordering and every byte of the XML
+  match, verified fixture-by-fixture before and after.
+
 ### Fixed
 
 - **A join filtered on a type's title/id field is no longer planned as if the

--- a/crates/kglite/src/graph/core/pattern_matching/matcher.rs
+++ b/crates/kglite/src/graph/core/pattern_matching/matcher.rs
@@ -14,7 +14,6 @@ use petgraph::graph::NodeIndex;
 use petgraph::Direction;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
@@ -1406,24 +1405,11 @@ impl<'a> PatternExecutor<'a> {
             }
         }
 
-        let value: Option<Cow<'_, Value>> = if field == "id" {
-            Some(node.id())
-        } else if field == "title" {
-            Some(node.title())
-        } else if let Some(v) = node.get(key) {
-            // Stored property wins (a user `label`/`type`/`name`… — KG-1).
-            Some(v)
-        } else {
-            // No stored property — structural convenience fallback.
-            crate::graph::schema::soft_alias_fallback(field).map(|fb| match fb {
-                crate::graph::schema::SoftAliasFallback::Title => node.title(),
-                crate::graph::schema::SoftAliasFallback::TypeString => {
-                    Cow::Owned(Value::String(type_str.to_string()))
-                }
-            })
-        };
-
-        match value {
+        // Identity fields, then a stored property (a user `label`/`type`/
+        // `name`… wins — KG-1), then the structural soft-alias fallback. Shared
+        // with the planner's NDV statistic so the two cannot disagree about
+        // what a filter on `field` sees.
+        match node.resolved_field(type_str, field, key) {
             Some(v) => self.value_matches(&v, matcher),
             None => false,
         }

--- a/crates/kglite/src/graph/core/statistics.rs
+++ b/crates/kglite/src/graph/core/statistics.rs
@@ -1,6 +1,6 @@
 // src/graph/statistics.rs
 use crate::datatypes::values::Value;
-use crate::graph::schema::{CurrentSelection, DirGraph};
+use crate::graph::schema::{CurrentSelection, DirGraph, InternedKey};
 use petgraph::graph::NodeIndex;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -92,25 +92,21 @@ pub fn calculate_grouped_property_stats(
         let Some(node) = graph.node_view(index) else {
             continue;
         };
-        let node_type = node.node_type_str(&graph.interner);
-        let resolved_group = graph.resolve_alias(node_type, group_by);
-        let key = match node.get_field_ref(resolved_group).as_deref() {
+        let key = match resolved_stat_field(graph, node, group_by).as_deref() {
             Some(Value::String(value)) => value.clone(),
             Some(Value::Int64(value)) => value.to_string(),
             Some(value) => format!("{:?}", value),
             None => "null".to_string(),
         };
         let values = grouped_values.entry(key).or_default();
-        let resolved_property = graph.resolve_alias(node_type, property);
-        let numeric =
-            node.get_field_ref(resolved_property)
-                .as_deref()
-                .and_then(|value| match value {
-                    Value::Int64(value) => Some(*value as f64),
-                    Value::Float64(value) => Some(*value),
-                    Value::UniqueId(value) => Some(*value as f64),
-                    _ => None,
-                });
+        let numeric = resolved_stat_field(graph, node, property)
+            .as_deref()
+            .and_then(|value| match value {
+                Value::Int64(value) => Some(*value as f64),
+                Value::Float64(value) => Some(*value),
+                Value::UniqueId(value) => Some(*value as f64),
+                _ => None,
+            });
         if let Some(value) = numeric {
             values.push(value);
         }
@@ -250,7 +246,7 @@ fn calculate_stats_for_nodes(
 
     for &node_idx in nodes {
         if let Some(node) = graph.node_view(node_idx) {
-            if let Some(value) = get_node_property(node, property) {
+            if let Some(value) = resolved_stat_field(graph, node, property) {
                 match &*value {
                     Value::Null => continue,
                     Value::String(s) if s.is_empty() => continue,
@@ -325,11 +321,146 @@ fn try_convert_to_float(value: &Value) -> Option<f64> {
     }
 }
 
-fn get_node_property<'a>(
+/// Read `property` off `node` the way a filter on it would.
+///
+/// Both statistics entry points come through here, so the grouped and
+/// ungrouped surfaces cannot disagree about what a field name means. The
+/// resolution is [`NodeView::resolved_field`]'s — a type's `unique_id_field` /
+/// `node_title_field` map onto the identity columns, then a stored property,
+/// then the structural soft alias. `calculate_property_stats` used to read the
+/// property map alone, so `.statistics()` on a type's own id/title column (in
+/// any spelling) reported `valid_count = 0` and no numeric stats.
+fn resolved_stat_field<'a>(
+    graph: &'a DirGraph,
     node: crate::graph::storage::NodeView<'a>,
     property: &str,
 ) -> Option<Cow<'a, Value>> {
-    node.get_property(property)
+    let node_type = node.node_type_str(&graph.interner);
+    let field = graph.resolve_alias(node_type, property);
+    node.resolved_field(node_type, field, InternedKey::from_str(field))
+}
+
+#[cfg(test)]
+mod identity_field_tests {
+    use super::*;
+    use crate::datatypes::DataFrame;
+    use crate::graph::mutation::maintain::add_nodes;
+
+    /// A type whose identity columns are named `term_id` / `term_name`, so
+    /// `add_nodes` hoists them onto `NodeData.id` / `NodeData.title` and
+    /// registers the alias. Nothing named `term_id`, `term_name`, `id` or
+    /// `title` remains in the property map — a read that skips alias
+    /// resolution finds nothing at all.
+    fn aliased_graph() -> DirGraph {
+        let rows: Vec<Vec<Value>> = (1..=5)
+            .map(|i| vec![Value::Int64(i), Value::String(format!("term-{i}"))])
+            .collect();
+        let df =
+            DataFrame::from_cypher_rows(vec!["term_id".to_string(), "term_name".to_string()], rows)
+                .expect("fixture frame");
+        let mut graph = DirGraph::new();
+        add_nodes(
+            &mut graph,
+            df,
+            "Term".to_string(),
+            "term_id".to_string(),
+            Some("term_name".to_string()),
+            None,
+        )
+        .expect("fixture add_nodes");
+        graph
+    }
+
+    fn stats_for(graph: &DirGraph, property: &str) -> PropertyStats {
+        let children: Vec<_> = graph
+            .type_indices
+            .get("Term")
+            .expect("Term type index")
+            .iter()
+            .collect();
+        let pairs = vec![ParentChildPair {
+            parent: None,
+            children,
+        }];
+        calculate_property_stats(graph, &pairs, property)
+            .pop()
+            .expect("one group")
+    }
+
+    /// `.statistics("term_id")` and `.statistics("id")` must both see the
+    /// identity column. Reading the property map alone reports
+    /// `valid_count = 0` with no numeric stats — silently wrong, not an error.
+    #[test]
+    fn statistics_resolve_the_types_id_field() {
+        let graph = aliased_graph();
+        for spelling in ["term_id", "id"] {
+            let stats = stats_for(&graph, spelling);
+            assert_eq!(stats.count, 5, "{spelling}: node count");
+            assert_eq!(
+                stats.valid_count, 5,
+                "{spelling}: every node carries the id field"
+            );
+            assert!(stats.is_numeric, "{spelling}: id values are integers");
+            assert_eq!(stats.min, Some(1.0), "{spelling}: min");
+            assert_eq!(stats.max, Some(5.0), "{spelling}: max");
+            assert_eq!(stats.sum, Some(15.0), "{spelling}: sum");
+            assert_eq!(stats.avg, Some(3.0), "{spelling}: avg");
+        }
+    }
+
+    /// Same for the title field, which is non-numeric: the fix is visible as
+    /// `valid_count` and the value type, not as min/max.
+    #[test]
+    fn statistics_resolve_the_types_title_field() {
+        let graph = aliased_graph();
+        for spelling in ["term_name", "title"] {
+            let stats = stats_for(&graph, spelling);
+            assert_eq!(stats.count, 5, "{spelling}: node count");
+            assert_eq!(
+                stats.valid_count, 5,
+                "{spelling}: every node carries the title field"
+            );
+            assert_eq!(stats.value_type, "string", "{spelling}: value type");
+        }
+    }
+
+    /// A genuinely absent property still reports nothing — the fix must not
+    /// invent values.
+    #[test]
+    fn statistics_on_an_absent_property_stay_empty() {
+        let graph = aliased_graph();
+        let stats = stats_for(&graph, "no_such_property");
+        assert_eq!(stats.count, 5);
+        assert_eq!(stats.valid_count, 0);
+        assert_eq!(stats.value_type, "null");
+        assert_eq!(stats.min, None);
+        assert_eq!(stats.max, None);
+    }
+
+    /// The grouped sibling resolves the same way — one graph, one field, two
+    /// entry points, one answer.
+    #[test]
+    fn grouped_statistics_resolve_the_types_id_field() {
+        let graph = aliased_graph();
+        let indices: Vec<_> = graph
+            .type_indices
+            .get("Term")
+            .expect("Term type index")
+            .iter()
+            .collect();
+        let mut selection = CurrentSelection::new();
+        selection
+            .get_level_mut(0)
+            .expect("root level")
+            .add_selection(None, indices);
+        let grouped =
+            calculate_grouped_property_stats(&graph, &selection, "term_id", "term_name", None);
+        assert_eq!(grouped.len(), 5, "one group per distinct title");
+        let one = &grouped["term-1"];
+        assert_eq!(one.count, 1);
+        assert_eq!(one.min, Some(1.0));
+        assert_eq!(one.max, Some(1.0));
+    }
 }
 
 #[cfg(test)]

--- a/crates/kglite/src/graph/dir_graph/caches.rs
+++ b/crates/kglite/src/graph/dir_graph/caches.rs
@@ -111,19 +111,31 @@ impl DirGraph {
     /// absent or larger than `MAX_SCAN` (caller falls back to the heuristic);
     /// at that scale a real property index is the right tool and gives exact
     /// selectivity anyway. Plan-time read path only — never the write hot path.
+    ///
+    /// The scan reads the same **alias-resolved field** a property filter would
+    /// ([`NodeView::resolved_field`](crate::graph::storage::NodeView::resolved_field)),
+    /// so a type's `node_title_field` / `unique_id_field` — which live on the
+    /// node's identity columns, not in its property map — report their real
+    /// distinct count. Reading the property map alone found nothing for those
+    /// and scored the filter as completely non-selective (Track H2).
     pub fn property_ndv(&self, node_type: &str, property: &str) -> Option<usize> {
         const MAX_SCAN: usize = 200_000;
         let nodes = self.type_indices.get(node_type)?;
         if nodes.is_empty() || nodes.len() > MAX_SCAN {
             return None;
         }
-        let key = (node_type.to_string(), property.to_string());
-        // Fast path: cache hit at the current graph version.
+        // Key the cache by the *resolved* field: two spellings of one identity
+        // field (`term_name` and `title`) are one statistic, not two scans.
+        let field = self.resolve_alias(node_type, property);
+        let key = (node_type.to_string(), field.to_string());
+        // Fast path: cache hit at the current graph version. A cached `0` is
+        // the "no information" verdict below, memoised so a fruitless scan is
+        // paid once rather than on every plan.
         {
             let read = self.property_ndv_cache.read().unwrap();
             if read.0 == self.version {
                 if let Some(&ndv) = read.1.get(&key) {
-                    return Some(ndv);
+                    return (ndv > 0).then_some(ndv);
                 }
             }
         }
@@ -131,15 +143,16 @@ impl DirGraph {
         // Arena guard: get_node -> node_weight materializes on the disk
         // backend (protocol in disk/graph.rs); no-op on memory/mapped.
         let _arena_guard = self.graph.begin_query();
+        let field_key = InternedKey::from_str(field);
         let mut seen: std::collections::HashSet<Value> = std::collections::HashSet::new();
         for idx in nodes.iter() {
             if let Some(node) = self.node_view(idx) {
-                if let Some(val) = node.get_property(property) {
+                if let Some(val) = node.resolved_field(node_type, field, field_key) {
                     seen.insert(val.into_owned());
                 }
             }
         }
-        let ndv = seen.len().max(1);
+        let ndv = seen.len();
         let mut write = self.property_ndv_cache.write().unwrap();
         // Drop a stale-version map before inserting (auto-invalidation).
         if write.0 != self.version {
@@ -147,7 +160,12 @@ impl DirGraph {
             write.0 = self.version;
         }
         write.1.insert(key, ndv);
-        Some(ndv)
+        // An empty scan means this route found no values at all — the property
+        // is absent from every node, or some future resolution gap hides it.
+        // That is *no information*, and it must not be handed to the estimator
+        // as `type_count / 1`, i.e. "this filter excludes nothing". Report
+        // `None` so the caller falls back to its flat heuristic.
+        (ndv > 0).then_some(ndv)
     }
 
     /// Check if edge type count cache is populated (avoids O(E) scan).

--- a/crates/kglite/src/graph/dir_graph/indexes.rs
+++ b/crates/kglite/src/graph/dir_graph/indexes.rs
@@ -9,7 +9,6 @@
 //! keys before save and `rebuild_indices_from_keys` replays them on load (both
 //! in `mod.rs`, with the other serialization helpers).
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 use super::index_layer::LayeredIndex;
@@ -76,15 +75,17 @@ impl DirGraph {
     /// Create an index on a property for a specific node type.
     /// Returns the number of entries indexed.
     ///
-    /// The id-alias / title-alias fields (e.g. `add_nodes(df, "Star",
-    /// "starId", "title")` makes `starId` the alias for the canonical
-    /// id) are intentionally NOT special-cased here: their indices
-    /// would build as empty (id/title live off the properties map).
-    /// Lookups against id-alias names route through `lookup_by_id_readonly`
-    /// in the matcher (`try_index_lookup`), which uses the auto-
-    /// maintained per-type `id_index` — no separate `create_index` call
-    /// required, and SET-on-id always stays in sync because id mutation
-    /// updates the id_index directly.
+    /// An index on an id-alias / title-alias field (e.g. `add_nodes(df, "Star",
+    /// "starId", "title")` makes `starId` the alias for the canonical id) is
+    /// keyed by the alias spelling but built from the node's id / title, since
+    /// that is where the value lives and what a `MATCH` on that name compares
+    /// against — [`Self::read_indexed`] does the resolving, and the incremental
+    /// updaters read through the same funnel so they agree with this build.
+    /// Such an index is not *required*, though: lookups against id-alias names
+    /// route through `lookup_by_id_readonly` in the matcher
+    /// (`try_index_lookup`), which uses the auto-maintained per-type
+    /// `id_index`, and SET-on-id stays in sync because id mutation updates the
+    /// id_index directly.
     pub fn create_index(&mut self, node_type: &str, property: &str) -> usize {
         // Store key uses the user's `property` name verbatim — the
         // matcher's `try_index_lookup` indexes into `property_indices`
@@ -641,75 +642,157 @@ impl DirGraph {
     // Incremental Index Maintenance (called by Cypher mutations)
     // ========================================================================
 
+    /// The value an index *rebuild* would file `node_idx` under for the index
+    /// registered as `property` — [`Self::create_index`]'s read, for one node.
+    ///
+    /// Incremental maintenance reads through here so it agrees with a rebuild
+    /// **by construction**. Index keys carry the user's spelling, but their
+    /// contents are the *resolved* field's values, so reading the node by the
+    /// user-facing key files it under a value the matcher's scan can never
+    /// produce — the phantom-row / poisoned-bucket divergence this replaced.
+    fn indexed_value(
+        &mut self,
+        node_type: &str,
+        property: &str,
+        node_idx: NodeIndex,
+    ) -> Option<Value> {
+        let reader = self.property_reader(node_type, property);
+        self.read_indexed(&reader, node_idx)
+    }
+
+    /// The properties carrying a single-value (hash or range) index on
+    /// `node_type`, **deduplicated**: a property carrying both kinds appears
+    /// once in each store, so iterating the two key sets naively appended the
+    /// node twice per bucket and an indexed `MATCH` returned it twice.
+    fn single_value_indexed_properties(&self, node_type: &str) -> Vec<String> {
+        let mut properties: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for (nt, property) in self
+            .property_indices
+            .keys()
+            .chain(self.range_indices.keys())
+        {
+            if nt == node_type {
+                properties.insert(property.as_str());
+            }
+        }
+        properties.into_iter().map(str::to_string).collect()
+    }
+
+    /// The single-value index keys on `node_type` whose contents are drawn from
+    /// `resolved` — the field a write to it moves the node within.
+    ///
+    /// Usually just `resolved` itself. It differs only for `id` / `title`,
+    /// which an index may also be registered under the type's *alias* spelling
+    /// for (`create_index("Term", "term_name")` on a title-aliased type builds
+    /// its buckets from `get_node_title`), and those keys have to move with the
+    /// field, not with the spelling of the statement that wrote it.
+    fn index_keys_for_field(&self, node_type: &str, resolved: &str) -> Vec<String> {
+        if self.id_field_aliases.is_empty() && self.title_field_aliases.is_empty() {
+            return vec![resolved.to_string()];
+        }
+        let mut keys: Vec<String> = self
+            .single_value_indexed_properties(node_type)
+            .into_iter()
+            .filter(|property| self.resolve_alias(node_type, property) == resolved)
+            .collect();
+        if !keys.iter().any(|property| property == resolved) {
+            keys.push(resolved.to_string());
+        }
+        keys
+    }
+
     /// Update property, composite, and range indices after a new node is added.
     /// Only updates indices that already exist for this node_type.
     pub fn update_property_indices_for_add(&mut self, node_type: &str, node_idx: NodeIndex) {
-        // Collect single-property index updates (immutable borrow of self.graph)
-        let prop_updates: Vec<(IndexKey, Value)> = {
-            // Disk backend: node_weight materializes into the query arena,
-            // which must run under a DiskQueryGuard (arena protocol in
-            // disk/graph.rs). No-op on memory/mapped backends.
-            let _guard = self.graph.begin_query();
-            let node = match self.graph.node_view(node_idx) {
-                Some(n) => n,
-                None => return,
+        for property in self.single_value_indexed_properties(node_type) {
+            let Some(value) = self.indexed_value(node_type, &property, node_idx) else {
+                continue;
             };
-            self.property_indices
-                .keys()
-                .chain(self.range_indices.keys())
-                .filter(|(nt, _)| nt == node_type)
-                .filter_map(|key| {
-                    node.get_property(&key.1)
-                        .map(|v| (key.clone(), v.into_owned()))
-                })
-                .collect()
-        };
-        for (key, value) in &prop_updates {
-            self.note_property_append(key, value, node_idx);
-            if let Some(value_map) = self.property_indices.get_mut(key) {
-                value_map.entry_or_default(value).push(node_idx);
+            let key = (node_type.to_string(), property);
+            self.note_property_append(&key, &value, node_idx);
+            if let Some(value_map) = self.property_indices.get_mut(&key) {
+                value_map.entry_or_default(&value).push(node_idx);
             }
-            self.note_range_append(key, value, node_idx);
-            if let Some(btree) = self.range_indices.get_mut(key) {
-                btree.entry(value.clone()).or_default().push(node_idx);
+            self.note_range_append(&key, &value, node_idx);
+            if let Some(btree) = self.range_indices.get_mut(&key) {
+                btree.entry(value).or_default().push(node_idx);
             }
         }
 
-        // Collect composite index updates
-        let comp_updates: Vec<(CompositeIndexKey, CompositeValue)> = {
-            // Arena guard: see prop_updates block above.
-            let _guard = self.graph.begin_query();
-            let node = match self.graph.node_view(node_idx) {
-                Some(n) => n,
-                None => return,
-            };
-            self.composite_indices
-                .keys()
-                .filter(|(nt, _)| nt == node_type)
-                .filter_map(|key| {
-                    let vals: Vec<Value> = key
-                        .1
-                        .iter()
-                        .map(|p| {
-                            node.get_property(p)
-                                .map(Cow::into_owned)
-                                .unwrap_or(Value::Null)
-                        })
-                        .collect();
-                    if vals.iter().any(|v| !matches!(v, Value::Null)) {
-                        Some((key.clone(), CompositeValue(vals)))
-                    } else {
-                        None
-                    }
+        let comp_keys: Vec<CompositeIndexKey> = self
+            .composite_indices
+            .keys()
+            .filter(|(nt, _)| nt == node_type)
+            .cloned()
+            .collect();
+        for key in comp_keys {
+            let values: Vec<Value> = key
+                .1
+                .iter()
+                .map(|property| {
+                    self.indexed_value(node_type, property, node_idx)
+                        .unwrap_or(Value::Null)
                 })
-                .collect()
-        };
-        for (key, comp_val) in comp_updates {
+                .collect();
+            if values.iter().all(|v| matches!(v, Value::Null)) {
+                continue;
+            }
+            let comp_val = CompositeValue(values);
             self.note_composite_append(&key, &comp_val, node_idx);
             if let Some(comp_map) = self.composite_indices.get_mut(&key) {
                 comp_map.entry_or_default(&comp_val).push(node_idx);
             }
         }
+    }
+
+    /// Vacate `node_idx` from the `value` bucket of the hash and range indices
+    /// keyed `key`, journalling each eviction first.
+    ///
+    /// Vacating the old bucket and joining the new one are journalled
+    /// separately, and each capture has to read the map as it stands just
+    /// before its own edit — hence the split borrows.
+    fn evict_from_single_value_indexes(&mut self, key: &IndexKey, value: &Value, node: NodeIndex) {
+        self.note_property_eviction(key, value, node);
+        if let Some(value_map) = self.property_indices.get_mut(key) {
+            if let Some(indices) = value_map.get_mut(value) {
+                indices.retain(|&idx| idx != node);
+                if indices.is_empty() {
+                    value_map.remove(value);
+                }
+            }
+        }
+        self.note_range_eviction(key, value, node);
+        if let Some(btree) = self.range_indices.get_mut(key) {
+            if let Some(indices) = btree.get_mut(value) {
+                indices.retain(|&idx| idx != node);
+                if indices.is_empty() {
+                    btree.remove(value);
+                }
+            }
+        }
+    }
+
+    /// Whether a write spelled `property` left the field every index on
+    /// `node_type` is built from untouched.
+    ///
+    /// True when `property` is one of the type's id/title **alias** spellings:
+    /// Cypher stores such a write verbatim in the property map (see the
+    /// CREATE/SET write path), while every index — under either spelling —
+    /// holds the node's id/title, read through [`Self::read_indexed`]. A
+    /// rebuild would therefore reproduce the buckets already present, so the
+    /// correct incremental action is none. Filing the written value here is
+    /// what produced buckets an equivalent scan can never match.
+    ///
+    /// `title` and `name` are the exception: they are the Cypher-level
+    /// spellings of the title itself, and the SET/REMOVE executor writes the
+    /// node's title through both (`write.rs::set_node_property_direct`), so a
+    /// write spelled either one *does* move the indexed field — even for a type
+    /// that also declares `name` as its title alias.
+    fn write_bypasses_indexed_fields(&self, node_type: &str, property: &str) -> bool {
+        if property == "title" || property == "name" {
+            return false;
+        }
+        self.resolve_alias(node_type, property) != property
     }
 
     /// Update property, range, and composite indices after a property value is changed.
@@ -722,40 +805,30 @@ impl DirGraph {
         old_value: Option<&Value>,
         new_value: &Value,
     ) {
-        let key = (node_type.to_string(), property.to_string());
-        // Update hash index. Vacating the old bucket and joining the new one
-        // are journalled separately, and each capture has to read the map as
-        // it stands just before its own edit — hence the split borrows.
-        if let Some(old_val) = old_value {
-            self.note_property_eviction(&key, old_val, node_idx);
+        if self.write_bypasses_indexed_fields(node_type, property) {
+            return;
+        }
+        // The value that actually landed, read the way a rebuild reads it, so
+        // storage that keeps the authoritative copy elsewhere (a columnar
+        // master, the node's id/title fields) buckets the node under what a
+        // `MATCH` will find. Falls back to the caller's value for a backend
+        // whose granular read cannot see the write yet.
+        let landed = self.indexed_value(node_type, property, node_idx);
+        let landed = landed.unwrap_or_else(|| new_value.clone());
+        let field = self.resolve_alias(node_type, property).to_string();
+        for indexed_as in self.index_keys_for_field(node_type, &field) {
+            let key = (node_type.to_string(), indexed_as);
+            if let Some(old_val) = old_value {
+                self.evict_from_single_value_indexes(&key, old_val, node_idx);
+            }
+            self.note_property_append(&key, &landed, node_idx);
             if let Some(value_map) = self.property_indices.get_mut(&key) {
-                if let Some(indices) = value_map.get_mut(old_val) {
-                    indices.retain(|&idx| idx != node_idx);
-                    if indices.is_empty() {
-                        value_map.remove(old_val);
-                    }
-                }
+                value_map.entry_or_default(&landed).push(node_idx);
             }
-        }
-        self.note_property_append(&key, new_value, node_idx);
-        if let Some(value_map) = self.property_indices.get_mut(&key) {
-            value_map.entry_or_default(new_value).push(node_idx);
-        }
-        // Update range index
-        if let Some(old_val) = old_value {
-            self.note_range_eviction(&key, old_val, node_idx);
+            self.note_range_append(&key, &landed, node_idx);
             if let Some(btree) = self.range_indices.get_mut(&key) {
-                if let Some(indices) = btree.get_mut(old_val) {
-                    indices.retain(|&idx| idx != node_idx);
-                    if indices.is_empty() {
-                        btree.remove(old_val);
-                    }
-                }
+                btree.entry(landed.clone()).or_default().push(node_idx);
             }
-        }
-        self.note_range_append(&key, new_value, node_idx);
-        if let Some(btree) = self.range_indices.get_mut(&key) {
-            btree.entry(new_value.clone()).or_default().push(node_idx);
         }
 
         // Update any composite indices that include this property
@@ -770,24 +843,13 @@ impl DirGraph {
         property: &str,
         old_value: &Value,
     ) {
-        let key = (node_type.to_string(), property.to_string());
-        self.note_property_eviction(&key, old_value, node_idx);
-        if let Some(value_map) = self.property_indices.get_mut(&key) {
-            if let Some(indices) = value_map.get_mut(old_value) {
-                indices.retain(|&idx| idx != node_idx);
-                if indices.is_empty() {
-                    value_map.remove(old_value);
-                }
-            }
+        if self.write_bypasses_indexed_fields(node_type, property) {
+            return;
         }
-        self.note_range_eviction(&key, old_value, node_idx);
-        if let Some(btree) = self.range_indices.get_mut(&key) {
-            if let Some(indices) = btree.get_mut(old_value) {
-                indices.retain(|&idx| idx != node_idx);
-                if indices.is_empty() {
-                    btree.remove(old_value);
-                }
-            }
+        let field = self.resolve_alias(node_type, property).to_string();
+        for indexed_as in self.index_keys_for_field(node_type, &field) {
+            let key = (node_type.to_string(), indexed_as);
+            self.evict_from_single_value_indexes(&key, old_value, node_idx);
         }
 
         // Update any composite indices that include this property
@@ -796,33 +858,33 @@ impl DirGraph {
 
     /// Re-index a single node in all composite indices that include the changed property.
     /// Reads current node properties to build the new composite value.
+    ///
+    /// Membership is decided by *field*, not spelling: a composite index
+    /// registered under a type's title-alias spelling holds titles, so a write
+    /// to `title` moves the node within it (same reasoning as
+    /// [`Self::index_keys_for_field`]).
     fn update_composite_indices_for_property_change(
         &mut self,
         node_type: &str,
         node_idx: NodeIndex,
         changed_property: &str,
     ) {
+        let changed_field = self.resolve_alias(node_type, changed_property);
         let comp_keys: Vec<CompositeIndexKey> = self
             .composite_indices
             .keys()
-            .filter(|(nt, props)| nt == node_type && props.contains(&changed_property.to_string()))
+            .filter(|(nt, props)| {
+                nt == node_type
+                    && props
+                        .iter()
+                        .any(|p| self.resolve_alias(node_type, p) == changed_field)
+            })
             .cloned()
             .collect();
 
         if comp_keys.is_empty() {
             return;
         }
-
-        // Read current node properties once. Arena guard: disk-backend
-        // node_weight materializes into the query arena (protocol in
-        // disk/graph.rs); no-op on memory/mapped backends.
-        let current_props: HashMap<String, Value> = {
-            let _guard = self.graph.begin_query();
-            match self.graph.node_view(node_idx) {
-                Some(node) => node.properties_cloned(&self.interner),
-                None => return,
-            }
-        };
 
         for key in comp_keys {
             // The buckets this node currently sits in, read before vacating
@@ -860,11 +922,15 @@ impl DirGraph {
                 }
             }
 
-            // Build new composite value from current properties
+            // Build the new composite value the way `create_composite_index`
+            // builds every other one — see `indexed_value`.
             let new_values: Vec<Value> = key
                 .1
                 .iter()
-                .map(|p| current_props.get(p).cloned().unwrap_or(Value::Null))
+                .map(|p| {
+                    self.indexed_value(node_type, p, node_idx)
+                        .unwrap_or(Value::Null)
+                })
                 .collect();
             if new_values.iter().any(|v| !matches!(v, Value::Null)) {
                 let value = CompositeValue(new_values);

--- a/crates/kglite/src/graph/introspection/schema_overview.rs
+++ b/crates/kglite/src/graph/introspection/schema_overview.rs
@@ -5,6 +5,7 @@ use crate::graph::constraints::ConstraintKind;
 use crate::graph::schema::{DirGraph, InternedKey};
 use crate::graph::storage::GraphRead;
 use petgraph::Direction;
+use rustc_hash::FxHashMap;
 use std::collections::{HashMap, HashSet};
 
 use super::capabilities::discover_endpoint_types_batch;
@@ -796,39 +797,84 @@ impl PropAccum {
     }
 }
 
+/// Accumulator keys for the two synthetic built-in fields.
+///
+/// `InternedKey` is the FNV hash of the name, so a property *literally* named
+/// `id`/`title` hashes to the same key and folds into the same accumulator —
+/// exactly what the previous `HashMap<String, _>` keying did (both wrote to the
+/// `"id"` entry).
+fn builtin_accum_keys() -> (InternedKey, InternedKey) {
+    (InternedKey::from_str("id"), InternedKey::from_str("title"))
+}
+
 /// Single pass over `scan_indices`, folding id / title / every stored property
 /// into `accum`.
+///
+/// Keyed by [`InternedKey`] (a `Copy` u64) rather than `String`: the row loop
+/// runs once per property per node, so string keying cost one allocation plus a
+/// string hash per property per node (~650k allocations for a 50k-node × 13-prop
+/// type). Names are resolved once, after the scan, in
+/// [`compute_property_stats`].
 ///
 /// Reads through [`NodeView`](crate::graph::storage::NodeView): the previous
 /// `NodeData::property_iter` route yielded **nothing** for columnar storage, so
 /// on a saved graph this pass contributed no values at all and the stats
 /// degraded to whatever the `type_schemas` pre-seed supplied — keys with a zero
-/// non-null count (D1 defect 1).
+/// non-null count (D1 defect 1). `property_pairs` is the same complete route as
+/// `property_pairs_named`, minus the per-key `String`.
 fn accumulate_property_values(
     graph: &DirGraph,
     scan_indices: &[petgraph::graph::NodeIndex],
     value_cap: usize,
-    accum: &mut HashMap<String, PropAccum>,
+    accum: &mut FxHashMap<InternedKey, PropAccum>,
 ) {
+    let (id_key, title_key) = builtin_accum_keys();
     for &idx in scan_indices {
         let Some(node) = graph.node_view(idx) else {
             continue;
         };
         accum
-            .entry("id".to_string())
+            .entry(id_key)
             .or_insert_with(|| PropAccum::new(value_cap))
             .add(&node.id());
         accum
-            .entry("title".to_string())
+            .entry(title_key)
             .or_insert_with(|| PropAccum::new(value_cap))
             .add(&node.title());
-        for (key, value) in node.property_pairs_named(&graph.interner) {
+        for (key, value) in node.property_pairs() {
             accum
                 .entry(key)
                 .or_insert_with(|| PropAccum::new(value_cap))
                 .add(&value);
         }
     }
+}
+
+/// Resolve the scan's interned accumulator keys back to property names.
+///
+/// Keys the interner cannot resolve are dropped, matching the
+/// `property_pairs_named` contract the scan used to enforce inline; the two
+/// built-ins resolve to their fixed names whether or not a real property shares
+/// the key.
+fn resolve_accum_names(
+    graph: &DirGraph,
+    interned: FxHashMap<InternedKey, PropAccum>,
+) -> HashMap<String, PropAccum> {
+    let (id_key, title_key) = builtin_accum_keys();
+    let mut out = HashMap::with_capacity(interned.len());
+    for (key, accum) in interned {
+        let name = if key == id_key {
+            "id"
+        } else if key == title_key {
+            "title"
+        } else if let Some(name) = graph.interner.try_resolve(key) {
+            name
+        } else {
+            continue;
+        };
+        out.insert(name.to_string(), accum);
+    }
+    out
 }
 
 pub fn compute_property_stats(
@@ -872,26 +918,27 @@ pub fn compute_property_stats(
         }
     };
 
-    // Single pass: accumulate stats for all properties simultaneously
-    let mut accum: HashMap<String, PropAccum> = HashMap::new();
+    // Single pass: accumulate stats for all properties simultaneously.
+    // Interned keys throughout — names are resolved once, after the scan.
+    let (id_key, title_key) = builtin_accum_keys();
+    let mut interned_accum: FxHashMap<InternedKey, PropAccum> = FxHashMap::default();
     // Pre-insert built-in fields so they appear even when all null
-    accum.insert("title".to_string(), PropAccum::new(value_cap));
-    accum.insert("id".to_string(), PropAccum::new(value_cap));
+    interned_accum.insert(title_key, PropAccum::new(value_cap));
+    interned_accum.insert(id_key, PropAccum::new(value_cap));
 
     // When sampling, pre-populate property keys from TypeSchema (knows ALL keys)
     if sample_size.is_some() {
         if let Some(schema) = graph.type_schemas.get(node_type) {
             for slot_key in schema.iter() {
-                if let Some(key_str) = graph.interner.try_resolve(slot_key.1) {
-                    accum
-                        .entry(key_str.to_string())
-                        .or_insert_with(|| PropAccum::new(value_cap));
-                }
+                interned_accum
+                    .entry(slot_key.1)
+                    .or_insert_with(|| PropAccum::new(value_cap));
             }
         }
     }
 
-    accumulate_property_values(graph, &scan_indices, value_cap, &mut accum);
+    accumulate_property_values(graph, &scan_indices, value_cap, &mut interned_accum);
+    let mut accum = resolve_accum_names(graph, interned_accum);
 
     // When sampling, scale non_null counts to the full population
     let scale_factor = if sample_count < total_nodes && sample_count > 0 {

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -1145,7 +1145,9 @@ struct LandedPropertyWrite<'a> {
 /// needs the old value, so it runs before the constraint plan is redeemed. The
 /// `updated_at` bump is skipped when the write *is* to `updated_at`, which would
 /// otherwise recurse. A `title` write touches only the title field, not a
-/// property map, so it skips both the schema key and the index move.
+/// property map, so it registers no schema key — but it still moves the node
+/// between index buckets: an index on `title`, or one registered under the
+/// type's title-alias spelling, is built from exactly the value it changed.
 fn finish_node_property_write(
     graph: &mut DirGraph,
     write: LandedPropertyWrite<'_>,
@@ -1158,14 +1160,14 @@ fn finish_node_property_write(
                 Arc::make_mut(schema_arc).add_key(ik);
             }
         }
-        graph.update_property_indices_for_set(
-            write.node_type,
-            write.node_idx,
-            write.property,
-            write.old_value,
-            write.value,
-        );
     }
+    graph.update_property_indices_for_set(
+        write.node_type,
+        write.node_idx,
+        write.property,
+        write.old_value,
+        write.value,
+    );
 
     graph.apply_property_write_plan(write.constraint_plan, write.node_idx);
 

--- a/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
+++ b/crates/kglite/src/graph/languages/cypher/planner/planner_tests.rs
@@ -1959,3 +1959,216 @@ fn test_text_score_unknown_parameter_still_errors() {
     .unwrap_err();
     assert!(err.contains("not found"), "unexpected error: {err}");
 }
+
+// ============================================================================
+// NDV selectivity on identity fields (Track H2)
+// ============================================================================
+//
+// `property_ndv` feeds `estimate_node_selectivity`'s `type_count / ndv`
+// equality estimate. It used to read the property map only, which does not
+// hold a type's `node_title_field` (`add_nodes` hoists that column into
+// `NodeData.title`), so the scan found nothing, `.max(1)` reported NDV = 1,
+// and the filter was scored *completely non-selective* — the planner then
+// anchored on the other, larger end of the pattern. These pin the anchor
+// choice, which the Cypher differential corpus cannot see (both plans return
+// the same rows; only the cost differs).
+
+/// `Doc` (the unfiltered end) outnumbers `Keyword` 3:1, and every `Keyword`
+/// has a distinct title. `Keyword` is therefore the right anchor for a
+/// `title`-equality filter (one node) and the wrong one only if the filter is
+/// scored as matching the whole type.
+fn title_anchor_graph() -> DirGraph {
+    fn typed(graph: &mut DirGraph, node_type: &str, n: i64) {
+        let rows: Vec<Vec<Value>> = (1..=n)
+            .map(|i| {
+                vec![
+                    Value::Int64(i),
+                    Value::String(format!("{}-{i}", node_type.to_lowercase())),
+                ]
+            })
+            .collect();
+        let df = crate::datatypes::DataFrame::from_cypher_rows(
+            vec!["id".to_string(), "title".to_string()],
+            rows,
+        )
+        .unwrap();
+        crate::graph::mutation::maintain::add_nodes(
+            graph,
+            df,
+            node_type.to_string(),
+            "id".to_string(),
+            Some("title".to_string()),
+            None,
+        )
+        .unwrap();
+    }
+    let mut graph = DirGraph::new();
+    typed(&mut graph, "Doc", 3000);
+    typed(&mut graph, "Keyword", 1000);
+    graph
+}
+
+fn optimized_start_variable(query: &str, graph: &DirGraph) -> String {
+    let mut query = parse_cypher(query).unwrap();
+    optimize(&mut query, graph, &HashMap::new());
+    let m = query
+        .clauses
+        .iter()
+        .find_map(|c| match c {
+            Clause::Match(m) => Some(m),
+            _ => None,
+        })
+        .expect("expected MATCH clause");
+    match &m.patterns[0].elements[0] {
+        PatternElement::Node(np) => np
+            .variable
+            .clone()
+            .expect("start node should carry a variable"),
+        _ => panic!("expected start node"),
+    }
+}
+
+#[test]
+fn test_ndv_counts_the_title_field() {
+    let graph = title_anchor_graph();
+    assert_eq!(
+        graph.property_ndv("Keyword", "title"),
+        Some(1000),
+        "`title` is Keyword's node_title_field, so its distinct values live on \
+         NodeData.title, not in the property map; reporting 1 (or None) makes \
+         the planner score a title equality filter as non-selective"
+    );
+}
+
+#[test]
+fn test_title_equality_anchors_on_the_filtered_type() {
+    let graph = title_anchor_graph();
+    assert_eq!(
+        optimized_start_variable(
+            "MATCH (a:Doc)-[:MENTIONS]->(b:Keyword) WHERE b.title = 'keyword-7' RETURN a, b",
+            &graph,
+        ),
+        "b",
+        "a unique title equality selects one Keyword; anchoring on the 3000 \
+         Docs instead means the filter was scored non-selective (NDV=1)"
+    );
+}
+
+#[test]
+fn test_title_in_list_anchors_on_the_filtered_type() {
+    let graph = title_anchor_graph();
+    assert_eq!(
+        optimized_start_variable(
+            "MATCH (a:Doc)-[:MENTIONS]->(b:Keyword) \
+             WHERE b.title IN ['keyword-7', 'keyword-9'] RETURN a, b",
+            &graph,
+        ),
+        "b",
+        "PropertyMatcher::In reads the same NDV; two of 1000 distinct titles \
+         is far more selective than a full Doc scan"
+    );
+}
+
+/// The reporter's real shape: the filtered type names its identity columns
+/// itself (`add_nodes(unique_id_field='term_id', node_title_field='term_name')`),
+/// so `term_name` is a *registered alias* for the title field — the matcher
+/// resolves it, and the statistic feeding the planner has to resolve it too.
+fn aliased_identity_graph() -> DirGraph {
+    let mut graph = DirGraph::new();
+    let rows: Vec<Vec<Value>> = (1..=3000)
+        .map(|i| vec![Value::Int64(i), Value::String(format!("doc-{i}"))])
+        .collect();
+    let df = crate::datatypes::DataFrame::from_cypher_rows(vec!["id".into(), "title".into()], rows)
+        .unwrap();
+    crate::graph::mutation::maintain::add_nodes(
+        &mut graph,
+        df,
+        "Doc".to_string(),
+        "id".to_string(),
+        Some("title".to_string()),
+        None,
+    )
+    .unwrap();
+
+    let rows: Vec<Vec<Value>> = (1..=1000)
+        .map(|i| vec![Value::Int64(i), Value::String(format!("term-{i}"))])
+        .collect();
+    let df = crate::datatypes::DataFrame::from_cypher_rows(
+        vec!["term_id".into(), "term_name".into()],
+        rows,
+    )
+    .unwrap();
+    crate::graph::mutation::maintain::add_nodes(
+        &mut graph,
+        df,
+        "Term".to_string(),
+        "term_id".to_string(),
+        Some("term_name".to_string()),
+        None,
+    )
+    .unwrap();
+    graph
+}
+
+#[test]
+fn test_aliased_title_equality_anchors_on_the_filtered_type() {
+    let graph = aliased_identity_graph();
+    assert_eq!(
+        graph.property_ndv("Term", "term_name"),
+        Some(1000),
+        "the statistic has to resolve the alias, not just the anchor it feeds"
+    );
+    assert_eq!(
+        optimized_start_variable(
+            "MATCH (a:Doc)-[:MENTIONS]->(b:Term) WHERE b.term_name = 'term-7' RETURN a, b",
+            &graph,
+        ),
+        "b",
+        "`term_name` is Term's registered title alias — the matcher resolves it \
+         to the title field, so the NDV statistic must resolve it the same way"
+    );
+}
+
+#[test]
+fn test_aliased_id_equality_anchors_on_the_filtered_type() {
+    let graph = aliased_identity_graph();
+    assert_eq!(
+        graph.property_ndv("Term", "term_id"),
+        Some(1000),
+        "the statistic has to resolve the alias, not just the anchor it feeds"
+    );
+    assert_eq!(
+        optimized_start_variable(
+            "MATCH (a:Doc)-[:MENTIONS]->(b:Term) WHERE b.term_id = 7 RETURN a, b",
+            &graph,
+        ),
+        "b",
+        "`term_id` is Term's registered id alias; only a literal `id` gets the \
+         dedicated selectivity-1 path, so the alias has to come out of the NDV \
+         statistic"
+    );
+}
+
+#[test]
+fn test_absent_property_is_no_information_not_zero_selectivity() {
+    // The safety net behind the alias fix: when the scan finds *no* values at
+    // all, "distinct = 0" must not collapse into "NDV = 1" — that reads as
+    // `type_count / 1`, i.e. a filter that excludes nothing, and anchors the
+    // join on the other, larger end. No information means fall back to the
+    // flat heuristic.
+    let graph = aliased_identity_graph();
+    assert_eq!(
+        graph.property_ndv("Term", "not_a_property"),
+        None,
+        "an empty scan is no information, not NDV=1"
+    );
+    assert_eq!(
+        optimized_start_variable(
+            "MATCH (a:Doc)-[:MENTIONS]->(b:Term) WHERE b.not_a_property = 'x' RETURN a, b",
+            &graph,
+        ),
+        "b",
+        "scanning the 1000 filtered Terms beats driving 3000 Docs through the \
+         same filter, however unselective the estimate"
+    );
+}

--- a/crates/kglite/src/graph/schema_tests.rs
+++ b/crates/kglite/src/graph/schema_tests.rs
@@ -1124,9 +1124,12 @@ mod alias_index_maintenance_tests {
         );
     }
 
+    /// One property index's buckets in comparable form: (value, members) rows.
+    type BucketRows = Vec<(Value, Vec<NodeIndex>)>;
+
     /// Every property-index bucket, in a comparable, order-normalised form.
-    fn index_snapshot(graph: &DirGraph) -> Vec<(IndexKey, Vec<(Value, Vec<NodeIndex>)>)> {
-        let mut snapshot: Vec<(IndexKey, Vec<(Value, Vec<NodeIndex>)>)> = graph
+    fn index_snapshot(graph: &DirGraph) -> Vec<(IndexKey, BucketRows)> {
+        let mut snapshot: Vec<(IndexKey, BucketRows)> = graph
             .property_indices
             .iter()
             .map(|(key, index)| {

--- a/crates/kglite/src/graph/schema_tests.rs
+++ b/crates/kglite/src/graph/schema_tests.rs
@@ -1032,3 +1032,357 @@ mod embedding_store_tests {
         }
     }
 }
+
+/// Incremental index maintenance must file a node under the value an index
+/// *rebuild* would file it under — including when the index is registered under
+/// an id/title **alias** spelling, where the value the matcher's scan consults
+/// is the node's id/title and not the verbatim property.
+///
+/// Before the fix, `update_property_indices_for_add` / `_for_set` read the node
+/// by the user-facing key (`NodeData::get_property`) while `create_index` /
+/// `refresh_indexes_for_type` read through the alias-resolving `read_indexed`.
+/// A Cypher `CREATE` into such a type filed the node under a bucket value the
+/// scan can never produce: indexed `MATCH` returned rows the same query without
+/// the index did not, and the two spellings of the same predicate (inline map
+/// vs `WHERE`) disagreed with each other.
+#[cfg(test)]
+mod alias_index_maintenance_tests {
+    use super::*;
+    use crate::datatypes::DataFrame;
+    use crate::graph::mutation::maintain::add_nodes;
+    use crate::graph::session::{execute_mut, execute_read, ExecuteOptions};
+    use petgraph::graph::NodeIndex;
+
+    /// `Term` carries both alias kinds: `term_id` is its id field and
+    /// `term_name` its title field, so `add_nodes` hoists both columns off the
+    /// property map. `city` is an ordinary property, for the non-alias arms.
+    fn aliased_graph() -> DirGraph {
+        let rows: Vec<Vec<Value>> = (1..=3)
+            .map(|i| {
+                vec![
+                    Value::Int64(i),
+                    Value::String(format!("term-{i}")),
+                    Value::String("Oslo".to_string()),
+                ]
+            })
+            .collect();
+        let df = DataFrame::from_cypher_rows(
+            vec![
+                "term_id".to_string(),
+                "term_name".to_string(),
+                "city".to_string(),
+            ],
+            rows,
+        )
+        .expect("frame");
+        let mut graph = DirGraph::new();
+        add_nodes(
+            &mut graph,
+            df,
+            "Term".to_string(),
+            "term_id".to_string(),
+            Some("term_name".to_string()),
+            None,
+        )
+        .expect("add_nodes");
+        graph
+    }
+
+    fn run(graph: &mut DirGraph, statement: &str) {
+        let params = HashMap::new();
+        execute_mut(graph, statement, &ExecuteOptions::eager(&params))
+            .unwrap_or_else(|error| panic!("{statement}: {error}"));
+    }
+
+    fn count(graph: &DirGraph, query: &str) -> usize {
+        let params = HashMap::new();
+        let result = execute_read(graph, query, &ExecuteOptions::eager(&params))
+            .unwrap_or_else(|error| panic!("{query}: {error}"));
+        result.result.rows.len()
+    }
+
+    /// A graph carrying `index_on`, mutated by `mutations`.
+    fn mutated(index_on: &str, mutations: &[&str]) -> DirGraph {
+        let mut graph = aliased_graph();
+        graph.create_index("Term", index_on);
+        for statement in mutations {
+            run(&mut graph, statement);
+        }
+        graph
+    }
+
+    /// The divergence oracle: ask `query` on the mutated graph with the index
+    /// installed, then drop the index — same data, same query — and ask again.
+    fn assert_index_agrees_with_scan(index_on: &str, mutations: &[&str], query: &str) {
+        let mut graph = mutated(index_on, mutations);
+        let with_index = count(&graph, query);
+        graph.drop_index("Term", index_on).expect("drop");
+        let scanned = count(&graph, query);
+        assert_eq!(
+            with_index, scanned,
+            "indexed and unindexed answers diverge after {mutations:?} for: {query}"
+        );
+    }
+
+    /// Every property-index bucket, in a comparable, order-normalised form.
+    fn index_snapshot(graph: &DirGraph) -> Vec<(IndexKey, Vec<(Value, Vec<NodeIndex>)>)> {
+        let mut snapshot: Vec<(IndexKey, Vec<(Value, Vec<NodeIndex>)>)> = graph
+            .property_indices
+            .iter()
+            .map(|(key, index)| {
+                let mut buckets: Vec<(Value, Vec<NodeIndex>)> = index
+                    .iter()
+                    .map(|(value, members)| {
+                        let mut members = members.clone();
+                        members.sort();
+                        (value.clone(), members)
+                    })
+                    .collect();
+                buckets.sort();
+                (key.clone(), buckets)
+            })
+            .collect();
+        snapshot.sort();
+        snapshot
+    }
+
+    const CREATE_X: &str = "CREATE (:Term {term_id: 99, term_name: 'created-x'})";
+    const CREATE_COLLIDING: &str = "CREATE (:Term {term_id: 98, term_name: 'term-1'})";
+
+    #[test]
+    fn cypher_create_on_a_title_aliased_index_agrees_with_the_scan() {
+        // The phantom: the CREATE's verbatim `term_name` becomes a bucket the
+        // scan can never produce, so the indexed MATCH returns a row the
+        // unindexed one does not.
+        assert_index_agrees_with_scan(
+            "term_name",
+            &[CREATE_X],
+            "MATCH (t:Term {term_name: 'created-x'}) RETURN t",
+        );
+        assert_index_agrees_with_scan(
+            "term_name",
+            &[CREATE_X],
+            "MATCH (t:Term) WHERE t.term_name = 'created-x' RETURN t",
+        );
+    }
+
+    #[test]
+    fn a_cypher_create_does_not_poison_an_existing_bucket() {
+        // The poisoned bucket: the CREATE's verbatim value equals an existing
+        // node's title, so the index reports two members for a value only one
+        // node really carries.
+        assert_index_agrees_with_scan(
+            "term_name",
+            &[CREATE_COLLIDING],
+            "MATCH (t:Term {term_name: 'term-1'}) RETURN t",
+        );
+        assert_index_agrees_with_scan(
+            "term_name",
+            &[CREATE_COLLIDING],
+            "MATCH (t:Term) WHERE t.term_name = 'term-1' RETURN t",
+        );
+    }
+
+    #[test]
+    fn the_two_spellings_of_one_predicate_agree_on_an_indexed_graph() {
+        // Inline map vs WHERE: only the first consults the index, so a poisoned
+        // index makes the same predicate answer two different ways.
+        let graph = mutated("term_name", &[CREATE_X, CREATE_COLLIDING]);
+        for value in ["created-x", "term-1", "term-2"] {
+            let inline = count(
+                &graph,
+                &format!("MATCH (t:Term {{term_name: '{value}'}}) RETURN t"),
+            );
+            let filtered = count(
+                &graph,
+                &format!("MATCH (t:Term) WHERE t.term_name = '{value}' RETURN t"),
+            );
+            assert_eq!(
+                inline, filtered,
+                "inline-map and WHERE spellings disagree for term_name = '{value}'"
+            );
+        }
+    }
+
+    #[test]
+    fn cypher_set_on_a_title_aliased_index_agrees_with_the_scan() {
+        let set = "MATCH (t:Term {term_id: 1}) SET t.term_name = 'renamed'";
+        for query in [
+            "MATCH (t:Term {term_name: 'renamed'}) RETURN t",
+            "MATCH (t:Term) WHERE t.term_name = 'renamed' RETURN t",
+            "MATCH (t:Term {term_name: 'term-1'}) RETURN t",
+            "MATCH (t:Term) WHERE t.term_name = 'term-1' RETURN t",
+        ] {
+            assert_index_agrees_with_scan("term_name", &[CREATE_X, set], query);
+        }
+    }
+
+    #[test]
+    fn cypher_set_on_the_title_keeps_an_alias_spelled_index_in_step() {
+        // The index is registered under the alias spelling but holds titles, so
+        // a write to `title` moves the node between its buckets.
+        let set = "MATCH (t:Term {term_id: 1}) SET t.title = 'retitled'";
+        for query in [
+            "MATCH (t:Term {term_name: 'retitled'}) RETURN t",
+            "MATCH (t:Term) WHERE t.term_name = 'retitled' RETURN t",
+            "MATCH (t:Term {term_name: 'term-1'}) RETURN t",
+        ] {
+            assert_index_agrees_with_scan("term_name", &[set], query);
+        }
+    }
+
+    #[test]
+    fn cypher_set_on_the_name_synonym_moves_the_node_between_buckets() {
+        // `name` is Cypher's own spelling of the title and the SET executor
+        // writes the title through it, so — unlike an arbitrary alias spelling —
+        // this write *does* move the field the index holds. A type that names
+        // its title column `name` gets both readings of the same word.
+        let rows: Vec<Vec<Value>> = (1..=3)
+            .map(|i| vec![Value::Int64(i), Value::String(format!("person-{i}"))])
+            .collect();
+        let df =
+            DataFrame::from_cypher_rows(vec!["person_id".to_string(), "name".to_string()], rows)
+                .expect("frame");
+        let mut graph = DirGraph::new();
+        add_nodes(
+            &mut graph,
+            df,
+            "Person".to_string(),
+            "person_id".to_string(),
+            Some("name".to_string()),
+            None,
+        )
+        .expect("add_nodes");
+        graph.create_index("Person", "name");
+        run(
+            &mut graph,
+            "MATCH (p:Person {name: 'person-1'}) SET p.name = 'renamed'",
+        );
+
+        assert_eq!(
+            count(&graph, "MATCH (p:Person {name: 'renamed'}) RETURN p"),
+            1,
+            "the index lost the node its SET renamed"
+        );
+        assert_eq!(
+            count(&graph, "MATCH (p:Person {name: 'person-1'}) RETURN p"),
+            0,
+            "the index still answers with the pre-SET value"
+        );
+    }
+
+    #[test]
+    fn cypher_remove_on_a_title_aliased_index_agrees_with_the_scan() {
+        let remove = "MATCH (t:Term {term_id: 1}) REMOVE t.term_name";
+        for query in [
+            "MATCH (t:Term {term_name: 'term-1'}) RETURN t",
+            "MATCH (t:Term) WHERE t.term_name = 'term-1' RETURN t",
+        ] {
+            assert_index_agrees_with_scan("term_name", &[remove], query);
+        }
+    }
+
+    #[test]
+    fn incremental_maintenance_reproduces_a_rebuilt_index() {
+        // The general contract, of which every case above is an instance:
+        // whatever the writes were, the incrementally maintained index must
+        // equal the one `refresh_indexes_for_type` builds from live state.
+        let mutations = [
+            CREATE_X,
+            CREATE_COLLIDING,
+            "MATCH (t:Term {term_id: 1}) SET t.term_name = 'renamed'",
+            "MATCH (t:Term {term_id: 2}) SET t.title = 'retitled'",
+            "MATCH (t:Term {term_id: 3}) SET t.city = 'Bergen'",
+            "MATCH (t:Term {term_id: 99}) REMOVE t.city",
+        ];
+        let mut graph = aliased_graph();
+        graph.create_index("Term", "term_name");
+        graph.create_index("Term", "term_id");
+        graph.create_index("Term", "city");
+        for statement in mutations {
+            run(&mut graph, statement);
+        }
+
+        let incremental = index_snapshot(&graph);
+        graph.refresh_indexes_for_type("Term");
+        assert_eq!(
+            incremental,
+            index_snapshot(&graph),
+            "incremental index maintenance diverged from a rebuild"
+        );
+    }
+
+    #[test]
+    fn a_created_node_joins_a_doubly_indexed_property_once() {
+        // A property carrying both a hash and a range index appears twice in
+        // the key iteration; the node must still land in each bucket once, or
+        // an indexed MATCH returns it twice.
+        let mut graph = aliased_graph();
+        graph.create_index("Term", "city");
+        graph.create_range_index("Term", "city");
+        run(&mut graph, "CREATE (:Term {term_id: 99, city: 'Bergen'})");
+
+        let bucket = graph
+            .lookup_by_index("Term", "city", &Value::String("Bergen".to_string()))
+            .expect("bucket");
+        assert_eq!(bucket.len(), 1, "hash-index bucket holds the node twice");
+        let range = graph
+            .lookup_range(
+                "Term",
+                "city",
+                std::ops::Bound::Included(&Value::String("Bergen".to_string())),
+                std::ops::Bound::Included(&Value::String("Bergen".to_string())),
+            )
+            .expect("range bucket");
+        assert_eq!(range.len(), 1, "range-index bucket holds the node twice");
+        assert_eq!(
+            count(&graph, "MATCH (t:Term {city: 'Bergen'}) RETURN t"),
+            1,
+            "indexed MATCH returned the node more than once"
+        );
+    }
+
+    /// Every node the index still points at, across all buckets.
+    fn indexed_members(graph: &DirGraph, property: &str) -> Vec<NodeIndex> {
+        graph
+            .property_indices
+            .get(&("Term".to_string(), property.to_string()))
+            .expect("index")
+            .iter()
+            .flat_map(|(_, members)| members.iter().copied())
+            .collect()
+    }
+
+    #[test]
+    fn deleting_every_node_empties_the_buckets() {
+        // The add/remove symmetry: whichever bucket a write filed a node under,
+        // the delete has to reclaim it. Deletion evicts by *membership*, so it
+        // is value-agnostic — this pins that it stays that way.
+        let mut graph = mutated("term_name", &[CREATE_X]);
+        run(&mut graph, "MATCH (t:Term) DELETE t");
+
+        assert!(
+            indexed_members(&graph, "term_name").is_empty(),
+            "deleted nodes left entries behind: {:?}",
+            indexed_members(&graph, "term_name")
+        );
+        assert_eq!(count(&graph, "MATCH (t:Term) RETURN t"), 0);
+    }
+
+    #[test]
+    fn deleting_one_node_leaves_the_survivors_indexed() {
+        let mut graph = mutated("term_name", &[CREATE_X]);
+        run(&mut graph, "MATCH (t:Term {term_id: 1}) DELETE t");
+
+        let members = indexed_members(&graph, "term_name");
+        assert!(
+            members.iter().all(|idx| graph.get_node(*idx).is_some()),
+            "the index points at a deleted node: {members:?}"
+        );
+        assert_index_agrees_with_scan(
+            "term_name",
+            &[CREATE_X, "MATCH (t:Term {term_id: 1}) DELETE t"],
+            "MATCH (t:Term {term_name: 'term-1'}) RETURN t",
+        );
+    }
+}

--- a/crates/kglite/src/graph/storage/column_ownership_tests.rs
+++ b/crates/kglite/src/graph/storage/column_ownership_tests.rs
@@ -807,8 +807,9 @@ fn r8_property_index_build_reads_the_authoritative_store() {
 }
 
 /// **R9 — incremental index maintenance.** The incremental updater
-/// (`update_property_indices_for_add`) bypasses `read_indexed`, so it gets its
-/// own arm: it must agree with the rebuild above.
+/// (`update_property_indices_for_add`) reads through `read_indexed` for exactly
+/// this reason; it gets its own arm because it is a separate call path from the
+/// rebuild above, and the two must file a row identically.
 #[test]
 fn r9_incremental_index_maintenance_reads_the_authoritative_store() {
     let mut graph = seeded_columnar();

--- a/crates/kglite/src/graph/storage/column_store.rs
+++ b/crates/kglite/src/graph/storage/column_store.rs
@@ -1392,14 +1392,20 @@ impl ColumnStore {
         // collisions. Pre-0.9.4 the mmap-backed branch short-
         // circuited and SET-introduced keys never appeared.
         let mut result = Vec::new();
-        let mut seen: std::collections::HashSet<InternedKey> = std::collections::HashSet::new();
         for (slot, ik) in self.schema.iter() {
             if let Some(val) = self.columns.get(slot as usize).and_then(|c| c.get(row_id)) {
-                seen.insert(ik);
                 result.push((ik, val));
             }
         }
         if let Some(ref ms) = self.mmap_store {
+            // The `seen` set exists only to keep the mmap row from
+            // re-reporting a key the overlay already answered, so it is built
+            // here rather than in the scan loop above: on a non-mmap store
+            // (every in-memory/saved graph) nothing consumes it, and this is
+            // the per-node allocation on every columnar row enumeration —
+            // `describe`, export, `keys(n)`, projection completion.
+            let seen: std::collections::HashSet<InternedKey> =
+                result.iter().map(|(ik, _)| *ik).collect();
             for (ik, val) in ms.row_properties(row_id) {
                 if !seen.contains(&ik) {
                     result.push((ik, val));
@@ -1407,17 +1413,14 @@ impl ColumnStore {
             }
             return result;
         }
-        for (slot, ik) in self.schema.iter() {
-            // re-iterate to keep overflow-bag fall-through unchanged for
-            // the non-mmap path (the loop above already inserted dense
-            // entries; below we only fill blanks).
-            if seen.contains(&ik) {
-                continue;
-            }
-            if let Some(val) = self.columns.get(slot as usize).and_then(|c| c.get(row_id)) {
-                result.push((ik, val));
-            }
-        }
+        // A second dense pass used to run here for the non-mmap path, skipping
+        // keys already in `seen`. It could never emit anything: its predicate
+        // is `columns[slot].get(row_id)` — identical to the first loop's, on
+        // the same `&self` — so any (slot, key) it visited had already
+        // answered `None` above, and any key it would have accepted was
+        // already pushed and thus in `seen`. Pinned by
+        // `row_properties_matches_forced_second_pass` in column_store_tests.
+        //
         // Append overflow bag properties
         let overflow = self.overflow_row_properties(row_id);
         result.extend(overflow);

--- a/crates/kglite/src/graph/storage/column_store_tests.rs
+++ b/crates/kglite/src/graph/storage/column_store_tests.rs
@@ -455,6 +455,127 @@ fn test_column_store_materialize_roundtrip() {
     assert_eq!(store.get(1, age_key), Some(Value::Int64(25)));
 }
 
+/// The `row_properties` shape that shipped before the second dense pass was
+/// removed: two passes over the schema, the second one filling blanks the first
+/// left. Kept here as the equivalence reference — see
+/// `row_properties_matches_forced_second_pass`.
+fn row_properties_forced_second_pass(
+    store: &ColumnStore,
+    row_id: u32,
+) -> Vec<(InternedKey, Value)> {
+    if row_id >= store.row_count
+        || store
+            .tombstones
+            .get(row_id as usize)
+            .copied()
+            .unwrap_or(false)
+    {
+        return Vec::new();
+    }
+    let mut result = Vec::new();
+    let mut seen: std::collections::HashSet<InternedKey> = std::collections::HashSet::new();
+    for (slot, ik) in store.schema.iter() {
+        if let Some(val) = store.columns.get(slot as usize).and_then(|c| c.get(row_id)) {
+            seen.insert(ik);
+            result.push((ik, val));
+        }
+    }
+    if let Some(ref ms) = store.mmap_store {
+        for (ik, val) in ms.row_properties(row_id) {
+            if !seen.contains(&ik) {
+                result.push((ik, val));
+            }
+        }
+        return result;
+    }
+    for (slot, ik) in store.schema.iter() {
+        if seen.contains(&ik) {
+            continue;
+        }
+        if let Some(val) = store.columns.get(slot as usize).and_then(|c| c.get(row_id)) {
+            result.push((ik, val));
+        }
+    }
+    result.extend(store.overflow_row_properties(row_id));
+    result
+}
+
+/// `row_properties` drops the second dense pass on the non-mmap path (it could
+/// never emit a row the first pass had not already emitted) and builds the
+/// `seen` set only for the mmap merge. This pins the output against the old
+/// two-pass shape over every row class: fully populated, partially null,
+/// carrying a schema key that has no value on any row, tombstoned, out of
+/// range, and with an overflow bag installed.
+#[test]
+fn row_properties_matches_forced_second_pass() {
+    use crate::graph::storage::mapped::mmap_vec::{MmapBytes, MmapOrVec};
+
+    let (schema, meta, interner) = make_schema_and_meta();
+    let mut store = ColumnStore::new(schema, &meta, &interner);
+
+    let name_key = InternedKey::from_str("name");
+    let age_key = InternedKey::from_str("age");
+    let salary_key = InternedKey::from_str("salary");
+    // `joined` and `active` stay unset on every row: schema keys whose column
+    // answers `None` for all of them — precisely the case the removed second
+    // pass claimed to cover.
+    store.push_row(&[
+        (name_key, Value::String("Alice".into())),
+        (age_key, Value::Int64(30)),
+        (salary_key, Value::Float64(1.5)),
+    ]);
+    store.push_row(&[(name_key, Value::String("Bob".into()))]);
+    store.push_row(&[(age_key, Value::Int64(41))]);
+    // A key added after the fact extends the schema and backfills nulls.
+    let nickname_key = InternedKey::from_str("nickname");
+    assert!(store.set(
+        1,
+        nickname_key,
+        &Value::String("Bobby".into()),
+        Some("string")
+    ));
+    store.tombstone(2);
+
+    // Overflow bag: row 0 carries a sparse property, row 1 none.
+    let mut data = Vec::new();
+    let mut offsets: Vec<u64> = vec![0];
+    let mut blob = 1u16.to_le_bytes().to_vec();
+    crate::graph::storage::overflow::encode_value(
+        &mut blob,
+        InternedKey::from_str("sparse"),
+        &Value::Int64(9),
+    );
+    data.extend_from_slice(&blob);
+    offsets.push(data.len() as u64);
+    for _ in 1..store.row_count {
+        offsets.push(data.len() as u64);
+    }
+    let mut data_bytes = MmapBytes::new();
+    data_bytes.extend(&data).expect("overflow data");
+    store.replace_overflow_bag(MmapOrVec::from_vec(offsets), data_bytes);
+
+    let schema_len = store.schema.iter().count();
+    let row0 = store.row_properties(0);
+    assert!(
+        row0.len() < schema_len,
+        "fixture must leave at least one schema key unset on row 0 \
+         (schema {schema_len}, row {row0:?})"
+    );
+    assert!(
+        row0.iter()
+            .any(|(k, _)| *k == InternedKey::from_str("sparse")),
+        "fixture must exercise the overflow bag: {row0:?}"
+    );
+
+    for row_id in 0..=store.row_count {
+        assert_eq!(
+            store.row_properties(row_id),
+            row_properties_forced_second_pass(&store, row_id),
+            "row {row_id} diverged from the two-pass reference"
+        );
+    }
+}
+
 #[test]
 fn test_overflow_value_list_roundtrip() {
     // Native list properties must survive the overflow-bag wire format

--- a/crates/kglite/src/graph/storage/node_view.rs
+++ b/crates/kglite/src/graph/storage/node_view.rs
@@ -171,6 +171,44 @@ impl<'a> NodeView<'a> {
         }
     }
 
+    /// Read an **alias-resolved matcher field** — the value a property filter
+    /// on this node actually compares against.
+    ///
+    /// `field`/`key` are the output of
+    /// [`DirGraph::resolve_alias`](crate::graph::schema::DirGraph::resolve_alias)
+    /// (a type's `unique_id_field` / `node_title_field` map onto `id` /
+    /// `title`), and the resolution order is the one the pattern matcher
+    /// applies: identity fields first, then a stored property (a user's own
+    /// `label`/`name`/… wins — KG-1), then the structural soft-alias fallback.
+    ///
+    /// Every consumer of "what would a filter on `field` see?" must come
+    /// through here. The planner's NDV statistic did not, read the property map
+    /// alone, and so found *nothing* for a type's title field — scoring an
+    /// equality filter on it as completely non-selective (Track H2).
+    #[inline]
+    pub fn resolved_field(
+        &self,
+        type_str: &str,
+        field: &str,
+        key: InternedKey,
+    ) -> Option<Cow<'a, Value>> {
+        if field == "id" {
+            return Some(self.id());
+        }
+        if field == "title" {
+            return Some(self.title());
+        }
+        if let Some(value) = self.get(key) {
+            return Some(value);
+        }
+        crate::graph::schema::soft_alias_fallback(field).map(|fallback| match fallback {
+            crate::graph::schema::SoftAliasFallback::Title => self.title(),
+            crate::graph::schema::SoftAliasFallback::TypeString => {
+                Cow::Owned(Value::String(type_str.to_string()))
+            }
+        })
+    }
+
     /// `true` when the property is present and non-`Null`.
     #[inline]
     pub fn contains(&self, key: InternedKey) -> bool {

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -2584,6 +2584,7 @@ pub fn kglite::api::NodeView<'a>::property_count(&self) -> usize
 pub fn kglite::api::NodeView<'a>::property_keys(&self, interner: &'a kglite::api::StringInterner) -> alloc::vec::Vec<&'a str>
 pub fn kglite::api::NodeView<'a>::property_pairs(&self) -> alloc::vec::Vec<(kglite::api::InternedKey, kglite::datatypes::values::Value)>
 pub fn kglite::api::NodeView<'a>::property_pairs_named(&self, interner: &kglite::api::StringInterner) -> alloc::vec::Vec<(alloc::string::String, kglite::datatypes::values::Value)>
+pub fn kglite::api::NodeView<'a>::resolved_field(&self, type_str: &str, field: &str, key: kglite::api::InternedKey) -> core::option::Option<alloc::borrow::Cow<'a, kglite::datatypes::values::Value>>
 pub fn kglite::api::NodeView<'a>::str_prop_eq(&self, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
 pub fn kglite::api::NodeView<'a>::title(&self) -> alloc::borrow::Cow<'a, kglite::datatypes::values::Value>
 pub fn kglite::api::NodeView<'a>::to_node_info(&self, interner: &kglite::api::StringInterner) -> kglite::api::NodeInfo

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -2560,6 +2560,7 @@ pub fn kglite::api::NodeView<'a>::property_count(&self) -> usize
 pub fn kglite::api::NodeView<'a>::property_keys(&self, interner: &'a kglite::api::StringInterner) -> alloc::vec::Vec<&'a str>
 pub fn kglite::api::NodeView<'a>::property_pairs(&self) -> alloc::vec::Vec<(kglite::api::InternedKey, kglite::datatypes::values::Value)>
 pub fn kglite::api::NodeView<'a>::property_pairs_named(&self, interner: &kglite::api::StringInterner) -> alloc::vec::Vec<(alloc::string::String, kglite::datatypes::values::Value)>
+pub fn kglite::api::NodeView<'a>::resolved_field(&self, type_str: &str, field: &str, key: kglite::api::InternedKey) -> core::option::Option<alloc::borrow::Cow<'a, kglite::datatypes::values::Value>>
 pub fn kglite::api::NodeView<'a>::str_prop_eq(&self, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
 pub fn kglite::api::NodeView<'a>::title(&self) -> alloc::borrow::Cow<'a, kglite::datatypes::values::Value>
 pub fn kglite::api::NodeView<'a>::to_node_info(&self, interner: &kglite::api::StringInterner) -> kglite::api::NodeInfo

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -2569,6 +2569,7 @@ pub fn kglite::api::NodeView<'a>::property_count(&self) -> usize
 pub fn kglite::api::NodeView<'a>::property_keys(&self, interner: &'a kglite::api::StringInterner) -> alloc::vec::Vec<&'a str>
 pub fn kglite::api::NodeView<'a>::property_pairs(&self) -> alloc::vec::Vec<(kglite::api::InternedKey, kglite::datatypes::values::Value)>
 pub fn kglite::api::NodeView<'a>::property_pairs_named(&self, interner: &kglite::api::StringInterner) -> alloc::vec::Vec<(alloc::string::String, kglite::datatypes::values::Value)>
+pub fn kglite::api::NodeView<'a>::resolved_field(&self, type_str: &str, field: &str, key: kglite::api::InternedKey) -> core::option::Option<alloc::borrow::Cow<'a, kglite::datatypes::values::Value>>
 pub fn kglite::api::NodeView<'a>::str_prop_eq(&self, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
 pub fn kglite::api::NodeView<'a>::title(&self) -> alloc::borrow::Cow<'a, kglite::datatypes::values::Value>
 pub fn kglite::api::NodeView<'a>::to_node_info(&self, interner: &kglite::api::StringInterner) -> kglite::api::NodeInfo

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -2560,6 +2560,7 @@ pub fn kglite::api::NodeView<'a>::property_count(&self) -> usize
 pub fn kglite::api::NodeView<'a>::property_keys(&self, interner: &'a kglite::api::StringInterner) -> alloc::vec::Vec<&'a str>
 pub fn kglite::api::NodeView<'a>::property_pairs(&self) -> alloc::vec::Vec<(kglite::api::InternedKey, kglite::datatypes::values::Value)>
 pub fn kglite::api::NodeView<'a>::property_pairs_named(&self, interner: &kglite::api::StringInterner) -> alloc::vec::Vec<(alloc::string::String, kglite::datatypes::values::Value)>
+pub fn kglite::api::NodeView<'a>::resolved_field(&self, type_str: &str, field: &str, key: kglite::api::InternedKey) -> core::option::Option<alloc::borrow::Cow<'a, kglite::datatypes::values::Value>>
 pub fn kglite::api::NodeView<'a>::str_prop_eq(&self, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
 pub fn kglite::api::NodeView<'a>::title(&self) -> alloc::borrow::Cow<'a, kglite::datatypes::values::Value>
 pub fn kglite::api::NodeView<'a>::to_node_info(&self, interner: &kglite::api::StringInterner) -> kglite::api::NodeInfo

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -2575,6 +2575,7 @@ pub fn kglite::api::NodeView<'a>::property_count(&self) -> usize
 pub fn kglite::api::NodeView<'a>::property_keys(&self, interner: &'a kglite::api::StringInterner) -> alloc::vec::Vec<&'a str>
 pub fn kglite::api::NodeView<'a>::property_pairs(&self) -> alloc::vec::Vec<(kglite::api::InternedKey, kglite::datatypes::values::Value)>
 pub fn kglite::api::NodeView<'a>::property_pairs_named(&self, interner: &kglite::api::StringInterner) -> alloc::vec::Vec<(alloc::string::String, kglite::datatypes::values::Value)>
+pub fn kglite::api::NodeView<'a>::resolved_field(&self, type_str: &str, field: &str, key: kglite::api::InternedKey) -> core::option::Option<alloc::borrow::Cow<'a, kglite::datatypes::values::Value>>
 pub fn kglite::api::NodeView<'a>::str_prop_eq(&self, key: kglite::api::InternedKey, target: &str) -> core::option::Option<bool>
 pub fn kglite::api::NodeView<'a>::title(&self) -> alloc::borrow::Cow<'a, kglite::datatypes::values::Value>
 pub fn kglite::api::NodeView<'a>::to_node_info(&self, interner: &kglite::api::StringInterner) -> kglite::api::NodeInfo

--- a/tests/test_cypher_ddl_indexes.py
+++ b/tests/test_cypher_ddl_indexes.py
@@ -125,6 +125,81 @@ def test_created_index_is_populated_and_the_lookup_still_answers(graph) -> None:
     assert sorted(r["n"] for r in rows) == ["Alice", "Charlie"]
 
 
+# ── Index content stays in step with writes ──────────────────────────
+
+
+def _aliased_graph() -> kglite.KnowledgeGraph:
+    """`Term` names its identity columns itself: `term_id` is the id field and
+    `term_name` the title field, so neither lives in the property map — an
+    index on either spelling is built from the node's id / title, which is also
+    what a `MATCH` on that name compares against."""
+    g = kglite.KnowledgeGraph()
+    g.add_nodes(
+        pd.DataFrame(
+            {
+                "term_id": [1, 2, 3],
+                "term_name": ["term-1", "term-2", "term-3"],
+                "city": ["Oslo", "Bergen", "Oslo"],
+            }
+        ),
+        "Term",
+        "term_id",
+        "term_name",
+    )
+    return g
+
+
+def _matched(g: kglite.KnowledgeGraph, predicate: str) -> int:
+    """Row counts for the indexed spelling and the scanning spelling of one
+    predicate. An index that has drifted from the data makes them disagree."""
+    inline = g.cypher(f"MATCH (t:Term {{{predicate}}}) RETURN t").to_list()
+    where_key, where_value = predicate.split(": ", 1)
+    scanned = g.cypher(f"MATCH (t:Term) WHERE t.{where_key} = {where_value} RETURN t").to_list()
+    assert len(inline) == len(scanned), (
+        f"the indexed and scanning spellings of `{predicate}` disagree: {len(inline)} vs {len(scanned)}"
+    )
+    return len(inline)
+
+
+@pytest.mark.parametrize("indexed_property", ["city", "term_name"])
+def test_a_cypher_create_keeps_the_index_in_step_with_the_scan(
+    indexed_property: str,
+) -> None:
+    """Incremental maintenance has to file a written node the way a rebuild
+    would, or the index answers with rows a scan cannot produce."""
+    g = _aliased_graph()
+    g.cypher(f"CREATE INDEX FOR (t:Term) ON (t.{indexed_property})")
+    g.cypher("CREATE (:Term {term_id: 99, term_name: 'created-x', city: 'Oslo'})")
+
+    _matched(g, "term_name: 'created-x'")
+    _matched(g, "term_name: 'term-1'")
+    assert _matched(g, "city: 'Oslo'") == 3
+
+
+def test_a_cypher_set_keeps_the_index_in_step_with_the_scan() -> None:
+    g = _aliased_graph()
+    g.cypher("CREATE INDEX FOR (t:Term) ON (t.term_name)")
+    g.cypher("CREATE INDEX FOR (t:Term) ON (t.city)")
+    g.cypher("MATCH (t:Term {term_id: 1}) SET t.city = 'Trondheim'")
+    g.cypher("MATCH (t:Term {term_id: 2}) SET t.term_name = 'renamed'")
+
+    assert _matched(g, "city: 'Trondheim'") == 1
+    assert _matched(g, "city: 'Oslo'") == 1
+    _matched(g, "term_name: 'renamed'")
+    _matched(g, "term_name: 'term-2'")
+
+
+def test_a_range_index_does_not_double_count_a_created_node() -> None:
+    """A RANGE index installs both structures on one property, so the write
+    path sees the same key twice — the node must still join each bucket once."""
+    g = _aliased_graph()
+    g.cypher("CREATE RANGE INDEX term_city FOR (t:Term) ON (t.city)")
+    g.cypher("CREATE (:Term {term_id: 99, term_name: 'Dana', city: 'Tromso'})")
+
+    assert _matched(g, "city: 'Tromso'") == 1
+    assert len(g.cypher("MATCH (t:Term) WHERE t.city > 'Trom' RETURN t").to_list()) == 1
+
+
 # ── SHOW INDEXES ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fix program from the Track H external perf report investigation (plan: `dev-docs/plans/perf-ndv-describe-fixes.md`, local). All defects confirmed by wheel-based A/B before fixing.

- [x] **Phase 1 (`fix:`)** — planner NDV statistic resolves title/id aliases (new `NodeView::resolved_field` chokepoint shared with the matcher) and treats an empty scan as no-information instead of NDV=1. Ends the since-0.11.9 mis-anchoring of joins filtered on title-field properties: ~25× (equality) / ~17× (IN) synthetic, 6×/10× on the reporting user's real graphs, controls flat. Five red-first planner tests pin anchor choice + statistic.
- [x] **Phase 1b (`fix:`)** — `.statistics()` on a type's id/title field returned `valid_count=0` with no stats (ungrouped path was alias-blind); both stat paths unified on the chokepoint.
- [x] **Phase 1c (`fix:`)** — incremental property-index maintenance filed nodes under verbatim values the resolving scan can never match: phantom rows, poisoned buckets, inline-map vs WHERE disagreement. Now reads through the same funnel as index rebuilds. Two adjacent defects fixed: dual-kind index double-append (duplicate MATCH rows) and SET-on-title leaving alias-spelled indexes stale. 10 Rust tests (7 red pre-fix) + Python DDL regressions, mutation-checked per arm.
- [x] **Phase 2 (`perf:`)** — describe/describe_types on columnar graphs recover 2.3× (85–89% of the avoidable 0.15.9 constant factor; output byte-parity pinned across 12 cells). `row_properties` drops a per-row HashSet + verified-dead second schema pass.

Final branch gate: `make lint-full`, full default pytest (5258+9 passed after full-extension rebuild; 8 initial failures were a narrow-build environment artifact), parity (111), `make bench-check` (27 cells, all flat-to-faster, worst −0.8%), workspace clippy — green.

Out of scope, filed: Cypher CREATE/MERGE alias-config design gap; M-sized column-major describe fast path; disk-mode concurrent-read RSS bug (separate program pending approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)