### PR TITLE
Bolt durability: checkpoint verb, exit/interval saves, WAL through Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,9 +103,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   final log flush before the exit save. Refused with `--readonly` (a server that
   never commits has nothing to log; `--durability off` beside `--readonly` is
   unchanged and fine) and for disk-mode graphs (a disk graph commits by
-  publishing an immutable generation, so it keeps no logical log). **The default
-  is `off`** — every existing invocation behaves exactly as before, and turning
-  the log on is opt-in this release.
+  publishing an immutable generation, so it keeps no logical log).
+
+  **The default is `normal`** — a commit this server acknowledges now survives
+  the server process dying, without any flag. The level was picked by
+  measurement, not preference: at 4 contended Bolt writers on a 10k-node graph,
+  `normal` cost nothing measurable against `off` (two runs straddled zero at
+  ±8% noise), while `full` cost **88%** of committed throughput — one device
+  barrier per commit, taken inside the session lock every Bolt commit already
+  serializes on, which also moved p95 latency from 0.9 ms to 76 ms and the
+  transaction-conflict rate from 1.5% to 17%. Power-loss safety is therefore
+  opt-in via `--durability full`, and the numbers live in
+  `tests/benchmarks/test_bench_bolt_writers.py::test_durability_sweep`.
+
+  Two consequences of the default, both deliberate: a served graph now grows a
+  `<graph>-wal` sidecar beside it (~95 bytes per single-node commit, truncated
+  by every checkpoint), and the configurations that cannot carry a log —
+  `--readonly` and disk-mode graphs — serve at `off` with a log line saying so
+  instead of failing to start. A level you *ask* for is still refused there,
+  rather than quietly weakened.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in ways that did not exist when a binding was written, and such an outcome
   must reach the binding's error path rather than falling through to success.
 
+### Fixed
+
+- **`kglite.open(path, durable=False)` no longer silently discards committed
+  writes still sitting in the WAL sidecar.** Recovery used to be conditional on
+  the level being asked for, so opening a crashed graph at `"off"` (or `False`)
+  ignored every frame the checkpoint did not already contain — the graph came
+  back missing writes that had been acknowledged, with no error, and the first
+  later `save()` truncated the log and destroyed them for good. Recovery on open
+  is now unconditional: opening a path is a decision about that path's *data*,
+  not only about how future writes will be logged. An `"off"` open over a
+  sidecar holding unrecovered commits raises `ValueError` naming the sidecar and
+  both ways out (reopen at `"full"`/`"normal"` to replay them, or move the
+  sidecar aside to discard them deliberately). Frames the checkpoint already
+  contains — the harmless residue of a crash between a `save()` and its
+  truncation — are not grounds to refuse and still open at every level. The
+  wheel and the engine's `Session` now perform the same open sequence through
+  one shared function (`kglite::api::durable::open_log`), so the two cannot
+  disagree about what a sidecar means.
+
 ## [0.15.13] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docker stop` and a Kubernetes pod shutdown terminated the process through
   the default handler — no connection shutdown, and (with the flag above) no
   exit save. Both signals now run one shutdown path.
+- **Durable sessions in the Rust API: `Session::open_durable(graph, path,
+  level)`.** The engine has shipped the write-ahead log itself since 0.14, but
+  the orchestration around it lived only in the Python wheel; it is now part of
+  `kglite::api::session`, so every binding gets the same behaviour instead of
+  reimplementing it. `open_durable` performs the whole open ordering — recover
+  the sidecar, replay the frames the loaded checkpoint does not already contain,
+  *then* wrap the backend for write capture (replaying after the wrap would log
+  every recovered op a second time), then open the log for append.
+  `Session::commit` appends the transaction's frame **between the OCC check and
+  the publish**, so a log that cannot be written blocks the commit rather than
+  reporting success over an unlogged write; the new
+  `CommitOutcome::DurabilityFailed { error }` says so, and the graph, its
+  version and its readers are untouched. `Session::save` becomes the four-step
+  checkpoint (flush the log → stamp `checkpoint_lsn` → write the `.kgl` →
+  truncate the log), and forces `fsync` on a durable session because it
+  destroys the log that would otherwise still describe those commits. New
+  `Session::sync()` takes the on-demand barrier that makes level `normal`
+  usable, and `Session::durability()` reports the level. Refusals are explicit:
+  disk-mode graphs at any logging level, a graph another durable owner already
+  wrapped, and — the data-safety one — level `off` over a sidecar holding
+  commits the checkpoint does not contain, which would otherwise be ignored and
+  then truncated away. `Session::write` / `Session::transact` are not logged
+  paths and are documented as unsupported on a durable session; taking one
+  anyway now latches the session so every later durability operation fails
+  loudly until a checkpoint folds the write in. Non-durable sessions are
+  unaffected in behaviour and in cost.
+
+### Changed
+
+- **`CommitOutcome` is now `#[non_exhaustive]`** (breaking for out-of-crate
+  code that matches it exhaustively — add a catch-all arm). A commit can fail
+  in ways that did not exist when a binding was written, and such an outcome
+  must reach the binding's error path rather than falling through to success.
 
 ## [0.15.13] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loudly until a checkpoint folds the write in. Non-durable sessions are
   unaffected in behaviour and in cost.
 
+- **`kglite-bolt-server --durability {full,normal,off}` puts the write-ahead
+  log under the Bolt server** (env mirror: `KGLITE_BOLT_DURABILITY=<level>`).
+  Until now the server's writes were process-local until something rewrote the
+  whole graph — the exit save, a `db.checkpoint()`, or an interval tick — so a
+  `SIGKILL` between checkpoints lost every commit since the last one. At `full`
+  and `normal` each commit is appended to `<graph>-wal` **before** it is
+  acknowledged: `full` barriers the frame to the device (an acknowledged commit
+  survives power loss), `normal` hands it to the kernel (survives this process
+  dying — `SIGKILL`, an OOM-kill, a panic — but not an OS crash or power loss).
+  A commit whose frame cannot be written is **not applied** and the client is
+  told so, rather than acknowledging a write the server has discarded.
+  **Recovery runs at startup at every level**: at `full`/`normal` a sidecar
+  holding commits the graph file does not contain is replayed before the port
+  is bound, and at `off` it is a startup error naming both ways out — never a
+  server quietly serving a graph that is missing acknowledged writes. The three
+  existing checkpoint routes become true checkpoints under a log: each folds the
+  log into the `.kgl` and truncates it, and the graceful shutdown path takes a
+  final log flush before the exit save. Refused with `--readonly` (a server that
+  never commits has nothing to log; `--durability off` beside `--readonly` is
+  unchanged and fine) and for disk-mode graphs (a disk graph commits by
+  publishing an immutable generation, so it keeps no logical log). **The default
+  is `off`** — every existing invocation behaves exactly as before, and turning
+  the log on is opt-in this release.
+
 ### Changed
 
+- **`kglite::api::io::open_or_create_graph_in_mode` takes the durability level
+  the caller is about to attach** (breaking for direct Rust callers: pass
+  `DurabilityLevel::Off` for today's behaviour). The unrecovered-sidecar
+  refusal above is correct for an opener that attaches no log and wrong for one
+  that is about to — a server restarting at `--durability full` *must* be
+  allowed to open the very path that refusal protects, because its log is the
+  recovery. The level is declared rather than inferred, so an `off` open still
+  gets the refusal and a graph created at a logging level over an orphaned
+  sidecar replays it instead of discarding it. `open_or_create_graph` (the
+  creation-default entry point) is unchanged and attaches no log. The C ABI's
+  `kglite_open_or_create_graph_in_mode` signature is unchanged.
 - **`CommitOutcome` is now `#[non_exhaustive]`** (breaking for out-of-crate
   code that matches it exhaustively — add a catch-all arm). A commit can fail
   in ways that did not exist when a binding was written, and such an outcome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writes), on a `--readonly` server, and for disk-mode graphs — the same
   reasons `--save-on-exit` refuses them. A save that fails is reported as a
   failure to the client, never a silent success.
+- **`kglite-bolt-server --checkpoint-interval <SECS>` checkpoints the served
+  graph on a timer** (env mirror: `KGLITE_BOLT_CHECKPOINT_INTERVAL=<secs>`),
+  bounding what a crash can lose to the writes since the last tick rather than
+  to the whole run. A background task saves the graph every SECS seconds and
+  logs the version it wrote; a tick whose graph is unchanged since the last
+  checkpoint — by this task *or* by `CALL db.checkpoint()`, which share one
+  recorded version — writes nothing, so an idle server does not rewrite its
+  file. The first checkpoint of a process always writes, because the file on
+  disk may predate the process. A failed tick is logged as an error and the
+  server keeps serving: degraded durability is worth saying loudly, not worth
+  disconnecting every client over. The interval is validated at startup (`0`
+  and anything that is not a whole number of seconds are refused, rather than
+  starting a server that silently never checkpoints), refused for `--readonly`
+  and for disk-mode graphs exactly as `--save-on-exit` is, and combinable with
+  it — the interval bounds the window while running, the exit save catches the
+  tail, and periodic checkpointing is stopped before the exit save runs.
 - **`SIGTERM` now triggers the same graceful shutdown as `SIGINT` in
   `kglite-bolt-server`.** Only Ctrl-C was wired, so `systemctl stop`,
   `docker stop` and a Kubernetes pod shutdown terminated the process through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deliberately unguarded: it is the primitive durable recovery is itself built
   on, and the way to read a graph another process is writing durably, where a
   sidecar running ahead of the checkpoint is the steady state.
+- **`load()` → mutate → `save()` over a live WAL sidecar is now refused
+  instead of being silently rolled back later.** `kglite.load(path)` (and
+  `kglite.open_session(path)`) read the checkpoint alone by design, so a path
+  whose sidecar still held commits the `.kgl` did not contain came back
+  missing them — and saving back over that path stranded the frames in front
+  of the new checkpoint, so the *next* durable open replayed them over it.
+  Measured end to end: a graph saved with `age=3` came back as `age=2`. The
+  save now refuses, in the single save dispatch
+  (`kglite::api::io::save_graph[_with]`, which the wheel, the MCP server, the
+  CLI, the C ABI and `Session::save` all route through), so every binding
+  gets the same refusal: `ValueError` in Python — the class every other
+  durability refusal already raises — naming the sidecar and both ways out
+  (reopen the path durably to replay the commits, or move the sidecar aside
+  to discard them deliberately). The rule is "the sidecar holds frames past
+  the `checkpoint_lsn` this save is about to write", which is exactly the set
+  a later durable open would replay over it; the target path's sidecar is what
+  counts, so a "save as" onto such a path is refused too. A durable owner's
+  own checkpoint is never refused, and not by an exemption: its prologue
+  stamps `checkpoint_lsn` before the write, so its frames are already at or
+  below the stamp. Crash residue (frames at or below the stamp) still saves
+  fine. `save_graph`/`save_graph_with` now return a typed `SaveError` whose
+  `Refused` variant means nothing was written, so a binding can map a refusal
+  to its own bad-request class instead of an I/O failure.
 
 ## [0.15.13] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`kglite-bolt-server --save-on-exit` writes the served graph back to
   `--graph` when the server shuts down** (env mirror:
-  `KGLITE_BOLT_SAVE_ON_EXIT=1`). A Bolt server's writes are process-local —
-  they live in the served graph's in-memory state and previously reached the
-  file only if a client saved it some other way — so a stopped server lost
+  `KGLITE_BOLT_SAVE_ON_EXIT=1`). A Bolt server's writes used to be
+  process-local — they lived in the served graph's in-memory state and reached
+  the file only if a client saved it some other way — so a stopped server lost
   every write it had accepted. With the flag, shutdown runs one fsync'd,
   atomic save and logs the saved graph version; a failed save is logged as an
-  error *and* exits non-zero, so a supervisor sees it. This is not a
-  durability guarantee: `SIGKILL`, a crash or a power loss still lose
-  everything since the last save, and because connections are not drained a
+  error *and* exits non-zero, so a supervisor sees it. What it is not is a
+  substitute for the write-ahead log added below: at `--durability off` a
+  `SIGKILL`, a crash or a power loss still lose everything since the last save,
+  and this flag only covers the two signals a graceful shutdown gets. Under the
+  default `--durability normal` those commits are in the sidecar and the next
+  start replays them, and the exit save's job becomes folding the log into the
+  file (which it now does, after flushing it) rather than being the only thing
+  standing between a stop and data loss. Because connections are not drained a
   commit that races shutdown can land after it — which is what the logged
   version is for. Refused at startup for `--readonly` (nothing to write back)
   and for disk-mode graphs (every disk save publishes a new generation and
@@ -37,8 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure to the client, never a silent success.
 - **`kglite-bolt-server --checkpoint-interval <SECS>` checkpoints the served
   graph on a timer** (env mirror: `KGLITE_BOLT_CHECKPOINT_INTERVAL=<secs>`),
-  bounding what a crash can lose to the writes since the last tick rather than
-  to the whole run. A background task saves the graph every SECS seconds and
+  bounding what an unlogged crash can lose to the writes since the last tick
+  rather than to the whole run — and, under the write-ahead log added below,
+  bounding instead how much sidecar a run accumulates and how long its replay
+  takes, since every checkpoint truncates the log. A background task saves the
+  graph every SECS seconds and
   logs the version it wrote; a tick whose graph is unchanged since the last
   checkpoint — by this task *or* by `CALL db.checkpoint()`, which share one
   recorded version — writes nothing, so an idle server does not rewrite its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`CREATE` no longer hands out an `id` that another node already holds.** A
+  `CREATE` with no `id` property asks the engine for an identity, and the
+  allocator was `node_bound()` — an index-space bound, not a counter. It
+  shrinks when the highest-indexed nodes are deleted and stalls while freed
+  slots are refilled, so ordinary histories minted collisions: `CREATE`×5 →
+  `DELETE` two → `CREATE`×3 put two nodes on one id, and a `save()`/`load()`
+  across earlier deletes put *three* consecutive nodes on the same id. The
+  duplicates were silent in both directions that matter — `MATCH (n {id: X})`
+  returns only one node per id, and WAL replay folds ops by `(node_type, id)`,
+  so a durable graph *recovered* the collided nodes as one and lost the rest.
+  Ids are now drawn from a monotonic high-water mark that never reuses a value
+  and is re-seeded above a loaded graph's own ids, and a caller-supplied id
+  raises the mark so the engine cannot later mint it. Ids handed out by an
+  append-only workload are unchanged (`0, 1, 2, …`); after a delete the counter
+  keeps climbing instead of reusing the freed value. Uniqueness for ids the
+  *caller* supplies is unchanged and still opt-in (`define_schema`'s
+  `primary_key`, or `MERGE`).
 - **`kglite.open(path, durable=False)` no longer silently discards committed
   writes still sitting in the WAL sidecar.** Recovery used to be conditional on
   the level being asked for, so opening a crashed graph at `"off"` (or `False`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kglite-bolt-server --save-on-exit` writes the served graph back to
+  `--graph` when the server shuts down** (env mirror:
+  `KGLITE_BOLT_SAVE_ON_EXIT=1`). A Bolt server's writes are process-local —
+  they live in the served graph's in-memory state and previously reached the
+  file only if a client saved it some other way — so a stopped server lost
+  every write it had accepted. With the flag, shutdown runs one fsync'd,
+  atomic save and logs the saved graph version; a failed save is logged as an
+  error *and* exits non-zero, so a supervisor sees it. This is not a
+  durability guarantee: `SIGKILL`, a crash or a power loss still lose
+  everything since the last save, and because connections are not drained a
+  commit that races shutdown can land after it — which is what the logged
+  version is for. Refused at startup for `--readonly` (nothing to write back)
+  and for disk-mode graphs (every disk save publishes a new generation and
+  nothing prunes them).
+- **`SIGTERM` now triggers the same graceful shutdown as `SIGINT` in
+  `kglite-bolt-server`.** Only Ctrl-C was wired, so `systemctl stop`,
+  `docker stop` and a Kubernetes pod shutdown terminated the process through
+  the default handler — no connection shutdown, and (with the flag above) no
+  exit save. Both signals now run one shutdown path.
+
 ## [0.15.13] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wheel and the engine's `Session` now perform the same open sequence through
   one shared function (`kglite::api::durable::open_log`), so the two cannot
   disagree about what a sidecar means.
+- **A server-style open over an unrecovered WAL sidecar no longer lets a later
+  durable open replay stale frames over newer saved data.** The MCP server, the
+  Bolt server and the CLI open graphs through
+  `kglite::api::io::open_or_create_graph[_in_mode]`, which read the `.kgl`
+  checkpoint alone and attach no log. Over a path whose sidecar still held
+  frames the checkpoint had not folded in — a durable writer that died between
+  a commit and its next checkpoint — that open silently returned a graph
+  missing those commits, and any subsequent save made it worse rather than
+  better: the save stamps no `checkpoint_lsn` and truncates nothing, so the
+  stale frames survived *in front of* the newer checkpoint and the next durable
+  open replayed them back over it, reverting saved state to an older commit.
+  These openers now refuse such a path on the same terms as `durable="off"`
+  (`kglite::api::durable::ensure_recovered`, shared with the wheel's refusal),
+  naming the sidecar and both ways out: open it through a durable entry point
+  to replay the frames, or move the sidecar aside to discard them
+  deliberately. The refusal covers read-only opens too, because an opener that
+  may later publish cannot be told apart from one that only looks, and it
+  covers a sidecar found beside a *missing* checkpoint, where a fresh graph
+  would replay every frame in it. Frames at or below `checkpoint_lsn` — crash
+  residue between a save and its truncation — still open fine. `load_file` is
+  deliberately unguarded: it is the primitive durable recovery is itself built
+  on, and the way to read a graph another process is writing durably, where a
+  sidecar running ahead of the checkpoint is the steady state.
 
 ## [0.15.13] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version is for. Refused at startup for `--readonly` (nothing to write back)
   and for disk-mode graphs (every disk save publishes a new generation and
   nothing prunes them).
+- **`CALL db.checkpoint()` over Bolt writes the served graph back on demand**,
+  returning Neo4j's `success, message` shape (an optional `YIELD` of either or
+  both columns is honoured). This is a **bolt-server verb, not a Cypher
+  procedure**: it is recognised and executed by the server, so it exists only
+  over Bolt — embedded bindings keep their own save calls, and the engine's
+  procedure list is unchanged. A checkpoint whose graph has not changed since
+  the last one *in this process* is skipped and says so; the first call of a
+  process always writes. Refused inside an explicit transaction (a checkpoint
+  writes the committed graph, which excludes that transaction's uncommitted
+  writes), on a `--readonly` server, and for disk-mode graphs — the same
+  reasons `--save-on-exit` refuses them. A save that fails is reported as a
+  failure to the client, never a silent success.
 - **`SIGTERM` now triggers the same graceful shutdown as `SIGINT` in
   `kglite-bolt-server`.** Only Ctrl-C was wired, so `systemctl stop`,
   `docker stop` and a Kubernetes pod shutdown terminated the process through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,6 +416,15 @@ Before any perf-related change:
    - **Every capture carries unchanged-path control cells**; they are the
      machine-drift meter. A *control* that regresses means the instrument
      moved, not the code — re-measure, don't bisect.
+   - **A control needs margin over its own resolution, and immunity from what
+     it anchors** (doctrine R11 corollary, 2026-08-13). Require the control's
+     median at **≥2×** the capture's noise floor — a control at ~1× the floor
+     measures nothing — and prefer the slowest query *measured* stable across
+     the last dependency move: a control chosen because "our source can't
+     touch it" silently expires when the thing that moves is a dependency.
+     A control that moves **deterministically** across repeated re-measures is
+     not instrument wander — "re-measure" cannot resolve it; the control's
+     premise is void and the control must be replaced.
    - **Measure a claim two independent ways** (two holders, two call routes)
      before believing it. A `WHERE` clause silently disqualifying the lazy path
      was invisible to either route alone and showed up only as disagreement

--- a/crates/kglite-bolt-server/README.md
+++ b/crates/kglite-bolt-server/README.md
@@ -88,6 +88,10 @@ Options:
   --checkpoint-interval <SECS> Save the served graph back to --graph every SECS
                                (also KGLITE_BOLT_CHECKPOINT_INTERVAL=<secs>;
                                unchanged graphs are skipped; same refusals)
+  --durability <LEVEL>         What a committed write survives: full (power
+                               loss), normal (this process dying), off — no log
+                               [default: off]. Also KGLITE_BOLT_DURABILITY=<level>;
+                               refused with --readonly and for disk-mode graphs
   --neo4j-compat               Report a Neo4j-compatible agent in the handshake
   --auth <USER:PASS>           Basic auth credentials
   --idle-timeout <SECS>        Per-session idle timeout

--- a/crates/kglite-bolt-server/README.md
+++ b/crates/kglite-bolt-server/README.md
@@ -90,8 +90,9 @@ Options:
                                unchanged graphs are skipped; same refusals)
   --durability <LEVEL>         What a committed write survives: full (power
                                loss), normal (this process dying), off — no log
-                               [default: off]. Also KGLITE_BOLT_DURABILITY=<level>;
-                               refused with --readonly and for disk-mode graphs
+                               [default: normal]. Also KGLITE_BOLT_DURABILITY=<level>;
+                               refused with --readonly and for disk-mode graphs,
+                               which serve the default at off instead
   --neo4j-compat               Report a Neo4j-compatible agent in the handshake
   --auth <USER:PASS>           Basic auth credentials
   --idle-timeout <SECS>        Per-session idle timeout

--- a/crates/kglite-bolt-server/README.md
+++ b/crates/kglite-bolt-server/README.md
@@ -82,6 +82,9 @@ Options:
   --bind <ADDR>                Bind address [default: 127.0.0.1]
   --port <PORT>                Port [default: 7687]
   --readonly                   Reject mutations
+  --save-on-exit               Save the served graph back to --graph on SIGINT/SIGTERM
+                               (also KGLITE_BOLT_SAVE_ON_EXIT=1; refused with
+                               --readonly and for disk-mode graphs)
   --neo4j-compat               Report a Neo4j-compatible agent in the handshake
   --auth <USER:PASS>           Basic auth credentials
   --idle-timeout <SECS>        Per-session idle timeout

--- a/crates/kglite-bolt-server/README.md
+++ b/crates/kglite-bolt-server/README.md
@@ -85,6 +85,9 @@ Options:
   --save-on-exit               Save the served graph back to --graph on SIGINT/SIGTERM
                                (also KGLITE_BOLT_SAVE_ON_EXIT=1; refused with
                                --readonly and for disk-mode graphs)
+  --checkpoint-interval <SECS> Save the served graph back to --graph every SECS
+                               (also KGLITE_BOLT_CHECKPOINT_INTERVAL=<secs>;
+                               unchanged graphs are skipped; same refusals)
   --neo4j-compat               Report a Neo4j-compatible agent in the handshake
   --auth <USER:PASS>           Basic auth credentials
   --idle-timeout <SECS>        Per-session idle timeout

--- a/crates/kglite-bolt-server/src/backend.rs
+++ b/crates/kglite-bolt-server/src/backend.rs
@@ -731,6 +731,22 @@ impl BoltBackend for KgliteBackend {
                     "commit (with mutations)"
                 );
             }
+            // Any outcome this build does not recognise — `CommitOutcome` is
+            // `#[non_exhaustive]` — is a failure, never a silent success.
+            // `DurabilityFailed` (a WAL frame that could not be appended, so
+            // the commit was not published) lands here today; R3.2 gives it
+            // its own arm once this server can open a durable session at all.
+            kglite::api::session::CommitOutcome::DurabilityFailed { ref error } => {
+                tracing::error!(
+                    session_id = %session.0,
+                    tx = %transaction.0,
+                    error = %error,
+                    "commit rejected: the write could not be made durable"
+                );
+                return Err(BoltError::Backend(format!(
+                    "commit was not applied: {error}"
+                )));
+            }
             kglite::api::session::CommitOutcome::ConflictDetected {
                 current_version,
                 base_version,
@@ -764,6 +780,22 @@ impl BoltBackend for KgliteBackend {
                          current version {current_version}). Retry the transaction."
                     ),
                 });
+            }
+            // `CommitOutcome` is `#[non_exhaustive]`: an outcome this build
+            // does not recognise reaches the error path, never the success
+            // path. Fail closed — the engine only ever adds outcomes that mean
+            // "not published".
+            ref other => {
+                tracing::error!(
+                    session_id = %session.0,
+                    tx = %transaction.0,
+                    outcome = ?other,
+                    "commit returned an outcome this build does not recognise"
+                );
+                return Err(BoltError::Backend(
+                    "commit returned an unrecognised outcome; the transaction was not applied"
+                        .to_string(),
+                ));
             }
         }
 

--- a/crates/kglite-bolt-server/src/backend.rs
+++ b/crates/kglite-bolt-server/src/backend.rs
@@ -150,6 +150,14 @@ pub struct KgliteBackend {
     /// Server-wide `--readonly` flag. Rejects begin_transaction and
     /// auto-commit mutations.
     readonly: bool,
+    /// Graph version at the last *successful* `db.checkpoint()` in this
+    /// process, or `None` until one has run — so the first checkpoint of a
+    /// process always writes, whatever the on-disk file happens to hold.
+    ///
+    /// The mutex is held across the save itself, which serializes concurrent
+    /// checkpoints: two clients asking at once produce one write and one
+    /// skip, never two interleaved saves of the same graph.
+    last_checkpoint_version: Mutex<Option<u64>>,
     /// Per-transaction state. Keyed by `TransactionHandle.0`. The
     /// outer mutex is brief-acquire-only (lookup/insert/remove); the
     /// per-tx work happens inside the inner mutex. See struct doc on
@@ -290,6 +298,7 @@ impl KgliteBackend {
             session: Arc::new(kglite::api::session::Session::new(graph)),
             graph_path,
             readonly,
+            last_checkpoint_version: Mutex::new(None),
             transactions: Arc::new(Mutex::new(HashMap::new())),
             session_counter: AtomicU64::new(0),
             tx_counter: AtomicU64::new(0),
@@ -503,6 +512,17 @@ impl BoltBackend for KgliteBackend {
                  issue separate RUNs)"
                     .into(),
             ));
+        }
+
+        // `CALL db.checkpoint()` is a *bolt-layer verb*, not an engine
+        // procedure: the Cypher executor has no session, no `&mut` graph and
+        // no served path to write to, and CALL is classified as a read — so
+        // an engine procedure would also slip straight past `--readonly`.
+        // Intercepting here is what gives the verb the three things it needs
+        // (the session, the served path, the readonly flag), and it runs
+        // before parameter decoding because the verb takes none.
+        if let Some(call) = parse_checkpoint_call(trimmed) {
+            return self.run_checkpoint(&call, transaction.is_some());
         }
 
         // Decode params (C.3). Errors here are genuine client errors
@@ -905,6 +925,118 @@ fn _query_appears_multi_statement(query: &str) -> bool {
     false
 }
 
+/// Output columns of `db.checkpoint()`, in declaration order — the shape
+/// Neo4j's own `db.checkpoint()` yields, so a client can call it the same way.
+const CHECKPOINT_COLUMNS: [&str; 2] = ["success", "message"];
+
+/// A recognized `CALL db.checkpoint()` invocation and the columns it asked
+/// for (all of [`CHECKPOINT_COLUMNS`] when there is no `YIELD`).
+#[derive(Debug, PartialEq, Eq)]
+struct CheckpointCall {
+    columns: Vec<&'static str>,
+}
+
+/// Strip `keyword` from the front of `input`, case-insensitively, requiring a
+/// word boundary after it; returns the remainder with leading whitespace
+/// trimmed.
+///
+/// The boundary check is what stops `CALLS ...` or `YIELDing` from being read
+/// as the keyword plus a remainder.
+fn strip_keyword_ci<'a>(input: &'a str, keyword: &str) -> Option<&'a str> {
+    if !input.get(..keyword.len())?.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    let rest = &input[keyword.len()..];
+    match rest.chars().next() {
+        Some(c) if c.is_alphanumeric() || c == '_' => None,
+        _ => Some(rest.trim_start()),
+    }
+}
+
+/// Recognize exactly `CALL db.checkpoint()`, optionally followed by a `YIELD`
+/// naming a subset of [`CHECKPOINT_COLUMNS`]; `None` for anything else.
+///
+/// **Deliberately narrow.** Keywords and the procedure name are matched
+/// case-insensitively (Cypher keywords are, and every driver spells the
+/// procedure lowercase anyway), surrounding whitespace and one trailing `;`
+/// are tolerated — but arguments inside the parentheses, an unknown or
+/// repeated `YIELD` column, an alias (`YIELD success AS ok`), or a differently
+/// *cased* column name all fall through to the engine, which answers with its
+/// standard "Unknown procedure 'db.checkpoint'". That is the intended
+/// behaviour, not a gap: YIELD names are Cypher identifiers, and quietly
+/// re-casing one would hand the driver a record whose key is not the key the
+/// client asked for. Only the exact verb is a bolt-layer verb.
+fn parse_checkpoint_call(query: &str) -> Option<CheckpointCall> {
+    let mut body = query.trim();
+    if let Some(stripped) = body.strip_suffix(';') {
+        body = stripped.trim_end();
+    }
+    let rest = strip_keyword_ci(body, "call")?;
+    let rest = strip_keyword_ci(rest, "db.checkpoint")?;
+    let rest = rest.strip_prefix('(')?.trim_start();
+    let rest = rest.strip_prefix(')')?.trim_start();
+    if rest.is_empty() {
+        return Some(CheckpointCall {
+            columns: CHECKPOINT_COLUMNS.to_vec(),
+        });
+    }
+    let yielded = strip_keyword_ci(rest, "yield")?;
+    let mut columns: Vec<&'static str> = Vec::with_capacity(CHECKPOINT_COLUMNS.len());
+    for raw in yielded.split(',') {
+        let name = raw.trim();
+        let canonical = CHECKPOINT_COLUMNS.iter().find(|column| **column == name)?;
+        if columns.contains(canonical) {
+            return None;
+        }
+        columns.push(*canonical);
+    }
+    Some(CheckpointCall { columns })
+}
+
+/// Build the single-record result a `db.checkpoint()` call answers with,
+/// projected onto the columns the client yielded.
+///
+/// `success` is always `true`: every way a checkpoint can fail — refused,
+/// or a save error — returns a Bolt FAILURE instead, so a record that reaches
+/// the client is a record about a checkpoint that either wrote or was
+/// deliberately skipped. `type` distinguishes the two ("w" wrote, "r" didn't).
+fn checkpoint_stream(
+    call: &CheckpointCall,
+    message: String,
+    type_str: &str,
+    started: Instant,
+) -> ResultStream {
+    let values: Vec<BoltValue> = call
+        .columns
+        .iter()
+        .map(|column| {
+            debug_assert!(
+                CHECKPOINT_COLUMNS.contains(column),
+                "parse_checkpoint_call yielded an unknown column: {column}"
+            );
+            if *column == CHECKPOINT_COLUMNS[0] {
+                BoltValue::Boolean(true)
+            } else {
+                BoltValue::String(message.clone())
+            }
+        })
+        .collect();
+    ResultStream {
+        metadata: ResultMetadata {
+            columns: call.columns.iter().map(|c| (*c).to_string()).collect(),
+            extra: BoltDict::new(),
+        },
+        records: vec![BoltRecord { values }],
+        summary: BoltDict::from([
+            ("type".to_string(), BoltValue::String(type_str.to_string())),
+            (
+                "t_last".to_string(),
+                BoltValue::Integer(started.elapsed().as_millis() as i64),
+            ),
+        ]),
+    }
+}
+
 impl KgliteBackend {
     /// Build the canonical `ExecuteOptions` the bolt-server uses for
     /// every query. Eager rows (`lazy_eligible: false`) — bolt-server
@@ -935,6 +1067,104 @@ impl KgliteBackend {
         // single chokepoint for both the auto-commit and in-transaction paths.
         opts.csv_import = self.csv_import.clone();
         opts
+    }
+
+    /// Run the `db.checkpoint()` verb: write the served graph back to the
+    /// path it came from, fsync'd, and report what happened.
+    ///
+    /// **Refusals, in order.** Inside an explicit transaction the call is a
+    /// `Protocol` error: a checkpoint saves the *session's* committed graph,
+    /// which by definition does not contain the calling transaction's
+    /// uncommitted writes — so a client that ran it inside a transaction
+    /// would get a file that silently omits the work it just did, and a
+    /// success record saying otherwise. There is no correct answer to give,
+    /// so the honest move is to refuse and name the reason. `--readonly` and
+    /// disk-mode graphs are `Forbidden`, for the same reasons `--save-on-exit`
+    /// refuses them at startup.
+    ///
+    /// **Digest-skip.** The graph version is read *before* the save, never
+    /// after. A commit that lands between the read and the save's lock
+    /// acquisition then makes the recorded version one behind what reached
+    /// disk, so the next checkpoint re-saves — a redundant write. Recording
+    /// the version afterwards would fail the other way: a commit landing in
+    /// the same window would be recorded as saved when it was not, and the
+    /// next checkpoint would skip, losing it.
+    ///
+    /// A failed save is `Backend` (fail-closed: the client is told the
+    /// checkpoint did not happen) and leaves the recorded version untouched,
+    /// so a later retry still writes.
+    fn run_checkpoint(
+        &self,
+        call: &CheckpointCall,
+        in_transaction: bool,
+    ) -> Result<ResultStream, BoltError> {
+        let started = Instant::now();
+        if in_transaction {
+            return Err(BoltError::Protocol(
+                "db.checkpoint() cannot run inside an explicit transaction — it \
+                 writes the committed graph, which does not include this \
+                 transaction's uncommitted writes; COMMIT first, then call it \
+                 in auto-commit"
+                    .into(),
+            ));
+        }
+        if self.readonly {
+            return Err(BoltError::Forbidden(
+                "server is read-only — db.checkpoint() rejected (--readonly flag)".into(),
+            ));
+        }
+        // Bound to a `let` so the snapshot Arc it borrows is dropped right
+        // here: a snapshot alive across the save below would turn the save's
+        // `Arc::make_mut` into a deep clone of the whole graph (see
+        // `Session::save`).
+        let mode = kglite::api::storage::live_storage_mode(&self.session.snapshot());
+        if mode == kglite::api::storage::StorageMode::Disk {
+            return Err(BoltError::Forbidden(
+                "db.checkpoint() is not supported for disk-mode graphs: every disk \
+                 save publishes a new on-disk generation and nothing prunes the old \
+                 ones, so repeated checkpoints grow the directory without bound"
+                    .into(),
+            ));
+        }
+
+        // Held across the save — see the field's doc comment.
+        let mut last = self
+            .last_checkpoint_version
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let version = self.session.version();
+        if *last == Some(version) {
+            tracing::debug!(
+                graph_version = version,
+                "db.checkpoint(): skipped (graph unchanged since the last checkpoint)"
+            );
+            return Ok(checkpoint_stream(
+                call,
+                format!("skipped: graph unchanged since version {version}"),
+                "r",
+                started,
+            ));
+        }
+        self.session
+            .save(&self.graph_path.to_string_lossy(), true)
+            .map_err(|e| {
+                BoltError::Backend(format!(
+                    "db.checkpoint() failed writing {}: {e}",
+                    self.graph_path.display()
+                ))
+            })?;
+        *last = Some(version);
+        tracing::info!(
+            path = %self.graph_path.display(),
+            graph_version = version,
+            "db.checkpoint(): graph written"
+        );
+        Ok(checkpoint_stream(
+            call,
+            format!("checkpoint written: version {version}"),
+            "w",
+            started,
+        ))
     }
 
     /// Auto-commit path: take a snapshot, delegate to
@@ -1132,11 +1362,18 @@ mod tests {
     }
 
     fn memory_backend() -> KgliteBackend {
+        memory_backend_at(unique_disk_path().join("memory.kgl"), false)
+    }
+
+    /// A memory-mode backend serving `path` — which, unlike
+    /// [`memory_backend`]'s, is a real writable location, so a checkpoint can
+    /// actually land there.
+    fn memory_backend_at(path: std::path::PathBuf, readonly: bool) -> KgliteBackend {
         let graph = new_dir_graph_in_mode(StorageMode::Memory, None).expect("create memory graph");
         KgliteBackend::new(
             graph,
-            unique_disk_path().join("memory.kgl"),
-            false,
+            path,
+            readonly,
             "127.0.0.1:0".into(),
             CsvImportPolicy::Denied,
             ServerIdentity::default(),
@@ -1386,5 +1623,277 @@ mod tests {
         );
         assert!(!matches("neo4j-python/6.2.0"));
         assert!(!matches(""));
+    }
+
+    // ---- `CALL db.checkpoint()` (Phase 2) --------------------------------
+
+    fn unique_kgl_path(tag: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "kglite-bolt-checkpoint-{tag}-{}-{nonce}.kgl",
+            std::process::id()
+        ))
+    }
+
+    async fn run_checkpoint_query(
+        backend: &KgliteBackend,
+        session: &SessionHandle,
+        query: &str,
+    ) -> Result<ResultStream, BoltError> {
+        backend
+            .execute(session, query, &HashMap::new(), &BoltDict::new(), None)
+            .await
+    }
+
+    fn summary_type(stream: &ResultStream) -> String {
+        match stream.summary.get("type") {
+            Some(BoltValue::String(t)) => t.clone(),
+            other => panic!("expected a string summary type, got {other:?}"),
+        }
+    }
+
+    fn checkpoint_message(stream: &ResultStream) -> String {
+        let index = stream
+            .metadata
+            .columns
+            .iter()
+            .position(|c| c == "message")
+            .expect("result carries a message column");
+        match &stream.records[0].values[index] {
+            BoltValue::String(m) => m.clone(),
+            other => panic!("expected a string message, got {other:?}"),
+        }
+    }
+
+    /// Every spelling the intercept must recognize, with the columns it
+    /// projects. Case, spacing, a trailing `;` and a `YIELD` subset in any
+    /// order are all tolerated — the YIELD order is the client's, not ours.
+    #[test]
+    fn checkpoint_normalization_accepts_the_verbs_spellings() {
+        let both = vec!["success", "message"];
+        let cases: &[(&str, Vec<&str>)] = &[
+            ("CALL db.checkpoint()", both.clone()),
+            ("call db.checkpoint()", both.clone()),
+            ("  CALL   db.checkpoint( )  ", both.clone()),
+            ("CALL db.checkpoint();", both.clone()),
+            ("CALL db.checkpoint()  ;  ", both.clone()),
+            ("CALL DB.CheckPoint()", both.clone()),
+            ("CALL db.checkpoint() YIELD success, message", both.clone()),
+            ("call db.checkpoint() yield success,message", both.clone()),
+            (
+                "CALL db.checkpoint() YIELD message, success",
+                vec!["message", "success"],
+            ),
+            ("CALL db.checkpoint() YIELD success", vec!["success"]),
+            ("CALL db.checkpoint() YIELD message;", vec!["message"]),
+        ];
+        for (query, expected) in cases {
+            let call = parse_checkpoint_call(query)
+                .unwrap_or_else(|| panic!("must be recognized as the checkpoint verb: {query:?}"));
+            assert_eq!(&call.columns, expected, "columns for {query:?}");
+        }
+    }
+
+    /// Everything else falls through to the engine, which answers "Unknown
+    /// procedure 'db.checkpoint'". Arguments, aliases, unknown or repeated
+    /// YIELD columns, and a differently *cased* column name are all deliberate
+    /// fall-throughs: re-casing a YIELD identifier would hand the driver a
+    /// record key the client never asked for.
+    #[test]
+    fn checkpoint_normalization_rejects_everything_else() {
+        let cases = [
+            "CALL db.checkpoint(true)",
+            "CALL db.checkpoint('/tmp/other.kgl')",
+            "CALL db.checkpoints()",
+            "CALL db.checkpoint",
+            "CALL db.labels()",
+            "CALLdb.checkpoint()",
+            "CALL db.checkpoint() YIELD",
+            "CALL db.checkpoint() YIELD success, other",
+            "CALL db.checkpoint() YIELD Success",
+            "CALL db.checkpoint() YIELD success AS ok",
+            "CALL db.checkpoint() YIELD success, success",
+            "CALL db.checkpoint() RETURN 1",
+            "CALL db.checkpoint() YIELD success, message RETURN success",
+            "RETURN 'CALL db.checkpoint()' AS s",
+            "MATCH (n) RETURN n",
+        ];
+        for query in cases {
+            assert_eq!(
+                parse_checkpoint_call(query),
+                None,
+                "must fall through to the engine: {query:?}"
+            );
+        }
+    }
+
+    /// The digest-skip, and its mutation check: a checkpoint after an
+    /// unchanged graph must skip, and a checkpoint after a *committed write*
+    /// must save again. Without the second half a parser that always skipped
+    /// would pass.
+    #[tokio::test]
+    async fn checkpoint_writes_then_skips_until_the_graph_changes() {
+        let path = unique_kgl_path("skip");
+        let backend = memory_backend_at(path.clone(), false);
+        let session = SessionHandle("checkpoint-session".into());
+        mutate_and_finish(&backend, &session, "CREATE (:Person {id: 1})", true).await;
+        let saved_version = backend.session.version();
+
+        let first = run_checkpoint_query(&backend, &session, "CALL db.checkpoint()")
+            .await
+            .expect("first checkpoint");
+        assert_eq!(summary_type(&first), "w", "a real save is a write");
+        assert_eq!(
+            checkpoint_message(&first),
+            format!("checkpoint written: version {saved_version}")
+        );
+        assert!(path.exists(), "the checkpoint must reach the served path");
+        let first_written = std::fs::metadata(&path)
+            .expect("checkpoint file metadata")
+            .modified()
+            .expect("modification time");
+
+        let second = run_checkpoint_query(&backend, &session, "CALL db.checkpoint()")
+            .await
+            .expect("second checkpoint");
+        assert_eq!(summary_type(&second), "r", "a skip did not write");
+        assert_eq!(
+            checkpoint_message(&second),
+            format!("skipped: graph unchanged since version {saved_version}")
+        );
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("checkpoint file metadata")
+                .modified()
+                .expect("modification time"),
+            first_written,
+            "a skipped checkpoint must not rewrite the file"
+        );
+
+        // Mutation check: bump the version and the next call must save.
+        mutate_and_finish(&backend, &session, "CREATE (:Person {id: 2})", true).await;
+        let bumped_version = backend.session.version();
+        assert_ne!(
+            bumped_version, saved_version,
+            "the write bumped the version"
+        );
+        let third = run_checkpoint_query(&backend, &session, "CALL db.checkpoint()")
+            .await
+            .expect("third checkpoint");
+        assert_eq!(summary_type(&third), "w");
+        assert_eq!(
+            checkpoint_message(&third),
+            format!("checkpoint written: version {bumped_version}")
+        );
+
+        drop(backend);
+        std::fs::remove_file(&path).expect("remove checkpoint fixture");
+    }
+
+    /// A `YIELD` subset projects exactly those columns, in the client's order.
+    #[tokio::test]
+    async fn checkpoint_projects_the_yielded_columns() {
+        let path = unique_kgl_path("yield");
+        let backend = memory_backend_at(path.clone(), false);
+        let session = SessionHandle("yield-session".into());
+
+        let stream = run_checkpoint_query(
+            &backend,
+            &session,
+            "CALL db.checkpoint() YIELD message, success",
+        )
+        .await
+        .expect("checkpoint with a reordered YIELD");
+        assert_eq!(stream.metadata.columns, vec!["message", "success"]);
+        assert_eq!(stream.records.len(), 1);
+        assert!(matches!(stream.records[0].values[0], BoltValue::String(_)));
+        assert_eq!(stream.records[0].values[1], BoltValue::Boolean(true));
+
+        drop(backend);
+        std::fs::remove_file(&path).expect("remove checkpoint fixture");
+    }
+
+    /// Inside an explicit transaction the verb is refused: it would write the
+    /// committed graph, which does not contain the caller's uncommitted work.
+    #[tokio::test]
+    async fn checkpoint_inside_a_transaction_is_refused() {
+        let path = unique_kgl_path("in-tx");
+        let backend = memory_backend_at(path.clone(), false);
+        let session = SessionHandle("tx-session".into());
+        let tx = backend
+            .begin_transaction(&session, &BoltDict::new())
+            .await
+            .expect("begin");
+        backend
+            .execute_in_tx(&tx.0, "CREATE (:Person {id: 1})", HashMap::new())
+            .expect("tx mutation");
+
+        let err = backend
+            .execute(
+                &session,
+                "CALL db.checkpoint()",
+                &HashMap::new(),
+                &BoltDict::new(),
+                Some(&tx),
+            )
+            .await
+            .expect_err("db.checkpoint() inside a transaction must be refused");
+        assert!(
+            matches!(&err, BoltError::Protocol(msg) if msg.contains("explicit transaction")),
+            "unexpected error: {err:?}"
+        );
+        assert!(
+            !path.exists(),
+            "a refused checkpoint must not have written anything"
+        );
+    }
+
+    /// `--readonly` refuses the verb by name, the same way it refuses writes.
+    #[tokio::test]
+    async fn checkpoint_is_refused_on_a_readonly_server() {
+        let path = unique_kgl_path("readonly");
+        let backend = memory_backend_at(path.clone(), true);
+        let session = SessionHandle("ro-session".into());
+
+        let err = run_checkpoint_query(&backend, &session, "CALL db.checkpoint()")
+            .await
+            .expect_err("a read-only server must refuse the checkpoint verb");
+        assert!(
+            matches!(&err, BoltError::Forbidden(msg) if msg.contains("--readonly")),
+            "unexpected error: {err:?}"
+        );
+        assert!(!path.exists(), "a refused checkpoint writes nothing");
+    }
+
+    /// Disk graphs are excluded: every disk save publishes a generation and
+    /// nothing prunes them.
+    #[tokio::test]
+    async fn checkpoint_is_refused_for_a_disk_graph() {
+        let path = unique_disk_path();
+        let graph = new_dir_graph_in_mode(StorageMode::Disk, Some(&path))
+            .expect("create disk-backed graph");
+        let backend = KgliteBackend::new(
+            graph,
+            path.clone(),
+            false,
+            "127.0.0.1:0".into(),
+            CsvImportPolicy::Denied,
+            ServerIdentity::default(),
+        );
+        let session = SessionHandle("disk-session".into());
+
+        let err = run_checkpoint_query(&backend, &session, "CALL db.checkpoint()")
+            .await
+            .expect_err("a disk graph must refuse the checkpoint verb");
+        assert!(
+            matches!(&err, BoltError::Forbidden(msg) if msg.contains("generation")),
+            "unexpected error: {err:?}"
+        );
+
+        drop(backend);
+        std::fs::remove_dir_all(path).expect("remove disk checkpoint fixture");
     }
 }

--- a/crates/kglite-bolt-server/src/backend.rs
+++ b/crates/kglite-bolt-server/src/backend.rs
@@ -140,6 +140,13 @@ pub struct KgliteBackend {
     /// `session.commit(tx, check_occ)` which handles the OCC
     /// version bump + Arc swap atomically.
     session: Arc<kglite::api::session::Session>,
+    /// The path this graph was served from — where a checkpoint writes.
+    ///
+    /// Held here rather than only in `main` because the checkpoint routes
+    /// (the exit save, and the `db.checkpoint()` verb) target the served
+    /// graph by definition: a save destination that could differ from what
+    /// the backend is serving is a footgun, not a feature.
+    graph_path: std::path::PathBuf,
     /// Server-wide `--readonly` flag. Rejects begin_transaction and
     /// auto-commit mutations.
     readonly: bool,
@@ -273,6 +280,7 @@ impl KgliteBackend {
     /// to `0.0.0.0` behind a hostname or reverse proxy.
     pub fn new(
         graph: DirGraph,
+        graph_path: std::path::PathBuf,
         readonly: bool,
         advertised_addr: String,
         csv_import: CsvImportPolicy,
@@ -280,6 +288,7 @@ impl KgliteBackend {
     ) -> Self {
         Self {
             session: Arc::new(kglite::api::session::Session::new(graph)),
+            graph_path,
             readonly,
             transactions: Arc::new(Mutex::new(HashMap::new())),
             session_counter: AtomicU64::new(0),
@@ -288,6 +297,18 @@ impl KgliteBackend {
             csv_import,
             identity,
         }
+    }
+
+    /// The shared session, cloned out so a caller can still reach the served
+    /// graph after the backend is moved into `BoltServer::serve` — which is
+    /// the only way to run a save *after* the accept loop has finished.
+    pub(crate) fn session_handle(&self) -> Arc<kglite::api::session::Session> {
+        Arc::clone(&self.session)
+    }
+
+    /// Where a checkpoint of this server's graph is written.
+    pub(crate) fn graph_path(&self) -> &std::path::Path {
+        &self.graph_path
     }
 
     /// Warn when a client whose driver gates on the agent prefix connects while
@@ -1073,6 +1094,7 @@ mod tests {
             .expect("create disk-backed graph");
         let backend = KgliteBackend::new(
             graph,
+            path.clone(),
             false,
             "127.0.0.1:0".into(),
             CsvImportPolicy::Denied,
@@ -1113,6 +1135,7 @@ mod tests {
         let graph = new_dir_graph_in_mode(StorageMode::Memory, None).expect("create memory graph");
         KgliteBackend::new(
             graph,
+            unique_disk_path().join("memory.kgl"),
             false,
             "127.0.0.1:0".into(),
             CsvImportPolicy::Denied,

--- a/crates/kglite-bolt-server/src/backend.rs
+++ b/crates/kglite-bolt-server/src/backend.rs
@@ -23,7 +23,7 @@ use boltr::server::{
 use boltr::types::{BoltDict, BoltValue};
 
 use kglite::api::session::CsvImportPolicy;
-use kglite::api::{cypher, DirGraph, Value};
+use kglite::api::{cypher, Value};
 
 use crate::error_map::kg_to_bolt;
 use crate::value_adapter;
@@ -285,8 +285,13 @@ impl TxMeta {
 }
 
 impl KgliteBackend {
-    /// Construct a backend. The DirGraph is wrapped in a
-    /// `session::Session` for shared-graph + commit-swap semantics.
+    /// Construct a backend around an already-opened session.
+    ///
+    /// The session arrives built rather than being constructed here because at
+    /// `--durability full`/`normal` its construction is part of opening the
+    /// path — the write-ahead sidecar is recovered into the graph inside the
+    /// writer lease, before any client can connect (see `startup::start_graph`).
+    ///
     /// `advertised_addr` (`host:port`, no scheme) is what `route()`
     /// returns to cluster-aware drivers using `neo4j://` URIs —
     /// they'll reconnect to this address for subsequent sessions,
@@ -294,7 +299,7 @@ impl KgliteBackend {
     /// this matches the bind address but should differ when bound
     /// to `0.0.0.0` behind a hostname or reverse proxy.
     pub fn new(
-        graph: DirGraph,
+        session: kglite::api::session::Session,
         graph_path: std::path::PathBuf,
         readonly: bool,
         advertised_addr: String,
@@ -302,7 +307,7 @@ impl KgliteBackend {
         identity: ServerIdentity,
     ) -> Self {
         Self {
-            session: Arc::new(kglite::api::session::Session::new(graph)),
+            session: Arc::new(session),
             graph_path,
             readonly,
             last_checkpoint_version: Arc::new(Mutex::new(None)),
@@ -731,20 +736,24 @@ impl BoltBackend for KgliteBackend {
                     "commit (with mutations)"
                 );
             }
-            // Any outcome this build does not recognise — `CommitOutcome` is
-            // `#[non_exhaustive]` — is a failure, never a silent success.
-            // `DurabilityFailed` (a WAL frame that could not be appended, so
-            // the commit was not published) lands here today; R3.2 gives it
-            // its own arm once this server can open a durable session at all.
+            // `--durability full`/`normal`: the frame could not be appended, so
+            // the engine did not publish the commit (append-then-publish — see
+            // `Session::commit`). The client must see FAILURE, because the
+            // alternative is a driver that returns success for a write the
+            // server deliberately discarded. `Backend` rather than `Query`: the
+            // statement was fine and re-running it may well work, but nothing
+            // about it can be fixed client-side, and the Neo4j taxonomy has no
+            // retriable class that means "the server's disk answered no".
             kglite::api::session::CommitOutcome::DurabilityFailed { ref error } => {
                 tracing::error!(
                     session_id = %session.0,
                     tx = %transaction.0,
                     error = %error,
-                    "commit rejected: the write could not be made durable"
+                    "commit rejected: the write could not be logged, so it was not applied"
                 );
                 return Err(BoltError::Backend(format!(
-                    "commit was not applied: {error}"
+                    "commit was NOT applied — the write-ahead log rejected it and the \
+                     server does not acknowledge writes it cannot log: {error}"
                 )));
             }
             kglite::api::session::CommitOutcome::ConflictDetected {
@@ -1427,7 +1436,7 @@ mod tests {
         let graph = new_dir_graph_in_mode(StorageMode::Disk, Some(&path))
             .expect("create disk-backed graph");
         let backend = KgliteBackend::new(
-            graph,
+            kglite::api::session::Session::new(graph),
             path.clone(),
             false,
             "127.0.0.1:0".into(),
@@ -1475,7 +1484,7 @@ mod tests {
     fn memory_backend_at(path: std::path::PathBuf, readonly: bool) -> KgliteBackend {
         let graph = new_dir_graph_in_mode(StorageMode::Memory, None).expect("create memory graph");
         KgliteBackend::new(
-            graph,
+            kglite::api::session::Session::new(graph),
             path,
             readonly,
             "127.0.0.1:0".into(),
@@ -1980,7 +1989,7 @@ mod tests {
         let graph = new_dir_graph_in_mode(StorageMode::Disk, Some(&path))
             .expect("create disk-backed graph");
         let backend = KgliteBackend::new(
-            graph,
+            kglite::api::session::Session::new(graph),
             path.clone(),
             false,
             "127.0.0.1:0".into(),

--- a/crates/kglite-bolt-server/src/backend.rs
+++ b/crates/kglite-bolt-server/src/backend.rs
@@ -150,14 +150,21 @@ pub struct KgliteBackend {
     /// Server-wide `--readonly` flag. Rejects begin_transaction and
     /// auto-commit mutations.
     readonly: bool,
-    /// Graph version at the last *successful* `db.checkpoint()` in this
-    /// process, or `None` until one has run — so the first checkpoint of a
-    /// process always writes, whatever the on-disk file happens to hold.
+    /// Graph version at the last *successful* checkpoint in this process, or
+    /// `None` until one has run — so the first checkpoint of a process always
+    /// writes, whatever the on-disk file happens to hold.
+    ///
+    /// Shared (not owned) because two routes checkpoint the same graph: the
+    /// `db.checkpoint()` verb and `--checkpoint-interval`'s periodic task,
+    /// which holds a clone of this handle. One skip-state for both is the
+    /// point — a verb call at version N must make the next tick skip, and a
+    /// tick at version N must make the next verb call report the skip. Two
+    /// counters would each re-save what the other just wrote.
     ///
     /// The mutex is held across the save itself, which serializes concurrent
-    /// checkpoints: two clients asking at once produce one write and one
+    /// checkpoints: two callers asking at once produce one write and one
     /// skip, never two interleaved saves of the same graph.
-    last_checkpoint_version: Mutex<Option<u64>>,
+    last_checkpoint_version: CheckpointState,
     /// Per-transaction state. Keyed by `TransactionHandle.0`. The
     /// outer mutex is brief-acquire-only (lookup/insert/remove); the
     /// per-tx work happens inside the inner mutex. See struct doc on
@@ -298,7 +305,7 @@ impl KgliteBackend {
             session: Arc::new(kglite::api::session::Session::new(graph)),
             graph_path,
             readonly,
-            last_checkpoint_version: Mutex::new(None),
+            last_checkpoint_version: Arc::new(Mutex::new(None)),
             transactions: Arc::new(Mutex::new(HashMap::new())),
             session_counter: AtomicU64::new(0),
             tx_counter: AtomicU64::new(0),
@@ -318,6 +325,15 @@ impl KgliteBackend {
     /// Where a checkpoint of this server's graph is written.
     pub(crate) fn graph_path(&self) -> &std::path::Path {
         &self.graph_path
+    }
+
+    /// The checkpoint skip-state, cloned out for the periodic checkpoint task.
+    ///
+    /// The clone is the whole point: the task and the `db.checkpoint()` verb
+    /// must read and write the *same* recorded version, so whichever route
+    /// saved last suppresses the other's redundant re-save.
+    pub(crate) fn checkpoint_state(&self) -> CheckpointState {
+        Arc::clone(&self.last_checkpoint_version)
     }
 
     /// Warn when a client whose driver gates on the agent prefix connects while
@@ -925,6 +941,65 @@ fn _query_appears_multi_statement(query: &str) -> bool {
     false
 }
 
+/// Graph version at the last successful checkpoint of this process, shared by
+/// every route that checkpoints the served graph (`db.checkpoint()` and the
+/// `--checkpoint-interval` task). `None` until one has run.
+///
+/// A plain `Mutex` rather than an atomic because the lock is deliberately held
+/// *across* the save — that is what serializes two concurrent checkpoints into
+/// one write plus one skip.
+pub(crate) type CheckpointState = Arc<Mutex<Option<u64>>>;
+
+/// What a checkpoint did, and at which graph version.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CheckpointOutcome {
+    /// The graph was written to the served path at this version.
+    Written(u64),
+    /// The graph was unchanged since the last successful checkpoint at this
+    /// version, so nothing was written.
+    Skipped(u64),
+}
+
+/// Save `session` to `path` unless it is unchanged since the last successful
+/// checkpoint recorded in `last`.
+///
+/// The one place a checkpoint of the served graph happens. Both routes call
+/// it — the `db.checkpoint()` verb (which adds the wire refusals and result
+/// shape) and the periodic task (which adds logging) — so the skip rule, the
+/// lock discipline and the version-recording order cannot drift apart between
+/// them.
+///
+/// **First call always writes.** `last` starts at `None` for the process, and
+/// the on-disk file may predate this process entirely (an operator's stale
+/// `.kgl`, or a graph mutated and never checkpointed by a previous run), so
+/// there is nothing on disk a version comparison could trust. The first
+/// checkpoint of a process establishes the correspondence the skips then rely
+/// on.
+///
+/// **Version read before the save, never after.** A commit landing between the
+/// read and the save's lock acquisition makes the recorded version one behind
+/// what reached disk, so the next checkpoint re-saves — a redundant write.
+/// Recording afterwards fails the other way: that same commit would be
+/// recorded as saved when it was not, and the next checkpoint would skip it.
+///
+/// A failed save leaves the recorded version untouched, so a later retry still
+/// writes.
+pub(crate) fn checkpoint_if_changed(
+    session: &kglite::api::session::Session,
+    path: &std::path::Path,
+    last: &Mutex<Option<u64>>,
+) -> Result<CheckpointOutcome, String> {
+    // Held across the save — see the type alias' doc comment.
+    let mut last = last.lock().unwrap_or_else(|p| p.into_inner());
+    let version = session.version();
+    if *last == Some(version) {
+        return Ok(CheckpointOutcome::Skipped(version));
+    }
+    session.save(&path.to_string_lossy(), true)?;
+    *last = Some(version);
+    Ok(CheckpointOutcome::Written(version))
+}
+
 /// Output columns of `db.checkpoint()`, in declaration order — the shape
 /// Neo4j's own `db.checkpoint()` yields, so a client can call it the same way.
 const CHECKPOINT_COLUMNS: [&str; 2] = ["success", "message"];
@@ -1082,13 +1157,10 @@ impl KgliteBackend {
     /// disk-mode graphs are `Forbidden`, for the same reasons `--save-on-exit`
     /// refuses them at startup.
     ///
-    /// **Digest-skip.** The graph version is read *before* the save, never
-    /// after. A commit that lands between the read and the save's lock
-    /// acquisition then makes the recorded version one behind what reached
-    /// disk, so the next checkpoint re-saves — a redundant write. Recording
-    /// the version afterwards would fail the other way: a commit landing in
-    /// the same window would be recorded as saved when it was not, and the
-    /// next checkpoint would skip, losing it.
+    /// **Digest-skip** and the save itself are [`checkpoint_if_changed`]'s —
+    /// shared with the `--checkpoint-interval` task, against the same recorded
+    /// version, so a periodic tick and a client call never re-save each
+    /// other's work.
     ///
     /// A failed save is `Backend` (fail-closed: the client is told the
     /// checkpoint did not happen) and leaves the recorded version untouched,
@@ -1127,44 +1199,44 @@ impl KgliteBackend {
             ));
         }
 
-        // Held across the save — see the field's doc comment.
-        let mut last = self
-            .last_checkpoint_version
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let version = self.session.version();
-        if *last == Some(version) {
-            tracing::debug!(
-                graph_version = version,
-                "db.checkpoint(): skipped (graph unchanged since the last checkpoint)"
-            );
-            return Ok(checkpoint_stream(
-                call,
-                format!("skipped: graph unchanged since version {version}"),
-                "r",
-                started,
-            ));
-        }
-        self.session
-            .save(&self.graph_path.to_string_lossy(), true)
-            .map_err(|e| {
-                BoltError::Backend(format!(
-                    "db.checkpoint() failed writing {}: {e}",
-                    self.graph_path.display()
+        let outcome = checkpoint_if_changed(
+            &self.session,
+            &self.graph_path,
+            &self.last_checkpoint_version,
+        )
+        .map_err(|e| {
+            BoltError::Backend(format!(
+                "db.checkpoint() failed writing {}: {e}",
+                self.graph_path.display()
+            ))
+        })?;
+        match outcome {
+            CheckpointOutcome::Skipped(version) => {
+                tracing::debug!(
+                    graph_version = version,
+                    "db.checkpoint(): skipped (graph unchanged since the last checkpoint)"
+                );
+                Ok(checkpoint_stream(
+                    call,
+                    format!("skipped: graph unchanged since version {version}"),
+                    "r",
+                    started,
                 ))
-            })?;
-        *last = Some(version);
-        tracing::info!(
-            path = %self.graph_path.display(),
-            graph_version = version,
-            "db.checkpoint(): graph written"
-        );
-        Ok(checkpoint_stream(
-            call,
-            format!("checkpoint written: version {version}"),
-            "w",
-            started,
-        ))
+            }
+            CheckpointOutcome::Written(version) => {
+                tracing::info!(
+                    path = %self.graph_path.display(),
+                    graph_version = version,
+                    "db.checkpoint(): graph written"
+                );
+                Ok(checkpoint_stream(
+                    call,
+                    format!("checkpoint written: version {version}"),
+                    "w",
+                    started,
+                ))
+            }
+        }
     }
 
     /// Auto-commit path: take a snapshot, delegate to

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -18,7 +18,9 @@ use kglite::api::io::OpenDisposition;
 use kglite::api::session::CsvImportPolicy;
 use kglite::api::storage::StorageMode;
 
-use crate::backend::{KgliteBackend, ServerIdentity};
+use crate::backend::{
+    checkpoint_if_changed, CheckpointOutcome, CheckpointState, KgliteBackend, ServerIdentity,
+};
 use crate::startup::start_graph;
 
 mod auth;
@@ -94,6 +96,33 @@ struct Cli {
     /// Also settable as `KGLITE_BOLT_SAVE_ON_EXIT=1`.
     #[arg(long, default_value_t = false, conflicts_with = "readonly")]
     save_on_exit: bool,
+
+    /// Checkpoint the served graph back to `--graph` every SECS seconds.
+    ///
+    /// Off by default, for the same reason `--save-on-exit` is: writes are
+    /// process-local until something checkpoints them, and periodically
+    /// overwriting the operator's file is a decision they should make. With
+    /// the flag, a background task saves the graph (fsync'd, atomic
+    /// temp+rename) on each tick and logs the version it wrote; a tick whose
+    /// graph is unchanged since the last checkpoint — by this task or by
+    /// `CALL db.checkpoint()` — writes nothing.
+    ///
+    /// Bounds the loss window rather than removing it: a crash loses at most
+    /// the writes since the last tick. A failed checkpoint is logged as an
+    /// error and the server keeps serving — degraded durability is worth
+    /// saying loudly, not worth dropping every connected client over.
+    ///
+    /// Refused for `--readonly` and for disk-mode graphs, exactly as
+    /// `--save-on-exit` is, and combinable with it (the interval bounds the
+    /// window while running; the exit save catches the tail). Also settable as
+    /// `KGLITE_BOLT_CHECKPOINT_INTERVAL=<secs>`.
+    #[arg(
+        long,
+        value_name = "SECS",
+        value_parser = parse_checkpoint_interval,
+        conflicts_with = "readonly"
+    )]
+    checkpoint_interval: Option<Duration>,
 
     /// Report a Neo4j-compatible product identifier in the Bolt handshake.
     ///
@@ -182,6 +211,9 @@ const NEO4J_COMPAT_ENV: &str = "KGLITE_BOLT_NEO4J_COMPAT";
 /// Environment variable mirroring `--save-on-exit`.
 const SAVE_ON_EXIT_ENV: &str = "KGLITE_BOLT_SAVE_ON_EXIT";
 
+/// Environment variable mirroring `--checkpoint-interval`.
+const CHECKPOINT_INTERVAL_ENV: &str = "KGLITE_BOLT_CHECKPOINT_INTERVAL";
+
 /// Read `name` as a boolean, accepting the spellings operators actually write.
 ///
 /// Parsed here rather than through clap's `env` support because clap would
@@ -207,35 +239,140 @@ fn env_flag(name: &str) -> Option<bool> {
     }
 }
 
-/// Refuse `--save-on-exit` in the configurations where an exit checkpoint is
-/// either meaningless or harmful.
+/// Parse a checkpoint interval in whole seconds.
 ///
-/// `mode` is `None` before the graph is opened (the readonly check needs
-/// nothing else) and `Some(live_mode)` afterwards. clap's
+/// Shared by clap's `value_parser` and the environment mirror so the two
+/// spellings cannot accept different things. Both rejections are startup
+/// errors rather than a warn-and-ignore (the treatment `env_flag` gives a
+/// malformed *boolean*): an operator who asked for periodic checkpoints and
+/// mistyped the number would otherwise get a server that silently never
+/// checkpoints, which is the exact failure the flag exists to prevent.
+///
+/// `0` is refused rather than treated as "disabled": tokio's `interval(0)`
+/// panics, and a zero-second interval reads as "checkpoint constantly", which
+/// would pin the session lock and stall every writer. Omitting the flag is how
+/// you disable it.
+fn parse_checkpoint_interval(raw: &str) -> Result<Duration, String> {
+    let trimmed = raw.trim();
+    let secs: u64 = trimmed.parse().map_err(|_| {
+        format!(
+            "invalid checkpoint interval {trimmed:?}: expected a whole number of \
+             seconds (for example 300)"
+        )
+    })?;
+    if secs == 0 {
+        return Err(
+            "invalid checkpoint interval 0: the interval must be at least 1 second — \
+             omit --checkpoint-interval (or KGLITE_BOLT_CHECKPOINT_INTERVAL) to \
+             disable periodic checkpoints"
+                .to_string(),
+        );
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+/// Read the checkpoint interval from the environment, if set.
+///
+/// An empty value is "unset" (a Compose file's `KGLITE_BOLT_CHECKPOINT_INTERVAL=`
+/// with nothing after it); anything else must parse, or startup fails naming
+/// the variable.
+fn env_checkpoint_interval() -> Result<Option<Duration>> {
+    let Ok(raw) = std::env::var(CHECKPOINT_INTERVAL_ENV) else {
+        return Ok(None);
+    };
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    parse_checkpoint_interval(&raw)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("{CHECKPOINT_INTERVAL_ENV}: {e}"))
+}
+
+/// Refuse a checkpointing feature in the configurations where writing the
+/// served graph back is either meaningless or harmful.
+///
+/// `flag`/`env_var` name the spelling the operator used, so the message points
+/// at what they typed. `mode` is `None` before the graph is opened (the
+/// readonly check needs nothing else) and `Some(live_mode)` afterwards. clap's
 /// `conflicts_with = "readonly"` already covers flag-versus-flag; the readonly
-/// arm here is what catches the *environment* spelling, which clap cannot see.
+/// arm here is what catches the *environment* spellings, which clap cannot see.
 ///
 /// Disk graphs are excluded deliberately: a disk save is an O(E) compaction
 /// that publishes a NEW generation, and nothing prunes the old ones — a server
 /// that checkpoints a disk graph grows the directory without bound. Mirrors
 /// the wheel's durable-mode restriction to the portable backends.
-fn ensure_save_on_exit_supported(readonly: bool, mode: Option<StorageMode>) -> Result<()> {
+fn ensure_checkpointing_supported(
+    flag: &str,
+    env_var: &str,
+    readonly: bool,
+    mode: Option<StorageMode>,
+) -> Result<()> {
     if readonly {
         anyhow::bail!(
-            "--save-on-exit (or KGLITE_BOLT_SAVE_ON_EXIT) cannot be combined with \
-             --readonly: a read-only server never changes the graph, so there is \
-             nothing to write back at exit"
+            "{flag} (or {env_var}) cannot be combined with --readonly: a read-only \
+             server never changes the graph, so there is nothing to write back"
         );
     }
     if mode == Some(StorageMode::Disk) {
         anyhow::bail!(
-            "--save-on-exit is not supported for disk-mode graphs: every disk save \
-             publishes a new on-disk generation and nothing prunes the old ones, so \
-             repeated checkpoints grow the directory without bound. Serve a `.kgl` \
-             graph (memory or mapped) if you want an exit checkpoint"
+            "{flag} is not supported for disk-mode graphs: every disk save publishes \
+             a new on-disk generation and nothing prunes the old ones, so repeated \
+             checkpoints grow the directory without bound. Serve a `.kgl` graph \
+             (memory or mapped) if you want checkpoints"
         );
     }
     Ok(())
+}
+
+/// When this server writes the served graph back: at shutdown, on a timer,
+/// both, or never.
+///
+/// Resolved once from the flags and their environment mirrors, so the two
+/// spellings of each setting are combined in exactly one place and the
+/// refusals below cannot end up applying to one spelling and not the other.
+#[derive(Clone, Copy, Debug)]
+struct Durability {
+    save_on_exit: bool,
+    checkpoint_interval: Option<Duration>,
+}
+
+impl Durability {
+    /// Flag OR environment for each setting, the flag winning when both are
+    /// present — the `--neo4j-compat` precedent. A malformed interval is a
+    /// startup error (see [`parse_checkpoint_interval`]), never a silently
+    /// disabled checkpoint.
+    ///
+    /// The `--readonly` refusals run here, before the graph is touched, so an
+    /// impossible configuration fails fast; the storage-mode refusals need the
+    /// opened graph, so [`Self::ensure_supported`] is called again with it.
+    fn resolve(cli: &Cli) -> Result<Self> {
+        let resolved = Self {
+            save_on_exit: cli.save_on_exit || env_flag(SAVE_ON_EXIT_ENV).unwrap_or(false),
+            checkpoint_interval: match cli.checkpoint_interval {
+                Some(interval) => Some(interval),
+                None => env_checkpoint_interval()?,
+            },
+        };
+        resolved.ensure_supported(cli.readonly, None)?;
+        Ok(resolved)
+    }
+
+    /// Refuse whichever features are enabled in a configuration that cannot
+    /// serve them. `mode` is `None` before the graph is opened.
+    fn ensure_supported(&self, readonly: bool, mode: Option<StorageMode>) -> Result<()> {
+        if self.save_on_exit {
+            ensure_checkpointing_supported("--save-on-exit", SAVE_ON_EXIT_ENV, readonly, mode)?;
+        }
+        if self.checkpoint_interval.is_some() {
+            ensure_checkpointing_supported(
+                "--checkpoint-interval",
+                CHECKPOINT_INTERVAL_ENV,
+                readonly,
+                mode,
+            )?;
+        }
+        Ok(())
+    }
 }
 
 /// Write the served graph back to `path`, fsync'd.
@@ -255,6 +392,84 @@ fn run_exit_save(session: &kglite::api::session::Session, path: &Path) -> Result
         "save-on-exit complete"
     );
     Ok(())
+}
+
+/// Spawn the `--checkpoint-interval` task: write the served graph back every
+/// `interval`, skipping ticks whose graph has not changed.
+///
+/// Shares the backend's checkpoint state rather than counting its own saves,
+/// so a `CALL db.checkpoint()` at version N makes the next tick a skip and
+/// vice versa — one recorded version, two routes to it.
+///
+/// A failing tick is logged at error and the loop continues. Durability that
+/// has degraded (a full disk, a path that went read-only) is worth saying
+/// loudly every interval; it is not worth tearing down a serving process and
+/// every connected client over, which would turn a recoverable disk problem
+/// into an outage *and* discard the graph the checkpoint failed to save.
+fn spawn_checkpoint_task(
+    session: Arc<kglite::api::session::Session>,
+    path: PathBuf,
+    state: CheckpointState,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // Delay, not tokio's default Burst. `Session::save` holds the session
+        // lock for the whole write, so a save that outruns the interval is
+        // precisely the case Burst handles worst: it answers one slow
+        // checkpoint by firing every missed tick back-to-back, stalling
+        // writers again for each. Delay re-bases the schedule on when the slow
+        // tick finished, so consecutive checkpoints stay at least `interval`
+        // apart no matter how long a save takes.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // `interval` completes its first tick immediately; consume it so the
+        // first checkpoint lands one interval in. Checkpointing at startup
+        // would rewrite the operator's file before a single client had
+        // connected — a write nobody asked for and nothing to save.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match checkpoint_if_changed(&session, &path, &state) {
+                Ok(CheckpointOutcome::Written(version)) => tracing::info!(
+                    path = %path.display(),
+                    graph_version = version,
+                    "checkpoint-interval: graph written"
+                ),
+                // Debug, not info: on an idle server every tick skips, and an
+                // hourly reminder that nothing changed is not worth a default
+                // log line. The writes are what an operator needs to see.
+                Ok(CheckpointOutcome::Skipped(version)) => tracing::debug!(
+                    graph_version = version,
+                    "checkpoint-interval: skipped (graph unchanged since the last checkpoint)"
+                ),
+                Err(e) => tracing::error!(
+                    path = %path.display(),
+                    error = %e,
+                    "checkpoint-interval: save FAILED — the server keeps serving, but \
+                     writes since the last successful checkpoint are not on disk"
+                ),
+            }
+        }
+    })
+}
+
+/// Read `--tls-cert` + `--tls-key` into a boltr TLS configuration, so drivers
+/// can connect via `bolt+s://` or `neo4j+s://`.
+///
+/// The cert/key are read once at startup; reloading requires a restart. For HA
+/// setups the typical pattern is a reverse proxy (nginx, Caddy) terminating
+/// TLS instead.
+fn read_tls_config(cert_path: &Path, key_path: &Path) -> Result<boltr::server::TlsConfig> {
+    // rustls 0.23+ requires a process-wide crypto provider. Install `ring`
+    // once at startup; ignore the result — duplicate installation is benign
+    // (only the first wins).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let cert_pem = std::fs::read(cert_path)
+        .with_context(|| format!("reading TLS cert {}", cert_path.display()))?;
+    let key_pem = std::fs::read(key_path)
+        .with_context(|| format!("reading TLS key {}", key_path.display()))?;
+    boltr::server::TlsConfig::from_pem(&cert_pem, &key_pem)
+        .map_err(|e| anyhow::anyhow!("invalid TLS cert/key: {}", e))
 }
 
 /// Resolve when the supervisor asks this process to stop.
@@ -342,13 +557,7 @@ async fn serve() -> Result<()> {
         .map(StorageMode::parse)
         .transpose()
         .map_err(|e| anyhow::anyhow!(e))?;
-    // Flag OR environment, like `--neo4j-compat`. The readonly refusal runs
-    // before the graph is touched so an impossible configuration fails fast;
-    // the storage-mode refusal needs the opened graph and runs below.
-    let save_on_exit = cli.save_on_exit || env_flag(SAVE_ON_EXIT_ENV).unwrap_or(false);
-    if save_on_exit {
-        ensure_save_on_exit_supported(cli.readonly, None)?;
-    }
+    let durability = Durability::resolve(&cli)?;
     let started = start_graph(&cli.graph, requested_mode, cli.readonly, &mut |_| {})?;
     // Bind the lease for the whole of `serve`. `_writer_lease` rather than
     // `_`: a bare `_` drops it here, releasing write ownership before the
@@ -369,12 +578,13 @@ async fn serve() -> Result<()> {
         converted_from = started.converted_from.map(StorageMode::as_str),
         "graph ready; constructing Bolt server"
     );
-    if save_on_exit {
-        ensure_save_on_exit_supported(
-            cli.readonly,
-            Some(kglite::api::storage::live_storage_mode(&dir_arc)),
-        )?;
-    }
+    // The storage-mode half of the refusals: only now is the *live* mode known
+    // (`--storage` may have converted, and a graph opened without the flag
+    // reports whatever it was saved in).
+    durability.ensure_supported(
+        cli.readonly,
+        Some(kglite::api::storage::live_storage_mode(&dir_arc)),
+    )?;
 
     // The backend stores the DirGraph behind its own Arc<Mutex<>> for
     // commit-swap. Unwrap the Arc — if no
@@ -421,6 +631,10 @@ async fn serve() -> Result<()> {
     // save cannot race another process taking write ownership.
     let exit_session = backend.session_handle();
     let served_path = backend.graph_path().to_path_buf();
+    // Cloned out for the same reason: the periodic task outlives the move of
+    // the backend into the server, and must record its saves in the backend's
+    // own skip-state so the verb and the task agree on what is already on disk.
+    let checkpoint_state = backend.checkpoint_state();
 
     let addr = SocketAddr::new(cli.bind, cli.port);
 
@@ -435,22 +649,8 @@ async fn serve() -> Result<()> {
         builder = builder.idle_timeout(Duration::from_secs(secs));
     }
 
-    // When --tls-cert + --tls-key are set, wrap the listener in TLS so drivers can connect via bolt+s://
-    // or neo4j+s://. The cert/key are read once at startup; reload
-    // requires a restart. For HA setups the typical pattern is a
-    // reverse proxy (nginx, Caddy) terminating TLS instead.
     if let (Some(cert_path), Some(key_path)) = (cli.tls_cert.as_ref(), cli.tls_key.as_ref()) {
-        // rustls 0.23+ requires a process-wide crypto provider.
-        // Install `ring` once at startup; ignore the result —
-        // duplicate installation is benign (only the first wins).
-        let _ = rustls::crypto::ring::default_provider().install_default();
-        let cert_pem = std::fs::read(cert_path)
-            .with_context(|| format!("reading TLS cert {}", cert_path.display()))?;
-        let key_pem = std::fs::read(key_path)
-            .with_context(|| format!("reading TLS key {}", key_path.display()))?;
-        let tls_config = boltr::server::TlsConfig::from_pem(&cert_pem, &key_pem)
-            .map_err(|e| anyhow::anyhow!("invalid TLS cert/key: {}", e))?;
-        builder = builder.tls(tls_config);
+        builder = builder.tls(read_tls_config(cert_path, key_path)?);
         tracing::info!(
             cert = %cert_path.display(),
             key = %key_path.display(),
@@ -475,20 +675,51 @@ async fn serve() -> Result<()> {
     tracing::info!(
         %addr,
         readonly = cli.readonly,
-        save_on_exit,
+        save_on_exit = durability.save_on_exit,
+        checkpoint_interval_secs = durability.checkpoint_interval.map(|d| d.as_secs()),
         "Bolt server starting"
     );
+    // Armed before the accept loop and stopped after it, the boltr idle-reaper
+    // shape: a task that only makes sense while the server is serving is owned
+    // by the same scope that serves.
+    let checkpoint_task = durability.checkpoint_interval.map(|interval| {
+        tracing::info!(
+            interval_secs = interval.as_secs(),
+            path = %served_path.display(),
+            "periodic checkpointing enabled"
+        );
+        spawn_checkpoint_task(
+            Arc::clone(&exit_session),
+            served_path.clone(),
+            checkpoint_state,
+            interval,
+        )
+    });
+
     let serve_result = builder
         .serve(addr)
         .await
         .map_err(|e| anyhow::anyhow!("BoltServer::serve failed: {}", e));
 
     tracing::info!("Bolt server stopped");
+    // Stop periodic checkpointing BEFORE the exit save, and wait for the task
+    // to actually be gone. `abort()` alone only *requests* cancellation: a
+    // task in the middle of a save is running synchronous code and cannot be
+    // cancelled until its next await point, so without the join a tick's save
+    // could still be in flight — or, worse, land after — the exit save.
+    // Awaiting the aborted handle resolves once the task has stopped, which
+    // makes the exit save the last write to the file by construction. (The
+    // join returns a cancellation `JoinError`; that is the expected result.)
+    if let Some(task) = checkpoint_task {
+        task.abort();
+        let _ = task.await;
+        tracing::info!("checkpoint-interval: stopped");
+    }
     // Attempted whether or not `serve` returned an error: an operator who
     // asked for an exit checkpoint wants one on the failure path too. Both
     // results are reported; a failed save exits non-zero rather than being
     // logged and swallowed.
-    let save_result = if save_on_exit {
+    let save_result = if durability.save_on_exit {
         run_exit_save(&exit_session, &served_path)
             .inspect_err(|e| tracing::error!(error = %format!("{e:#}"), "save-on-exit FAILED"))
     } else {
@@ -503,34 +734,171 @@ async fn serve() -> Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn save_on_exit_is_refused_for_a_readonly_server() {
-        let error = ensure_save_on_exit_supported(true, None)
-            .expect_err("a read-only server has nothing to save");
-        let message = format!("{error:#}");
-        assert!(
-            message.contains("--readonly") && message.contains("--save-on-exit"),
-            "the refusal must name both flags: {message}"
-        );
+    /// A unique scratch directory for a test that writes a real `.kgl`.
+    /// Process id + nanosecond clock so parallel test threads (and parallel
+    /// `cargo test` invocations) cannot collide.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("kglite-bolt-{tag}-{}-{nonce}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
     }
 
+    /// Both checkpointing features refuse the same two configurations, and the
+    /// refusal names the spelling the operator actually used.
     #[test]
-    fn save_on_exit_is_refused_for_a_disk_graph() {
-        let error = ensure_save_on_exit_supported(false, Some(StorageMode::Disk))
-            .expect_err("disk-mode exit saves grow the directory without bound");
-        let message = format!("{error:#}");
-        assert!(
-            message.contains("disk-mode") && message.contains("generation"),
-            "the refusal must carry the reason, not just the verdict: {message}"
-        );
-    }
-
-    #[test]
-    fn save_on_exit_is_allowed_for_the_portable_modes() {
-        for mode in [StorageMode::Memory, StorageMode::Mapped] {
-            ensure_save_on_exit_supported(false, Some(mode))
-                .unwrap_or_else(|e| panic!("{} must support an exit save: {e:#}", mode.as_str()));
+    fn checkpointing_is_refused_for_a_readonly_server() {
+        for (flag, env) in [
+            ("--save-on-exit", SAVE_ON_EXIT_ENV),
+            ("--checkpoint-interval", CHECKPOINT_INTERVAL_ENV),
+        ] {
+            let error = ensure_checkpointing_supported(flag, env, true, None)
+                .expect_err("a read-only server has nothing to save");
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("--readonly") && message.contains(flag) && message.contains(env),
+                "the refusal must name the flag, its env mirror and --readonly: {message}"
+            );
         }
+    }
+
+    #[test]
+    fn checkpointing_is_refused_for_a_disk_graph() {
+        for (flag, env) in [
+            ("--save-on-exit", SAVE_ON_EXIT_ENV),
+            ("--checkpoint-interval", CHECKPOINT_INTERVAL_ENV),
+        ] {
+            let error = ensure_checkpointing_supported(flag, env, false, Some(StorageMode::Disk))
+                .expect_err("disk-mode checkpoints grow the directory without bound");
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("disk-mode") && message.contains("generation"),
+                "the refusal must carry the reason, not just the verdict: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn checkpointing_is_allowed_for_the_portable_modes() {
+        for mode in [StorageMode::Memory, StorageMode::Mapped] {
+            ensure_checkpointing_supported("--save-on-exit", SAVE_ON_EXIT_ENV, false, Some(mode))
+                .unwrap_or_else(|e| panic!("{} must support an exit save: {e:#}", mode.as_str()));
+            ensure_checkpointing_supported(
+                "--checkpoint-interval",
+                CHECKPOINT_INTERVAL_ENV,
+                false,
+                Some(mode),
+            )
+            .unwrap_or_else(|e| {
+                panic!("{} must support periodic checkpoints: {e:#}", mode.as_str())
+            });
+        }
+    }
+
+    #[test]
+    fn checkpoint_interval_accepts_whole_seconds() {
+        assert_eq!(
+            parse_checkpoint_interval("300").expect("a plain integer is the documented spelling"),
+            Duration::from_secs(300)
+        );
+        // The environment hands over whatever the unit file wrote, whitespace
+        // and all.
+        assert_eq!(
+            parse_checkpoint_interval(" 1 \n").expect("surrounding whitespace is not a typo"),
+            Duration::from_secs(1)
+        );
+    }
+
+    /// Zero and junk are startup errors, not a warn-and-ignore: a server that
+    /// silently never checkpoints is the failure the flag exists to prevent.
+    #[test]
+    fn checkpoint_interval_rejects_zero_and_junk() {
+        let zero = parse_checkpoint_interval("0").expect_err("0 would checkpoint continuously");
+        assert!(
+            zero.contains("at least 1 second") && zero.contains("--checkpoint-interval"),
+            "the refusal must say what to write instead: {zero}"
+        );
+        for junk in ["", "abc", "5s", "1.5", "-1", "300 seconds"] {
+            let outcome = parse_checkpoint_interval(junk);
+            assert!(
+                outcome.is_err(),
+                "{junk:?} must be rejected, not guessed at — got {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn checkpoint_interval_junk_reports_what_was_typed() {
+        let error = parse_checkpoint_interval("5s").expect_err("units are not supported");
+        assert!(
+            error.contains("\"5s\"") && error.contains("whole number of seconds"),
+            "the error must quote the value and name the accepted form: {error}"
+        );
+    }
+
+    /// The first checkpoint of a process writes even though the graph has not
+    /// changed since it was loaded — the on-disk file may predate the process,
+    /// so there is no version comparison worth trusting yet. Mutation
+    /// evidence: seeding the state with `Some(session.version())` (the shape a
+    /// "skip the first tick too" implementation would have) turns the first
+    /// call into `Skipped` and fails this test's first assertion.
+    #[test]
+    fn first_checkpoint_writes_then_unchanged_ones_skip() {
+        let dir = scratch_dir("first-tick");
+        let path = dir.join("served.kgl");
+
+        let graph = kglite::api::storage::new_dir_graph_in_mode(StorageMode::Memory, None)
+            .expect("memory graph");
+        let session = kglite::api::session::Session::new(graph);
+        let state: CheckpointState = Arc::new(std::sync::Mutex::new(None));
+
+        let first = checkpoint_if_changed(&session, &path, &state).expect("first checkpoint");
+        assert_eq!(
+            first,
+            CheckpointOutcome::Written(session.version()),
+            "the first checkpoint of a process must write whatever the file holds"
+        );
+        assert!(path.exists(), "a Written outcome must produce the file");
+
+        let second = checkpoint_if_changed(&session, &path, &state).expect("second checkpoint");
+        assert_eq!(
+            second,
+            CheckpointOutcome::Skipped(session.version()),
+            "an unchanged graph must not be rewritten"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A failed checkpoint leaves the recorded version untouched, so the next
+    /// one still writes rather than skipping work that never reached disk.
+    #[test]
+    fn a_failed_checkpoint_does_not_record_a_version() {
+        let dir = scratch_dir("failed-tick");
+        let unwritable = dir.join("no-such-directory").join("served.kgl");
+
+        let graph = kglite::api::storage::new_dir_graph_in_mode(StorageMode::Memory, None)
+            .expect("memory graph");
+        let session = kglite::api::session::Session::new(graph);
+        let state: CheckpointState = Arc::new(std::sync::Mutex::new(None));
+
+        checkpoint_if_changed(&session, &unwritable, &state)
+            .expect_err("a save into a missing directory must be reported");
+        assert_eq!(
+            *state.lock().expect("uncontended"),
+            None,
+            "a failed checkpoint must not record its version"
+        );
+
+        let retry = checkpoint_if_changed(&session, &dir.join("served.kgl"), &state)
+            .expect("the retry writes");
+        assert!(matches!(retry, CheckpointOutcome::Written(_)));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The exit save writes a file a later open can read back, and reports a
@@ -539,15 +907,7 @@ mod tests {
     /// `Ok(())` and fails the second half of this test.
     #[test]
     fn exit_save_writes_the_graph_and_reports_failure() {
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!(
-            "kglite-bolt-exit-save-{}-{nonce}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let dir = scratch_dir("exit-save");
         let path = dir.join("served.kgl");
 
         let graph = kglite::api::storage::new_dir_graph_in_mode(StorageMode::Memory, None)

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -14,6 +14,7 @@ use boltr::server::BoltServer;
 use clap::{Parser, ValueEnum};
 use tracing_subscriber::EnvFilter;
 
+use kglite::api::durable::DurabilityLevel;
 use kglite::api::io::OpenDisposition;
 use kglite::api::session::CsvImportPolicy;
 use kglite::api::storage::StorageMode;
@@ -124,6 +125,38 @@ struct Cli {
     )]
     checkpoint_interval: Option<Duration>,
 
+    /// What a committed write survives: `full`, `normal`, or `off`
+    /// [default: off].
+    ///
+    /// `full` and `normal` attach a write-ahead log beside the served graph
+    /// (`<graph>-wal`) and append every commit to it *before* the commit is
+    /// acknowledged, so the loss window stops being "everything since the last
+    /// checkpoint":
+    ///
+    /// `full` — an acknowledged commit survives power loss: the frame is
+    /// barriered to the device before COMMIT returns.
+    ///
+    /// `normal` — an acknowledged commit survives this **process** dying
+    /// (`SIGKILL`, an OOM-kill, a panic), because the frame is already in the
+    /// kernel's page cache. An OS crash or power loss can still lose the
+    /// commits made since the last checkpoint.
+    ///
+    /// `off` — no log. Writes are process-local until `--save-on-exit`,
+    /// `--checkpoint-interval` or `CALL db.checkpoint()` writes them back.
+    ///
+    /// Recovery runs at startup whatever the level: a sidecar holding commits
+    /// the graph file does not contain is replayed at `full`/`normal`, and at
+    /// `off` it is a startup error rather than a server quietly missing them.
+    /// A checkpoint (any of the three routes above) folds the log into the
+    /// `.kgl` and truncates it.
+    ///
+    /// Refused with `--readonly` (a server that never writes has nothing to
+    /// log) and for disk-mode graphs (a disk graph commits by publishing a
+    /// generation, so it keeps no logical log). Also settable as
+    /// `KGLITE_BOLT_DURABILITY=<level>`.
+    #[arg(long, value_name = "LEVEL", value_parser = parse_durability_level)]
+    durability: Option<DurabilityLevel>,
+
     /// Report a Neo4j-compatible product identifier in the Bolt handshake.
     ///
     /// Off by default: the server identifies honestly as
@@ -214,6 +247,20 @@ const SAVE_ON_EXIT_ENV: &str = "KGLITE_BOLT_SAVE_ON_EXIT";
 /// Environment variable mirroring `--checkpoint-interval`.
 const CHECKPOINT_INTERVAL_ENV: &str = "KGLITE_BOLT_CHECKPOINT_INTERVAL";
 
+/// Environment variable mirroring `--durability`.
+const DURABILITY_ENV: &str = "KGLITE_BOLT_DURABILITY";
+
+/// The level this server logs at when neither the flag nor the environment
+/// says otherwise.
+///
+/// `off` — today's behaviour, unchanged. Turning the log on by default would
+/// silently change what four other things mean: `--readonly` and disk-mode
+/// graphs would become startup errors, and a graph whose server was killed
+/// would refuse a later `off` open. The level that ships as the default is
+/// decided by R3.3's throughput measurement (see the program plan); this
+/// release makes durability opt-in and preserves every existing invocation.
+const DEFAULT_DURABILITY: DurabilityLevel = DurabilityLevel::Off;
+
 /// Read `name` as a boolean, accepting the spellings operators actually write.
 ///
 /// Parsed here rather than through clap's `env` support because clap would
@@ -288,6 +335,64 @@ fn env_checkpoint_interval() -> Result<Option<Duration>> {
         .map_err(|e| anyhow::anyhow!("{CHECKPOINT_INTERVAL_ENV}: {e}"))
 }
 
+/// Parse a durability level name.
+///
+/// Shared by clap's `value_parser` and the environment mirror, on the engine's
+/// own [`DurabilityLevel::from_name`], so the server cannot end up accepting a
+/// vocabulary the log itself does not speak. A bad value is a startup error
+/// rather than a warn-and-ignore: an operator who asked for durability and
+/// mistyped the level would otherwise get a server that silently logs nothing,
+/// which is the exact failure the flag exists to prevent.
+fn parse_durability_level(raw: &str) -> Result<DurabilityLevel, String> {
+    let trimmed = raw.trim();
+    DurabilityLevel::from_name(&trimmed.to_ascii_lowercase()).ok_or_else(|| {
+        format!(
+            "invalid durability level {trimmed:?}: expected one of {:?}",
+            DurabilityLevel::NAMES
+        )
+    })
+}
+
+/// Read the durability level from the environment, if set.
+///
+/// An empty value is "unset" (a Compose file's `KGLITE_BOLT_DURABILITY=` with
+/// nothing after it); anything else must parse, or startup fails naming the
+/// variable.
+fn env_durability_level() -> Result<Option<DurabilityLevel>> {
+    let Ok(raw) = std::env::var(DURABILITY_ENV) else {
+        return Ok(None);
+    };
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    parse_durability_level(&raw)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("{DURABILITY_ENV}: {e}"))
+}
+
+/// Refuse a logging durability level for a server that cannot serve one.
+///
+/// `--readonly` is the flag-versus-flag case clap cannot express here, because
+/// `--readonly --durability off` is perfectly legal — the conflict is with the
+/// *level*, not with the argument being present — and because the environment
+/// spelling is invisible to clap either way.
+///
+/// The disk-mode refusal is the engine's ([`Session::open_durable`]) and is not
+/// duplicated here: it needs the opened graph, and its message already names
+/// the reason. What this function owes the operator is the two decisions that
+/// can be made before anything is opened.
+fn ensure_durability_supported(level: DurabilityLevel, readonly: bool) -> Result<()> {
+    if level.logs() && readonly {
+        anyhow::bail!(
+            "--durability {} (or {DURABILITY_ENV}) cannot be combined with --readonly: a \
+             read-only server never commits, so there is nothing to log — pass \
+             --durability off, or drop --readonly",
+            level.name()
+        );
+    }
+    Ok(())
+}
+
 /// Refuse a checkpointing feature in the configurations where writing the
 /// served graph back is either meaningless or harmful.
 ///
@@ -334,13 +439,18 @@ fn ensure_checkpointing_supported(
 struct Durability {
     save_on_exit: bool,
     checkpoint_interval: Option<Duration>,
+    /// The write-ahead level the served session logs at. Unlike the two
+    /// checkpoint settings this one is not a background task but a property of
+    /// the session itself, so it is resolved here and handed to startup.
+    level: DurabilityLevel,
 }
 
 impl Durability {
     /// Flag OR environment for each setting, the flag winning when both are
-    /// present — the `--neo4j-compat` precedent. A malformed interval is a
-    /// startup error (see [`parse_checkpoint_interval`]), never a silently
-    /// disabled checkpoint.
+    /// present — the `--neo4j-compat` precedent. A malformed interval or level
+    /// is a startup error (see [`parse_checkpoint_interval`] /
+    /// [`parse_durability_level`]), never a silently disabled checkpoint or a
+    /// silently unlogged server.
     ///
     /// The `--readonly` refusals run here, before the graph is touched, so an
     /// impossible configuration fails fast; the storage-mode refusals need the
@@ -352,6 +462,10 @@ impl Durability {
                 Some(interval) => Some(interval),
                 None => env_checkpoint_interval()?,
             },
+            level: match cli.durability {
+                Some(level) => level,
+                None => env_durability_level()?.unwrap_or(DEFAULT_DURABILITY),
+            },
         };
         resolved.ensure_supported(cli.readonly, None)?;
         Ok(resolved)
@@ -360,6 +474,7 @@ impl Durability {
     /// Refuse whichever features are enabled in a configuration that cannot
     /// serve them. `mode` is `None` before the graph is opened.
     fn ensure_supported(&self, readonly: bool, mode: Option<StorageMode>) -> Result<()> {
+        ensure_durability_supported(self.level, readonly)?;
         if self.save_on_exit {
             ensure_checkpointing_supported("--save-on-exit", SAVE_ON_EXIT_ENV, readonly, mode)?;
         }
@@ -558,39 +673,41 @@ async fn serve() -> Result<()> {
         .transpose()
         .map_err(|e| anyhow::anyhow!(e))?;
     let durability = Durability::resolve(&cli)?;
-    let started = start_graph(&cli.graph, requested_mode, cli.readonly, &mut |_| {})?;
+    // The graph is opened *and* wrapped in its session here: at a logging level
+    // the two are one step, because recovering the write-ahead sidecar is part
+    // of opening the path (see `startup::start_graph`).
+    let started = start_graph(
+        &cli.graph,
+        requested_mode,
+        cli.readonly,
+        durability.level,
+        &mut |_| {},
+    )?;
     // Bind the lease for the whole of `serve`. `_writer_lease` rather than
     // `_`: a bare `_` drops it here, releasing write ownership before the
     // first client connects. It is released by this binding going out of
     // scope, i.e. after `BoltServer::serve` returns at shutdown.
     let _writer_lease = started.writer_lease;
-    let dir_arc = started.graph;
     tracing::info!(
         disposition = match started.disposition {
             OpenDisposition::Opened => "opened",
             OpenDisposition::Created => "created",
         },
-        storage = kglite::api::storage::live_storage_mode(&dir_arc).as_str(),
+        storage = started.live_mode.as_str(),
         // Present only when `--storage` moved an existing graph off the mode it
         // was saved in. Logged because an operator who does not see the switch
         // cannot tell it from the flag being ignored, which is the failure this
         // path used to have.
         converted_from = started.converted_from.map(StorageMode::as_str),
+        durability = durability.level.name(),
         "graph ready; constructing Bolt server"
     );
     // The storage-mode half of the refusals: only now is the *live* mode known
     // (`--storage` may have converted, and a graph opened without the flag
-    // reports whatever it was saved in).
-    durability.ensure_supported(
-        cli.readonly,
-        Some(kglite::api::storage::live_storage_mode(&dir_arc)),
-    )?;
+    // reports whatever it was saved in). The durability level's own disk
+    // refusal has already fired inside `start_graph`, where the engine owns it.
+    durability.ensure_supported(cli.readonly, Some(started.live_mode))?;
 
-    // The backend stores the DirGraph behind its own Arc<Mutex<>> for
-    // commit-swap. Unwrap the Arc — if no
-    // other refs (typical for fresh load), try_unwrap succeeds;
-    // otherwise we deep-clone (one-time cost at boot).
-    let dir = Arc::try_unwrap(dir_arc).unwrap_or_else(|arc| (*arc).clone());
     // Address advertised in route() responses for neo4j:// (cluster-aware)
     // drivers. Default: format the bind
     // address; override via --advertise-addr.
@@ -618,7 +735,7 @@ async fn serve() -> Result<()> {
         "bolt handshake identity"
     );
     let backend = KgliteBackend::new(
-        dir,
+        started.session,
         cli.graph.clone(),
         cli.readonly,
         advertised_addr,
@@ -675,6 +792,7 @@ async fn serve() -> Result<()> {
     tracing::info!(
         %addr,
         readonly = cli.readonly,
+        durability = durability.level.name(),
         save_on_exit = durability.save_on_exit,
         checkpoint_interval_secs = durability.checkpoint_interval.map(|d| d.as_secs()),
         "Bolt server starting"
@@ -715,6 +833,38 @@ async fn serve() -> Result<()> {
         let _ = task.await;
         tracing::info!("checkpoint-interval: stopped");
     }
+    // The log's final barrier, before any decision about saving. Under
+    // `normal` the tail of the log is in the page cache, which survives this
+    // process dying but not the machine dying, and shutdown is the one moment
+    // the server knows no further commit is coming — so it is worth paying a
+    // barrier that per-commit `normal` deliberately does not. Under `full`
+    // every frame is already on stable storage and this is a no-op; at `off`
+    // there is no log to flush and calling `sync` would be an error, so it is
+    // skipped rather than reported.
+    //
+    // Ordered before the exit save on purpose: if the save then fails, the
+    // commits it could not write are already on disk in the log for the next
+    // startup to replay.
+    let sync_result = if durability.level.logs() {
+        exit_session
+            .sync()
+            .map_err(|e| anyhow::anyhow!("flushing the write-ahead log at shutdown: {e}"))
+            .inspect(|()| {
+                tracing::info!(
+                    durability = durability.level.name(),
+                    "write-ahead log flushed"
+                )
+            })
+            .inspect_err(|e| {
+                tracing::error!(
+                    error = %format!("{e:#}"),
+                    "write-ahead log flush FAILED — commits acknowledged since the last \
+                     checkpoint may not be on disk"
+                )
+            })
+    } else {
+        Ok(())
+    };
     // Attempted whether or not `serve` returned an error: an operator who
     // asked for an exit checkpoint wants one on the failure path too. Both
     // results are reported; a failed save exits non-zero rather than being
@@ -726,6 +876,7 @@ async fn serve() -> Result<()> {
         Ok(())
     };
     serve_result?;
+    sync_result?;
     save_result?;
     Ok(())
 }
@@ -829,6 +980,72 @@ mod tests {
                 "{junk:?} must be rejected, not guessed at — got {outcome:?}"
             );
         }
+    }
+
+    // ── --durability ────────────────────────────────────────────────────────
+
+    /// The vocabulary is the engine's, not a second list that could drift from
+    /// it, and the environment hands over whatever a unit file wrote.
+    #[test]
+    fn durability_accepts_every_engine_level() {
+        for name in DurabilityLevel::NAMES {
+            let parsed = parse_durability_level(name)
+                .unwrap_or_else(|e| panic!("{name} is an engine level: {e}"));
+            assert_eq!(parsed.name(), name);
+        }
+        assert_eq!(
+            parse_durability_level(" FULL \n").expect("case and whitespace are not typos"),
+            DurabilityLevel::Full
+        );
+    }
+
+    #[test]
+    fn durability_rejects_an_unknown_level_naming_the_accepted_ones() {
+        for junk in ["", "on", "true", "fsync", "none", "1"] {
+            let error = parse_durability_level(junk)
+                .err()
+                .unwrap_or_else(|| panic!("{junk:?} must not be guessed at"));
+            assert!(
+                error.contains("full") && error.contains("normal") && error.contains("off"),
+                "the refusal must list the levels that exist: {error}"
+            );
+        }
+    }
+
+    /// A read-only server never commits, so a log would only ever be empty —
+    /// and the operator who asked for one has misunderstood the deployment.
+    /// `off` beside `--readonly` stays legal, which is why this is a check on
+    /// the *level* rather than a clap `conflicts_with` on the argument.
+    #[test]
+    fn a_logging_level_is_refused_for_a_readonly_server() {
+        for level in [DurabilityLevel::Full, DurabilityLevel::Normal] {
+            let error = ensure_durability_supported(level, true)
+                .expect_err("a read-only server has nothing to log");
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("--readonly")
+                    && message.contains(level.name())
+                    && message.contains(DURABILITY_ENV),
+                "the refusal must name the level, its env mirror and --readonly: {message}"
+            );
+        }
+        ensure_durability_supported(DurabilityLevel::Off, true)
+            .expect("--readonly --durability off is the read-only server's normal shape");
+        for level in [DurabilityLevel::Full, DurabilityLevel::Normal] {
+            ensure_durability_supported(level, false)
+                .unwrap_or_else(|e| panic!("a writable server may log at {}: {e}", level.name()));
+        }
+    }
+
+    /// The shipped default is `off` — today's behaviour, preserved. Pinned as
+    /// a test because flipping it silently changes what `--readonly`,
+    /// disk-mode graphs and every existing invocation do (see
+    /// [`DEFAULT_DURABILITY`]); the flip is R3.3's measured decision, and it
+    /// should have to edit a test that says so.
+    #[test]
+    fn the_default_level_is_off() {
+        assert_eq!(DEFAULT_DURABILITY, DurabilityLevel::Off);
+        assert!(!DEFAULT_DURABILITY.logs());
     }
 
     #[test]

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -22,7 +22,7 @@ use kglite::api::storage::StorageMode;
 use crate::backend::{
     checkpoint_if_changed, CheckpointOutcome, CheckpointState, KgliteBackend, ServerIdentity,
 };
-use crate::startup::start_graph;
+use crate::startup::{start_graph, DurabilityRequest};
 
 mod auth;
 mod backend;
@@ -126,7 +126,7 @@ struct Cli {
     checkpoint_interval: Option<Duration>,
 
     /// What a committed write survives: `full`, `normal`, or `off`
-    /// [default: off].
+    /// [default: normal].
     ///
     /// `full` and `normal` attach a write-ahead log beside the served graph
     /// (`<graph>-wal`) and append every commit to it *before* the commit is
@@ -144,6 +144,12 @@ struct Cli {
     /// `off` — no log. Writes are process-local until `--save-on-exit`,
     /// `--checkpoint-interval` or `CALL db.checkpoint()` writes them back.
     ///
+    /// `normal` is the default because it is the level that is free: measured
+    /// at 4 contended writers, it cost nothing against `off` while `full` cost
+    /// 88% of committed throughput (one device barrier per commit, taken
+    /// inside the lock every commit already serializes on). Ask for `full`
+    /// when a power cut must not cost an acknowledged commit.
+    ///
     /// Recovery runs at startup whatever the level: a sidecar holding commits
     /// the graph file does not contain is replayed at `full`/`normal`, and at
     /// `off` it is a startup error rather than a server quietly missing them.
@@ -152,8 +158,10 @@ struct Cli {
     ///
     /// Refused with `--readonly` (a server that never writes has nothing to
     /// log) and for disk-mode graphs (a disk graph commits by publishing a
-    /// generation, so it keeps no logical log). Also settable as
-    /// `KGLITE_BOLT_DURABILITY=<level>`.
+    /// generation, so it keeps no logical log). Those two configurations serve
+    /// the *default* at `off` instead of refusing it, and say so in the log; a
+    /// level you asked for is still refused rather than quietly weakened. Also
+    /// settable as `KGLITE_BOLT_DURABILITY=<level>`.
     #[arg(long, value_name = "LEVEL", value_parser = parse_durability_level)]
     durability: Option<DurabilityLevel>,
 
@@ -253,13 +261,24 @@ const DURABILITY_ENV: &str = "KGLITE_BOLT_DURABILITY";
 /// The level this server logs at when neither the flag nor the environment
 /// says otherwise.
 ///
-/// `off` — today's behaviour, unchanged. Turning the log on by default would
-/// silently change what four other things mean: `--readonly` and disk-mode
-/// graphs would become startup errors, and a graph whose server was killed
-/// would refuse a later `off` open. The level that ships as the default is
-/// decided by R3.3's throughput measurement (see the program plan); this
-/// release makes durability opt-in and preserves every existing invocation.
-const DEFAULT_DURABILITY: DurabilityLevel = DurabilityLevel::Off;
+/// `normal` — a commit this server acknowledges survives the server process
+/// dying. The measurement that picked it (R3.3, `bolt_durability:*` in
+/// `dev-docs/bench/results/results.csv`): at 4 contended writers on a 10k-node
+/// graph, `normal` cost nothing measurable against `off` (the two runs
+/// straddled zero at ±8% noise) while `full` cost **88%** of committed
+/// throughput — one device barrier per commit, taken inside the session lock
+/// every Bolt commit already serializes on, which also drove p95 from 0.9 ms
+/// to 76 ms and the conflict rate from 1.5% to 17%. Power-loss safety is
+/// therefore opt-in (`--durability full`) rather than the default, and the
+/// default is the level that is free.
+///
+/// A **default** level is degraded rather than enforced where the
+/// configuration cannot carry a log: `--readonly` (nothing commits) and
+/// disk-mode graphs (no logical WAL exists for them) serve at `off` with a log
+/// line saying so. An explicitly requested level is still a startup error in
+/// both cases — an operator who typed `--durability full` must not be quietly
+/// given something weaker.
+const DEFAULT_DURABILITY: DurabilityLevel = DurabilityLevel::Normal;
 
 /// Read `name` as a boolean, accepting the spellings operators actually write.
 ///
@@ -443,6 +462,14 @@ struct Durability {
     /// checkpoint settings this one is not a background task but a property of
     /// the session itself, so it is resolved here and handed to startup.
     level: DurabilityLevel,
+    /// Whether [`Self::level`] is what the operator asked for (flag or
+    /// environment) rather than [`DEFAULT_DURABILITY`].
+    ///
+    /// It is the difference between a refusal and a degrade: a configuration
+    /// that cannot carry a log refuses an explicit request and serves an
+    /// implicit default at `off`. Without it, flipping the default would turn
+    /// `--readonly` and every disk-mode graph into a startup error.
+    level_requested: bool,
 }
 
 impl Durability {
@@ -455,18 +482,34 @@ impl Durability {
     /// The `--readonly` refusals run here, before the graph is touched, so an
     /// impossible configuration fails fast; the storage-mode refusals need the
     /// opened graph, so [`Self::ensure_supported`] is called again with it.
+    ///
+    /// A read-only server also degrades the *default* level to `off` here
+    /// rather than refusing it — see [`Durability::level_requested`].
     fn resolve(cli: &Cli) -> Result<Self> {
-        let resolved = Self {
+        let (level, level_requested) = match cli.durability {
+            Some(level) => (level, true),
+            None => match env_durability_level()? {
+                Some(level) => (level, true),
+                None => (DEFAULT_DURABILITY, false),
+            },
+        };
+        let mut resolved = Self {
             save_on_exit: cli.save_on_exit || env_flag(SAVE_ON_EXIT_ENV).unwrap_or(false),
             checkpoint_interval: match cli.checkpoint_interval {
                 Some(interval) => Some(interval),
                 None => env_checkpoint_interval()?,
             },
-            level: match cli.durability {
-                Some(level) => level,
-                None => env_durability_level()?.unwrap_or(DEFAULT_DURABILITY),
-            },
+            level,
+            level_requested,
         };
+        if resolved.level.logs() && cli.readonly && !resolved.level_requested {
+            tracing::info!(
+                default_level = resolved.level.name(),
+                "--readonly: serving at durability off (a read-only server never commits, \
+                 so there is nothing to log)"
+            );
+            resolved.level = DurabilityLevel::Off;
+        }
         resolved.ensure_supported(cli.readonly, None)?;
         Ok(resolved)
     }
@@ -672,7 +715,7 @@ async fn serve() -> Result<()> {
         .map(StorageMode::parse)
         .transpose()
         .map_err(|e| anyhow::anyhow!(e))?;
-    let durability = Durability::resolve(&cli)?;
+    let mut durability = Durability::resolve(&cli)?;
     // The graph is opened *and* wrapped in its session here: at a logging level
     // the two are one step, because recovering the write-ahead sidecar is part
     // of opening the path (see `startup::start_graph`).
@@ -680,9 +723,16 @@ async fn serve() -> Result<()> {
         &cli.graph,
         requested_mode,
         cli.readonly,
-        durability.level,
+        DurabilityRequest {
+            level: durability.level,
+            explicit: durability.level_requested,
+        },
         &mut |_| {},
     )?;
+    // Adopt whatever startup could actually serve: a disk graph degrades a
+    // *default* level to `off` there, and the shutdown flush below must not
+    // then call `sync()` on a session that has no log.
+    durability.level = started.level;
     // Bind the lease for the whole of `serve`. `_writer_lease` rather than
     // `_`: a bare `_` drops it here, releasing write ownership before the
     // first client connects. It is released by this binding going out of
@@ -1037,15 +1087,52 @@ mod tests {
         }
     }
 
-    /// The shipped default is `off` — today's behaviour, preserved. Pinned as
-    /// a test because flipping it silently changes what `--readonly`,
-    /// disk-mode graphs and every existing invocation do (see
-    /// [`DEFAULT_DURABILITY`]); the flip is R3.3's measured decision, and it
-    /// should have to edit a test that says so.
+    /// The shipped default is `normal`: a commit this server acknowledges
+    /// survives the process dying. Pinned as a test because the level decides
+    /// what an operator gets without asking, and because `full` — the level
+    /// that also survives power loss — costs 88% of committed throughput here
+    /// (R3.3, `bolt_durability:*` in the results CSV) and is therefore opt-in.
     #[test]
-    fn the_default_level_is_off() {
-        assert_eq!(DEFAULT_DURABILITY, DurabilityLevel::Off);
-        assert!(!DEFAULT_DURABILITY.logs());
+    fn the_default_level_is_normal() {
+        assert_eq!(DEFAULT_DURABILITY, DurabilityLevel::Normal);
+        assert!(DEFAULT_DURABILITY.logs());
+    }
+
+    /// A default level is degraded where it cannot be served, not enforced:
+    /// `--readonly` keeps working with no `--durability off` added to it.
+    ///
+    /// Mutation evidence: dropping the `!level_requested` guard from
+    /// `resolve` makes this fail with the readonly refusal.
+    #[test]
+    fn a_readonly_server_serves_the_default_level_at_off() {
+        let cli = Cli::parse_from(["kglite-bolt-server", "--graph", "g.kgl", "--readonly"]);
+        let resolved = Durability::resolve(&cli).expect(
+            "--readonly must not become a startup error the day the default starts logging",
+        );
+        assert_eq!(resolved.level, DurabilityLevel::Off);
+        assert!(!resolved.level_requested);
+    }
+
+    /// The other half: a level the operator typed is still refused with
+    /// `--readonly`, rather than silently weakened to what the default does.
+    #[test]
+    fn a_requested_level_is_still_refused_with_readonly() {
+        let cli = Cli::parse_from([
+            "kglite-bolt-server",
+            "--graph",
+            "g.kgl",
+            "--readonly",
+            "--durability",
+            "normal",
+        ]);
+        let error = Durability::resolve(&cli)
+            .err()
+            .map(|e| format!("{e:#}"))
+            .expect("an explicit level with --readonly is a startup error");
+        assert!(
+            error.contains("--durability normal") && error.contains("--readonly"),
+            "the refusal must name both flags: {error}"
+        );
     }
 
     #[test]

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -805,6 +805,54 @@ async fn serve() -> Result<()> {
 
     let addr = SocketAddr::new(cli.bind, cli.port);
 
+    let builder = configure_builder(&cli, backend)?;
+
+    tracing::info!(
+        %addr,
+        readonly = cli.readonly,
+        durability = durability.level.name(),
+        save_on_exit = durability.save_on_exit,
+        checkpoint_interval_secs = durability.checkpoint_interval.map(|d| d.as_secs()),
+        "Bolt server starting"
+    );
+    // Armed before the accept loop and stopped after it, the boltr idle-reaper
+    // shape: a task that only makes sense while the server is serving is owned
+    // by the same scope that serves.
+    let checkpoint_task = durability.checkpoint_interval.map(|interval| {
+        tracing::info!(
+            interval_secs = interval.as_secs(),
+            path = %served_path.display(),
+            "periodic checkpointing enabled"
+        );
+        spawn_checkpoint_task(
+            Arc::clone(&exit_session),
+            served_path.clone(),
+            checkpoint_state,
+            interval,
+        )
+    });
+
+    let serve_result = builder
+        .serve(addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("BoltServer::serve failed: {}", e));
+
+    tracing::info!("Bolt server stopped");
+    finish_shutdown(
+        &durability,
+        &exit_session,
+        &served_path,
+        checkpoint_task,
+        serve_result,
+    )
+    .await
+}
+
+/// Everything between `BoltServer::builder` and `serve`: session/message
+/// bounds, the SIGINT/SIGTERM shutdown future, idle timeout, TLS, and the
+/// `--auth basic` validator. Split from [`serve`] purely to keep each half
+/// readable; the ordering of these calls carries no invariants.
+fn configure_builder(cli: &Cli, backend: KgliteBackend) -> Result<BoltServer<KgliteBackend>> {
     let mut builder = BoltServer::builder(backend)
         .max_sessions(cli.max_sessions)
         .max_message_size(cli.max_message_size)
@@ -838,63 +886,33 @@ async fn serve() -> Result<()> {
         builder = builder.auth(crate::auth::BasicAuthValidator::new(user, pass));
         tracing::info!(user = %cli.auth_user.as_deref().unwrap_or(""), "wired --auth basic validator");
     }
+    Ok(builder)
+}
 
-    tracing::info!(
-        %addr,
-        readonly = cli.readonly,
-        durability = durability.level.name(),
-        save_on_exit = durability.save_on_exit,
-        checkpoint_interval_secs = durability.checkpoint_interval.map(|d| d.as_secs()),
-        "Bolt server starting"
-    );
-    // Armed before the accept loop and stopped after it, the boltr idle-reaper
-    // shape: a task that only makes sense while the server is serving is owned
-    // by the same scope that serves.
-    let checkpoint_task = durability.checkpoint_interval.map(|interval| {
-        tracing::info!(
-            interval_secs = interval.as_secs(),
-            path = %served_path.display(),
-            "periodic checkpointing enabled"
-        );
-        spawn_checkpoint_task(
-            Arc::clone(&exit_session),
-            served_path.clone(),
-            checkpoint_state,
-            interval,
-        )
-    });
-
-    let serve_result = builder
-        .serve(addr)
-        .await
-        .map_err(|e| anyhow::anyhow!("BoltServer::serve failed: {}", e));
-
-    tracing::info!("Bolt server stopped");
-    // Stop periodic checkpointing BEFORE the exit save, and wait for the task
-    // to actually be gone. `abort()` alone only *requests* cancellation: a
-    // task in the middle of a save is running synchronous code and cannot be
-    // cancelled until its next await point, so without the join a tick's save
-    // could still be in flight — or, worse, land after — the exit save.
-    // Awaiting the aborted handle resolves once the task has stopped, which
-    // makes the exit save the last write to the file by construction. (The
-    // join returns a cancellation `JoinError`; that is the expected result.)
+/// The shutdown tail of [`serve`], in its load-bearing order: stop-and-JOIN
+/// the checkpoint task (abort alone only requests cancellation — a task
+/// mid-save runs synchronous code and could otherwise land a tick's save
+/// after the exit save; awaiting the aborted handle makes the exit save the
+/// last write by construction), then the log's final barrier BEFORE any
+/// decision about saving (under `normal` the tail is in the page cache and
+/// shutdown is the one moment no further commit is coming; if the save then
+/// fails, the commits it could not write are already in the log for the next
+/// startup to replay), then the exit save — attempted on the failure path
+/// too, with a failed save exiting non-zero rather than being swallowed.
+async fn finish_shutdown(
+    durability: &Durability,
+    exit_session: &kglite::api::session::Session,
+    served_path: &Path,
+    checkpoint_task: Option<tokio::task::JoinHandle<()>>,
+    serve_result: Result<()>,
+) -> Result<()> {
     if let Some(task) = checkpoint_task {
         task.abort();
         let _ = task.await;
         tracing::info!("checkpoint-interval: stopped");
     }
-    // The log's final barrier, before any decision about saving. Under
-    // `normal` the tail of the log is in the page cache, which survives this
-    // process dying but not the machine dying, and shutdown is the one moment
-    // the server knows no further commit is coming — so it is worth paying a
-    // barrier that per-commit `normal` deliberately does not. Under `full`
-    // every frame is already on stable storage and this is a no-op; at `off`
-    // there is no log to flush and calling `sync` would be an error, so it is
-    // skipped rather than reported.
-    //
-    // Ordered before the exit save on purpose: if the save then fails, the
-    // commits it could not write are already on disk in the log for the next
-    // startup to replay.
+    // At `off` there is no log to flush and calling `sync` would be an
+    // error, so it is skipped rather than reported.
     let sync_result = if durability.level.logs() {
         exit_session
             .sync()
@@ -915,12 +933,8 @@ async fn serve() -> Result<()> {
     } else {
         Ok(())
     };
-    // Attempted whether or not `serve` returned an error: an operator who
-    // asked for an exit checkpoint wants one on the failure path too. Both
-    // results are reported; a failed save exits non-zero rather than being
-    // logged and swallowed.
     let save_result = if durability.save_on_exit {
-        run_exit_save(&exit_session, &served_path)
+        run_exit_save(exit_session, served_path)
             .inspect_err(|e| tracing::error!(error = %format!("{e:#}"), "save-on-exit FAILED"))
     } else {
         Ok(())

--- a/crates/kglite-bolt-server/src/main.rs
+++ b/crates/kglite-bolt-server/src/main.rs
@@ -5,7 +5,7 @@
 //! optional basic authentication, and graceful shutdown.
 
 use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,6 +74,26 @@ struct Cli {
     /// Reject all mutation queries at the execute boundary.
     #[arg(long, default_value_t = false)]
     readonly: bool,
+
+    /// Write the served graph back to `--graph` when the server shuts down.
+    ///
+    /// Off by default: this server's writes are process-local until something
+    /// checkpoints them, and an unasked-for write to the operator's file at
+    /// exit is not a default worth having. With the flag, `SIGINT` and
+    /// `SIGTERM` run a final save (fsync'd, atomic temp+rename) before the
+    /// process exits; a failed save is logged as an error AND exits non-zero,
+    /// so a supervisor sees the failure instead of a clean stop.
+    ///
+    /// Not a durability guarantee: `SIGKILL`, a power loss, or a crash lose
+    /// everything since the last checkpoint, and because connections are not
+    /// drained a commit racing shutdown can land *after* the save — the saved
+    /// graph version is logged so that case is diagnosable.
+    ///
+    /// Refused for `--readonly` (nothing to save) and for disk-mode graphs
+    /// (every disk save publishes a new generation and nothing prunes them).
+    /// Also settable as `KGLITE_BOLT_SAVE_ON_EXIT=1`.
+    #[arg(long, default_value_t = false, conflicts_with = "readonly")]
+    save_on_exit: bool,
 
     /// Report a Neo4j-compatible product identifier in the Bolt handshake.
     ///
@@ -159,6 +179,9 @@ struct Cli {
 /// Environment variable mirroring `--neo4j-compat`.
 const NEO4J_COMPAT_ENV: &str = "KGLITE_BOLT_NEO4J_COMPAT";
 
+/// Environment variable mirroring `--save-on-exit`.
+const SAVE_ON_EXIT_ENV: &str = "KGLITE_BOLT_SAVE_ON_EXIT";
+
 /// Read `name` as a boolean, accepting the spellings operators actually write.
 ///
 /// Parsed here rather than through clap's `env` support because clap would
@@ -182,6 +205,96 @@ fn env_flag(name: &str) -> Option<bool> {
             None
         }
     }
+}
+
+/// Refuse `--save-on-exit` in the configurations where an exit checkpoint is
+/// either meaningless or harmful.
+///
+/// `mode` is `None` before the graph is opened (the readonly check needs
+/// nothing else) and `Some(live_mode)` afterwards. clap's
+/// `conflicts_with = "readonly"` already covers flag-versus-flag; the readonly
+/// arm here is what catches the *environment* spelling, which clap cannot see.
+///
+/// Disk graphs are excluded deliberately: a disk save is an O(E) compaction
+/// that publishes a NEW generation, and nothing prunes the old ones — a server
+/// that checkpoints a disk graph grows the directory without bound. Mirrors
+/// the wheel's durable-mode restriction to the portable backends.
+fn ensure_save_on_exit_supported(readonly: bool, mode: Option<StorageMode>) -> Result<()> {
+    if readonly {
+        anyhow::bail!(
+            "--save-on-exit (or KGLITE_BOLT_SAVE_ON_EXIT) cannot be combined with \
+             --readonly: a read-only server never changes the graph, so there is \
+             nothing to write back at exit"
+        );
+    }
+    if mode == Some(StorageMode::Disk) {
+        anyhow::bail!(
+            "--save-on-exit is not supported for disk-mode graphs: every disk save \
+             publishes a new on-disk generation and nothing prunes the old ones, so \
+             repeated checkpoints grow the directory without bound. Serve a `.kgl` \
+             graph (memory or mapped) if you want an exit checkpoint"
+        );
+    }
+    Ok(())
+}
+
+/// Write the served graph back to `path`, fsync'd.
+///
+/// The graph version is logged next to the path because shutdown does not
+/// drain in-flight connections: a commit that lands after this save is lost,
+/// and comparing the logged version against the client's last committed
+/// version is how an operator tells that apart from a save that never ran.
+fn run_exit_save(session: &kglite::api::session::Session, path: &Path) -> Result<()> {
+    tracing::info!(path = %path.display(), "save-on-exit: writing the served graph back");
+    session
+        .save(&path.to_string_lossy(), true)
+        .map_err(|e| anyhow::anyhow!("save-on-exit failed writing {}: {e}", path.display()))?;
+    tracing::info!(
+        path = %path.display(),
+        graph_version = session.version(),
+        "save-on-exit complete"
+    );
+    Ok(())
+}
+
+/// Resolve when the supervisor asks this process to stop.
+///
+/// Both SIGINT (a terminal Ctrl-C) and SIGTERM (`systemctl stop`, `docker
+/// stop`, a Kubernetes pod shutdown) run the *same* graceful path. Waiting on
+/// SIGINT alone would leave every supervised deployment terminating through
+/// the default SIGTERM handler, which kills the process outright — no
+/// connection shutdown and, with `--save-on-exit`, no exit save.
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    match signal(SignalKind::terminate()) {
+        Ok(mut sigterm) => {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => tracing::info!("SIGINT received; shutting down"),
+                _ = sigterm.recv() => tracing::info!("SIGTERM received; shutting down"),
+            }
+        }
+        Err(e) => {
+            // Registration can only fail on a platform/permission problem.
+            // Degrade to SIGINT rather than refusing to serve, but say so:
+            // silently serving without the SIGTERM path is exactly the
+            // failure this function exists to remove.
+            tracing::warn!(
+                error = %e,
+                "could not install a SIGTERM handler; only SIGINT will shut down gracefully"
+            );
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("SIGINT received; shutting down");
+        }
+    }
+}
+
+/// Non-unix has no SIGTERM; Ctrl-C is the whole surface.
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!("SIGINT received; shutting down");
 }
 
 fn init_tracing() {
@@ -229,6 +342,13 @@ async fn serve() -> Result<()> {
         .map(StorageMode::parse)
         .transpose()
         .map_err(|e| anyhow::anyhow!(e))?;
+    // Flag OR environment, like `--neo4j-compat`. The readonly refusal runs
+    // before the graph is touched so an impossible configuration fails fast;
+    // the storage-mode refusal needs the opened graph and runs below.
+    let save_on_exit = cli.save_on_exit || env_flag(SAVE_ON_EXIT_ENV).unwrap_or(false);
+    if save_on_exit {
+        ensure_save_on_exit_supported(cli.readonly, None)?;
+    }
     let started = start_graph(&cli.graph, requested_mode, cli.readonly, &mut |_| {})?;
     // Bind the lease for the whole of `serve`. `_writer_lease` rather than
     // `_`: a bare `_` drops it here, releasing write ownership before the
@@ -249,6 +369,12 @@ async fn serve() -> Result<()> {
         converted_from = started.converted_from.map(StorageMode::as_str),
         "graph ready; constructing Bolt server"
     );
+    if save_on_exit {
+        ensure_save_on_exit_supported(
+            cli.readonly,
+            Some(kglite::api::storage::live_storage_mode(&dir_arc)),
+        )?;
+    }
 
     // The backend stores the DirGraph behind its own Arc<Mutex<>> for
     // commit-swap. Unwrap the Arc — if no
@@ -281,19 +407,29 @@ async fn serve() -> Result<()> {
         neo4j_compat,
         "bolt handshake identity"
     );
-    let backend = KgliteBackend::new(dir, cli.readonly, advertised_addr, csv_import, identity);
+    let backend = KgliteBackend::new(
+        dir,
+        cli.graph.clone(),
+        cli.readonly,
+        advertised_addr,
+        csv_import,
+        identity,
+    );
+    // Keep the served graph reachable after the backend moves into the
+    // server: `serve` consumes the builder, and the exit hook below runs once
+    // the accept loop is done — while `_writer_lease` is still held, so the
+    // save cannot race another process taking write ownership.
+    let exit_session = backend.session_handle();
+    let served_path = backend.graph_path().to_path_buf();
 
     let addr = SocketAddr::new(cli.bind, cli.port);
 
     let mut builder = BoltServer::builder(backend)
         .max_sessions(cli.max_sessions)
         .max_message_size(cli.max_message_size)
-        .shutdown(async {
-            // Single SIGINT triggers graceful shutdown. Subsequent SIGINTs
-            // bypass this and let tokio's default handler abort.
-            let _ = tokio::signal::ctrl_c().await;
-            tracing::info!("SIGINT received; shutting down");
-        });
+        // A single SIGINT or SIGTERM triggers graceful shutdown. Subsequent
+        // signals bypass this and let the default handler abort.
+        .shutdown(shutdown_signal());
 
     if let Some(secs) = cli.idle_timeout {
         builder = builder.idle_timeout(Duration::from_secs(secs));
@@ -336,12 +472,98 @@ async fn serve() -> Result<()> {
         tracing::info!(user = %cli.auth_user.as_deref().unwrap_or(""), "wired --auth basic validator");
     }
 
-    tracing::info!(%addr, readonly = cli.readonly, "Bolt server starting");
-    builder
+    tracing::info!(
+        %addr,
+        readonly = cli.readonly,
+        save_on_exit,
+        "Bolt server starting"
+    );
+    let serve_result = builder
         .serve(addr)
         .await
-        .map_err(|e| anyhow::anyhow!("BoltServer::serve failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("BoltServer::serve failed: {}", e));
 
     tracing::info!("Bolt server stopped");
+    // Attempted whether or not `serve` returned an error: an operator who
+    // asked for an exit checkpoint wants one on the failure path too. Both
+    // results are reported; a failed save exits non-zero rather than being
+    // logged and swallowed.
+    let save_result = if save_on_exit {
+        run_exit_save(&exit_session, &served_path)
+            .inspect_err(|e| tracing::error!(error = %format!("{e:#}"), "save-on-exit FAILED"))
+    } else {
+        Ok(())
+    };
+    serve_result?;
+    save_result?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_on_exit_is_refused_for_a_readonly_server() {
+        let error = ensure_save_on_exit_supported(true, None)
+            .expect_err("a read-only server has nothing to save");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("--readonly") && message.contains("--save-on-exit"),
+            "the refusal must name both flags: {message}"
+        );
+    }
+
+    #[test]
+    fn save_on_exit_is_refused_for_a_disk_graph() {
+        let error = ensure_save_on_exit_supported(false, Some(StorageMode::Disk))
+            .expect_err("disk-mode exit saves grow the directory without bound");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("disk-mode") && message.contains("generation"),
+            "the refusal must carry the reason, not just the verdict: {message}"
+        );
+    }
+
+    #[test]
+    fn save_on_exit_is_allowed_for_the_portable_modes() {
+        for mode in [StorageMode::Memory, StorageMode::Mapped] {
+            ensure_save_on_exit_supported(false, Some(mode))
+                .unwrap_or_else(|e| panic!("{} must support an exit save: {e:#}", mode.as_str()));
+        }
+    }
+
+    /// The exit save writes a file a later open can read back, and reports a
+    /// failure rather than logging one. Mutation evidence: dropping the
+    /// `map_err` in `run_exit_save` makes the unwritable-path case pass
+    /// `Ok(())` and fails the second half of this test.
+    #[test]
+    fn exit_save_writes_the_graph_and_reports_failure() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "kglite-bolt-exit-save-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let path = dir.join("served.kgl");
+
+        let graph = kglite::api::storage::new_dir_graph_in_mode(StorageMode::Memory, None)
+            .expect("memory graph");
+        let session = kglite::api::session::Session::new(graph);
+        run_exit_save(&session, &path).expect("exit save on a writable path");
+        assert!(path.exists(), "the exit save must produce the served file");
+
+        let unwritable = dir.join("no-such-directory").join("served.kgl");
+        let error = run_exit_save(&session, &unwritable)
+            .expect_err("a save into a missing directory must be reported");
+        assert!(
+            format!("{error:#}").contains("save-on-exit failed"),
+            "the error must identify the exit save: {error:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/kglite-bolt-server/src/startup.rs
+++ b/crates/kglite-bolt-server/src/startup.rs
@@ -41,9 +41,28 @@ pub(crate) enum StartupStep {
     SessionOpened,
 }
 
+/// What the operator asked of the write-ahead log, and whether they asked.
+///
+/// The pair travels together because the two answers mean different things to
+/// a graph that cannot carry a log: an explicitly requested level is a startup
+/// error (the engine's, naming the reason), while the server's *default* level
+/// degrades to `off` so that serving a disk-mode graph does not stop working
+/// the day the default changes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DurabilityRequest {
+    pub(crate) level: DurabilityLevel,
+    /// False when `level` came from the server's default rather than from
+    /// `--durability` or its environment mirror.
+    pub(crate) explicit: bool,
+}
+
 /// A session ready to serve, plus the write ownership it depends on.
 pub(crate) struct StartedGraph {
     pub(crate) session: Session,
+    /// The level the session is actually logging at. Equal to the requested
+    /// level except where a default was degraded (see [`DurabilityRequest`]) —
+    /// the caller must serve and report *this* one, not what it asked for.
+    pub(crate) level: DurabilityLevel,
     pub(crate) disposition: OpenDisposition,
     /// The mode the served graph is actually in, read while startup still owns
     /// the graph alone. Read here rather than from a snapshot later because a
@@ -86,7 +105,7 @@ pub(crate) fn start_graph(
     path: &Path,
     requested_mode: Option<StorageMode>,
     readonly: bool,
-    durability: DurabilityLevel,
+    durability: DurabilityRequest,
     record: &mut dyn FnMut(StartupStep),
 ) -> Result<StartedGraph> {
     let writer_lease = if readonly {
@@ -102,24 +121,42 @@ pub(crate) fn start_graph(
         record(StartupStep::LeaseAcquired);
         Some(lease)
     };
-    let opened = open_or_create_graph_in_mode(path, requested_mode, durability)
+    let opened = open_or_create_graph_in_mode(path, requested_mode, durability.level)
         .with_context(|| format!("opening or creating {}", path.display()))?;
     record(StartupStep::GraphOpened);
     let live_mode = live_storage_mode(&opened.graph);
+    // The one refusal that becomes a degrade: a disk graph has no logical WAL
+    // at any level, so an operator who asked for one hears the engine's error
+    // below, while a graph merely inheriting the server's default is served
+    // unlogged rather than refused. Decided here because it is the first point
+    // where the *live* mode is known — `--storage` may have converted, and a
+    // graph opened without the flag reports whatever it was saved in.
+    let level = if durability.level.logs() && !durability.explicit && live_mode == StorageMode::Disk
+    {
+        tracing::info!(
+            default_level = durability.level.name(),
+            "disk-mode graph: serving at durability off (a disk graph commits by \
+             publishing a generation, so it carries no write-ahead log)"
+        );
+        DurabilityLevel::Off
+    } else {
+        durability.level
+    };
     // `opened.graph` is the only reference to this graph, which is what
     // `open_durable` requires: a shared Arc would be deep-cloned here and the
     // other holder would keep mutating an unlogged copy.
-    let session = Session::open_durable(opened.graph, &path.to_string_lossy(), durability)
-        .map_err(|e| {
+    let session =
+        Session::open_durable(opened.graph, &path.to_string_lossy(), level).map_err(|e| {
             anyhow::anyhow!(
                 "opening {} at --durability {}: {e}",
                 path.display(),
-                durability.name()
+                level.name()
             )
         })?;
     record(StartupStep::SessionOpened);
     Ok(StartedGraph {
         session,
+        level,
         disposition: opened.disposition,
         live_mode,
         converted_from: opened.converted_from,
@@ -133,6 +170,23 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// A level the operator named — what every test here means unless it is
+    /// specifically about the default's degrade path.
+    fn explicit(level: DurabilityLevel) -> DurabilityRequest {
+        DurabilityRequest {
+            level,
+            explicit: true,
+        }
+    }
+
+    /// The server's default level, i.e. one nobody typed.
+    fn defaulted(level: DurabilityLevel) -> DurabilityRequest {
+        DurabilityRequest {
+            level,
+            explicit: false,
+        }
+    }
 
     /// Unique scratch directory, removed on drop. Mirrors `backend.rs`'s
     /// temp-path idiom rather than adding a dev-dependency for one test file.
@@ -173,7 +227,7 @@ mod tests {
             &scratch.graph_path(),
             Some(StorageMode::Memory),
             false,
-            DurabilityLevel::Off,
+            explicit(DurabilityLevel::Off),
             &mut |step| steps.push(step),
         )
         .expect("writable startup on a free path");
@@ -207,7 +261,7 @@ mod tests {
             &path,
             Some(StorageMode::Memory),
             false,
-            DurabilityLevel::Off,
+            explicit(DurabilityLevel::Off),
             &mut |step| steps.push(step),
         ) {
             Ok(_) => panic!("a second writable server must not open a leased graph"),
@@ -247,7 +301,13 @@ mod tests {
     }
 
     fn start(path: &Path, requested: Option<StorageMode>) -> Result<StartedGraph> {
-        start_graph(path, requested, false, DurabilityLevel::Off, &mut |_| {})
+        start_graph(
+            path,
+            requested,
+            false,
+            explicit(DurabilityLevel::Off),
+            &mut |_| {},
+        )
     }
 
     #[test]
@@ -293,7 +353,7 @@ mod tests {
                 &path,
                 Some(requested),
                 false,
-                DurabilityLevel::Off,
+                explicit(DurabilityLevel::Off),
                 &mut |step| steps.push(step),
             )
             .expect("portable conversion at startup");
@@ -351,7 +411,7 @@ mod tests {
             &path,
             Some(StorageMode::Memory),
             true,
-            DurabilityLevel::Off,
+            explicit(DurabilityLevel::Off),
             &mut |step| steps.push(step),
         )
         .expect("readonly startup beside a live writer");
@@ -419,7 +479,7 @@ mod tests {
             let path = scratch.graph_path();
             seed_graph(&path, StorageMode::Memory);
 
-            let first = start_graph(&path, None, false, level, &mut |_| {})
+            let first = start_graph(&path, None, false, explicit(level), &mut |_| {})
                 .expect("durable startup on a saved graph");
             commit_write(&first.session, "CREATE (:Person {id: 1, title: 'Zed'})");
             assert_eq!(person_count(&first.session), 1);
@@ -427,7 +487,7 @@ mod tests {
             // killed process would, leaving the commit only in the sidecar.
             drop(first);
 
-            let reopened = start_graph(&path, None, false, level, &mut |_| {})
+            let reopened = start_graph(&path, None, false, explicit(level), &mut |_| {})
                 .unwrap_or_else(|e| panic!("durable restart at {}: {e:#}", level.name()));
             assert_eq!(
                 person_count(&reopened.session),
@@ -449,12 +509,24 @@ mod tests {
         let path = scratch.graph_path();
         seed_graph(&path, StorageMode::Memory);
 
-        let durable = start_graph(&path, None, false, DurabilityLevel::Full, &mut |_| {})
-            .expect("durable startup on a saved graph");
+        let durable = start_graph(
+            &path,
+            None,
+            false,
+            explicit(DurabilityLevel::Full),
+            &mut |_| {},
+        )
+        .expect("durable startup on a saved graph");
         commit_write(&durable.session, "CREATE (:Person {id: 1, title: 'Zed'})");
         drop(durable);
 
-        let error = match start_graph(&path, None, false, DurabilityLevel::Off, &mut |_| {}) {
+        let error = match start_graph(
+            &path,
+            None,
+            false,
+            explicit(DurabilityLevel::Off),
+            &mut |_| {},
+        ) {
             Ok(_) => panic!("serving at off would silently drop the logged commit"),
             Err(error) => format!("{error:#}"),
         };
@@ -464,8 +536,70 @@ mod tests {
         );
 
         // Non-vacuity: the same path opens at a logging level, with the write.
-        let recovered = start_graph(&path, None, false, DurabilityLevel::Full, &mut |_| {})
-            .expect("the refusal is about the level, not the path");
+        let recovered = start_graph(
+            &path,
+            None,
+            false,
+            explicit(DurabilityLevel::Full),
+            &mut |_| {},
+        )
+        .expect("the refusal is about the level, not the path");
         assert_eq!(person_count(&recovered.session), 1);
+    }
+    /// A disk graph carries no logical log at any level, and after the
+    /// default flipped to `normal` that would make *every* disk-mode server
+    /// fail to start. The default degrades instead: the graph is served,
+    /// unlogged.
+    ///
+    /// Mutation evidence: passing `explicit(...)` here fails with the engine's
+    /// disk refusal, which is the next test.
+    #[test]
+    fn a_default_level_degrades_to_off_for_a_disk_graph() {
+        let scratch = ScratchDir::new("disk-default");
+        let path = scratch.0.join("disk-graph");
+
+        let started = start_graph(
+            &path,
+            Some(StorageMode::Disk),
+            false,
+            defaulted(DurabilityLevel::Normal),
+            &mut |_| {},
+        )
+        .expect("a disk graph must still be servable once the default logs");
+
+        assert_eq!(started.live_mode, StorageMode::Disk);
+        assert_eq!(
+            started.level,
+            DurabilityLevel::Off,
+            "the degraded level is what the caller must serve and report"
+        );
+        assert_eq!(
+            started.session.durability(),
+            None,
+            "a degraded session must carry no log at all"
+        );
+    }
+
+    /// The other half of the same rule: a level the operator *typed* is
+    /// refused for a disk graph rather than quietly weakened.
+    #[test]
+    fn an_explicit_level_is_still_refused_for_a_disk_graph() {
+        let scratch = ScratchDir::new("disk-explicit");
+        let path = scratch.0.join("disk-graph");
+
+        let error = match start_graph(
+            &path,
+            Some(StorageMode::Disk),
+            false,
+            explicit(DurabilityLevel::Normal),
+            &mut |_| {},
+        ) {
+            Ok(_) => panic!("an operator who asked for a log must not be given none"),
+            Err(error) => format!("{error:#}"),
+        };
+        assert!(
+            error.contains("storage='disk'"),
+            "the refusal must name the reason: {error}"
+        );
     }
 }

--- a/crates/kglite-bolt-server/src/startup.rs
+++ b/crates/kglite-bolt-server/src/startup.rs
@@ -1,19 +1,25 @@
-//! Graph startup: take cross-process write ownership of the graph path, then
-//! open it.
+//! Graph startup: take cross-process write ownership of the graph path, open
+//! it, and wrap it in the session the backend serves.
 //!
 //! Split out of `main` so the acquire-then-open *order* is testable. Ordering
 //! is the whole point of the lease: acquiring it after the read is a guard
 //! that lets the very race it exists to stop happen first.
+//!
+//! The session is built here rather than in the backend because at
+//! `--durability full`/`normal` its construction *is* part of opening the path:
+//! [`Session::open_durable`] recovers the write-ahead sidecar into the graph
+//! before the first client can connect, and it must happen inside the writer
+//! lease this module already takes.
 
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 
+use kglite::api::durable::DurabilityLevel;
 use kglite::api::io::{open_or_create_graph_in_mode, GraphWriterLease, OpenDisposition};
-use kglite::api::storage::StorageMode;
-use kglite::api::DirGraph;
+use kglite::api::session::Session;
+use kglite::api::storage::{live_storage_mode, StorageMode};
 
 /// How long startup waits for another writer to release the graph.
 ///
@@ -32,12 +38,18 @@ const WRITER_LEASE_TIMEOUT: Duration = Duration::ZERO;
 pub(crate) enum StartupStep {
     LeaseAcquired,
     GraphOpened,
+    SessionOpened,
 }
 
-/// A graph ready to serve, plus the write ownership it depends on.
+/// A session ready to serve, plus the write ownership it depends on.
 pub(crate) struct StartedGraph {
-    pub(crate) graph: Arc<DirGraph>,
+    pub(crate) session: Session,
     pub(crate) disposition: OpenDisposition,
+    /// The mode the served graph is actually in, read while startup still owns
+    /// the graph alone. Read here rather than from a snapshot later because a
+    /// snapshot Arc held across a checkpoint turns its `Arc::make_mut` into a
+    /// deep clone of the whole graph.
+    pub(crate) live_mode: StorageMode,
     /// The mode the graph was in before `--storage` converted it, so startup
     /// can say so. `None` when nothing was converted.
     pub(crate) converted_from: Option<StorageMode>,
@@ -47,18 +59,34 @@ pub(crate) struct StartedGraph {
     pub(crate) writer_lease: Option<GraphWriterLease>,
 }
 
-/// Acquire write ownership (unless `readonly`), then open or create the graph
-/// in `requested_mode`.
+/// Acquire write ownership (unless `readonly`), open or create the graph in
+/// `requested_mode`, and wrap it in a session logging at `durability`.
 ///
 /// `requested_mode` is the operator's `--storage`, and it means the same thing
 /// on both branches: create a missing graph in it, and convert an existing one
 /// to it. `None` — no flag — means the checkpoint decides, matching
 /// `kglite.open(path)` with no `storage=`. A request with no conversion (either
 /// disk direction) fails startup rather than serving a different mode silently.
+///
+/// `durability` is the operator's `--durability`, and it travels into *both*
+/// steps for one reason: recovery. The open is told a log is coming so it does
+/// not refuse a sidecar holding commits the checkpoint lacks, and
+/// [`Session::open_durable`] then replays exactly those frames before the
+/// server binds its port. At `off` neither happens and the open keeps the
+/// refusal, which is what makes an operator who turns durability off over a
+/// crashed server's graph hear about it instead of serving a graph that is
+/// missing committed writes.
+///
+/// A `--storage` conversion is safe under a log because it is performed in
+/// memory, before the session exists: the `.kgl` on disk — and therefore the
+/// `checkpoint_lsn` the replay is gated on — is untouched until the first
+/// checkpoint, which then writes the converted graph and truncates the log
+/// together.
 pub(crate) fn start_graph(
     path: &Path,
     requested_mode: Option<StorageMode>,
     readonly: bool,
+    durability: DurabilityLevel,
     record: &mut dyn FnMut(StartupStep),
 ) -> Result<StartedGraph> {
     let writer_lease = if readonly {
@@ -74,12 +102,26 @@ pub(crate) fn start_graph(
         record(StartupStep::LeaseAcquired);
         Some(lease)
     };
-    let opened = open_or_create_graph_in_mode(path, requested_mode)
+    let opened = open_or_create_graph_in_mode(path, requested_mode, durability)
         .with_context(|| format!("opening or creating {}", path.display()))?;
     record(StartupStep::GraphOpened);
+    let live_mode = live_storage_mode(&opened.graph);
+    // `opened.graph` is the only reference to this graph, which is what
+    // `open_durable` requires: a shared Arc would be deep-cloned here and the
+    // other holder would keep mutating an unlogged copy.
+    let session = Session::open_durable(opened.graph, &path.to_string_lossy(), durability)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "opening {} at --durability {}: {e}",
+                path.display(),
+                durability.name()
+            )
+        })?;
+    record(StartupStep::SessionOpened);
     Ok(StartedGraph {
-        graph: opened.graph,
+        session,
         disposition: opened.disposition,
+        live_mode,
         converted_from: opened.converted_from,
         writer_lease,
     })
@@ -89,6 +131,7 @@ pub(crate) fn start_graph(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     /// Unique scratch directory, removed on drop. Mirrors `backend.rs`'s
@@ -130,13 +173,18 @@ mod tests {
             &scratch.graph_path(),
             Some(StorageMode::Memory),
             false,
+            DurabilityLevel::Off,
             &mut |step| steps.push(step),
         )
         .expect("writable startup on a free path");
 
         assert_eq!(
             steps,
-            vec![StartupStep::LeaseAcquired, StartupStep::GraphOpened]
+            vec![
+                StartupStep::LeaseAcquired,
+                StartupStep::GraphOpened,
+                StartupStep::SessionOpened
+            ]
         );
         assert!(
             started.writer_lease.is_some(),
@@ -155,9 +203,13 @@ mod tests {
         let mut steps = Vec::new();
         // `expect_err` is unavailable: `StartedGraph` holds a `DirGraph` and a
         // lease, neither of which is `Debug`.
-        let error = match start_graph(&path, Some(StorageMode::Memory), false, &mut |step| {
-            steps.push(step)
-        }) {
+        let error = match start_graph(
+            &path,
+            Some(StorageMode::Memory),
+            false,
+            DurabilityLevel::Off,
+            &mut |step| steps.push(step),
+        ) {
             Ok(_) => panic!("a second writable server must not open a leased graph"),
             Err(error) => error,
         };
@@ -186,8 +238,6 @@ mod tests {
     // Now the file decides when nothing is asked, and an explicit request is
     // either applied or refused.
 
-    use kglite::api::storage::live_storage_mode;
-
     /// Save a two-node graph at `path` in `mode`, then drop it.
     fn seed_graph(path: &Path, mode: StorageMode) {
         let mut graph = Arc::new(
@@ -197,7 +247,7 @@ mod tests {
     }
 
     fn start(path: &Path, requested: Option<StorageMode>) -> Result<StartedGraph> {
-        start_graph(path, requested, false, &mut |_| {})
+        start_graph(path, requested, false, DurabilityLevel::Off, &mut |_| {})
     }
 
     #[test]
@@ -208,7 +258,7 @@ mod tests {
 
         let started = start(&path, None).expect("startup on a mapped checkpoint");
         assert_eq!(
-            live_storage_mode(&started.graph),
+            started.live_mode,
             StorageMode::Mapped,
             "with no --storage the file decides, and this one recorded mapped"
         );
@@ -221,7 +271,7 @@ mod tests {
         seed_graph(&path, StorageMode::Mapped);
 
         let started = start(&path, Some(StorageMode::Mapped)).expect("agreeing request");
-        assert_eq!(live_storage_mode(&started.graph), StorageMode::Mapped);
+        assert_eq!(started.live_mode, StorageMode::Mapped);
         assert_eq!(
             started.converted_from, None,
             "nothing was converted, so nothing may be reported as converted"
@@ -239,12 +289,17 @@ mod tests {
             seed_graph(&path, recorded);
 
             let mut steps = Vec::new();
-            let started = start_graph(&path, Some(requested), false, &mut |step| steps.push(step))
-                .expect("portable conversion at startup");
+            let started = start_graph(
+                &path,
+                Some(requested),
+                false,
+                DurabilityLevel::Off,
+                &mut |step| steps.push(step),
+            )
+            .expect("portable conversion at startup");
 
             assert_eq!(
-                live_storage_mode(&started.graph),
-                requested,
+                started.live_mode, requested,
                 "the server must serve the mode the operator asked for"
             );
             assert_eq!(
@@ -254,7 +309,11 @@ mod tests {
             );
             assert_eq!(
                 steps,
-                vec![StartupStep::LeaseAcquired, StartupStep::GraphOpened],
+                vec![
+                    StartupStep::LeaseAcquired,
+                    StartupStep::GraphOpened,
+                    StartupStep::SessionOpened
+                ],
                 "converting must not disturb the acquire-then-open order"
             );
         }
@@ -288,16 +347,125 @@ mod tests {
         let held = GraphWriterLease::acquire(&path, Duration::ZERO).expect("writer lease");
 
         let mut steps = Vec::new();
-        let started = start_graph(&path, Some(StorageMode::Memory), true, &mut |step| {
-            steps.push(step)
-        })
+        let started = start_graph(
+            &path,
+            Some(StorageMode::Memory),
+            true,
+            DurabilityLevel::Off,
+            &mut |step| steps.push(step),
+        )
         .expect("readonly startup beside a live writer");
 
-        assert_eq!(steps, vec![StartupStep::GraphOpened]);
+        assert_eq!(
+            steps,
+            vec![StartupStep::GraphOpened, StartupStep::SessionOpened]
+        );
         assert!(
             started.writer_lease.is_none(),
             "a readonly server must not take write ownership"
         );
         drop(held);
+    }
+
+    // ── Durability ──────────────────────────────────────────────────────────
+
+    /// Commit one mutation the way the Bolt backend does — begin, mutate the
+    /// working copy, commit — so the write travels the path a durable session
+    /// logs.
+    fn commit_write(session: &Session, query: &str) {
+        use kglite::api::session::{execute_mut, CommitOutcome, ExecuteOptions};
+        let params = std::collections::HashMap::new();
+        let mut tx = session.begin();
+        execute_mut(
+            tx.working_mut().expect("a fresh transaction is writable"),
+            query,
+            &ExecuteOptions::eager(&params),
+        )
+        .expect("the mutation runs");
+        match session.commit(tx, true) {
+            CommitOutcome::Committed { .. } => {}
+            other => panic!("the commit must publish: {other:?}"),
+        }
+    }
+
+    fn person_count(session: &Session) -> i64 {
+        use kglite::api::session::{execute_read, ExecuteOptions};
+        let params = std::collections::HashMap::new();
+        let snapshot = session.snapshot();
+        let outcome = execute_read(
+            &snapshot,
+            "MATCH (p:Person) RETURN count(p) AS c",
+            &ExecuteOptions::eager(&params),
+        )
+        .expect("the count runs");
+        match outcome.result.rows.first().and_then(|row| row.first()) {
+            Some(kglite::api::Value::Int64(c)) => *c,
+            other => panic!("expected a count, got {other:?}"),
+        }
+    }
+
+    /// The headline of the rung, at the layer the server starts from: a
+    /// durable session whose process dies without ever checkpointing comes
+    /// back with its committed writes, because startup recovers the sidecar
+    /// before anything else happens.
+    ///
+    /// Mutation evidence: passing `DurabilityLevel::Off` for the *first*
+    /// session (nothing logged) or for the second (nothing replayed) both
+    /// drop the count back to 0.
+    #[test]
+    fn a_crashed_durable_session_replays_on_the_next_startup() {
+        for level in [DurabilityLevel::Full, DurabilityLevel::Normal] {
+            let scratch = ScratchDir::new("replay");
+            let path = scratch.graph_path();
+            seed_graph(&path, StorageMode::Memory);
+
+            let first = start_graph(&path, None, false, level, &mut |_| {})
+                .expect("durable startup on a saved graph");
+            commit_write(&first.session, "CREATE (:Person {id: 1, title: 'Zed'})");
+            assert_eq!(person_count(&first.session), 1);
+            // No checkpoint, no clean shutdown: drop everything exactly as a
+            // killed process would, leaving the commit only in the sidecar.
+            drop(first);
+
+            let reopened = start_graph(&path, None, false, level, &mut |_| {})
+                .unwrap_or_else(|e| panic!("durable restart at {}: {e:#}", level.name()));
+            assert_eq!(
+                person_count(&reopened.session),
+                1,
+                "a committed write must survive a crash-shaped restart at {} with no \
+                 checkpoint in between",
+                level.name()
+            );
+        }
+    }
+
+    /// The inherited half of the same rule: turning durability off over a
+    /// sidecar that still holds commits is refused at startup, not served as a
+    /// graph missing them. The refusal is the engine's; what is asserted here
+    /// is that the bolt server takes it rather than routing around it.
+    #[test]
+    fn startup_at_off_refuses_an_unrecovered_sidecar() {
+        let scratch = ScratchDir::new("off-refusal");
+        let path = scratch.graph_path();
+        seed_graph(&path, StorageMode::Memory);
+
+        let durable = start_graph(&path, None, false, DurabilityLevel::Full, &mut |_| {})
+            .expect("durable startup on a saved graph");
+        commit_write(&durable.session, "CREATE (:Person {id: 1, title: 'Zed'})");
+        drop(durable);
+
+        let error = match start_graph(&path, None, false, DurabilityLevel::Off, &mut |_| {}) {
+            Ok(_) => panic!("serving at off would silently drop the logged commit"),
+            Err(error) => format!("{error:#}"),
+        };
+        assert!(
+            error.contains("graph.kgl-wal") && error.contains("'full' or 'normal'"),
+            "the refusal must name the sidecar and the way out: {error}"
+        );
+
+        // Non-vacuity: the same path opens at a logging level, with the write.
+        let recovered = start_graph(&path, None, false, DurabilityLevel::Full, &mut |_| {})
+            .expect("the refusal is about the level, not the path");
+        assert_eq!(person_count(&recovered.session), 1);
     }
 }

--- a/crates/kglite-c/src/graph.rs
+++ b/crates/kglite-c/src/graph.rs
@@ -613,10 +613,13 @@ pub unsafe extern "C" fn kglite_save_graph(
                     }
                     KgliteStatusCode::Ok
                 }
-                Err(msg) => {
+                // A refusal (`SaveError::Refused`) reports FILE_IO too: the
+                // status set is ABI-frozen within this major, and the message
+                // names the sidecar and both ways out.
+                Err(error) => {
                     if !out_error_msg.is_null() {
                         unsafe {
-                            *out_error_msg = alloc_c_string(&msg);
+                            *out_error_msg = alloc_c_string(&error.to_string());
                         }
                     }
                     KgliteStatusCode::FileIo
@@ -874,10 +877,13 @@ pub unsafe extern "C" fn kglite_save_graph_durable(
                     }
                     KgliteStatusCode::Ok
                 }
-                Err(msg) => {
+                // A refusal (`SaveError::Refused`) reports FILE_IO too: the
+                // status set is ABI-frozen within this major, and the message
+                // names the sidecar and both ways out.
+                Err(error) => {
                     if !out_error_msg.is_null() {
                         unsafe {
-                            *out_error_msg = alloc_c_string(&msg);
+                            *out_error_msg = alloc_c_string(&error.to_string());
                         }
                     }
                     KgliteStatusCode::FileIo

--- a/crates/kglite-c/src/open.rs
+++ b/crates/kglite-c/src/open.rs
@@ -10,6 +10,7 @@
 use crate::graph::{classify_io_error, GraphState, KgliteGraph};
 use crate::status::KgliteStatusCode;
 use crate::strings::alloc_c_string;
+use kglite::api::durable::DurabilityLevel;
 use kglite::api::io::{open_or_create_graph_in_mode, GraphWriterLease};
 use kglite::api::storage::StorageMode;
 use std::ffi::{c_char, CStr};
@@ -264,7 +265,11 @@ pub unsafe extern "C" fn kglite_open_or_create_graph_in_mode(
                 }
             };
 
-            match open_or_create_graph_in_mode(Path::new(path_str), requested) {
+            // `DurabilityLevel::Off`: this entry point attaches no
+            // write-ahead log, so it inherits the unrecovered-sidecar refusal.
+            // A durable C-ABI open is a separate symbol when one ships.
+            match open_or_create_graph_in_mode(Path::new(path_str), requested, DurabilityLevel::Off)
+            {
                 Ok(opened) => {
                     unsafe {
                         *out_graph = GraphState::into_handle(opened.graph);

--- a/crates/kglite-mcp-server/src/tools/state.rs
+++ b/crates/kglite-mcp-server/src/tools/state.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
 use kglite::api::cypher::ValueCodec;
+use kglite::api::durable::DurabilityLevel;
 use kglite::api::introspection::compute_schema;
 use kglite::api::io::{open_or_create_graph_in_mode, GraphWriterLease, OpenDisposition};
 use kglite::api::storage::StorageMode;
@@ -166,7 +167,10 @@ impl GraphState {
                     .map_err(|e| anyhow::anyhow!("kglite writer lease failed: {e}"))?,
             )
         };
-        let opened = open_or_create_graph_in_mode(path, requested_mode)
+        // `DurabilityLevel::Off`: this server attaches no write-ahead log, so
+        // it takes the unrecovered-sidecar refusal rather than opening a graph
+        // that is silently missing another writer's committed frames.
+        let opened = open_or_create_graph_in_mode(path, requested_mode, DurabilityLevel::Off)
             .map_err(|e| anyhow::anyhow!("kglite graph open/create failed: {e}"))?;
         let kg = KnowledgeGraph::from_arc(opened.graph);
         let mut guard = write_lock(&self.inner);

--- a/crates/kglite-mcp-server/src/tools/tests/lifecycle.rs
+++ b/crates/kglite-mcp-server/src/tools/tests/lifecycle.rs
@@ -116,6 +116,57 @@ fn disk_request_on_a_portable_graph_is_refused_with_the_core_reason() {
     assert_eq!(active_mode(&after), "memory");
 }
 
+/// This server opens graphs with no write-ahead log attached, so a path whose
+/// sidecar still holds frames the checkpoint has not folded in must be refused
+/// rather than served. Opening it would hand back a graph missing committed
+/// writes, and the next `save_graph` would strand those frames in front of a
+/// newer checkpoint for a later durable open to replay back over it.
+///
+/// The refusal is the engine's (`api::io::open_or_create_graph`); asserted here
+/// because inheriting it is the whole point of routing through that entry.
+#[test]
+fn an_unrecovered_wal_sidecar_is_refused_rather_than_served() {
+    use kglite::api::durable::{wal_path, DurabilityLevel};
+    use kglite::api::session::{execute_mut, CommitOutcome, ExecuteOptions, Session};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let p = tmp.path().join("unrecovered.kgl");
+    let path = p.to_string_lossy().into_owned();
+    seed(&p, StorageMode::Memory);
+
+    // A real durable writer commits one frame and dies before checkpointing:
+    // the checkpoint just seeded carries `checkpoint_lsn` 0, so that frame is
+    // unfolded, and dropping the session is the crash (no save, no truncate).
+    {
+        let graph = kglite::api::io::load_file(&path).unwrap();
+        let session = Session::open_durable(graph, &path, DurabilityLevel::Full).unwrap();
+        let mut tx = session.begin();
+        let params = std::collections::HashMap::new();
+        let opts = ExecuteOptions::eager(&params);
+        execute_mut(tx.working_mut().unwrap(), "CREATE (:Task {id:'t1'})", &opts).unwrap();
+        assert!(matches!(
+            session.commit(tx, true),
+            CommitOutcome::Committed { .. }
+        ));
+    }
+
+    let state = GraphState::default();
+    let error = state
+        .open_or_create(&p, None)
+        .expect_err("a log-less open over unfolded frames must be refused")
+        .to_string();
+    assert!(
+        error.contains("unrecovered.kgl-wal")
+            && error.contains("holds commits this checkpoint does not contain"),
+        "the refusal must carry the core reason: {error}"
+    );
+
+    // The named remedy works: with the sidecar moved aside, the same open
+    // succeeds — and the refusal released the writer lease it took.
+    std::fs::rename(wal_path(&p), tmp.path().join("aside")).unwrap();
+    GraphState::default().open_or_create(&p, None).unwrap();
+}
+
 #[test]
 fn path_backed_active_graph_retains_writer_lease() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/kglite-py/src/graph/mod.rs
+++ b/crates/kglite-py/src/graph/mod.rs
@@ -336,19 +336,6 @@ impl KnowledgeGraph {
         self.embedder.as_ref()
     }
 
-    /// Wrap a `DirGraph`'s backend in the `Recording` write-capture layer
-    /// so mutations are buffered for the WAL. Idempotent. Used by
-    /// `kglite.open(..., durable=True)` after load / create.
-    pub(crate) fn wrap_backend_for_durability(dir: &mut DirGraph) {
-        use kglite_core::api::durable::RecordingGraph;
-        use kglite_core::api::storage::GraphBackend;
-        if matches!(dir.graph, GraphBackend::Recording(_)) {
-            return;
-        }
-        let inner = std::mem::replace(&mut dir.graph, GraphBackend::new());
-        dir.graph = GraphBackend::Recording(Box::new(RecordingGraph::new(inner)));
-    }
-
     /// Post-mutation bookkeeping for a Cypher write: make it durable, then
     /// run the pyapi-specific auto-vacuum and stats housekeeping.
     ///

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -611,47 +611,24 @@ impl KnowledgeGraph {
         self.lifecycle.source_path = Some(std::path::PathBuf::from(&effective));
         let path: &str = &effective;
 
-        // Force any WAL frames that are still only in the OS page cache onto
-        // stable storage BEFORE the checkpoint that supersedes them.
-        //
-        // **This is load-bearing for `durable="normal"`, not belt-and-braces.**
-        // The checkpoint below truncates the log, and replay folds whatever
-        // frames survive into net per-entity state. Under `full` every frame
-        // is already on disk at this point, so a crash in the write→truncate
-        // window leaves the *complete* frame set and replaying it reproduces
-        // exactly the checkpointed state — harmless, as the comment further
-        // down says. Under `normal` the tail may still be in the page cache,
-        // so the same crash can leave a *prefix*; folding that prefix over a
-        // newer checkpoint would roll properties back to their values as of
-        // an earlier commit, destroying data that was already durably saved.
-        // Syncing here restores the `full`-mode invariant — at checkpoint
-        // time the on-disk log is complete — and costs one barrier per
-        // save(), against a full serialize-and-fsync that is already running.
+        // Checkpoint steps 1–2, shared with every other owner of a log
+        // (`kglite::api::durable::checkpoint_prologue`): flush frames that are
+        // still only in the OS page cache — load-bearing under
+        // `durable="normal"`, where a crash in the write→truncate window would
+        // otherwise leave a *prefix* whose replay rolls properties back over
+        // this newer checkpoint — and then stamp how far this checkpoint has
+        // consumed the log, so a reopen can *gate* replay instead of trusting
+        // the log's extent. Any ops still sitting in the capture buffer are
+        // folded in by the serialize below and then dropped un-logged, so they
+        // consume no LSN and the stamp's arithmetic stays exact.
         if let Some(ds) = self.lifecycle.durable.as_mut() {
-            ds.wal
-                .sync()
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-        }
-
-        // Stamp how far this checkpoint has consumed the log, so a reopen can
-        // *gate* replay instead of trusting the log's extent.
-        //
-        // The barrier above stops a stale prefix from arising under a clean
-        // crash; it cannot make replay robust to one that arises any other way
-        // (an operator restoring an old sidecar from backup, a copied graph
-        // directory, a filesystem that resurrects a truncated file). The gate
-        // is anchored here, in the checkpoint, because the checkpoint is the
-        // only artifact that knows which frames it already contains.
-        //
-        // `next_lsn` is the LSN the *next* frame will carry, so the newest
-        // frame folded into this snapshot is `next_lsn - 1`; a session that has
-        // logged nothing leaves the stamp at 0 (replay everything, unchanged
-        // behaviour). Any ops still sitting in the capture buffer are folded in
-        // by the serialize below and then dropped un-logged, so they consume no
-        // LSN and the arithmetic stays exact.
-        if let Some(ds) = self.lifecycle.durable.as_ref() {
-            let checkpoint_lsn = ds.next_lsn.saturating_sub(1);
-            get_graph_mut(&mut self.inner).checkpoint_lsn = checkpoint_lsn;
+            let next_lsn = ds.next_lsn;
+            kglite_core::api::durable::checkpoint_prologue(
+                &mut ds.wal,
+                next_lsn,
+                get_graph_mut(&mut self.inner),
+            )
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
         }
 
         // Mode-aware durable save lives in core (`save_graph_with`): disk dir
@@ -664,29 +641,24 @@ impl KnowledgeGraph {
         py.detach(move || io::save_graph_with(inner, path, fsync))
             .map_err(PyErr::new::<pyo3::exceptions::PyIOError, _>)?;
 
-        // Durable checkpoint: the .kgl now holds the full current state, so
-        // discard the capture buffer (those ops are folded in) and truncate
-        // the WAL. Order matters — the .kgl write above succeeded before we
-        // truncate, and replay is idempotent, so a crash between the two
-        // only costs a harmless re-apply on the next open.
-        if self.lifecycle.durable.is_some() {
-            if let kglite_core::api::storage::GraphBackend::Recording(rg) =
-                &mut Arc::make_mut(&mut self.inner).graph
-            {
-                let _ = rg.take_ops();
-            }
-            if let Some(ds) = self.lifecycle.durable.as_mut() {
-                ds.wal
-                    .reset()
-                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-                // `next_lsn` deliberately keeps climbing across the truncation.
-                // Restarting it at 1 would make every post-checkpoint frame
-                // reuse LSNs a pre-checkpoint frame already spent, so the
-                // checkpoint stamp above could never distinguish a stale frame
-                // from a fresh one — and, since the stamp is taken as
-                // `next_lsn - 1`, the very next checkpoint would record 0 and
-                // the replay gate would be vacuous.
-            }
+        // Checkpoint step 4 (`kglite::api::durable::checkpoint_epilogue`): the
+        // .kgl now holds the full current state, so discard the capture buffer
+        // (those ops are folded in) and truncate the WAL. Order matters — the
+        // .kgl write above succeeded before we truncate, and replay is
+        // idempotent, so a crash between the two only costs a harmless re-apply
+        // on the next open. `next_lsn` is deliberately left climbing across the
+        // truncation: restarting it at 1 would make every post-checkpoint frame
+        // reuse an LSN a pre-checkpoint frame already spent, and the stamp above
+        // could never tell a stale frame from a fresh one.
+        if let Some(ds) = self.lifecycle.durable.as_mut() {
+            // `Arc::make_mut` rather than `get_graph_mut`: draining a capture
+            // buffer the save already folded in changes nothing a reader could
+            // observe, so it does not warrant a version bump.
+            kglite_core::api::durable::checkpoint_epilogue(
+                &mut ds.wal,
+                Arc::make_mut(&mut self.inner),
+            )
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
         }
         Ok(())
     }

--- a/crates/kglite-py/src/graph/pyapi/kg_core.rs
+++ b/crates/kglite-py/src/graph/pyapi/kg_core.rs
@@ -637,9 +637,22 @@ impl KnowledgeGraph {
         // directory fsync (when `fsync`). Routing through the one shared
         // dispatch keeps the wheel / MCP server / C ABI from drifting. Release
         // the GIL for the heavy serialize+write.
+        //
+        // The dispatch also enforces the write-ahead rule: a save that would
+        // strand committed frames in front of the checkpoint it writes is
+        // refused before the file is touched. That is a `ValueError` — the
+        // class every other durability refusal raises (`kglite.open` at
+        // `durable='off'` over a live sidecar), and the one a caller catches
+        // to mean "this path is not a safe target as it stands" — while a
+        // genuine write failure stays an `IOError`.
         let inner = &mut self.inner;
         py.detach(move || io::save_graph_with(inner, path, fsync))
-            .map_err(PyErr::new::<pyo3::exceptions::PyIOError, _>)?;
+            .map_err(|error| match error {
+                io::SaveError::Refused(message) => {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>(message)
+                }
+                io::SaveError::Io(message) => PyErr::new::<pyo3::exceptions::PyIOError, _>(message),
+            })?;
 
         // Checkpoint step 4 (`kglite::api::durable::checkpoint_epilogue`): the
         // .kgl now holds the full current state, so discard the capture buffer

--- a/crates/kglite-py/src/lib.rs
+++ b/crates/kglite-py/src/lib.rs
@@ -467,9 +467,11 @@ fn open(
         None if kg.inner.graph.is_disk() => DurabilityLevel::Off,
         None => DurabilityLevel::Full,
     };
-    if level.logs() {
-        setup_durable(&mut kg, &path, level)?;
-    }
+    // Called at every level, including `off`: recovery on open is a decision
+    // about the path's *data*, not only about how future writes are logged, and
+    // an `off` open over an unreplayed sidecar is refused rather than silently
+    // dropping committed writes. See `setup_durable`.
+    setup_durable(&mut kg, &path, level)?;
     Ok(kg)
 }
 
@@ -490,14 +492,23 @@ fn convert_open_graph_to_mode(
     )
 }
 
-/// Turn `kg` into a durable graph: replay any WAL frames committed since
-/// the last checkpoint onto the loaded graph, wrap its backend in the
-/// write-capture layer, and open the WAL for append.
+/// Attach durability to a freshly opened graph: replay any WAL frames
+/// committed since the last checkpoint, wrap the backend in the write-capture
+/// layer, and open the WAL for append.
+///
+/// **Called at every level, `off` included.** The sequence itself lives in
+/// `kglite::api::durable::open_log`, shared with the engine's `Session`, and it
+/// reads the sidecar even at `off` so an open over frames the checkpoint does
+/// not contain is refused instead of silently discarding them at the next
+/// `save()`. What stays here is the binding's half: the disk refusal (whose
+/// message names *this* API's alternative) and the mapping from refusal
+/// category to Python exception class.
 ///
 /// Storage-mode-agnostic by construction: the capture wrapper wraps the
 /// `GraphBackend` enum rather than a concrete backend, and both memory and
 /// mapped graphs mutate the same heap `StableDiGraph` underneath, so one
-/// capture path covers both. Disk is refused — see the error below.
+/// capture path covers both. Disk is refused at every logging level — see the
+/// error below.
 fn setup_durable(
     kg: &mut KnowledgeGraph,
     path: &str,
@@ -508,7 +519,7 @@ fn setup_durable(
     // deferred to a high-level durable-transaction api lift (roadmap Piece 2).
     use kglite_core::api::durable as wal;
 
-    if kg.inner.graph.is_disk() {
+    if level.logs() && kg.inner.graph.is_disk() {
         // `ValueError`, not one of the typed `kglite.*Error` classes, and that
         // is deliberate: `error_py`'s taxonomy reserves the typed hierarchy for
         // *engine* failures and keeps "argument-shape" rejections in their
@@ -535,37 +546,32 @@ fn setup_durable(
             level.name(),
         )));
     }
-    let sync = level
-        .sync_mode()
-        .expect("caller checks level.logs() before setup_durable");
 
-    let wpath = wal::wal_path(std::path::Path::new(path));
-    // Read (do not truncate) any frames committed since the last checkpoint.
-    let frames = wal::recover(&wpath)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    // The whole recover → replay → wrap → open-for-append sequence, plus the
+    // `off`-over-unreplayed-frames refusal, in one shared call. The error
+    // classes are the binding's own: an unreadable sidecar is an `IOError`, a
+    // replay that cannot be applied is a `RuntimeError`, and a refusal joins
+    // the `durable=` rejections above in the built-in `ValueError` family.
+    let opened = wal::open_log(&mut kg.inner, std::path::Path::new(path), level).map_err(|e| {
+        let message = e.to_string();
+        match e {
+            wal::DurableOpenError::Io(_) => PyErr::new::<pyo3::exceptions::PyIOError, _>(message),
+            wal::DurableOpenError::Replay(_) => {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(message)
+            }
+            wal::DurableOpenError::Refused(_) => {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(message)
+            }
+        }
+    })?;
 
-    // Replay onto the (unwrapped) loaded graph, then wrap so subsequent
-    // mutations are captured. Replaying before wrapping keeps the replay's
-    // own GraphWrite calls out of the capture buffer.
-    let dir = crate::graph::get_graph_mut(&mut kg.inner);
-    // Gate replay on what the checkpoint says it already contains. Frames at or
-    // below this LSN are a **stale prefix** — already folded into the `.kgl` we
-    // just loaded — and folding them again would roll properties back to their
-    // values as of an earlier commit. A graph with no durable history (or a
-    // `.kgl` written before the stamp existed) reports 0, i.e. replay
-    // everything, which is the pre-gate behaviour.
-    let checkpoint_lsn = dir.checkpoint_lsn;
-    let max_lsn = kglite_core::api::durable::apply_frames(dir, &frames, checkpoint_lsn)
-        .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)?;
-    KnowledgeGraph::wrap_backend_for_durability(dir);
-
-    let walh = wal::Wal::open(wpath, sync)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
-    kg.lifecycle.durable = Some(crate::graph::DurableState {
-        wal: walh,
-        next_lsn: max_lsn + 1,
-        level,
-    });
+    if let Some((walh, next_lsn)) = opened {
+        kg.lifecycle.durable = Some(crate::graph::DurableState {
+            wal: walh,
+            next_lsn,
+            level,
+        });
+    }
     Ok(())
 }
 

--- a/crates/kglite/src/graph/dir_graph/mod.rs
+++ b/crates/kglite/src/graph/dir_graph/mod.rs
@@ -360,6 +360,12 @@ pub struct DirGraph {
     /// plan-cache key so a cached plan can never leak across graphs.
     #[serde(skip, default = "next_graph_id")]
     pub graph_id: u64,
+    /// High-water mark for engine-minted node ids — see
+    /// [`DirGraph::next_auto_node_id`]. Never serialized: it is re-derived
+    /// from `node_bound()` on first use, so a loaded `.kgl` starts above the
+    /// ids it holds without persisting (or format-breaking for) a counter.
+    #[serde(skip, default)]
+    pub(crate) next_auto_id: u32,
     /// Property key interner: maps InternedKey(u64) → original string.
     /// Populated during ingestion (add_nodes, CREATE, SET) and deserialization.
     /// Skipped during serde — rebuilt on load by the InternedKey Deserialize impl.
@@ -476,6 +482,55 @@ impl DirGraph {
         self.graph_id
     }
 
+    /// Mint the next **engine-assigned** node id, for a `CREATE` that supplied
+    /// no `id` property.
+    ///
+    /// ## Why this is not `node_bound()`
+    ///
+    /// It used to be. `StableDiGraph::node_bound` is an *index-space* bound,
+    /// not an allocator: it shrinks when the highest-indexed nodes are removed,
+    /// and it stalls while `add_node` refills previously-freed slots. So both
+    /// of these minted a live id a second time — silently, since the per-type
+    /// id index is a map and simply drops the loser:
+    ///
+    /// - `CREATE`×5, `DELETE` two, `CREATE`×3 → two nodes with id 5.
+    /// - `CREATE`, `DELETE`, `save()`, `load()`, `CREATE`×3 → *three* nodes
+    ///   sharing one id.
+    ///
+    /// That is engine-side identity corruption, and it is distinct from the
+    /// documented "uniqueness is opt-in" rule (CYPHER.md), which governs ids
+    /// the **caller** supplies: a caller who writes `{id: 1}` twice has asked
+    /// for two nodes and gets a `duplicate_id`-auditable graph, whereas a
+    /// caller who supplies no id has asked the engine for an identity and must
+    /// get a distinct one. It is also how the defect reaches durability: WAL
+    /// replay folds ops by `(node_type, id)`, so a duplicate id makes recovery
+    /// silently *merge* two nodes the live graph kept apart.
+    ///
+    /// The mark is a session-scoped high-water line rather than a persisted
+    /// counter: `max`-ing against `node_bound()` on every call re-seeds it
+    /// above a freshly loaded graph's own ids for free, so no `.kgl` field —
+    /// and no postcard format break — is needed. In the common no-delete case
+    /// the two advance in lockstep and the ids handed out are byte-identical
+    /// to the old ones (0, 1, 2, …).
+    pub(crate) fn next_auto_node_id(&mut self) -> Value {
+        let candidate = self.next_auto_id.max(self.graph.node_bound() as u32);
+        self.next_auto_id = candidate.saturating_add(1);
+        Value::UniqueId(candidate)
+    }
+
+    /// Keep the auto-id high-water mark above an id the *caller* supplied, so
+    /// a later engine-minted id cannot land on it. Cheap enough (one compare)
+    /// to call from every write path that accepts caller ids; a non-integer id
+    /// shares no value space with `UniqueId` and is ignored.
+    pub(crate) fn observe_explicit_id(&mut self, id: &Value) {
+        let seen = match id {
+            Value::UniqueId(u) => *u,
+            Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => *i as u32,
+            _ => return,
+        };
+        self.next_auto_id = self.next_auto_id.max(seen.saturating_add(1));
+    }
+
     /// Set the version directly. Used by [`crate::graph::session::Session::commit`]
     /// to bump the working DirGraph's version on commit-swap. Not
     /// for general use — mutation paths bump version through their
@@ -551,6 +606,7 @@ impl DirGraph {
     pub fn new() -> Self {
         DirGraph {
             graph_id: next_graph_id(),
+            next_auto_id: 0,
             graph: GraphBackend::new(),
             type_indices: TypeIndexStore::new(),
             schema_definition: None,
@@ -608,6 +664,7 @@ impl DirGraph {
     pub fn from_graph(graph: GraphBackend) -> Self {
         DirGraph {
             graph_id: next_graph_id(),
+            next_auto_id: 0,
             graph,
             type_indices: TypeIndexStore::new(),
             schema_definition: None,

--- a/crates/kglite/src/graph/durability.rs
+++ b/crates/kglite/src/graph/durability.rs
@@ -1,0 +1,219 @@
+//! Durable-open and checkpoint orchestration, independent of any binding.
+//!
+//! The engine has shipped the WAL machinery itself since 0.14 (`graph/wal.rs`
+//! for the frame format and recovery scan, `graph/mutation/wal_replay.rs` for
+//! replay, `graph/storage/recording.rs` for write capture). What sits here is
+//! the *orchestration* around it — the orderings that make those pieces add up
+//! to crash safety — so that a durability owner is assembled the same way
+//! whichever binding is doing the assembling.
+//!
+//! Two owners exist today and neither can be expressed in terms of the other:
+//! [`Session`](crate::graph::session::Session) holds its log beside a
+//! `Mutex<Arc<DirGraph>>` and appends between the OCC check and the `Arc` swap,
+//! while the Python wheel's `KnowledgeGraph` holds it beside a graph it mutates
+//! in place and appends after the fact. What they share is exactly what is
+//! here: how a log is opened over a checkpoint, and what a checkpoint does to
+//! the log on the way past.
+//!
+//! ## The orderings that are correctness, not preference
+//!
+//! 1. **Open: recover → replay → wrap → open-for-append** ([`open_log`]).
+//!    Replay must happen *before* the backend is wrapped for capture, or the
+//!    replay's own `GraphWrite` calls land in the capture buffer and get logged
+//!    a second time. Replay is gated on the loaded graph's `checkpoint_lsn`, so
+//!    frames already folded into the `.kgl` are skipped rather than rolled back
+//!    over newer state.
+//!
+//! 2. **Checkpoint: sync → stamp → save → reset** ([`checkpoint_prologue`],
+//!    then the binding's own save, then [`checkpoint_epilogue`]). The flush is
+//!    load-bearing under [`DurabilityLevel::Normal`], where the tail may still
+//!    be in the page cache; the stamp records how far the checkpoint consumed
+//!    the log; the truncation comes last so the `.kgl` is known to have landed
+//!    before the log describing the same commits is destroyed. `next_lsn`
+//!    deliberately keeps climbing across the truncation: restarting it would
+//!    let a stale pre-checkpoint frame carry the same LSN as a fresh one,
+//!    making the replay gate meaningless.
+//!
+//! The third ordering — *append the frame, then publish the commit* — is not
+//! here, because it is not shared: it is a property of how each owner publishes
+//! writes. See [`Session::commit`](crate::graph::session::Session::commit).
+//!
+//! ## Recovery on open is unconditional
+//!
+//! Opening a path is a decision about that path's *data*, not only about how
+//! future writes will be logged. A sidecar carrying frames the loaded
+//! checkpoint does not contain is unrecovered data at every level, so
+//! [`DurabilityLevel::Off`] is refused over one rather than silently returning
+//! a graph that is missing committed writes — the first checkpoint afterwards
+//! would truncate the log and destroy them for good. Frames at or below
+//! `checkpoint_lsn` are the harmless residue of a crash between the `.kgl`
+//! write and the truncation, and are not grounds to refuse.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::handle::make_dir_graph_mut;
+use crate::graph::mutation::wal_replay::apply_frames;
+use crate::graph::storage::recording::wrap_for_durability;
+use crate::graph::wal::{recover, wal_path, DurabilityLevel, Wal, WalFrame};
+
+/// Why [`open_log`] could not hand back a durability owner.
+///
+/// Three categories rather than one string because bindings map them to
+/// different error classes — the Python wheel raises `IOError` for
+/// [`Io`](Self::Io), `RuntimeError` for [`Replay`](Self::Replay) and
+/// `ValueError` for [`Refused`](Self::Refused), and flattening them would
+/// change what a caller's `except` clause catches.
+#[derive(Debug)]
+pub enum DurableOpenError {
+    /// The sidecar could not be read, or could not be opened for append.
+    Io(String),
+    /// The recovered frames could not be applied to the checkpoint.
+    Replay(String),
+    /// The open is structurally unsafe and was refused: unreplayed frames at
+    /// level `off`, or a graph another durability owner already holds.
+    Refused(String),
+}
+
+impl std::fmt::Display for DurableOpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(m) | Self::Replay(m) | Self::Refused(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for DurableOpenError {}
+
+/// Open the write-ahead log for `graph`, checkpointed at `checkpoint_path`,
+/// performing the full recover → replay → wrap → open-for-append ordering.
+///
+/// `checkpoint_path` is the `.kgl` path, not the log path; the sidecar is
+/// derived from it by [`wal_path`] exactly as every binding derives it, so a
+/// graph saved by one and reopened by another finds the same log.
+///
+/// Returns the open log plus the LSN its next frame should carry, or `None` at
+/// [`DurabilityLevel::Off`] — which still *reads* the sidecar, because
+/// recovery on open is unconditional (module docs).
+///
+/// # Refusals
+///
+/// - **Unreplayed frames at level `off`** — the data-loss case the module docs
+///   describe.
+/// - **A graph already wrapped for capture** — the observable signature of
+///   another durable owner over the same data. Two owners sharing one log
+///   interleave their `next_lsn` counters and each checkpoint stamps a
+///   `checkpoint_lsn` the other's frames sit below, so replay silently drops
+///   committed data.
+///
+/// **Disk-mode graphs are the caller's refusal, not this function's.** A disk
+/// graph commits by publishing an immutable generation, so it keeps no logical
+/// log at any level — but `off` on a disk graph is legal, and the message a
+/// binding owes its users names that binding's own save API. Check
+/// `graph.graph.is_disk()` before calling at a logging level.
+pub fn open_log(
+    graph: &mut Arc<DirGraph>,
+    checkpoint_path: &Path,
+    level: DurabilityLevel,
+) -> Result<Option<(Wal, u64)>, DurableOpenError> {
+    let wpath = wal_path(checkpoint_path);
+    // Read (do not truncate) whatever the last session left behind. Torn tails
+    // stop the scan; see `wal::read_frames`.
+    let frames = recover(&wpath).map_err(|e| {
+        DurableOpenError::Io(format!(
+            "failed to read the write-ahead log at '{}': {e}",
+            wpath.display()
+        ))
+    })?;
+    let checkpoint_lsn = graph.checkpoint_lsn;
+
+    if !level.logs() {
+        if unreplayed(&frames, checkpoint_lsn) {
+            return Err(DurableOpenError::Refused(format!(
+                "the write-ahead log at '{}' holds commits this checkpoint does not \
+                 contain, and durability level 'off' would neither replay them nor keep \
+                 them — the next checkpoint would truncate the log and the commits would \
+                 be gone. Open with level 'full' or 'normal' to replay and continue the \
+                 log, or move the sidecar aside first to deliberately discard those \
+                 commits.",
+                wpath.display(),
+            )));
+        }
+        return Ok(None);
+    }
+
+    if graph.graph.is_recording() {
+        return Err(DurableOpenError::Refused(
+            "this graph is already wrapped for durable capture, which means another \
+             durable owner (a durable graph handle, or a Session) holds it. Two owners \
+             over one write-ahead log interleave their log-sequence numbers and each \
+             checkpoint invalidates the other's replay gate, so the second open is \
+             refused. Take a non-durable snapshot for reads, or hand ownership over \
+             instead of duplicating it."
+                .to_string(),
+        ));
+    }
+
+    let sync = level
+        .sync_mode()
+        .expect("level.logs() is true, so sync_mode is Some");
+
+    let dir = make_dir_graph_mut(graph);
+    // Replay BEFORE wrapping: the replay's own writes must not enter the
+    // capture buffer, or the next commit would log them all over again.
+    let max_lsn = apply_frames(dir, &frames, checkpoint_lsn).map_err(DurableOpenError::Replay)?;
+    wrap_for_durability(dir);
+
+    let wal = Wal::open(wpath.clone(), sync).map_err(|e| {
+        DurableOpenError::Io(format!(
+            "failed to open the write-ahead log at '{}': {e}",
+            wpath.display()
+        ))
+    })?;
+    Ok(Some((wal, max_lsn + 1)))
+}
+
+/// Checkpoint steps 1–2: flush the log, then stamp how far this checkpoint
+/// will have consumed it into the graph that is about to be serialized.
+///
+/// The flush is load-bearing under [`DurabilityLevel::Normal`], not
+/// belt-and-braces. The checkpoint truncates the log, and replay folds whatever
+/// frames survive into net per-entity state. Under `full` every frame is
+/// already on disk here, so a crash in the write→truncate window leaves the
+/// *complete* frame set and replaying it reproduces exactly the checkpointed
+/// state. Under `normal` the tail may still be in the page cache, so the same
+/// crash can leave a *prefix*, and folding that prefix over a newer checkpoint
+/// rolls properties back to their values as of an earlier commit — destroying
+/// data that was already durably saved.
+///
+/// `next_lsn` is the LSN the *next* frame will carry, so the newest frame
+/// folded into this snapshot is `next_lsn - 1`. An owner that has logged
+/// nothing leaves the stamp at 0, i.e. replay everything, which is the ungated
+/// behaviour.
+pub fn checkpoint_prologue(wal: &mut Wal, next_lsn: u64, graph: &mut DirGraph) -> io::Result<()> {
+    wal.sync()?;
+    graph.checkpoint_lsn = next_lsn.saturating_sub(1);
+    Ok(())
+}
+
+/// Checkpoint step 4: the `.kgl` now holds the full current state, so drop the
+/// capture buffer (those ops are folded in) and truncate the log.
+///
+/// Ordered after the save on purpose: the checkpoint is known to have landed
+/// before the log that describes the same commits is destroyed, and replay is
+/// idempotent, so a crash between the two costs only a harmless re-apply on the
+/// next open.
+pub fn checkpoint_epilogue(wal: &mut Wal, graph: &mut DirGraph) -> io::Result<()> {
+    if let Some(rg) = graph.graph.recording_mut() {
+        let _ = rg.take_ops();
+    }
+    wal.reset()
+}
+
+/// Whether `frames` hold anything the checkpoint at `checkpoint_lsn` has not
+/// already folded in.
+fn unreplayed(frames: &[WalFrame], checkpoint_lsn: u64) -> bool {
+    frames.iter().any(|f| f.lsn > checkpoint_lsn)
+}

--- a/crates/kglite/src/graph/durability.rs
+++ b/crates/kglite/src/graph/durability.rs
@@ -58,7 +58,15 @@
 //! commit. [`ensure_recovered`] is that refusal, shared so the two openers
 //! decide on identical terms.
 //!
+//! One route stays open even then, because [`load_file`] is deliberately
+//! unguarded (it is the primitive recovery itself is built on): load, mutate,
+//! save back. [`ensure_save_target_recovered`] closes it at the *save*, on the
+//! same predicate — a save whose outgoing `checkpoint_lsn` would leave frames
+//! in front of it is refused, which the four-step checkpoint order makes
+//! impossible for a durable owner's own checkpoint.
+//!
 //! [`open_or_create_graph`]: crate::graph::io::open::open_or_create_graph
+//! [`load_file`]: crate::graph::io::file::load_file
 
 use std::io;
 use std::path::Path;
@@ -245,8 +253,7 @@ pub fn ensure_recovered(
     checkpoint_path: &Path,
     checkpoint_lsn: u64,
 ) -> Result<(), DurableOpenError> {
-    let wpath = wal_path(checkpoint_path);
-    if unreplayed(&read_sidecar(&wpath)?, checkpoint_lsn) {
+    if let Some(wpath) = unrecovered_sidecar(checkpoint_path, checkpoint_lsn)? {
         return Err(DurableOpenError::Refused(format!(
             "the write-ahead log at '{}' holds commits this checkpoint does not contain, \
              and this open attaches no log — it would neither replay them nor keep them, \
@@ -260,8 +267,57 @@ pub fn ensure_recovered(
     Ok(())
 }
 
-/// The exit that is the same whichever open was refused: the frames are only
-/// discardable deliberately, by moving the sidecar out of the way.
+/// Refuse a **checkpoint write** to `checkpoint_path` while its sidecar holds
+/// frames that a graph stamped `checkpoint_lsn` would strand in front of it.
+///
+/// The save-side half of the same rule, for the route [`ensure_recovered`]
+/// cannot cover: [`load_file`] is deliberately unguarded, so a non-durable
+/// owner still *reads* a path whose sidecar runs ahead — and may then save back
+/// over it. That save neither stamps `checkpoint_lsn` nor truncates the log, so
+/// the frames outlive it and the next durable open replays them over the newer
+/// state: data that was saved comes back as an older commit. Refusing the save
+/// closes that without taking the read away.
+///
+/// `checkpoint_lsn` is the stamp the *outgoing* `.kgl` will carry, so the
+/// frames this refuses on are exactly the ones a later durable open would
+/// replay over it — replay is gated on that same stamp. A durable owner's
+/// checkpoint therefore passes by construction rather than by exemption: step 2
+/// of the checkpoint order ([`checkpoint_prologue`]) stamps `next_lsn - 1`
+/// before the save, which is at or above every frame in its own log.
+///
+/// [`load_file`]: crate::graph::io::file::load_file
+pub fn ensure_save_target_recovered(
+    checkpoint_path: &Path,
+    checkpoint_lsn: u64,
+) -> Result<(), DurableOpenError> {
+    if let Some(wpath) = unrecovered_sidecar(checkpoint_path, checkpoint_lsn)? {
+        return Err(DurableOpenError::Refused(format!(
+            "the write-ahead log at '{}' holds commits the graph being saved does not \
+             contain, and saving here would strand them: they sit past this checkpoint's \
+             log-sequence stamp, so a later durable open would replay them back over the \
+             state this save is about to write. Open the graph through a durable entry \
+             point (a durable graph handle, or a Session, at level 'full' or 'normal') to \
+             replay them first, {DISCARD_EXIT}",
+            wpath.display(),
+        )));
+    }
+    Ok(())
+}
+
+/// The one predicate both refusals ask, so an open and a save can never
+/// disagree about what counts as unrecovered: the sidecar path when it holds
+/// frames past `checkpoint_lsn`, `None` when it does not.
+fn unrecovered_sidecar(
+    checkpoint_path: &Path,
+    checkpoint_lsn: u64,
+) -> Result<Option<std::path::PathBuf>, DurableOpenError> {
+    let wpath = wal_path(checkpoint_path);
+    let frames = read_sidecar(&wpath)?;
+    Ok(unreplayed(&frames, checkpoint_lsn).then_some(wpath))
+}
+
+/// The exit that is the same whichever operation was refused: the frames are
+/// only discardable deliberately, by moving the sidecar out of the way.
 const DISCARD_EXIT: &str = "or move the sidecar aside first to deliberately discard those commits.";
 
 /// Read (do not truncate) whatever the last durable owner left behind. Torn

--- a/crates/kglite/src/graph/durability.rs
+++ b/crates/kglite/src/graph/durability.rs
@@ -48,6 +48,17 @@
 //! would truncate the log and destroy them for good. Frames at or below
 //! `checkpoint_lsn` are the harmless residue of a crash between the `.kgl`
 //! write and the truncation, and are not grounds to refuse.
+//!
+//! The same decision is owed by an opener that has no durability argument at
+//! all — the server-style [`open_or_create_graph`] lifecycle — because the
+//! damage is not confined to the missing reads. Such an opener writes and
+//! saves without stamping `checkpoint_lsn` or truncating the sidecar, so the
+//! stale frames outlive the newer `.kgl` and the *next* durable open replays
+//! them over it: state that was already saved is rolled back to an older
+//! commit. [`ensure_recovered`] is that refusal, shared so the two openers
+//! decide on identical terms.
+//!
+//! [`open_or_create_graph`]: crate::graph::io::open::open_or_create_graph
 
 use std::io;
 use std::path::Path;
@@ -119,14 +130,7 @@ pub fn open_log(
     level: DurabilityLevel,
 ) -> Result<Option<(Wal, u64)>, DurableOpenError> {
     let wpath = wal_path(checkpoint_path);
-    // Read (do not truncate) whatever the last session left behind. Torn tails
-    // stop the scan; see `wal::read_frames`.
-    let frames = recover(&wpath).map_err(|e| {
-        DurableOpenError::Io(format!(
-            "failed to read the write-ahead log at '{}': {e}",
-            wpath.display()
-        ))
-    })?;
+    let frames = read_sidecar(&wpath)?;
     let checkpoint_lsn = graph.checkpoint_lsn;
 
     if !level.logs() {
@@ -136,8 +140,7 @@ pub fn open_log(
                  contain, and durability level 'off' would neither replay them nor keep \
                  them — the next checkpoint would truncate the log and the commits would \
                  be gone. Open with level 'full' or 'normal' to replay and continue the \
-                 log, or move the sidecar aside first to deliberately discard those \
-                 commits.",
+                 log, {DISCARD_EXIT}",
                 wpath.display(),
             )));
         }
@@ -210,6 +213,66 @@ pub fn checkpoint_epilogue(wal: &mut Wal, graph: &mut DirGraph) -> io::Result<()
         let _ = rg.take_ops();
     }
     wal.reset()
+}
+
+/// Refuse a **log-less** open of `checkpoint_path` while its sidecar still
+/// holds frames the checkpoint at `checkpoint_lsn` does not contain.
+///
+/// The companion to [`open_log`]'s `off` refusal, for openers that take no
+/// durability argument and attach no log — [`open_or_create_graph`] and every
+/// binding built on it (the MCP and Bolt servers, the CLI). They read the
+/// `.kgl` alone, so without this they open a graph that is silently missing
+/// committed writes and, worse, may then *save* over the path: the save
+/// neither stamps `checkpoint_lsn` nor truncates the sidecar, so the stale
+/// frames survive it and the next durable open replays them over the newer
+/// state. That is a rollback of saved data, not merely a stale read, which is
+/// why the refusal covers reads too — an opener that can later publish cannot
+/// be distinguished at open time from one that only looks.
+///
+/// Frames at or below `checkpoint_lsn` are crash residue between the `.kgl`
+/// write and the truncation, exactly as in [`open_log`], and open fine.
+///
+/// **Not called by [`load_file`].** That is the primitive the durable path is
+/// itself built on — every durable owner loads the checkpoint and *then*
+/// replays — so a guard there would make recovery unreachable. It is also the
+/// documented way to read a graph another process is writing durably, where a
+/// sidecar ahead of the checkpoint is the normal steady state rather than a
+/// fault.
+///
+/// [`open_or_create_graph`]: crate::graph::io::open::open_or_create_graph
+/// [`load_file`]: crate::graph::io::file::load_file
+pub fn ensure_recovered(
+    checkpoint_path: &Path,
+    checkpoint_lsn: u64,
+) -> Result<(), DurableOpenError> {
+    let wpath = wal_path(checkpoint_path);
+    if unreplayed(&read_sidecar(&wpath)?, checkpoint_lsn) {
+        return Err(DurableOpenError::Refused(format!(
+            "the write-ahead log at '{}' holds commits this checkpoint does not contain, \
+             and this open attaches no log — it would neither replay them nor keep them, \
+             and the first save over this path would strand them in front of a newer \
+             checkpoint for a later durable open to replay back over it. Open the graph \
+             through a durable entry point (a durable graph handle, or a Session, at \
+             level 'full' or 'normal') to replay them first, {DISCARD_EXIT}",
+            wpath.display(),
+        )));
+    }
+    Ok(())
+}
+
+/// The exit that is the same whichever open was refused: the frames are only
+/// discardable deliberately, by moving the sidecar out of the way.
+const DISCARD_EXIT: &str = "or move the sidecar aside first to deliberately discard those commits.";
+
+/// Read (do not truncate) whatever the last durable owner left behind. Torn
+/// tails stop the scan; see `wal::read_frames`.
+fn read_sidecar(wpath: &Path) -> Result<Vec<WalFrame>, DurableOpenError> {
+    recover(wpath).map_err(|e| {
+        DurableOpenError::Io(format!(
+            "failed to read the write-ahead log at '{}': {e}",
+            wpath.display()
+        ))
+    })
 }
 
 /// Whether `frames` hold anything the checkpoint at `checkpoint_lsn` has not

--- a/crates/kglite/src/graph/io/file.rs
+++ b/crates/kglite/src/graph/io/file.rs
@@ -1540,7 +1540,7 @@ pub fn save_inmemory_with(graph: &mut Arc<DirGraph>, path: &str, fsync: bool) ->
 /// save-dispatch — the wheel (`KnowledgeGraph::save`), the MCP server,
 /// and the C ABI (`kglite_save_graph`) all route through it so dispatch
 /// + durability behaviour can't drift between bindings.
-pub fn save_graph(graph: &mut Arc<DirGraph>, path: &str) -> Result<(), String> {
+pub fn save_graph(graph: &mut Arc<DirGraph>, path: &str) -> Result<(), SaveError> {
     save_graph_with(graph, path, true)
 }
 
@@ -1549,12 +1549,24 @@ pub fn save_graph(graph: &mut Arc<DirGraph>, path: &str) -> Result<(), String> {
 /// disk-backed graphs persist through `DirGraph::save_disk`, which manages
 /// its own durability, so the flag does not apply to them. `fsync = false`
 /// is the fast, non-durable opt-out (atomic rename, no crash barrier).
-pub fn save_graph_with(graph: &mut Arc<DirGraph>, path: &str, fsync: bool) -> Result<(), String> {
+///
+/// Being the single dispatch, this is also where the *write-ahead* rule is
+/// enforced: a save that would strand unreplayed frames in front of the
+/// checkpoint it writes is refused before the path is touched
+/// ([`save_guard`], and [`SaveError::Refused`] for what a binding does with
+/// it). A durable owner's own checkpoint is never refused — its prologue
+/// stamps `checkpoint_lsn` first.
+pub fn save_graph_with(
+    graph: &mut Arc<DirGraph>,
+    path: &str,
+    fsync: bool,
+) -> Result<(), SaveError> {
+    save_guard::ensure_target_recovered(graph, path)?;
     if graph.graph.is_disk() {
         let dir = crate::graph::handle::make_dir_graph_mut_preserving_lineage(graph);
-        return dir.save_disk(path);
+        return dir.save_disk(path).map_err(SaveError::Io);
     }
-    save_inmemory_with(graph, path, fsync).map_err(|e| e.to_string())
+    save_inmemory_with(graph, path, fsync).map_err(|e| SaveError::Io(e.to_string()))
 }
 
 // ─── Load ────────────────────────────────────────────────────────────────────
@@ -2378,6 +2390,9 @@ fn load_portable_columnar(
 
 mod columns;
 use columns::{attach_portable_column_stores, load_column_sidecars};
+
+mod save_guard;
+pub use save_guard::SaveError;
 
 mod vector_persistence;
 

--- a/crates/kglite/src/graph/io/file.rs
+++ b/crates/kglite/src/graph/io/file.rs
@@ -1619,6 +1619,19 @@ impl<'a> SectionCursor<'a> {
     }
 }
 
+/// Load the `.kgl` checkpoint (or disk-graph directory) at `path`.
+///
+/// **The checkpoint only.** Any write-ahead sidecar beside it is neither read
+/// nor consulted, deliberately: this is the primitive the durable path is
+/// built on — a durable owner loads the checkpoint here and *then* replays the
+/// log over it ([`crate::graph::durability::open_log`]) — so a recovery check
+/// at this level would make recovery itself unreachable. It is also the way to
+/// read a graph another process is writing durably, where a sidecar running
+/// ahead of the checkpoint is the steady state rather than a fault.
+///
+/// A caller that takes the path over — one that may later save back to it —
+/// wants [`crate::graph::io::open::open_or_create_graph`], which adds the
+/// recovery refusal, or a durable open, which replays.
 pub fn load_file(path: &str) -> io::Result<Arc<DirGraph>> {
     // If path is a directory, load as disk graph
     let p = std::path::Path::new(path);

--- a/crates/kglite/src/graph/io/file/save_guard.rs
+++ b/crates/kglite/src/graph/io/file/save_guard.rs
@@ -1,0 +1,307 @@
+//! The save side of the recovery rule: a checkpoint write must not strand
+//! write-ahead frames in front of itself.
+//!
+//! [`crate::graph::durability::ensure_recovered`] refuses an *open* that
+//! attaches no log over a live sidecar. That closes the route through
+//! [`open_or_create_graph`](crate::graph::io::open::open_or_create_graph), but
+//! not the one through [`load_file`](crate::graph::io::file::load_file), which
+//! is deliberately unguarded — it is the primitive durable recovery is built
+//! on, and the documented way to read a graph another process writes durably.
+//!
+//! So the same hazard still reaches the disk through the *other* end: `load`,
+//! mutate, `save` back over the path (`kglite.load()` + `save()`, or a
+//! non-durable `Session::save`). That save neither stamps `checkpoint_lsn` nor
+//! truncates the sidecar, so the frames outlive it and the next durable open
+//! replays them over the newer state — the saved value comes back overwritten
+//! by an older commit. Refusing at the save is what closes it without taking
+//! the read away.
+//!
+//! ## The rule
+//!
+//! A save to `path` is refused while `<path>-wal` holds frames whose `lsn` is
+//! greater than the `checkpoint_lsn` of the graph being written — which is
+//! exactly the set a later durable open would replay *over* the file this save
+//! is about to produce, because replay is gated on the `checkpoint_lsn` the
+//! `.kgl` carries.
+//!
+//! ## Why a durable owner's checkpoint is never caught by it
+//!
+//! Not by an exemption, but by the checkpoint's own ordering: step 2 stamps
+//! `checkpoint_lsn = next_lsn - 1` into the graph *before* the save
+//! ([`checkpoint_prologue`](crate::graph::durability::checkpoint_prologue)), so
+//! every frame in that owner's log sits at or below the stamp and the predicate
+//! is false by construction. The rule therefore needs no "is this the recording
+//! owner?" branch — and gets a property such a branch would have thrown away:
+//! a *recording* graph saved through some route that skipped the prologue
+//! strands its own frames exactly like a non-durable owner does, and is
+//! refused for it. Frames at or below the stamp are crash residue between the
+//! `.kgl` write and the truncation and are not grounds to refuse, exactly as in
+//! [`ensure_recovered`](crate::graph::durability::ensure_recovered).
+
+use std::sync::Arc;
+
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::durability::{ensure_save_target_recovered, DurableOpenError};
+
+/// Why a save did not happen.
+///
+/// Two variants rather than one string because bindings map them to different
+/// error classes — the Python wheel raises `IOError` for [`Io`](Self::Io) and
+/// `ValueError` for [`Refused`](Self::Refused), which is the class every other
+/// durability refusal already raises — and flattening them would change what a
+/// caller's `except` clause catches.
+#[derive(Debug)]
+pub enum SaveError {
+    /// The write itself failed: serialize, temp-file, rename, fsync, or a disk
+    /// generation publish. The path may or may not have been touched.
+    Io(String),
+    /// The save was refused *before* the path was touched, because writing
+    /// here would strand unreplayed write-ahead frames in front of the new
+    /// checkpoint (module docs). Nothing was written.
+    Refused(String),
+}
+
+impl std::fmt::Display for SaveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(m) | Self::Refused(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for SaveError {}
+
+impl From<DurableOpenError> for SaveError {
+    fn from(error: DurableOpenError) -> Self {
+        match error {
+            // An unreadable sidecar is not a refusal — it says nothing about
+            // whether the data is unrecovered, only that we could not look.
+            DurableOpenError::Io(message) | DurableOpenError::Replay(message) => Self::Io(message),
+            DurableOpenError::Refused(message) => Self::Refused(message),
+        }
+    }
+}
+
+/// The guard every save runs before writing `path` (module docs for the rule).
+///
+/// **Cost, measured release-profile 2026-08-13** (min-of-N, machine under
+/// normal load): 3.2 µs when no sidecar exists — a failed `open`, and the
+/// overwhelmingly common case — against 5.5 ms for the whole save of even a
+/// one-node graph, i.e. 0.06%. When a sidecar *does* exist the scan is
+/// proportional to it: 27 µs for one frame, 1.7 ms for 10 000 frames
+/// (350 KB, ~0.17 µs/frame). That is the durable owner's own log at
+/// checkpoint time, and it is bounded by the same thing the checkpoint is:
+/// the truncation at the end of each checkpoint means the log only ever holds
+/// the frames written since the last one.
+pub(crate) fn ensure_target_recovered(graph: &Arc<DirGraph>, path: &str) -> Result<(), SaveError> {
+    ensure_save_target_recovered(std::path::Path::new(path), graph.checkpoint_lsn)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datatypes::Value;
+    use crate::graph::durability::{self, checkpoint_prologue};
+    use crate::graph::io::file::{load_file, save_graph};
+    use crate::graph::storage::GraphRead;
+    use crate::graph::wal::{wal_path, DurabilityLevel, MutationOp, SyncMode, Wal, WalFrame};
+    use std::path::Path;
+
+    fn person_frame(lsn: u64, age: i64) -> WalFrame {
+        WalFrame {
+            lsn,
+            ops: vec![MutationOp::UpsertNode {
+                node_type: "Person".into(),
+                id: Value::Int64(1),
+                title: Value::String("Alice".into()),
+                properties: vec![("age".to_string(), Value::Int64(age))],
+            }],
+        }
+    }
+
+    fn graph_with_person(age: i64) -> Arc<DirGraph> {
+        let mut graph = Arc::new(DirGraph::new());
+        crate::graph::mutation::wal_replay::apply_frames(
+            crate::graph::handle::make_dir_graph_mut(&mut graph),
+            &[person_frame(1, age)],
+            0,
+        )
+        .unwrap();
+        graph
+    }
+
+    fn age_of(graph: &mut Arc<DirGraph>) -> Option<Value> {
+        let dir = crate::graph::handle::make_dir_graph_mut(graph);
+        let idx = dir.lookup_by_id("Person", &Value::Int64(1))?;
+        dir.graph
+            .node_view(idx)
+            .and_then(|n| n.get_field_ref("age").map(|c| c.into_owned()))
+    }
+
+    /// The third route into the same corruption, and the one `load_file`'s
+    /// deliberate lack of a guard leaves open: load the checkpoint (missing a
+    /// committed frame), write, save back. Measured before this guard, through
+    /// the Python wheel: the saved `age=3` came back as `age=2`.
+    ///
+    /// The refusal must name both exits, and — the half that makes refusing
+    /// better than discarding — the commit must still be there for a durable
+    /// open to recover.
+    #[test]
+    fn a_save_that_would_strand_frames_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("graph.kgl");
+        let path_str = path.to_string_lossy().into_owned();
+
+        // A durable owner checkpointed `age=1` at lsn 1, then committed
+        // `age=2` as frame lsn 2 and died before its next checkpoint.
+        let mut seeded = graph_with_person(1);
+        crate::graph::handle::make_dir_graph_mut(&mut seeded).checkpoint_lsn = 1;
+        save_graph(&mut seeded, &path_str).unwrap();
+        Wal::open(wal_path(&path), SyncMode::Barrier)
+            .unwrap()
+            .append(&person_frame(2, 2))
+            .unwrap();
+
+        // A non-durable owner loads the checkpoint (`age=1`, the commit is
+        // invisible to it), writes `age=3`, and saves back over the path.
+        let mut loaded = load_file(&path_str).unwrap();
+        crate::graph::mutation::wal_replay::apply_frames(
+            crate::graph::handle::make_dir_graph_mut(&mut loaded),
+            &[person_frame(3, 3)],
+            2,
+        )
+        .unwrap();
+        let refusal = match save_graph(&mut loaded, &path_str) {
+            Err(SaveError::Refused(message)) => message,
+            other => panic!("a save that would strand committed frames must be refused: {other:?}"),
+        };
+        assert!(refusal.contains("graph.kgl-wal"), "{refusal}");
+        assert!(refusal.contains("'full' or 'normal'"), "{refusal}");
+        assert!(refusal.contains("move the sidecar aside"), "{refusal}");
+
+        // Nothing was written, and nothing was consumed: the checkpoint still
+        // holds the value it did, and the commit is still recoverable durably.
+        let mut untouched = load_file(&path_str).unwrap();
+        assert_eq!(age_of(&mut untouched), Some(Value::Int64(1)));
+        let mut recovered = load_file(&path_str).unwrap();
+        durability::open_log(&mut recovered, &path, DurabilityLevel::Full).unwrap();
+        assert_eq!(age_of(&mut recovered), Some(Value::Int64(2)));
+    }
+
+    /// The boundary, from both sides, so the comparison cannot drift: a frame
+    /// the checkpoint being written already contains is crash residue and
+    /// saves fine (`>=` would refuse it); one frame past it is unrecovered
+    /// data (`>` reversed, or `<`, would let it through).
+    #[test]
+    fn frames_at_or_below_the_checkpoint_still_save() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let residue = tmp.path().join("residue.kgl");
+        let mut folded = graph_with_person(1);
+        crate::graph::handle::make_dir_graph_mut(&mut folded).checkpoint_lsn = 7;
+        Wal::open(wal_path(&residue), SyncMode::Barrier)
+            .unwrap()
+            .append(&person_frame(7, 9))
+            .unwrap();
+        save_graph(&mut folded, &residue.to_string_lossy())
+            .expect("a frame the checkpoint already folded in is harmless residue");
+
+        let ahead = tmp.path().join("ahead.kgl");
+        let mut same = graph_with_person(1);
+        crate::graph::handle::make_dir_graph_mut(&mut same).checkpoint_lsn = 7;
+        Wal::open(wal_path(&ahead), SyncMode::Barrier)
+            .unwrap()
+            .append(&person_frame(8, 9))
+            .unwrap();
+        assert!(
+            matches!(
+                save_graph(&mut same, &ahead.to_string_lossy()),
+                Err(SaveError::Refused(_))
+            ),
+            "one frame past the checkpoint would be replayed over this save"
+        );
+    }
+
+    /// A virgin path — no sidecar at all — is the overwhelmingly common save,
+    /// and must be untouched by any of this.
+    #[test]
+    fn a_path_with_no_sidecar_saves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fresh.kgl");
+        save_graph(&mut graph_with_person(1), &path.to_string_lossy()).unwrap();
+        assert!(path.exists());
+    }
+
+    /// The durable owner's checkpoint, in the four-step order the format
+    /// requires, over its own live sidecar: the prologue stamps
+    /// `checkpoint_lsn` *before* the save, so its own frames are at or below
+    /// the stamp and the guard has nothing to refuse.
+    ///
+    /// This is what makes the guard safe without a "recording owner" branch —
+    /// and it is asserted here rather than left to the Python durability suite
+    /// because it is the ordering, not the graph's backend, that exempts it.
+    #[test]
+    fn a_durable_checkpoint_over_its_own_log_is_unaffected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("durable.kgl");
+        let path_str = path.to_string_lossy().into_owned();
+
+        // A durable owner: log opened over the checkpoint, one commit logged.
+        let mut graph = graph_with_person(1);
+        let (mut wal, next_lsn) = durability::open_log(&mut graph, &path, DurabilityLevel::Full)
+            .unwrap()
+            .expect("a logging level attaches a log");
+        wal.append(&person_frame(next_lsn, 2)).unwrap();
+        let next_lsn = next_lsn + 1;
+
+        // Steps 1–2, then the save that would otherwise look exactly like the
+        // stranding case above.
+        checkpoint_prologue(
+            &mut wal,
+            next_lsn,
+            crate::graph::handle::make_dir_graph_mut(&mut graph),
+        )
+        .unwrap();
+        save_graph(&mut graph, &path_str).expect("a durable checkpoint must not refuse itself");
+
+        // And without the stamp — the mutation that proves the exemption is
+        // the ordering — the same save is refused.
+        let unstamped = tmp.path().join("unstamped.kgl");
+        let mut skipped = graph_with_person(1);
+        Wal::open(wal_path(&unstamped), SyncMode::Barrier)
+            .unwrap()
+            .append(&person_frame(1, 2))
+            .unwrap();
+        assert!(
+            matches!(
+                save_graph(&mut skipped, &unstamped.to_string_lossy()),
+                Err(SaveError::Refused(_))
+            ),
+            "a save that skips the checkpoint stamp strands the frames it left behind"
+        );
+    }
+
+    /// A disk graph is a directory, and disk mode keeps no logical log, so the
+    /// guard must not invent one — but a sidecar sitting beside the directory
+    /// path is the same hazard and is refused there too.
+    #[test]
+    fn disk_directories_save_without_a_sidecar_and_refuse_with_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("disk");
+        let mut graph = graph_with_person(1);
+        crate::graph::handle::make_dir_graph_mut(&mut graph)
+            .enable_disk_mode()
+            .unwrap();
+        save_graph(&mut graph, &root.to_string_lossy()).expect("a disk publish needs no sidecar");
+
+        Wal::open(wal_path(Path::new(&root)), SyncMode::Barrier)
+            .unwrap()
+            .append(&person_frame(1, 2))
+            .unwrap();
+        assert!(matches!(
+            save_graph(&mut graph, &root.to_string_lossy()),
+            Err(SaveError::Refused(_))
+        ));
+    }
+}

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -13,6 +13,7 @@ use crate::graph::io::file::load_file;
 use crate::graph::storage::mode::{
     convert_dir_graph_to_mode, live_storage_mode, new_dir_graph_in_mode, StorageMode,
 };
+use crate::graph::wal::DurabilityLevel;
 
 /// How [`open_or_create_graph`] obtained the returned graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -366,10 +367,23 @@ impl GraphFileIdentity {
 /// The graph comes back with **no write-ahead log attached**, so a path whose
 /// sidecar still holds unfolded frames is refused rather than opened — see
 /// [`crate::graph::durability::ensure_recovered`] for why that refusal covers
-/// reads as well as writes.
+/// reads as well as writes. A caller that *will* attach a log immediately
+/// afterwards wants [`open_or_create_graph_in_mode`], whose `attaching_log`
+/// argument stands the refusal down because that log is the recovery.
 pub fn open_or_create_graph(
     path: &Path,
     create_mode: Option<StorageMode>,
+) -> io::Result<OpenGraphResult> {
+    open_or_create_graph_logged(path, create_mode, DurabilityLevel::Off)
+}
+
+/// [`open_or_create_graph`], plus the caller's declaration of the log it is
+/// about to attach. Private because the two public entry points express the
+/// same choice in the vocabulary their own callers have.
+fn open_or_create_graph_logged(
+    path: &Path,
+    create_mode: Option<StorageMode>,
+    attaching_log: DurabilityLevel,
 ) -> io::Result<OpenGraphResult> {
     match std::fs::metadata(path) {
         Ok(_) => {
@@ -382,7 +396,9 @@ pub fn open_or_create_graph(
                     format!("graph path {} changed while it was loading", path.display()),
                 ));
             }
-            unrecovered_sidecar_check(path, graph.checkpoint_lsn)?;
+            if !attaching_log.logs() {
+                unrecovered_sidecar_check(path, graph.checkpoint_lsn)?;
+            }
             return Ok(OpenGraphResult {
                 graph,
                 disposition: OpenDisposition::Opened,
@@ -407,8 +423,13 @@ pub fn open_or_create_graph(
     // surviving a stale checkpoint, and worse-signposted: a fresh graph has
     // `checkpoint_lsn` 0, so every frame in it would replay over whatever this
     // caller saves here. Checked before the graph is created, so a refused
-    // disk-mode open leaves no directory behind.
-    unrecovered_sidecar_check(path, 0)?;
+    // disk-mode open leaves no directory behind. A caller attaching a log is
+    // exempt for the same reason as above — it replays the orphaned frames onto
+    // the fresh graph, which is recovery from a lost checkpoint rather than a
+    // rollback of a newer one.
+    if !attaching_log.logs() {
+        unrecovered_sidecar_check(path, 0)?;
+    }
     let graph = new_dir_graph_in_mode(mode, Some(path))
         .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))?;
     Ok(OpenGraphResult {
@@ -448,11 +469,36 @@ fn unrecovered_sidecar_check(path: &Path, checkpoint_lsn: u64) -> io::Result<()>
 /// Requests that have no conversion (either disk direction) fail here with the
 /// reason and the alternative named, instead of serving a mode nobody asked
 /// for.
+///
+/// # `attaching_log`
+///
+/// The level of the write-ahead log the caller will attach to this graph
+/// *immediately* after this call — [`Session::open_durable`] or a binding's
+/// durable graph handle. [`DurabilityLevel::Off`] means none, and is what every
+/// caller without a durability story passes.
+///
+/// It is asked here because recovery-on-open is unconditional
+/// ([`crate::graph::durability`]): a sidecar holding frames this checkpoint does
+/// not contain makes a **log-less** open a refusal, since nothing would replay
+/// them and the first save over the path would strand them. A caller that
+/// attaches a log at a logging level *is* the recovery — `open_durable` replays
+/// those frames before the first commit — so for it the same sidecar is the
+/// normal state after a crash, not a fault. Declaring the level rather than
+/// inferring it keeps that decision at the one place that knows the answer: a
+/// server whose `--durability` is `off` still gets the refusal, and a graph
+/// created at a logging level over an orphaned sidecar replays it instead of
+/// discarding it.
+///
+/// The caller must actually attach the log. Passing a logging level and then
+/// not opening one leaves exactly the hazard the refusal exists to stop.
+///
+/// [`Session::open_durable`]: crate::graph::session::Session::open_durable
 pub fn open_or_create_graph_in_mode(
     path: &Path,
     requested: Option<StorageMode>,
+    attaching_log: DurabilityLevel,
 ) -> io::Result<OpenGraphResult> {
-    let mut opened = open_or_create_graph(path, requested)?;
+    let mut opened = open_or_create_graph_logged(path, requested, attaching_log)?;
     let Some(requested) = requested else {
         return Ok(opened);
     };
@@ -537,9 +583,10 @@ mod tests {
         checkpoint_with_pending_frame(&path, 0, 1, 1);
 
         // The MCP server's opener — no WAL awareness at all.
-        let refusal = open_or_create_graph_in_mode(&path, Some(StorageMode::Memory))
-            .err()
-            .expect("an open that attaches no log must not proceed over unfolded frames");
+        let refusal =
+            open_or_create_graph_in_mode(&path, Some(StorageMode::Memory), DurabilityLevel::Off)
+                .err()
+                .expect("an open that attaches no log must not proceed over unfolded frames");
         assert_eq!(refusal.kind(), io::ErrorKind::InvalidData);
         let message = refusal.to_string();
         assert!(message.contains("graph.kgl-wal"), "{message}");
@@ -552,6 +599,54 @@ mod tests {
         let mut recovered = crate::graph::io::file::load_file(&path.to_string_lossy()).unwrap();
         crate::graph::durability::open_log(&mut recovered, &path, DurabilityLevel::Full).unwrap();
         assert_eq!(age_of(&mut recovered), Some(Value::Int64(2)));
+    }
+
+    /// The other half of the same rule: a caller that says it is about to
+    /// attach a log opens the *identical* path fine, because its log is the
+    /// recovery. Both directions asserted here and above, so neither an
+    /// always-guard nor a never-guard implementation can pass: dropping the
+    /// `attaching_log.logs()` test makes this one fail, and inverting it makes
+    /// the refusal test above fail.
+    #[test]
+    fn a_caller_attaching_a_log_opens_the_same_stale_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("graph.kgl");
+        checkpoint_with_pending_frame(&path, 0, 1, 1);
+
+        for level in [DurabilityLevel::Full, DurabilityLevel::Normal] {
+            let opened = open_or_create_graph_in_mode(&path, Some(StorageMode::Memory), level)
+                .unwrap_or_else(|e| panic!("durable={} must open to recover: {e}", level.name()));
+            let mut graph = opened.graph;
+            // The frames are still there, and the log this caller now attaches
+            // replays them — the recovery the refusal was protecting.
+            assert_eq!(age_of(&mut graph), Some(Value::Int64(1)));
+            crate::graph::durability::open_log(&mut graph, &path, level).unwrap();
+            assert_eq!(age_of(&mut graph), Some(Value::Int64(2)));
+        }
+    }
+
+    /// A sidecar that outlived its checkpoint entirely: at `off` the creation
+    /// path refuses (the frames would be stranded in front of a brand-new
+    /// graph), and a caller attaching a log recovers them onto it instead.
+    #[test]
+    fn an_orphaned_sidecar_refuses_creation_but_replays_for_a_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("orphan.kgl");
+        let mut wal = Wal::open(wal_path(&path), SyncMode::Barrier).unwrap();
+        wal.append(&person_frame(1, 42)).unwrap();
+        drop(wal);
+
+        open_or_create_graph_in_mode(&path, Some(StorageMode::Memory), DurabilityLevel::Off)
+            .err()
+            .expect("creating over an orphaned sidecar strands its commits");
+
+        let opened =
+            open_or_create_graph_in_mode(&path, Some(StorageMode::Memory), DurabilityLevel::Full)
+                .expect("a durable creator recovers the orphaned commits");
+        assert_eq!(opened.disposition, OpenDisposition::Created);
+        let mut graph = opened.graph;
+        crate::graph::durability::open_log(&mut graph, &path, DurabilityLevel::Full).unwrap();
+        assert_eq!(age_of(&mut graph), Some(Value::Int64(42)));
     }
 
     /// Crash residue — frames the checkpoint already folded in — is not

--- a/crates/kglite/src/graph/io/open.rs
+++ b/crates/kglite/src/graph/io/open.rs
@@ -362,6 +362,11 @@ impl GraphFileIdentity {
 /// A caller that may later publish to `path` must hold its own cross-process
 /// writer lease across the read/modify/save interval. Read-only callers should
 /// not acquire such a lease merely to open a graph.
+///
+/// The graph comes back with **no write-ahead log attached**, so a path whose
+/// sidecar still holds unfolded frames is refused rather than opened — see
+/// [`crate::graph::durability::ensure_recovered`] for why that refusal covers
+/// reads as well as writes.
 pub fn open_or_create_graph(
     path: &Path,
     create_mode: Option<StorageMode>,
@@ -377,6 +382,7 @@ pub fn open_or_create_graph(
                     format!("graph path {} changed while it was loading", path.display()),
                 ));
             }
+            unrecovered_sidecar_check(path, graph.checkpoint_lsn)?;
             return Ok(OpenGraphResult {
                 graph,
                 disposition: OpenDisposition::Opened,
@@ -397,6 +403,12 @@ pub fn open_or_create_graph(
             ),
         )
     })?;
+    // A sidecar surviving a *deleted* checkpoint is the same hazard as one
+    // surviving a stale checkpoint, and worse-signposted: a fresh graph has
+    // `checkpoint_lsn` 0, so every frame in it would replay over whatever this
+    // caller saves here. Checked before the graph is created, so a refused
+    // disk-mode open leaves no directory behind.
+    unrecovered_sidecar_check(path, 0)?;
     let graph = new_dir_graph_in_mode(mode, Some(path))
         .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))?;
     Ok(OpenGraphResult {
@@ -404,6 +416,18 @@ pub fn open_or_create_graph(
         disposition: OpenDisposition::Created,
         identity: GraphFileIdentity::capture(path)?,
         converted_from: None,
+    })
+}
+
+/// The log-less half of the recovery-on-open rule, in the error type this
+/// module speaks. [`DurableOpenError::Refused`] becomes [`io::ErrorKind::InvalidData`]
+/// — the path's on-disk state is not something this entry point can safely
+/// open — while an unreadable sidecar stays an uncategorised I/O failure, since
+/// it says nothing about the data's shape.
+fn unrecovered_sidecar_check(path: &Path, checkpoint_lsn: u64) -> io::Result<()> {
+    crate::graph::durability::ensure_recovered(path, checkpoint_lsn).map_err(|e| match e {
+        crate::graph::durability::DurableOpenError::Io(message) => io::Error::other(message),
+        other => io::Error::new(io::ErrorKind::InvalidData, other.to_string()),
     })
 }
 
@@ -451,8 +475,125 @@ pub fn open_or_create_graph_in_mode(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::datatypes::Value;
     use crate::graph::storage::GraphRead;
+    use crate::graph::wal::{wal_path, DurabilityLevel, MutationOp, SyncMode, Wal, WalFrame};
     use std::process::Command;
+
+    /// Seed a checkpoint at `path` holding `Person 1` with `age` and stamped
+    /// `checkpoint_lsn`, then leave the sidecar holding one frame at `lsn` that
+    /// upserts the same node with `age + 1` — the residue a durable writer
+    /// leaves when it dies between a commit and its next checkpoint.
+    fn checkpoint_with_pending_frame(path: &Path, checkpoint_lsn: u64, age: i64, lsn: u64) {
+        let mut graph = Arc::new(DirGraph::new());
+        crate::graph::mutation::wal_replay::apply_frames(
+            crate::graph::handle::make_dir_graph_mut(&mut graph),
+            &[person_frame(1, age)],
+            0,
+        )
+        .unwrap();
+        crate::graph::handle::make_dir_graph_mut(&mut graph).checkpoint_lsn = checkpoint_lsn;
+        crate::graph::io::file::save_graph(&mut graph, &path.to_string_lossy()).unwrap();
+
+        let mut wal = Wal::open(wal_path(path), SyncMode::Barrier).unwrap();
+        wal.append(&person_frame(lsn, age + 1)).unwrap();
+    }
+
+    fn person_frame(lsn: u64, age: i64) -> WalFrame {
+        WalFrame {
+            lsn,
+            ops: vec![MutationOp::UpsertNode {
+                node_type: "Person".into(),
+                id: Value::Int64(1),
+                title: Value::String("Alice".into()),
+                properties: vec![("age".to_string(), Value::Int64(age))],
+            }],
+        }
+    }
+
+    fn age_of(graph: &mut Arc<DirGraph>) -> Option<Value> {
+        let dir = crate::graph::handle::make_dir_graph_mut(graph);
+        let idx = dir.lookup_by_id("Person", &Value::Int64(1))?;
+        dir.graph
+            .node_view(idx)
+            .and_then(|n| n.get_field_ref("age").map(|c| c.into_owned()))
+    }
+
+    /// The end-to-end hazard this guard closes: an opener that never consults
+    /// the WAL used to open such a path, write, and save — and because that
+    /// save neither stamps `checkpoint_lsn` nor truncates the sidecar, the
+    /// next *durable* open replayed the stale frames over the newer state.
+    /// Measured before the guard: the saved `age=3` came back as `age=2`.
+    ///
+    /// The open is now refused, so the sequence cannot start; the committed
+    /// frame is still there for a durable open to recover, which is the whole
+    /// point of refusing rather than silently discarding it.
+    #[test]
+    fn a_stale_sidecar_cannot_be_replayed_over_a_newer_save() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("graph.kgl");
+        // Checkpoint holds age=1; a durable writer committed age=2 as frame
+        // lsn 1 and died before checkpointing.
+        checkpoint_with_pending_frame(&path, 0, 1, 1);
+
+        // The MCP server's opener — no WAL awareness at all.
+        let refusal = open_or_create_graph_in_mode(&path, Some(StorageMode::Memory))
+            .err()
+            .expect("an open that attaches no log must not proceed over unfolded frames");
+        assert_eq!(refusal.kind(), io::ErrorKind::InvalidData);
+        let message = refusal.to_string();
+        assert!(message.contains("graph.kgl-wal"), "{message}");
+        assert!(message.contains("holds commits this checkpoint does not contain"));
+        // Both exits named: replay them, or discard them deliberately.
+        assert!(message.contains("'full' or 'normal'"), "{message}");
+        assert!(message.contains("move the sidecar aside"), "{message}");
+
+        // Nothing was consumed: the commit is still recoverable durably.
+        let mut recovered = crate::graph::io::file::load_file(&path.to_string_lossy()).unwrap();
+        crate::graph::durability::open_log(&mut recovered, &path, DurabilityLevel::Full).unwrap();
+        assert_eq!(age_of(&mut recovered), Some(Value::Int64(2)));
+    }
+
+    /// Crash residue — frames the checkpoint already folded in — is not
+    /// grounds to refuse, exactly as at `durable='off'`. The boundary is
+    /// asserted from both sides so the comparison cannot drift: `lsn ==
+    /// checkpoint_lsn` is folded in (`>=` would refuse it), `lsn ==
+    /// checkpoint_lsn + 1` is not (`>` on a wrong operand order, or a `<`,
+    /// would let it through).
+    #[test]
+    fn frames_at_or_below_the_checkpoint_still_open() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let folded = tmp.path().join("folded.kgl");
+        checkpoint_with_pending_frame(&folded, 7, 1, 7);
+        let opened = open_or_create_graph(&folded, Some(StorageMode::Memory))
+            .expect("a frame the checkpoint already contains is harmless residue");
+        assert_eq!(opened.disposition, OpenDisposition::Opened);
+
+        let ahead = tmp.path().join("ahead.kgl");
+        checkpoint_with_pending_frame(&ahead, 7, 1, 8);
+        assert!(
+            open_or_create_graph(&ahead, Some(StorageMode::Memory)).is_err(),
+            "one frame past the checkpoint is unrecovered data"
+        );
+    }
+
+    /// A sidecar outliving a *deleted* checkpoint is the same hazard wearing a
+    /// missing file: the fresh graph starts at `checkpoint_lsn` 0, so every
+    /// frame in the sidecar would replay over whatever this caller saves.
+    #[test]
+    fn a_live_sidecar_beside_a_missing_checkpoint_refuses_creation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("gone.kgl");
+        let mut wal = Wal::open(wal_path(&path), SyncMode::Barrier).unwrap();
+        wal.append(&person_frame(1, 2)).unwrap();
+
+        let refusal = open_or_create_graph(&path, Some(StorageMode::Memory))
+            .err()
+            .expect("creating over a live sidecar must be refused");
+        assert_eq!(refusal.kind(), io::ErrorKind::InvalidData);
+        assert!(!path.exists(), "a refused open must leave no graph behind");
+    }
 
     #[test]
     fn missing_path_requires_explicit_create_mode() {

--- a/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/tests/mutations.rs
@@ -76,6 +76,59 @@ fn test_create_rejects_duplicate_primary_key() {
     assert_eq!(graph.graph.node_count(), 3);
 }
 
+/// Every id the *engine* mints must be unique — a `CREATE` with no `id`
+/// property asks the engine for an identity, so handing out one that is
+/// already live is engine-side identity corruption, not the documented
+/// "uniqueness is opt-in" behaviour (which is about ids the *caller*
+/// supplies).
+///
+/// The regression: the allocator was `Value::UniqueId(node_bound())`, and
+/// `StableDiGraph::node_bound` is neither monotonic nor injective — it
+/// shrinks when the highest nodes are deleted and stalls while freed slots
+/// are refilled. So `DELETE` followed by `CREATE` re-minted a live id, and
+/// the resulting duplicate is silently *merged* by WAL replay (recovery is
+/// keyed on `(node_type, id)`), turning it into durable data loss.
+#[test]
+fn test_auto_assigned_ids_are_never_reused_after_delete() {
+    fn run(g: &mut DirGraph, q: &str) {
+        let query = parser::parse_cypher(q).unwrap();
+        execute_mutable(
+            g,
+            &query,
+            HashMap::new(),
+            crate::graph::algorithms::Interrupt::default(),
+        )
+        .unwrap();
+    }
+    fn live_ids(g: &DirGraph) -> Vec<Value> {
+        g.graph
+            .node_indices()
+            .filter_map(|i| g.graph.node_view(i).map(|n| n.id().into_owned()))
+            .collect()
+    }
+
+    let mut graph = DirGraph::new();
+    for i in 0..5 {
+        run(&mut graph, &format!("CREATE (n:T {{tag: 'a{i}'}})"));
+    }
+    // Free two slots in the middle of the index space.
+    run(
+        &mut graph,
+        "MATCH (n:T) WHERE n.tag IN ['a3','a4'] DELETE n",
+    );
+    for i in 0..3 {
+        run(&mut graph, &format!("CREATE (n:T {{tag: 'b{i}'}})"));
+    }
+
+    let ids = live_ids(&graph);
+    let unique: std::collections::HashSet<&Value> = ids.iter().collect();
+    assert_eq!(
+        unique.len(),
+        ids.len(),
+        "engine-minted ids collided after DELETE: {ids:?}"
+    );
+}
+
 #[test]
 fn test_create_node_with_properties() {
     let mut graph = DirGraph::new();

--- a/crates/kglite/src/graph/languages/cypher/executor/write.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/write.rs
@@ -872,9 +872,17 @@ fn create_node(
     // The `id` is the identity, not a duplicate property, so it is removed
     // from the property map (mirroring add_nodes, which does not store the
     // unique-id column as a property). Absent → auto-assign a fresh UniqueId.
-    let id = properties
-        .remove("id")
-        .unwrap_or_else(|| Value::UniqueId(graph.graph.node_bound() as u32));
+    // A caller-supplied id is taken as given (uniqueness is opt-in — see the
+    // PRIMARY KEY gate below); an absent one is *allocated*, and an allocator
+    // must never hand out a live id. See `DirGraph::next_auto_node_id` for the
+    // node_bound() reuse bug this replaced.
+    let id = match properties.remove("id") {
+        Some(explicit) => {
+            graph.observe_explicit_id(&explicit);
+            explicit
+        }
+        None => graph.next_auto_node_id(),
+    };
 
     // Determine title: use 'name' or 'title' property if present
     let title = properties

--- a/crates/kglite/src/graph/mod.rs
+++ b/crates/kglite/src/graph/mod.rs
@@ -12,6 +12,7 @@ pub mod blueprint;
 pub mod constraints;
 pub mod core;
 pub mod dir_graph;
+pub mod durability;
 pub mod embedder;
 pub mod embedding_carry;
 pub mod embeddings;

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -284,6 +284,36 @@ impl RowBuilder<'_> {
     }
 }
 
+/// Parse the user-facing `conflict_handling` option shared by `add_nodes`
+/// and `add_connections`; `None` and `"update"` are the default mode.
+fn parse_conflict_mode(option: Option<&str>) -> Result<ConflictHandling, String> {
+    match option {
+        Some("replace") => Ok(ConflictHandling::Replace),
+        Some("skip") => Ok(ConflictHandling::Skip),
+        Some("preserve") => Ok(ConflictHandling::Preserve),
+        Some("sum") => Ok(ConflictHandling::Sum),
+        Some("update") | None => Ok(ConflictHandling::Update),
+        Some(other) => Err(format!(
+            "Unknown conflict handling mode: '{}'. Valid options: 'update' (default), 'replace', 'skip', 'preserve', 'sum'",
+            other
+        )),
+    }
+}
+
+/// Track the numeric ids a bulk load supplies, so the engine's auto-id
+/// high-water mark can be raised past them once after the row loop (see
+/// `DirGraph::next_auto_node_id` — an unraised mark would let a later
+/// bare `CREATE` mint a live id).
+fn note_loaded_id(max_loaded_id: &mut u32, id: &Value) {
+    match id {
+        Value::UniqueId(u) => *max_loaded_id = (*max_loaded_id).max(*u),
+        Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => {
+            *max_loaded_id = (*max_loaded_id).max(*i as u32)
+        }
+        _ => {}
+    }
+}
+
 pub fn add_nodes(
     graph: &mut DirGraph,
     df_data: DataFrame,
@@ -301,18 +331,7 @@ pub fn add_nodes(
     graph
         .prepare_disk_mutation()
         .map_err(|e| format!("disk mutation lease failed: {e}"))?;
-    // Parse conflict handling option
-    let conflict_mode = match conflict_handling.as_deref() {
-        Some("replace") => ConflictHandling::Replace,
-        Some("skip") => ConflictHandling::Skip,
-        Some("preserve") => ConflictHandling::Preserve,
-        Some("sum") => ConflictHandling::Sum,
-        Some("update") | None => ConflictHandling::Update, // Default
-        Some(other) => return Err(format!(
-            "Unknown conflict handling mode: '{}'. Valid options: 'update' (default), 'replace', 'skip', 'preserve', 'sum'",
-            other
-        )),
-    };
+    let conflict_mode = parse_conflict_mode(conflict_handling.as_deref())?;
 
     let should_update_title = node_title_field.is_some();
     let title_field = node_title_field.unwrap_or_else(|| unique_id_field.clone());
@@ -479,13 +498,7 @@ pub fn add_nodes(
             }
         };
 
-        match &id {
-            Value::UniqueId(u) => max_loaded_id = max_loaded_id.max(*u),
-            Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => {
-                max_loaded_id = max_loaded_id.max(*i as u32)
-            }
-            _ => {}
-        }
+        note_loaded_id(&mut max_loaded_id, &id);
 
         if pk_enforced && !seen_pk_ids.insert(id.clone()) {
             return Err(format!(
@@ -740,18 +753,7 @@ pub fn add_connections(
     graph
         .prepare_disk_mutation()
         .map_err(|e| format!("disk mutation lease failed: {e}"))?;
-    // Parse conflict handling option
-    let conflict_mode = match conflict_handling.as_deref() {
-        Some("replace") => ConflictHandling::Replace,
-        Some("skip") => ConflictHandling::Skip,
-        Some("preserve") => ConflictHandling::Preserve,
-        Some("sum") => ConflictHandling::Sum,
-        Some("update") | None => ConflictHandling::Update, // Default
-        Some(other) => return Err(format!(
-            "Unknown conflict handling mode: '{}'. Valid options: 'update' (default), 'replace', 'skip', 'preserve', 'sum'",
-            other
-        )),
-    };
+    let conflict_mode = parse_conflict_mode(conflict_handling.as_deref())?;
 
     // Track errors
     let mut errors = Vec::new();

--- a/crates/kglite/src/graph/mutation/maintain.rs
+++ b/crates/kglite/src/graph/mutation/maintain.rs
@@ -457,6 +457,13 @@ pub fn add_nodes(
     let mut batch_claims: std::collections::HashSet<(UniqueConstraintKey, CompositeValue)> =
         std::collections::HashSet::new();
 
+    // Loaded ids raise the engine's auto-id high-water mark (applied once
+    // after the loop, so the borrow stays out of the hot row path). Without
+    // it, a load of sparse ids — one row with id 5 into an empty graph —
+    // leaves the mark at 0 and a later `CREATE` with no `id` walks up onto a
+    // live id. See `DirGraph::next_auto_node_id`.
+    let mut max_loaded_id: u32 = 0;
+
     for row_idx in 0..df_data.row_count() {
         let id = match df_data.get_value_by_index(row_idx, id_idx) {
             Some(Value::Null) => {
@@ -471,6 +478,14 @@ pub fn add_nodes(
                 continue;
             }
         };
+
+        match &id {
+            Value::UniqueId(u) => max_loaded_id = max_loaded_id.max(*u),
+            Value::Int64(i) if *i >= 0 && *i <= u32::MAX as i64 => {
+                max_loaded_id = max_loaded_id.max(*i as u32)
+            }
+            _ => {}
+        }
 
         if pk_enforced && !seen_pk_ids.insert(id.clone()) {
             return Err(format!(
@@ -508,6 +523,8 @@ pub fn add_nodes(
         let action = row_builder.action(graph, &df_data, row_idx, id, title, existing_idx);
         batch.add_action(action, graph)?;
     }
+
+    graph.observe_explicit_id(&Value::UniqueId(max_loaded_id));
 
     describe_skipped_rows(
         &mut errors,

--- a/crates/kglite/src/graph/session/durable.rs
+++ b/crates/kglite/src/graph/session/durable.rs
@@ -11,12 +11,19 @@
 //!
 //! ## The three orders that are correctness, not preference
 //!
+//! Two of them are not session-specific and live in
+//! [`graph::durability`](crate::graph::durability), which this module calls and
+//! the Python wheel's durable `KnowledgeGraph` calls too — the open ordering
+//! (including the unconditional recovery-on-open refusal) and the two halves of
+//! the checkpoint. Only the second order below belongs to `Session`, because it
+//! is a property of how a session publishes a commit.
+//!
 //! 1. **Open: recover → replay → wrap → open-for-append.** Replay must happen
 //!    *before* the backend is wrapped for capture, or the replay's own
 //!    `GraphWrite` calls land in the capture buffer and get logged a second
 //!    time. Replay is gated on the loaded graph's `checkpoint_lsn`, so frames
 //!    already folded into the `.kgl` are skipped rather than rolled back over
-//!    newer state.
+//!    newer state. ([`durability::open_log`](crate::graph::durability::open_log))
 //!
 //! 2. **Commit: append *then* publish.** [`Session::commit`] appends the
 //!    frame between the OCC check and the `Arc` swap, so a failed append
@@ -33,6 +40,9 @@
 //!    truncates the log. `next_lsn` deliberately keeps climbing across the
 //!    truncation: restarting it would let a stale pre-checkpoint frame carry
 //!    the same LSN as a fresh one, making the replay gate meaningless.
+//!    ([`durability::checkpoint_prologue`](crate::graph::durability::checkpoint_prologue)
+//!    and
+//!    [`checkpoint_epilogue`](crate::graph::durability::checkpoint_epilogue))
 //!
 //! ## Lock ordering
 //!
@@ -59,10 +69,10 @@ use std::sync::{Arc, Mutex};
 
 use super::transaction::Session;
 use crate::graph::dir_graph::DirGraph;
-use crate::graph::mutation::wal_replay::apply_frames;
-use crate::graph::storage::recording::{resolve_ops, wrap_for_durability};
+use crate::graph::durability;
+use crate::graph::storage::recording::resolve_ops;
 use crate::graph::storage::GraphRead;
-use crate::graph::wal::{recover, wal_path, DurabilityLevel, Wal, WalFrame};
+use crate::graph::wal::{DurabilityLevel, Wal, WalFrame};
 
 /// Session-scoped durability state. Held by the [`Session`] rather than the
 /// graph because it owns an open `File`; see the module docs for the lock
@@ -160,74 +170,25 @@ impl Session {
             ));
         }
 
-        let wpath = wal_path(Path::new(checkpoint_path));
-        // Read (do not truncate) whatever the last session left behind. Torn
-        // tails stop the scan; see `wal::read_frames`.
-        let frames = recover(&wpath).map_err(|e| {
-            format!(
-                "failed to read the write-ahead log at '{}': {e}",
-                wpath.display()
-            )
-        })?;
-        let checkpoint_lsn = graph.checkpoint_lsn;
-
-        if !level.logs() {
-            // Recovery-on-open is unconditional: a sidecar carrying frames the
-            // loaded checkpoint does not contain is unrecovered data, and
-            // opening `off` over it would ignore those commits and then destroy
-            // them at the first checkpoint. Frames at or below `checkpoint_lsn`
-            // are a stale prefix already folded into the graph (the harmless
-            // residue of a crash between the `.kgl` write and the log
-            // truncation) and are not grounds to refuse.
-            if unreplayed(&frames, checkpoint_lsn) {
-                return Err(format!(
-                    "the write-ahead log at '{}' holds commits this checkpoint does not \
-                     contain, and durability level 'off' would neither replay them nor \
-                     keep them — the next Session::save would truncate the log and the \
-                     commits would be gone. Open with level 'full' or 'normal' to replay \
-                     and continue the log, or move the sidecar aside first to \
-                     deliberately discard those commits.",
-                    wpath.display(),
-                ));
-            }
-            return Ok(Session::from_arc(graph));
-        }
-
-        if graph.graph.is_recording() {
-            return Err(
-                "this graph is already wrapped for durable capture, which means another \
-                 durable owner (a durable KnowledgeGraph, or another Session) holds it. \
-                 Two owners over one write-ahead log interleave their log-sequence \
-                 numbers and each checkpoint invalidates the other's replay gate, so the \
-                 second open is refused. Take a non-durable snapshot for reads, or hand \
-                 ownership over instead of duplicating it."
-                    .to_string(),
-            );
-        }
-
-        let sync = level
-            .sync_mode()
-            .expect("level.logs() is true, so sync_mode is Some");
-
         let mut graph = graph;
-        let dir = Arc::make_mut(&mut graph);
-        // Replay BEFORE wrapping: the replay's own writes must not enter the
-        // capture buffer, or the next commit would log them all over again.
-        let max_lsn = apply_frames(dir, &frames, checkpoint_lsn)?;
-        wrap_for_durability(dir);
+        // Everything from here to the open log is the shared orchestration
+        // (`graph::durability`): recover → replay → wrap → open-for-append, plus
+        // the unconditional recovery-on-open refusal that makes `off` over an
+        // unreplayed sidecar an error rather than silent data loss. The wheel's
+        // durable `KnowledgeGraph` performs the same sequence through the same
+        // function, so the two cannot drift.
+        let opened = durability::open_log(&mut graph, Path::new(checkpoint_path), level)
+            .map_err(|e| e.to_string())?;
 
-        let wal = Wal::open(wpath.clone(), sync).map_err(|e| {
-            format!(
-                "failed to open the write-ahead log at '{}': {e}",
-                wpath.display()
-            )
-        })?;
+        let Some((wal, next_lsn)) = opened else {
+            return Ok(Session::from_arc(graph));
+        };
 
         Ok(Session::with_durable(
             graph,
             DurableState {
                 wal,
-                next_lsn: max_lsn + 1,
+                next_lsn,
                 level,
                 diverged: false,
                 #[cfg(test)]
@@ -342,18 +303,11 @@ impl Session {
         let Some(ds) = slot.as_mut() else {
             return Ok(false);
         };
-        // Force frames that are still only in the page cache onto stable
-        // storage BEFORE the checkpoint that supersedes them. Under `Full`
-        // this is the no-op it looks like; under `Normal` it is what stops a
-        // crash in the write→truncate window from leaving a *prefix* of the
-        // log, whose replay would roll properties back over the newer
-        // checkpoint.
-        ds.wal.sync().map_err(|e| e.to_string())?;
-        // `next_lsn` is the LSN the *next* frame will carry, so the newest
-        // frame folded into this snapshot is `next_lsn - 1`. A session that has
-        // logged nothing leaves the stamp at 0 — replay everything, which is
-        // the ungated behaviour.
-        Arc::make_mut(graph).checkpoint_lsn = ds.next_lsn.saturating_sub(1);
+        // Flush-then-stamp, shared with every other owner of a log; see
+        // `durability::checkpoint_prologue` for why the flush is load-bearing
+        // under `Normal` and how the stamp is derived.
+        durability::checkpoint_prologue(&mut ds.wal, ds.next_lsn, Arc::make_mut(graph))
+            .map_err(|e| e.to_string())?;
         Ok(true)
     }
 
@@ -369,10 +323,8 @@ impl Session {
         let Some(ds) = slot.as_mut() else {
             return Ok(());
         };
-        if let Some(rg) = Arc::make_mut(graph).graph.recording_mut() {
-            let _ = rg.take_ops();
-        }
-        ds.wal.reset().map_err(|e| e.to_string())?;
+        durability::checkpoint_epilogue(&mut ds.wal, Arc::make_mut(graph))
+            .map_err(|e| e.to_string())?;
         // The checkpoint just folded in everything a direct write left
         // unlogged, so the log describes the graph again.
         ds.diverged = false;
@@ -445,12 +397,6 @@ impl Session {
     }
 }
 
-/// Whether `frames` hold anything the checkpoint at `checkpoint_lsn` has not
-/// already folded in.
-fn unreplayed(frames: &[WalFrame], checkpoint_lsn: u64) -> bool {
-    frames.iter().any(|f| f.lsn > checkpoint_lsn)
-}
-
 // ────────────────────────────────────────────────────────────────────
 // Tests
 // ────────────────────────────────────────────────────────────────────
@@ -461,6 +407,7 @@ mod tests {
     use crate::graph::session::execute::{execute_mut, execute_read, ExecuteOptions};
     use crate::graph::session::CommitOutcome;
     use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+    use crate::graph::wal::{recover, wal_path};
     use std::collections::HashMap;
 
     fn params() -> HashMap<String, crate::datatypes::Value> {

--- a/crates/kglite/src/graph/session/durable.rs
+++ b/crates/kglite/src/graph/session/durable.rs
@@ -1,0 +1,906 @@
+//! Durable sessions — the write-ahead log wired through [`Session`].
+//!
+//! The engine has shipped a complete logical WAL since 0.14 (`graph/wal.rs`:
+//! CRC frames, torn-tail recovery, [`DurabilityLevel`], the `checkpoint_lsn`
+//! replay gate) plus the write-capture layer that feeds it
+//! (`graph/storage/recording.rs`). What lived *only* in the Python wheel was
+//! the orchestration: the open ordering, the commit-time flush, and the
+//! four-step checkpoint. This module lifts that orchestration into the engine
+//! so every binding — wheel, bolt server, C ABI, JVM — gets it from one place
+//! instead of writing it again.
+//!
+//! ## The three orders that are correctness, not preference
+//!
+//! 1. **Open: recover → replay → wrap → open-for-append.** Replay must happen
+//!    *before* the backend is wrapped for capture, or the replay's own
+//!    `GraphWrite` calls land in the capture buffer and get logged a second
+//!    time. Replay is gated on the loaded graph's `checkpoint_lsn`, so frames
+//!    already folded into the `.kgl` are skipped rather than rolled back over
+//!    newer state.
+//!
+//! 2. **Commit: append *then* publish.** [`Session::commit`] appends the
+//!    frame between the OCC check and the `Arc` swap, so a failed append
+//!    blocks the publish and the caller is told
+//!    ([`CommitOutcome::DurabilityFailed`](super::CommitOutcome::DurabilityFailed))
+//!    instead of holding an acknowledged-but-unlogged write. This is strictly
+//!    stronger than the wheel's apply-then-log ordering, which can only report
+//!    the failure after the mutation is already visible.
+//!
+//! 3. **Checkpoint: sync → stamp → save → reset.** [`Session::save`] flushes
+//!    the log (load-bearing under [`DurabilityLevel::Normal`], where the tail
+//!    may still be in the page cache), stamps `checkpoint_lsn = next_lsn - 1`
+//!    into the graph it is about to write, writes the `.kgl`, and only then
+//!    truncates the log. `next_lsn` deliberately keeps climbing across the
+//!    truncation: restarting it would let a stale pre-checkpoint frame carry
+//!    the same LSN as a fresh one, making the replay gate meaningless.
+//!
+//! ## Lock ordering
+//!
+//! `DurableState` lives on the [`Session`] behind its own `Mutex`, not on
+//! `DirGraph` — the WAL owns a `File` handle and `DirGraph` must stay `Clone`.
+//! **The durability mutex is only ever acquired while the session's graph
+//! mutex is already held** (or on its own, never the other way round), which
+//! is what makes "append the frame, then publish the Arc" one indivisible
+//! step for concurrent committers.
+//!
+//! ## Single owner per path
+//!
+//! One `DurableState` per checkpoint path, full stop. Two owners logging to
+//! one sidecar interleave their independent `next_lsn` counters and each
+//! checkpoint stamps a `checkpoint_lsn` the other's frames sit below, so
+//! replay silently drops committed data. The engine enforces what it can
+//! observe: [`Session::open_durable`] refuses a graph whose backend is
+//! *already* wrapped for capture, which is the signature another durable owner
+//! leaves behind. Making the wheel's `KnowledgeGraph` and a `Session` mutually
+//! exclusive over one path is the binding layer's half of the same rule.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use super::transaction::Session;
+use crate::graph::dir_graph::DirGraph;
+use crate::graph::mutation::wal_replay::apply_frames;
+use crate::graph::storage::recording::{resolve_ops, wrap_for_durability};
+use crate::graph::storage::GraphRead;
+use crate::graph::wal::{recover, wal_path, DurabilityLevel, Wal, WalFrame};
+
+/// Session-scoped durability state. Held by the [`Session`] rather than the
+/// graph because it owns an open `File`; see the module docs for the lock
+/// ordering it participates in.
+#[derive(Debug)]
+pub(super) struct DurableState {
+    wal: Wal,
+    /// Log-sequence number the next frame will carry. Monotonic for the life
+    /// of the log; never reset by a checkpoint.
+    next_lsn: u64,
+    /// The level the caller asked for. Never [`DurabilityLevel::Off`] — an
+    /// `Off` session has no `DurableState` at all.
+    level: DurabilityLevel,
+    /// Set when a mutation reached the graph through a path the log cannot
+    /// describe ([`Session::write`] / [`Session::transact`]). See
+    /// [`Session::write`] for why this is a latch rather than a refusal.
+    diverged: bool,
+    /// Test-only append fault injection. The guarantee under test — a failed
+    /// append blocks the publish — is about *ordering*, and ordering cannot be
+    /// exercised without a reachable append failure; no portable filesystem
+    /// trick fails a write on an already-open append handle.
+    #[cfg(test)]
+    fail_append: bool,
+}
+
+/// Message shared by every operation that a direct write has invalidated.
+const DIVERGED_MSG: &str = "this durable session was mutated through Session::write / \
+     Session::transact, which the write-ahead log cannot describe: those mutations are \
+     captured but never drained into a frame, so the log no longer describes the graph. \
+     Take a checkpoint (Session::save) to fold them in and start a fresh log, or run \
+     mutations through Session::begin / Session::commit, which are logged.";
+
+/// Message shared by the two direct-write paths.
+pub(super) const DIRECT_WRITE_REFUSAL: &str =
+    "a durable session does not support direct writes through Session::write / \
+     Session::transact: their mutations are captured by the recording backend but \
+     nothing drains that buffer into a WAL frame, and the next copy-on-write fork \
+     resets it — the write would apply and then vanish on a crash, with no error. \
+     Run mutations through Session::begin / Session::commit, which append a frame \
+     before publishing.";
+
+impl Session {
+    /// Open `graph` as a **durable session** checkpointed at `checkpoint_path`,
+    /// performing the full recover → replay → wrap → open-for-append ordering
+    /// described in the module docs.
+    ///
+    /// `checkpoint_path` is the `.kgl` path, not the log path; the sidecar is
+    /// derived from it by [`wal_path`] exactly as every other binding derives
+    /// it, so a graph saved by one and reopened by another finds the same log.
+    ///
+    /// # Levels
+    ///
+    /// [`DurabilityLevel::Full`] and [`DurabilityLevel::Normal`] produce a
+    /// logging session. [`DurabilityLevel::Off`] produces an ordinary
+    /// non-durable session — **unless** the sidecar still holds frames this
+    /// graph has not folded in, in which case the call is refused rather than
+    /// silently opening a graph that is missing committed writes (the first
+    /// checkpoint would then truncate them away for good).
+    ///
+    /// # Refusals
+    ///
+    /// - **Disk-mode graphs**, at any logging level: a disk graph commits by
+    ///   publishing an immutable generation, so there is no logical WAL for it
+    ///   at any level.
+    /// - **A graph already wrapped for capture**: that is the observable
+    ///   signature of another durable owner over the same data, and two owners
+    ///   sharing one log corrupt each other's replay gate (module docs).
+    /// - **Unreplayed frames at level `Off`**, as above.
+    ///
+    /// # Ownership
+    ///
+    /// Pass a graph you solely own. A shared `Arc` is deep-cloned here (the
+    /// replay and the capture wrap both need `&mut DirGraph`), and the session
+    /// then owns the copy while the other holder keeps the original — two
+    /// divergent graphs, only one of them logged. The caller must also hold
+    /// its own
+    /// [`GraphWriterLease`](crate::graph::io::open::GraphWriterLease) over
+    /// `checkpoint_path` for the life of the session: a durable session both
+    /// appends to the sidecar and republishes the checkpoint.
+    pub fn open_durable(
+        graph: Arc<DirGraph>,
+        checkpoint_path: &str,
+        level: DurabilityLevel,
+    ) -> Result<Session, String> {
+        if level.logs() && graph.graph.is_disk() {
+            return Err(format!(
+                "durable={} is not supported for storage='disk' (only 'off' is). A disk \
+                 graph commits by publishing an immutable generation, so its durability \
+                 boundary is the generation publish, not a logical write-ahead log: a \
+                 replayed WAL frame and a published generation can each describe the same \
+                 commit, and reconciling them needs a generation-aware log this release \
+                 does not have. Use Session::save checkpoints for disk graphs, or a \
+                 mapped / in-memory graph if you need per-commit crash safety.",
+                level.name(),
+            ));
+        }
+
+        let wpath = wal_path(Path::new(checkpoint_path));
+        // Read (do not truncate) whatever the last session left behind. Torn
+        // tails stop the scan; see `wal::read_frames`.
+        let frames = recover(&wpath).map_err(|e| {
+            format!(
+                "failed to read the write-ahead log at '{}': {e}",
+                wpath.display()
+            )
+        })?;
+        let checkpoint_lsn = graph.checkpoint_lsn;
+
+        if !level.logs() {
+            // Recovery-on-open is unconditional: a sidecar carrying frames the
+            // loaded checkpoint does not contain is unrecovered data, and
+            // opening `off` over it would ignore those commits and then destroy
+            // them at the first checkpoint. Frames at or below `checkpoint_lsn`
+            // are a stale prefix already folded into the graph (the harmless
+            // residue of a crash between the `.kgl` write and the log
+            // truncation) and are not grounds to refuse.
+            if unreplayed(&frames, checkpoint_lsn) {
+                return Err(format!(
+                    "the write-ahead log at '{}' holds commits this checkpoint does not \
+                     contain, and durability level 'off' would neither replay them nor \
+                     keep them — the next Session::save would truncate the log and the \
+                     commits would be gone. Open with level 'full' or 'normal' to replay \
+                     and continue the log, or move the sidecar aside first to \
+                     deliberately discard those commits.",
+                    wpath.display(),
+                ));
+            }
+            return Ok(Session::from_arc(graph));
+        }
+
+        if graph.graph.is_recording() {
+            return Err(
+                "this graph is already wrapped for durable capture, which means another \
+                 durable owner (a durable KnowledgeGraph, or another Session) holds it. \
+                 Two owners over one write-ahead log interleave their log-sequence \
+                 numbers and each checkpoint invalidates the other's replay gate, so the \
+                 second open is refused. Take a non-durable snapshot for reads, or hand \
+                 ownership over instead of duplicating it."
+                    .to_string(),
+            );
+        }
+
+        let sync = level
+            .sync_mode()
+            .expect("level.logs() is true, so sync_mode is Some");
+
+        let mut graph = graph;
+        let dir = Arc::make_mut(&mut graph);
+        // Replay BEFORE wrapping: the replay's own writes must not enter the
+        // capture buffer, or the next commit would log them all over again.
+        let max_lsn = apply_frames(dir, &frames, checkpoint_lsn)?;
+        wrap_for_durability(dir);
+
+        let wal = Wal::open(wpath.clone(), sync).map_err(|e| {
+            format!(
+                "failed to open the write-ahead log at '{}': {e}",
+                wpath.display()
+            )
+        })?;
+
+        Ok(Session::with_durable(
+            graph,
+            DurableState {
+                wal,
+                next_lsn: max_lsn + 1,
+                level,
+                diverged: false,
+                #[cfg(test)]
+                fail_append: false,
+            },
+        ))
+    }
+
+    /// The durability level this session logs at, or `None` for an ordinary
+    /// non-durable session (including one opened with
+    /// [`DurabilityLevel::Off`], which carries no log at all).
+    pub fn durability(&self) -> Option<DurabilityLevel> {
+        self.durable
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .map(|ds| ds.level)
+    }
+
+    /// Flush every committed frame to stable storage — the barrier
+    /// [`DurabilityLevel::Full`] takes on every commit, taken on demand.
+    ///
+    /// This is what makes [`DurabilityLevel::Normal`] adoptable rather than
+    /// merely fast: without it, a `Normal` session's only route to
+    /// power-safety is a full checkpoint, which republishes the entire graph —
+    /// the wrong granularity for "flush at the end of a request".
+    ///
+    /// Under `Full` every frame is already on stable storage when `commit`
+    /// returns, so this is a no-op. On a non-durable session it is an error
+    /// rather than a silent success: there is no log to flush, so reporting
+    /// "flushed" would be a lie about the only thing the caller asked.
+    pub fn sync(&self) -> Result<(), String> {
+        // Graph lock first, then the durability lock — the module's ordering
+        // rule, kept even though this path touches only the latter.
+        let _graph = self.graph.lock().unwrap_or_else(|p| p.into_inner());
+        let mut slot = self.durable.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(ds) = slot.as_mut() else {
+            return Err(
+                "sync() needs a session opened with a write-ahead log (Session::open_durable \
+                 at level 'full' or 'normal'). This session has none, so there is nothing to \
+                 flush and no power-safe point to take — call Session::save to write a \
+                 checkpoint instead."
+                    .to_string(),
+            );
+        };
+        if ds.diverged {
+            return Err(DIVERGED_MSG.to_string());
+        }
+        if ds.level == DurabilityLevel::Full {
+            return Ok(());
+        }
+        ds.wal.sync().map_err(|e| e.to_string())
+    }
+
+    /// Append `working`'s captured mutations as one WAL frame. Called by
+    /// [`Session::commit`] with the session's graph lock already held, between
+    /// the OCC check and the `Arc` swap, so an error here means the commit is
+    /// never published.
+    ///
+    /// A no-op on a non-durable session, and on a transaction that captured
+    /// nothing: an empty frame would consume an LSN and describe no change,
+    /// which is exactly the accounting the checkpoint stamp reads.
+    pub(super) fn log_working_commit(&self, working: &mut DirGraph) -> Result<(), String> {
+        let mut slot = self.durable.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(ds) = slot.as_mut() else {
+            return Ok(());
+        };
+        if ds.diverged {
+            return Err(DIVERGED_MSG.to_string());
+        }
+        // A durable session wraps its graph at open and every fork preserves
+        // the wrapper, so an unwrapped backend here means the capture seam was
+        // lost and this commit is unloggable. Fail closed rather than publish
+        // an unlogged write.
+        let raw = match working.graph.recording_mut() {
+            Some(rg) => rg.take_ops(),
+            None => {
+                return Err(
+                    "durable commit found no recording backend: this session's write-capture \
+                     layer was replaced, so the commit cannot be logged and has not been \
+                     published."
+                        .to_string(),
+                )
+            }
+        };
+        if raw.is_empty() {
+            return Ok(());
+        }
+        // Secondary labels are read back through `working` because they are not
+        // backend state — see `resolve_ops`.
+        let ops = resolve_ops(&raw, &working.graph, &working.interner, |idx| {
+            working.secondary_label_names(idx)
+        });
+        #[cfg(test)]
+        if ds.fail_append {
+            return Err("injected WAL append failure".to_string());
+        }
+        let lsn = ds.next_lsn;
+        ds.wal
+            .append(&WalFrame { lsn, ops })
+            .map_err(|e| e.to_string())?;
+        // Only a frame that reached the log consumes its LSN.
+        ds.next_lsn = lsn + 1;
+        Ok(())
+    }
+
+    /// Checkpoint steps 1–2: flush the log, then stamp how far this checkpoint
+    /// will have consumed it into the graph about to be serialized. Returns
+    /// whether this session is durable (i.e. whether the epilogue runs).
+    pub(super) fn checkpoint_prologue(&self, graph: &mut Arc<DirGraph>) -> Result<bool, String> {
+        let mut slot = self.durable.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(ds) = slot.as_mut() else {
+            return Ok(false);
+        };
+        // Force frames that are still only in the page cache onto stable
+        // storage BEFORE the checkpoint that supersedes them. Under `Full`
+        // this is the no-op it looks like; under `Normal` it is what stops a
+        // crash in the write→truncate window from leaving a *prefix* of the
+        // log, whose replay would roll properties back over the newer
+        // checkpoint.
+        ds.wal.sync().map_err(|e| e.to_string())?;
+        // `next_lsn` is the LSN the *next* frame will carry, so the newest
+        // frame folded into this snapshot is `next_lsn - 1`. A session that has
+        // logged nothing leaves the stamp at 0 — replay everything, which is
+        // the ungated behaviour.
+        Arc::make_mut(graph).checkpoint_lsn = ds.next_lsn.saturating_sub(1);
+        Ok(true)
+    }
+
+    /// Checkpoint step 4: the `.kgl` now holds the full current state, so drop
+    /// the capture buffer (those ops are folded in) and truncate the log.
+    ///
+    /// Ordered after the save on purpose: the checkpoint is known to have
+    /// landed before the log that describes the same commits is destroyed, and
+    /// replay is idempotent, so a crash between the two costs only a harmless
+    /// re-apply on the next open.
+    pub(super) fn checkpoint_epilogue(&self, graph: &mut Arc<DirGraph>) -> Result<(), String> {
+        let mut slot = self.durable.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(ds) = slot.as_mut() else {
+            return Ok(());
+        };
+        if let Some(rg) = Arc::make_mut(graph).graph.recording_mut() {
+            let _ = rg.take_ops();
+        }
+        ds.wal.reset().map_err(|e| e.to_string())?;
+        // The checkpoint just folded in everything a direct write left
+        // unlogged, so the log describes the graph again.
+        ds.diverged = false;
+        Ok(())
+    }
+
+    /// Record that a mutation reached the graph through a path the log cannot
+    /// describe. See [`Session::write`] for the reasoning behind the latch.
+    pub(super) fn mark_diverged(&self) {
+        if let Some(ds) = self
+            .durable
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_mut()
+        {
+            ds.diverged = true;
+        }
+    }
+
+    /// Whether direct mutation through [`Session::write`] / [`Session::transact`]
+    /// is allowed on this session, as a checkable precondition.
+    ///
+    /// A durable session answers `Err` with the message those paths would
+    /// otherwise have to swallow — neither of them has an error channel of its
+    /// own (`write` returns a guard, `transact` returns the *caller's* error
+    /// type, which the engine cannot construct). A caller that owns an error
+    /// channel calls this first; a caller that does not still cannot lose data
+    /// silently, because both paths latch the session (see [`Session::write`]).
+    pub fn check_direct_write_allowed(&self) -> Result<(), String> {
+        if self
+            .durable
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .is_some()
+        {
+            return Err(DIRECT_WRITE_REFUSAL.to_string());
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_fail_append(&self, fail: bool) {
+        if let Some(ds) = self
+            .durable
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_mut()
+        {
+            ds.fail_append = fail;
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn next_lsn(&self) -> Option<u64> {
+        self.durable
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .map(|ds| ds.next_lsn)
+    }
+
+    /// Build a session that already owns durability state. Private to the
+    /// session module: [`Session::open_durable`] is the only constructor that
+    /// can establish the recover→replay→wrap ordering the state assumes.
+    fn with_durable(graph: Arc<DirGraph>, state: DurableState) -> Session {
+        Session {
+            graph: Mutex::new(graph),
+            durable: Mutex::new(Some(state)),
+        }
+    }
+}
+
+/// Whether `frames` hold anything the checkpoint at `checkpoint_lsn` has not
+/// already folded in.
+fn unreplayed(frames: &[WalFrame], checkpoint_lsn: u64) -> bool {
+    frames.iter().any(|f| f.lsn > checkpoint_lsn)
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::session::execute::{execute_mut, execute_read, ExecuteOptions};
+    use crate::graph::session::CommitOutcome;
+    use crate::graph::storage::mode::{new_dir_graph_in_mode, StorageMode};
+    use std::collections::HashMap;
+
+    fn params() -> HashMap<String, crate::datatypes::Value> {
+        HashMap::new()
+    }
+
+    /// Run one mutation through the begin → mutate → commit path, i.e. the
+    /// only write path a durable session supports.
+    fn commit_query(session: &Session, query: &str) -> CommitOutcome {
+        let params = params();
+        let opts = ExecuteOptions::eager(&params);
+        let mut tx = session.begin();
+        execute_mut(tx.working_mut().unwrap(), query, &opts).unwrap();
+        session.commit(tx, /* check_occ = */ true)
+    }
+
+    /// The refusal message from a rejected `open_durable`. A helper rather
+    /// than `expect_err` because `Session` deliberately carries no `Debug`
+    /// impl — printing a session would print the whole graph.
+    fn refusal(result: Result<Session, String>) -> String {
+        match result {
+            Err(message) => message,
+            Ok(_) => panic!("expected a refusal, got an open session"),
+        }
+    }
+
+    fn count_nodes(graph: &DirGraph) -> usize {
+        let params = params();
+        let opts = ExecuteOptions::eager(&params);
+        execute_read(graph, "MATCH (n:N) RETURN n.id AS id", &opts)
+            .unwrap()
+            .result
+            .rows
+            .len()
+    }
+
+    fn fresh(path: &std::path::Path) -> Session {
+        Session::open_durable(
+            Arc::new(DirGraph::new()),
+            &path.to_string_lossy(),
+            DurabilityLevel::Full,
+        )
+        .unwrap()
+    }
+
+    /// Reopen the way a *crash* reopens: load whatever checkpoint exists (none
+    /// on the first run) and let `open_durable` replay the sidecar.
+    fn reopen(path: &std::path::Path, level: DurabilityLevel) -> Result<Session, String> {
+        let p = path.to_string_lossy().into_owned();
+        let graph = if path.exists() {
+            crate::graph::io::file::load_file(&p).unwrap()
+        } else {
+            Arc::new(DirGraph::new())
+        };
+        Session::open_durable(graph, &p, level)
+    }
+
+    // ── the headline guarantee ──────────────────────────────────────
+
+    /// Crash-shaped: commits, no checkpoint, process gone. The reopen must
+    /// replay every committed write out of the sidecar.
+    #[test]
+    fn committed_writes_replay_after_a_crash_shaped_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+
+        let session = fresh(&path);
+        assert!(matches!(
+            commit_query(&session, "CREATE (:N {id: 1})"),
+            CommitOutcome::Committed { .. }
+        ));
+        assert!(matches!(
+            commit_query(&session, "CREATE (:N {id: 2})"),
+            CommitOutcome::Committed { .. }
+        ));
+        assert_eq!(count_nodes(&session.snapshot()), 2);
+        drop(session); // no save() — the checkpoint never happened
+
+        assert!(!path.exists(), "the crash-shaped run wrote no checkpoint");
+        let recovered = reopen(&path, DurabilityLevel::Full).unwrap();
+        assert_eq!(
+            count_nodes(&recovered.snapshot()),
+            2,
+            "both committed writes must come back out of the log"
+        );
+        // Replay must not have re-entered the capture buffer: the next commit
+        // logs its own op and nothing else.
+        assert_eq!(recovered.next_lsn(), Some(3));
+        // …which is the replay-before-wrap rule, checked at its own seam.
+        // Wrapping first would leave every replayed op sitting in the capture
+        // buffer, ready to be logged a second time.
+        match recovered.snapshot().graph.recording() {
+            Some(rg) => assert_eq!(
+                rg.ops_len(),
+                0,
+                "replay ran before the capture wrap, so it captured nothing"
+            ),
+            None => panic!("a durable session must be wrapped for capture"),
+        }
+    }
+
+    /// **A failed append must block the publish.** Mutation-checked: moving
+    /// the `log_working_commit` call after the `Arc` swap in `Session::commit`
+    /// turns every assertion below red.
+    #[test]
+    fn a_failed_append_blocks_the_publish() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let session = fresh(&path);
+
+        commit_query(&session, "CREATE (:N {id: 1})");
+        let version_before = session.version();
+        let snapshot_before = session.snapshot();
+
+        session.set_fail_append(true);
+        let outcome = commit_query(&session, "CREATE (:N {id: 2})");
+        match outcome {
+            CommitOutcome::DurabilityFailed { ref error } => {
+                assert!(error.contains("injected"), "unexpected error: {error}")
+            }
+            other => panic!("expected DurabilityFailed, got {other:?}"),
+        }
+        assert_eq!(
+            session.version(),
+            version_before,
+            "a commit that could not be logged must not bump the version"
+        );
+        assert!(
+            Arc::ptr_eq(&snapshot_before, &session.snapshot()),
+            "a commit that could not be logged must not swap the live Arc"
+        );
+        assert_eq!(
+            count_nodes(&session.snapshot()),
+            1,
+            "the unlogged write must not be visible"
+        );
+
+        // Non-vacuity: with the fault cleared the same write commits and lands.
+        session.set_fail_append(false);
+        assert!(matches!(
+            commit_query(&session, "CREATE (:N {id: 2})"),
+            CommitOutcome::Committed { .. }
+        ));
+        assert_eq!(count_nodes(&session.snapshot()), 2);
+    }
+
+    /// The four-step checkpoint, checked at each of its four observable
+    /// consequences.
+    #[test]
+    fn save_truncates_the_log_and_stamps_the_replay_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let wpath = wal_path(&path);
+        let session = fresh(&path);
+
+        commit_query(&session, "CREATE (:N {id: 1})");
+        commit_query(&session, "CREATE (:N {id: 2})");
+        let logged_len = std::fs::metadata(&wpath).unwrap().len();
+        assert!(logged_len > 0);
+
+        session.save(&path.to_string_lossy(), true).unwrap();
+
+        // (a) the log is truncated back to its header …
+        let after_len = std::fs::metadata(&wpath).unwrap().len();
+        assert!(
+            after_len < logged_len,
+            "checkpoint must truncate the log: {logged_len} -> {after_len}"
+        );
+        assert!(recover(&wpath).unwrap().is_empty());
+        // (b) … the checkpoint carries the gate …
+        let reloaded = crate::graph::io::file::load_file(&path.to_string_lossy()).unwrap();
+        assert_eq!(reloaded.checkpoint_lsn, 2, "next_lsn(3) - 1");
+        assert_eq!(count_nodes(&reloaded), 2);
+        // (c) … and `next_lsn` keeps climbing across the truncation.
+        assert_eq!(session.next_lsn(), Some(3));
+
+        // (d) post-checkpoint commits land in the fresh log, and a
+        // crash-shaped reopen replays only those.
+        commit_query(&session, "CREATE (:N {id: 3})");
+        drop(session);
+        let frames = recover(&wpath).unwrap();
+        assert_eq!(frames.len(), 1, "only the post-checkpoint commit is logged");
+        assert_eq!(frames[0].lsn, 3);
+
+        let recovered = reopen(&path, DurabilityLevel::Full).unwrap();
+        assert_eq!(
+            count_nodes(&recovered.snapshot()),
+            3,
+            "checkpointed 2 + replayed 1"
+        );
+    }
+
+    /// The replay gate is not decorative: a sidecar whose frames the
+    /// checkpoint already contains must not be folded in a second time. (Here
+    /// the second fold is harmless-by-idempotence for counts, so the check is
+    /// that `open_durable` skips the stale prefix — `next_lsn` proves it.)
+    #[test]
+    fn a_stale_prefix_below_the_checkpoint_is_not_replayed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let wpath = wal_path(&path);
+
+        let session = fresh(&path);
+        commit_query(&session, "CREATE (:N {id: 1})");
+        let logged = std::fs::read(&wpath).unwrap();
+        session.save(&path.to_string_lossy(), true).unwrap();
+        drop(session);
+        // Restore the pre-checkpoint sidecar — the "operator put the backup
+        // back" / "crash between save and truncate" shape.
+        std::fs::write(&wpath, &logged).unwrap();
+
+        let recovered = reopen(&path, DurabilityLevel::Full).unwrap();
+        assert_eq!(count_nodes(&recovered.snapshot()), 1);
+        assert_eq!(
+            recovered.next_lsn(),
+            Some(2),
+            "the stale frame must not advance the log-sequence counter"
+        );
+    }
+
+    // ── refusals ────────────────────────────────────────────────────
+
+    #[test]
+    fn level_off_refuses_an_unreplayed_sidecar_but_accepts_a_stale_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let wpath = wal_path(&path);
+
+        let session = fresh(&path);
+        commit_query(&session, "CREATE (:N {id: 1})");
+        drop(session);
+
+        // Unreplayed frames + level off ⇒ refuse, naming the way out.
+        let err = refusal(reopen(&path, DurabilityLevel::Off));
+        assert!(err.contains("'full' or 'normal'"), "message was: {err}");
+        assert!(err.contains("move the sidecar aside"), "message was: {err}");
+
+        // Same sidecar, but now folded into a checkpoint: level off is fine.
+        let session = reopen(&path, DurabilityLevel::Full).unwrap();
+        let logged = std::fs::read(&wpath).unwrap();
+        session.save(&path.to_string_lossy(), true).unwrap();
+        drop(session);
+        std::fs::write(&wpath, &logged).unwrap();
+        let plain = reopen(&path, DurabilityLevel::Off).unwrap();
+        assert!(plain.durability().is_none());
+        assert_eq!(count_nodes(&plain.snapshot()), 1);
+    }
+
+    #[test]
+    fn an_empty_sidecar_is_not_a_refusal_at_level_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let session = reopen(&path, DurabilityLevel::Off).unwrap();
+        assert!(session.durability().is_none());
+    }
+
+    #[test]
+    fn disk_graphs_are_refused_at_every_logging_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let graph_dir = dir.path().join("disk-graph");
+        for level in [DurabilityLevel::Full, DurabilityLevel::Normal] {
+            let g = new_dir_graph_in_mode(StorageMode::Disk, Some(&graph_dir)).unwrap();
+            let err = refusal(Session::open_durable(
+                Arc::new(g),
+                &dir.path().join("g.kgl").to_string_lossy(),
+                level,
+            ));
+            assert!(err.contains("storage='disk'"), "message was: {err}");
+            assert!(err.contains(level.name()), "message was: {err}");
+        }
+        // Non-vacuity: `off` over a disk graph is a plain session, not an error.
+        let g = new_dir_graph_in_mode(StorageMode::Disk, Some(&graph_dir)).unwrap();
+        let session = Session::open_durable(
+            Arc::new(g),
+            &dir.path().join("g.kgl").to_string_lossy(),
+            DurabilityLevel::Off,
+        )
+        .unwrap();
+        assert!(session.durability().is_none());
+    }
+
+    #[test]
+    fn a_second_durable_owner_over_one_graph_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let session = fresh(&path);
+        commit_query(&session, "CREATE (:N {id: 1})");
+
+        // The observable signature of the first owner: the graph is wrapped.
+        let err = refusal(Session::open_durable(
+            session.snapshot(),
+            &path.to_string_lossy(),
+            DurabilityLevel::Full,
+        ));
+        assert!(err.contains("already wrapped"), "message was: {err}");
+    }
+
+    #[test]
+    fn mapped_graphs_are_durable_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let g = new_dir_graph_in_mode(StorageMode::Mapped, None).unwrap();
+        let session = Session::open_durable(
+            Arc::new(g),
+            &path.to_string_lossy(),
+            DurabilityLevel::Normal,
+        )
+        .unwrap();
+        assert_eq!(session.durability(), Some(DurabilityLevel::Normal));
+        commit_query(&session, "CREATE (:N {id: 1})");
+        session.sync().unwrap();
+        drop(session);
+
+        let recovered = reopen(&path, DurabilityLevel::Normal).unwrap();
+        assert_eq!(count_nodes(&recovered.snapshot()), 1);
+    }
+
+    #[test]
+    fn open_durable_reports_an_unopenable_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        // Make the sidecar path a directory — a real IO failure inside
+        // `Wal::open`, not an injected one.
+        std::fs::create_dir(wal_path(&path)).unwrap();
+        let err = refusal(Session::open_durable(
+            Arc::new(DirGraph::new()),
+            &path.to_string_lossy(),
+            DurabilityLevel::Full,
+        ));
+        assert!(
+            err.contains("write-ahead log"),
+            "IO failure must name the log: {err}"
+        );
+    }
+
+    // ── direct-write refusal ────────────────────────────────────────
+
+    #[test]
+    fn direct_writes_are_refused_and_latch_the_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let session = fresh(&path);
+        commit_query(&session, "CREATE (:N {id: 1})");
+
+        let err = session
+            .check_direct_write_allowed()
+            .expect_err("expected a refusal");
+        assert!(err.contains("does not support direct writes"));
+
+        // A caller that ignores the precondition does not lose data silently:
+        // the write applies, and the session refuses every later durability
+        // operation until a checkpoint folds it in.
+        {
+            let mut graph = session.write();
+            graph.bump_version();
+        }
+        match commit_query(&session, "CREATE (:N {id: 2})") {
+            CommitOutcome::DurabilityFailed { ref error } => {
+                assert!(error.contains("Session::write"), "message was: {error}")
+            }
+            other => panic!("expected DurabilityFailed, got {other:?}"),
+        }
+        assert!(session
+            .sync()
+            .expect_err("expected a refusal")
+            .contains("Session::write"));
+
+        // A checkpoint is the documented repair: it folds the direct write in
+        // and starts a fresh log.
+        session.save(&path.to_string_lossy(), true).unwrap();
+        assert!(session.sync().is_ok());
+        assert!(matches!(
+            commit_query(&session, "CREATE (:N {id: 2})"),
+            CommitOutcome::Committed { .. }
+        ));
+    }
+
+    #[test]
+    fn transact_latches_a_durable_session_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let session = fresh(&path);
+
+        session
+            .transact(|working| {
+                working.bump_version();
+                Ok::<_, &'static str>(())
+            })
+            .unwrap();
+        assert!(matches!(
+            commit_query(&session, "CREATE (:N {id: 1})"),
+            CommitOutcome::DurabilityFailed { .. }
+        ));
+    }
+
+    // ── accounting ──────────────────────────────────────────────────
+
+    #[test]
+    fn a_commit_with_no_writes_appends_no_frame() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.kgl");
+        let wpath = wal_path(&path);
+        let session = fresh(&path);
+        let header_len = std::fs::metadata(&wpath).unwrap().len();
+
+        // (a) never materialised.
+        assert!(matches!(
+            session.commit(session.begin(), true),
+            CommitOutcome::NoWritesNoOp
+        ));
+        // (b) materialised but captured nothing.
+        let mut tx = session.begin();
+        tx.working_mut().unwrap();
+        assert!(matches!(
+            session.commit(tx, true),
+            CommitOutcome::Committed { .. }
+        ));
+
+        assert_eq!(
+            std::fs::metadata(&wpath).unwrap().len(),
+            header_len,
+            "an empty commit must not append a frame"
+        );
+        assert_eq!(
+            session.next_lsn(),
+            Some(1),
+            "an empty commit must not consume an LSN"
+        );
+
+        // Non-vacuity: a real write does append and does consume one.
+        commit_query(&session, "CREATE (:N {id: 1})");
+        assert!(std::fs::metadata(&wpath).unwrap().len() > header_len);
+        assert_eq!(session.next_lsn(), Some(2));
+    }
+
+    #[test]
+    fn sync_is_an_error_on_a_non_durable_session() {
+        let session = Session::new(DirGraph::new());
+        assert!(session.durability().is_none());
+        let err = session.sync().expect_err("expected a refusal");
+        assert!(err.contains("write-ahead log"), "message was: {err}");
+    }
+}

--- a/crates/kglite/src/graph/session/mod.rs
+++ b/crates/kglite/src/graph/session/mod.rs
@@ -43,12 +43,17 @@
 //!   `output_format`, `explain` flags that callers need for
 //!   serialization decisions.
 //! - [`CommitOutcome`] — `NoWritesNoOp` / `Committed` /
-//!   `ConflictDetected` so the binding maps to its own error type
-//!   (PyErr / BoltError / etc.).
+//!   `ConflictDetected` / `DurabilityFailed` so the binding maps to
+//!   its own error type (PyErr / BoltError / etc.).
+//! - [`Session::open_durable`] + [`Session::sync`] — the write-ahead
+//!   log wired through the session: commits append a frame before
+//!   they publish, and [`Session::save`] is the four-step checkpoint.
+//!   See [`durable`] for the orderings that are correctness.
 
 pub use self::execute::{execute_mut, execute_read, ExecuteOptions, ExecuteOutcome};
 pub use self::transaction::{CommitOutcome, Session, Transaction};
 
+pub(crate) mod durable;
 pub(crate) mod execute;
 #[cfg(test)]
 mod plan_cache_cost_tests;

--- a/crates/kglite/src/graph/session/transaction.rs
+++ b/crates/kglite/src/graph/session/transaction.rs
@@ -255,7 +255,8 @@ impl Session {
     pub fn save(&self, path: &str, fsync: bool) -> Result<(), String> {
         let mut guard = self.graph.lock().unwrap_or_else(|p| p.into_inner());
         let durable = self.checkpoint_prologue(&mut guard)?;
-        crate::graph::io::file::save_graph_with(&mut guard, path, fsync || durable)?;
+        crate::graph::io::file::save_graph_with(&mut guard, path, fsync || durable)
+            .map_err(|e| e.to_string())?;
         if durable {
             self.checkpoint_epilogue(&mut guard)?;
         }

--- a/crates/kglite/src/graph/session/transaction.rs
+++ b/crates/kglite/src/graph/session/transaction.rs
@@ -55,7 +55,17 @@ impl DirGraph {
 pub struct Session {
     /// Inner Arc allows cheap reader snapshots; outer Mutex allows
     /// atomic commit-swap.
-    graph: Mutex<Arc<DirGraph>>,
+    pub(super) graph: Mutex<Arc<DirGraph>>,
+    /// Write-ahead-log state for a session opened via
+    /// [`Session::open_durable`]; `None` for every ordinary session.
+    ///
+    /// It lives here rather than on `DirGraph` because it owns an open `File`
+    /// and `DirGraph` must stay `Clone`. **The lock is only ever taken while
+    /// [`graph`](Self::graph)'s lock is already held, or on its own — never
+    /// the other way round.** That ordering is what makes "append the frame,
+    /// then publish the Arc" indivisible for concurrent committers. See
+    /// [`super::durable`].
+    pub(super) durable: Mutex<Option<super::durable::DurableState>>,
 }
 
 /// Serialized mutable access to a Session graph. The guard holds the Session
@@ -86,17 +96,19 @@ impl DerefMut for SessionWriteGuard<'_> {
 impl Session {
     /// Construct from an owned DirGraph.
     pub fn new(graph: DirGraph) -> Self {
-        Self {
-            graph: Mutex::new(Arc::new(graph)),
-        }
+        Self::from_arc(Arc::new(graph))
     }
 
     /// Construct from an existing Arc<DirGraph>. Used when the
     /// caller already shares the graph via Arc (e.g. wrapping
     /// `KnowledgeGraph.inner`).
+    ///
+    /// The session is **not** durable; see [`Session::open_durable`] for the
+    /// write-ahead-logged constructor.
     pub fn from_arc(graph: Arc<DirGraph>) -> Self {
         Self {
             graph: Mutex::new(graph),
+            durable: Mutex::new(None),
         }
     }
 
@@ -122,7 +134,28 @@ impl Session {
     /// Arc, so the unique mutable path is reachable when no reader snapshot
     /// is alive. Readers that already hold a snapshot remain on the
     /// prior graph; new snapshots wait for this short write guard.
+    ///
+    /// # Not for durable sessions
+    ///
+    /// A session opened via [`Session::open_durable`] **refuses** this path —
+    /// its mutations are captured by the recording backend but nothing drains
+    /// that buffer into a WAL frame, and the next copy-on-write fork resets
+    /// it, so the write would apply and then vanish on a crash. Callers with
+    /// an error channel check [`Session::check_direct_write_allowed`] first.
+    ///
+    /// This signature has none: it returns a guard, and a guard cannot carry a
+    /// refusal. Panicking is not an option and silently dropping the write is
+    /// the very hazard being closed, so the refusal is **latched** instead —
+    /// the durable session records that the log no longer describes the graph,
+    /// and every subsequent durability operation fails loudly:
+    /// [`commit`](Self::commit) returns [`CommitOutcome::DurabilityFailed`]
+    /// and [`sync`](Session::sync) errors, until a [`save`](Self::save)
+    /// checkpoint folds the direct write in and starts a fresh log. The
+    /// mutation is never lost, and it is never mistaken for a logged one.
+    /// (Giving this method a fallible signature would ripple through the C ABI
+    /// and wheel call sites; that is the rung where it belongs, not this one.)
     pub fn write(&self) -> SessionWriteGuard<'_> {
+        self.mark_diverged();
         SessionWriteGuard {
             guard: self.graph.lock().unwrap_or_else(|p| p.into_inner()),
         }
@@ -150,10 +183,21 @@ impl Session {
     /// `&mut DirGraph` and the atomicity guarantee (an error publishes
     /// nothing) depends on mutating a copy. Since D2 that fork is O(changes),
     /// and skipping the swap is what the caller actually observes.
+    ///
+    /// # Not for durable sessions
+    ///
+    /// Like [`write`](Self::write), and for the same reason: the closure's
+    /// mutations are captured but never drained into a WAL frame. The refusal
+    /// cannot travel in-band either — `E` is the *caller's* error type and the
+    /// engine cannot construct one — so this path latches the session exactly
+    /// as `write` does, and every later durability operation fails until a
+    /// checkpoint repairs it. Callers that own an error channel check
+    /// [`Session::check_direct_write_allowed`] before calling.
     pub fn transact<T, E>(
         &self,
         operation: impl FnOnce(&mut DirGraph) -> Result<T, E>,
     ) -> Result<T, E> {
+        self.mark_diverged();
         let mut guard = self.graph.lock().unwrap_or_else(|p| p.into_inner());
         let current_version = guard.version();
         let mut working = guard.fork_transaction();
@@ -193,9 +237,29 @@ impl Session {
     /// that may publish to `path` must hold its own
     /// [`GraphWriterLease`](crate::graph::io::open::GraphWriterLease) across
     /// the whole open/mutate/save interval.
+    /// # Durable sessions
+    ///
+    /// For a session opened via [`Session::open_durable`] this method is the
+    /// **checkpoint**, and it runs the four-step order the format requires:
+    /// flush the log → stamp `checkpoint_lsn` into the graph being written →
+    /// write the `.kgl` → drop the capture buffer and truncate the log. The
+    /// `graph::session::durable` module documents why each step sits where it
+    /// does.
+    ///
+    /// `fsync=false` is **overridden to true** on a durable session, silently
+    /// and deliberately: the checkpoint destroys the log that would otherwise
+    /// still describe those commits, so pairing a maybe-not-on-disk checkpoint
+    /// with a destroyed log would let one crash lose both. (The Python wheel
+    /// warns as well as overriding; the engine has no warning channel, so the
+    /// contract is stated here.)
     pub fn save(&self, path: &str, fsync: bool) -> Result<(), String> {
         let mut guard = self.graph.lock().unwrap_or_else(|p| p.into_inner());
-        crate::graph::io::file::save_graph_with(&mut guard, path, fsync)
+        let durable = self.checkpoint_prologue(&mut guard)?;
+        crate::graph::io::file::save_graph_with(&mut guard, path, fsync || durable)?;
+        if durable {
+            self.checkpoint_epilogue(&mut guard)?;
+        }
+        Ok(())
     }
 
     /// Begin a new read-write transaction. The snapshot is taken
@@ -260,6 +324,17 @@ impl Session {
                 current_version,
                 base_version,
             };
+        }
+
+        // Durable sessions log the commit BEFORE publishing it. A frame that
+        // could not be appended means the caller must not be told the write
+        // happened, so the Arc swap below is skipped entirely — the working
+        // copy is dropped and the graph is exactly as it was. (The wheel's
+        // apply-then-log ordering can only report the same failure *after* the
+        // mutation is visible; this is the stronger half of the rung.) No-op
+        // for a non-durable session.
+        if let Err(error) = self.log_working_commit(&mut working) {
+            return CommitOutcome::DurabilityFailed { error };
         }
 
         // Bump from the *current* version (not the possibly-stale base) so the
@@ -373,7 +448,13 @@ impl Transaction {
 
 /// Outcome of [`Session::commit`]. Bindings inspect this to decide
 /// what to surface to their consumers.
+///
+/// `#[non_exhaustive]`: a commit can fail in ways that did not exist when a
+/// binding was written — [`DurabilityFailed`](Self::DurabilityFailed) is the
+/// first — and an outcome a binding does not recognise must reach its error
+/// path, not its success path. Downstream matches carry a catch-all arm.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CommitOutcome {
     /// Read-only-then-commit / no mutations happened. Cheap path.
     NoWritesNoOp,
@@ -388,6 +469,15 @@ pub enum CommitOutcome {
         current_version: u64,
         base_version: u64,
     },
+    /// **Durable sessions only.** The commit's write-ahead-log frame could not
+    /// be appended, so the commit was not published: the graph is unchanged,
+    /// the version did not move, and the working copy is dropped (lost).
+    ///
+    /// This is a hard failure, not a retriable conflict — the disk, not
+    /// another writer, said no. A binding surfaces it as an IO/backend error;
+    /// re-running the unit of work will hit the same wall until the underlying
+    /// problem is cleared.
+    DurabilityFailed { error: String },
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -873,8 +963,8 @@ mod tests {
                             match s.commit(tx, /* check_occ = */ true) {
                                 CommitOutcome::Committed { .. } => break,
                                 CommitOutcome::ConflictDetected { .. } => continue,
-                                CommitOutcome::NoWritesNoOp => {
-                                    panic!("materialised tx must commit as a write")
+                                other => {
+                                    panic!("materialised tx must commit as a write: {other:?}")
                                 }
                             }
                         }

--- a/crates/kglite/src/graph/storage/backend.rs
+++ b/crates/kglite/src/graph/storage/backend.rs
@@ -167,6 +167,55 @@ impl GraphBackend {
         GraphBackend::Memory(Arc::new(MemoryGraph::new()))
     }
 
+    /// Whether this backend is wrapped in the WAL write-capture layer, i.e.
+    /// whether some owner is logging its mutations.
+    ///
+    /// The durable machinery reads and reaches into the capture layer from
+    /// several places; those questions are answered here, on the dispatcher,
+    /// rather than by re-matching the variant at each site.
+    #[inline]
+    pub(crate) fn is_recording(&self) -> bool {
+        matches!(self, GraphBackend::Recording(_))
+    }
+
+    /// The write-capture layer, if this backend is wrapped in one.
+    ///
+    /// Read-side only, and therefore test-only: the production durable paths
+    /// all *drain* the buffer and use [`recording_mut`](Self::recording_mut).
+    /// This exists so the durable session's replay-before-wrap ordering has an
+    /// observable — a graph wrapped before its WAL replay carries every
+    /// replayed op in this buffer, which nothing else can see.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn recording(&self) -> Option<&RecordingGraph<GraphBackend>> {
+        match self {
+            GraphBackend::Recording(rg) => Some(rg),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the write-capture layer, if this backend is wrapped
+    /// in one. The durable commit and checkpoint paths drain the op buffer
+    /// through this.
+    #[inline]
+    pub(crate) fn recording_mut(&mut self) -> Option<&mut RecordingGraph<GraphBackend>> {
+        match self {
+            GraphBackend::Recording(rg) => Some(rg),
+            _ => None,
+        }
+    }
+
+    /// Wrap this backend in the write-capture layer, idempotently. See
+    /// [`crate::graph::storage::recording::wrap_for_durability`] for the
+    /// `DirGraph`-shaped entry point every binding calls.
+    pub(crate) fn wrap_for_durability(&mut self) {
+        if self.is_recording() {
+            return;
+        }
+        let inner = std::mem::replace(self, GraphBackend::new());
+        *self = GraphBackend::Recording(Box::new(RecordingGraph::new(inner)));
+    }
+
     /// Whether a proven-infallible mutation may commit without a full rollback
     /// checkpoint. Recording/durable wrappers deliberately return false even
     /// when their inner backend is memory: their post-write WAL lifecycle is a

--- a/crates/kglite/src/graph/storage/recording.rs
+++ b/crates/kglite/src/graph/storage/recording.rs
@@ -170,6 +170,24 @@ impl<G: GraphRead + Clone> Clone for RecordingGraph<G> {
     }
 }
 
+/// Wrap `dir`'s backend in the [`RecordingGraph`] write-capture layer so every
+/// mutation that crosses the `GraphWrite` seam is buffered for the WAL.
+/// Idempotent — an already-wrapped graph is left alone.
+///
+/// Storage-mode-agnostic by construction: the wrapper wraps the
+/// [`GraphBackend`](crate::graph::storage::backend::GraphBackend) *enum* rather
+/// than a concrete backend, so one capture path
+/// covers memory and mapped alike. (Disk is refused a rung earlier, by the
+/// durable-open path, because it has no logical WAL at all.)
+///
+/// Lifted out of the wheel: `Session::open_durable` and every non-Rust binding
+/// that opens a durable graph need exactly this, byte for byte, so it is core
+/// rather than per-binding (CLAUDE.md's boundary principle — "anything two or
+/// more wrappers would write identically belongs in `kglite::api`").
+pub fn wrap_for_durability(dir: &mut crate::graph::dir_graph::DirGraph) {
+    dir.graph.wrap_for_durability();
+}
+
 /// Resolve buffered [`RawOp`]s into string-keyed, identity-keyed
 /// [`MutationOp`]s, reading final node/edge state from `graph` and
 /// resolving interned keys through `interner`. Upserts whose node/edge

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -432,9 +432,11 @@ pub mod api {
         /// recover→replay→wrap→append ordering every owner of a log performs at
         /// open (`open_log`, which also enforces the unconditional
         /// recovery-on-open refusal), and the two halves of the four-step
-        /// checkpoint that bracket a binding's own save.
+        /// checkpoint that bracket a binding's own save. `ensure_recovered` is
+        /// that same refusal for an opener that attaches no log at all, and is
+        /// already applied by `io::open_or_create_graph`.
         pub use crate::graph::durability::{
-            checkpoint_epilogue, checkpoint_prologue, open_log, DurableOpenError,
+            checkpoint_epilogue, checkpoint_prologue, ensure_recovered, open_log, DurableOpenError,
         };
         pub use crate::graph::mutation::wal_replay::apply_frames;
         pub use crate::graph::storage::recording::{

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -370,10 +370,15 @@ pub mod api {
             export_embeddings_to_file, import_embeddings_from_file, EmbeddingExportFilter,
             ImportStats,
         };
-        /// `.kgl` load / save (the canonical persistence format).
+        /// `.kgl` load / save (the canonical persistence format). `save_graph`
+        /// and `save_graph_with` are the single save dispatch and report
+        /// `SaveError`, whose `Refused` variant is a save declined *before*
+        /// the path was touched — a write-ahead sidecar beside the target
+        /// holds commits this checkpoint would strand. Bindings map that to
+        /// their own class for a bad request, not to an I/O failure.
         pub use crate::graph::io::file::{
             load_file, load_kgl_bytes, prepare_save, save_graph, save_graph_with, write_kgl,
-            write_kgl_to, write_kgl_with,
+            write_kgl_to, write_kgl_with, SaveError,
         };
         pub use crate::graph::io::ntriples::{
             load_ntriples, Cancelled, NTriplesConfig, ProgressEvent, ProgressSink, ProgressValue,

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -429,7 +429,9 @@ pub mod api {
     /// save in `io`). Lifted in roadmap Piece 4.
     pub mod durable {
         pub use crate::graph::mutation::wal_replay::apply_frames;
-        pub use crate::graph::storage::recording::{resolve_ops, RecordingGraph};
+        pub use crate::graph::storage::recording::{
+            resolve_ops, wrap_for_durability, RecordingGraph,
+        };
         pub use crate::graph::wal::{recover, wal_path, DurabilityLevel, SyncMode, Wal, WalFrame};
     }
 

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -428,6 +428,14 @@ pub mod api {
     /// feature. The in-process WAL mechanism (distinct from the checkpoint
     /// save in `io`). Lifted in roadmap Piece 4.
     pub mod durable {
+        /// Binding-agnostic durable-open + checkpoint orchestration: the
+        /// recover→replay→wrap→append ordering every owner of a log performs at
+        /// open (`open_log`, which also enforces the unconditional
+        /// recovery-on-open refusal), and the two halves of the four-step
+        /// checkpoint that bracket a binding's own save.
+        pub use crate::graph::durability::{
+            checkpoint_epilogue, checkpoint_prologue, open_log, DurableOpenError,
+        };
         pub use crate::graph::mutation::wal_replay::apply_frames;
         pub use crate::graph::storage::recording::{
             resolve_ops, wrap_for_durability, RecordingGraph,

--- a/docs/concepts/concurrency.md
+++ b/docs/concepts/concurrency.md
@@ -63,6 +63,16 @@ generation exists.
   driver-managed transactions, and what that does to throughput and latency as
   writers are added — is stated in
   [Bolt server → Write concurrency](../operators/bolt-server.md#write-concurrency).
+- A session can also be **durable**: `Session::open_durable(graph, path, level)`
+  recovers the path's write-ahead sidecar before the session serves anyone, and
+  every later commit appends its frame between the OCC check and the Arc swap,
+  so a frame that cannot be written blocks the publish instead of following it.
+  Concurrency is unchanged — one owner per path, readers still on snapshots —
+  but the commit point now includes an append, and at `full` a device barrier
+  taken inside the lock all writers serialize on. Bolt exposes the level as
+  `--durability`; see
+  [Bolt server → Durability](../operators/bolt-server.md#durability) for the
+  per-level loss windows and the measured cost.
 - MCP uses the native session pipeline; writable workbench mode is explicit.
 - A new binding owns async/runtime scheduling but should reuse
   `kglite::api::session` rather than creating a second lock/transaction model.
@@ -83,6 +93,17 @@ deterministically, then required to both land via driver retry), and the
 contended-writer load test `tests/benchmarks/test_bench_bolt_writers.py`
 (writer-count sweep producing the throughput/retry/latency curve behind the
 operator contract). All three are opt-in (`-m bolt_stress`).
+
+Durability under that same model is pinned by
+`tests/test_bolt_server_durability.py` (`-m bolt`): child-process
+`SIGKILL`-and-restart tests at each `--durability` level, with `off` as the
+control that loses the commit; the unconditional recovery-on-open behaviour and
+its `off`-over-an-unreplayed-log refusal; and that a checkpoint truncates the
+log while post-checkpoint commits still recover. `tests/test_durability.py` and
+`tests/test_durable_save.py` cover the same engine surface from the embedded
+side. The cost of each level — why the Bolt default is `normal` — is the
+`test_durability_sweep` cell of the benchmark above, alongside
+`test_checkpoint_under_contention`.
 
 See [Python transactions](../python/transactions.md),
 [Rust session](../rust/session.md), and [Architecture](architecture.md).

--- a/docs/operators/bolt-server.md
+++ b/docs/operators/bolt-server.md
@@ -24,6 +24,13 @@ authorization. Reads run against snapshots and scale across concurrent sessions.
 - **One writer.** Writes serialize at commit within the process, and one
   writable server per graph is enforced by a cross-process lease (see
   *Operations and security* below).
+- **The graph file is not rewritten continuously.** Every commit is appended to
+  a write-ahead log as it is acknowledged, but the `.kgl` itself changes only
+  when a checkpoint runs — `CALL db.checkpoint()`, `--checkpoint-interval`, or
+  `--save-on-exit`. Turn the log off with `--durability off` and a commit is
+  process-local until one of those runs: the file is whatever it was when the
+  server opened it. See *Durability* below for what each level costs and what
+  it leaves behind.
 
 If you need per-user access control, the supported shape is not this server: it
 is the [derived-index / traversal-component pattern](../python/guides/derived-index.md#an-embedded-traversal-component-behind-your-api),
@@ -66,9 +73,12 @@ Important options (run `--help` on the installed version for the authority):
 | Option | Purpose |
 |---|---|
 | `--bind`, `--port` | listener, default `127.0.0.1:7687` |
-| `--storage memory|mapped|disk` | create a missing graph in this mode, or convert an existing one to it (memory ⇄ mapped; disk directions refused) |
+| `--storage memory\|mapped\|disk` | create a missing graph in this mode, or convert an existing one to it (memory ⇄ mapped; disk directions refused) |
 | `--readonly` | reject mutations at execution |
-| `--auth none|basic`, `--auth-user`, `--auth-pass` | Bolt LOGON policy |
+| `--durability full\|normal\|off` | what an acknowledged commit survives, default `normal` (see *Durability*) |
+| `--save-on-exit` | checkpoint the served graph back to `--graph` on `SIGINT`/`SIGTERM` |
+| `--checkpoint-interval SECS` | checkpoint the served graph on a timer |
+| `--auth none\|basic`, `--auth-user`, `--auth-pass` | Bolt LOGON policy |
 | `--idle-timeout`, `--max-sessions`, `--max-message-size` | resource bounds |
 | `--advertise-addr HOST:PORT` | address returned to `neo4j://` routing clients |
 | `--tls-cert`, `--tls-key` | PEM TLS pair for `bolt+s://` / `neo4j+s://` |
@@ -161,6 +171,156 @@ that conflicts are retriable and managed transactions actually retry them —
 is pinned by `tests/test_bolt_server_transactions.py` and
 `tests/test_bolt_server_concurrency.py`.
 
+## Durability
+
+Two independent mechanisms decide what a stopped or killed server leaves
+behind. A **write-ahead log** records each commit to a sidecar file as it is
+acknowledged, so an interruption costs at most what the log does not hold. A
+**checkpoint** rewrites the whole `.kgl` from the committed graph and truncates
+the log. They are complements, not alternatives: the log bounds the window
+while the server runs, the checkpoint is what folds the log back into the file.
+
+### Levels (`--durability`)
+
+`--durability full|normal|off` — or `KGLITE_BOLT_DURABILITY=<level>`, the flag
+winning if both are set — selects what an *acknowledged* commit survives. The
+frame is written **before** the client is told the commit succeeded, so a
+commit whose frame cannot be written is not applied at all and is reported as a
+failure, rather than acknowledged over a write the server then discards.
+
+| Level | An acknowledged commit survives | It does not survive |
+|---|---|---|
+| `full` | the server process dying, and — by asking the device for a write barrier before acknowledging — an OS crash or power loss | media failure, or anything the filesystem itself loses |
+| `normal` (default) | the server process dying: `SIGKILL`, an OOM kill, a panic. The frame is in the kernel's page cache | an OS crash or power loss before the kernel writes that page out |
+| `off` | nothing by itself — commits stay in this process until a checkpoint rewrites the file | the process ending at all, unless a checkpoint ran first |
+
+What is pinned by test is the process-kill case: at `full` and at `normal`,
+committing over Bolt and then `SIGKILL`ing the server with no checkpoint of any
+kind leaves the `.kgl` byte-identical, and the restarted server replays the
+commit out of the log. `off` is the control — the same write is gone. Nothing
+in a user-space test can take the page cache or the power away, so the
+`full`-versus-`normal` distinction above is a statement about the barrier each
+level takes, not a measured one.
+
+**The default is `normal`, and it was chosen by measurement.** Under contended
+managed writers on one graph, `normal` cost nothing distinguishable from `off`
+— the two comparison runs straddled zero, inside the cell's own noise — while
+`full` cost roughly seven-eighths of committed throughput, about an eightfold
+drop. One device barrier is taken per commit, inside the lock every Bolt commit
+already serializes on, which is also why `full`'s committed rate does not
+change between one writer and four, why its p95 unit-of-work latency grew by
+nearly two orders of magnitude at four writers, and why its transaction-conflict
+rate rose about tenfold: contenders lose the optimistic-concurrency race far
+more often when the winner holds the lock across a barrier. Power-loss safety
+is therefore opt-in rather than on by default. The sweep is
+`tests/benchmarks/test_bench_bolt_writers.py::test_durability_sweep`
+(`-m "benchmark and bolt_stress"`).
+
+### Recovery on startup
+
+Recovery is unconditional and runs before the listener binds, at every level —
+opening a path is a decision about that path's *data*, not only about how
+future writes will be logged. At `full` and `normal` a sidecar holding commits
+the `.kgl` does not contain is replayed into the graph. At `off` the same
+sidecar is a startup error naming both ways out: restart at `full` or `normal`
+to replay the commits, or move the sidecar aside to discard them deliberately.
+A server that would otherwise serve a graph missing acknowledged writes does
+not start.
+
+Frames the checkpoint already contains — the harmless residue of a crash
+between a checkpoint's file write and its log truncation — are not grounds to
+refuse, and open at every level.
+
+### Checkpoints
+
+Three routes rewrite the served `.kgl`, and all three are the same operation:
+flush the log, stamp the checkpoint position, write the file, truncate the log.
+
+- **`CALL db.checkpoint()`** — on demand, over the wire. It is a *bolt-server
+  verb*, not an engine procedure: it exists only over Bolt, and embedded
+  bindings keep their own save calls. It answers in Neo4j's `success, message`
+  shape, and an optional `YIELD` of either or both columns is honoured. A
+  checkpoint whose graph has not changed since the last one *in this process*
+  is skipped and says so; the first call of a process always writes, because
+  the file may predate the process.
+- **`--checkpoint-interval SECS`** (`KGLITE_BOLT_CHECKPOINT_INTERVAL`) — on a
+  timer. The interval task and the verb share one recorded version, so a
+  checkpoint by either makes the next tick a skip; an idle server does not
+  rewrite its file. A failed tick is logged as an error and the server keeps
+  serving. The interval is validated at startup rather than starting a server
+  that silently never checkpoints.
+- **`--save-on-exit`** (`KGLITE_BOLT_SAVE_ON_EXIT`) — once, on `SIGINT` or
+  `SIGTERM`, after periodic checkpointing has been stopped. The saved graph
+  version is logged; a failed exit save is logged as an error *and* exits
+  non-zero, so a supervisor sees it. Connections are not drained, so a commit
+  racing shutdown can land after the save — the logged version is how that is
+  told apart from a save that never ran. Under a log the commit is still in the
+  sidecar and the next start replays it.
+
+A checkpoint pauses writers and new snapshots for its duration — `Session::save`
+mutates the graph, so it holds the session lock for the whole write — while
+readers already holding a snapshot are unaffected. That pause is bounded by
+what a full save of the graph costs, so it is the graph's size that sets it. At
+the benchmark's ten-thousand-node scale a checkpoint every second under four
+contended writers cost **no measured committed throughput** (the checkpointed
+arm in fact committed more than its own baseline in every pairing, and a
+sham-thread control ruled out the extra session as the explanation; the
+mechanism is not established). Size the interval for a large graph by timing
+one `CALL db.checkpoint()` on it.
+
+Retention is one: each checkpoint atomically replaces the previous file. Use
+filesystem tooling — a snapshot, a copy, a backup job — if you want history.
+
+### The sidecar file
+
+At `full` and `normal` the server keeps `<graph>-wal` beside the graph file,
+and every checkpoint truncates it back to its header. Between checkpoints it
+grows by under a hundred bytes per single-node commit — multiply that by your
+commit rate to size it — so a busy server with no checkpointing configured
+accumulates a sidecar in proportion to how long it has been running, and a
+restart pays a replay proportional to the same thing. `--checkpoint-interval`
+bounds both at once, which is the reason to set it: not to make commits safer
+(the log already did that) but to keep replay time and sidecar size bounded.
+
+Back up the sidecar with the graph, or checkpoint before copying the `.kgl`
+alone — a `.kgl` copied while a sidecar runs ahead of it is missing the commits
+the sidecar holds. The engine refuses the dangerous half of this by itself: a
+non-durable open, and a save, over a path whose sidecar runs ahead are errors
+rather than silent data loss.
+
+### Refusal matrix
+
+Two configurations cannot carry a log or a checkpoint: `--readonly` (a server
+that never commits has nothing to log, and nothing to write back) and
+disk-mode graphs (a disk graph commits by publishing an immutable generation,
+so it keeps no logical log, and every disk save publishes a *new* generation
+that nothing prunes — repeated checkpoints would grow the directory without
+bound).
+
+An explicitly requested level or feature is refused there. The *default* level
+degrades instead, so that flipping the default did not turn every read-only
+and disk-mode server into a startup error:
+
+| Configuration | `--durability full`/`normal` (asked for) | `--durability` (default) | `--save-on-exit`, `--checkpoint-interval` | `CALL db.checkpoint()` |
+|---|---|---|---|---|
+| `.kgl`, writable | serves at that level | serves at `normal` | supported | supported |
+| `--readonly` | startup error | serves at `off`, logged | startup error | `Neo.ClientError.Security.Forbidden` |
+| disk-mode graph | startup error | serves at `off`, logged | startup error | `Neo.ClientError.Security.Forbidden` |
+
+The one refusal that is about *data* rather than configuration is `off` over a
+sidecar that runs ahead of the file, above: a level nobody asked for replays it
+instead, which is what makes the default safe to inherit.
+
+Environment mirrors are refused exactly as the flags are; a mistyped level or
+interval is a startup error rather than a server that silently logs nothing.
+`CALL db.checkpoint()` is also refused inside an explicit transaction — it
+writes the *committed* graph, which by definition excludes that transaction's
+uncommitted writes — so commit first and call it in auto-commit.
+
+The behavior above is pinned by `tests/test_bolt_server_durability.py`
+(`-m bolt`), including the `SIGKILL`-and-restart tests behind each level, the
+checkpoint-truncates-the-log test, and every row of this matrix.
+
 ## Driver identity (`--neo4j-compat`)
 
 The handshake reports `kglite-bolt-server/<version>` by default. The official
@@ -206,7 +366,10 @@ switched automatically.
 - Use `--readonly` for read-only analytical instances sharing the same graph
   file, and for agent connections that do not need writes. A `--readonly`
   server is a second process opening the same graph, not a replica: it serves
-  what the file contained when it opened it.
+  what the file contained when it opened it — which, beside a durable writer,
+  excludes whatever that writer has committed to its sidecar since the last
+  checkpoint (see *Durability*). A read-only server keeps no log itself and
+  serves at `--durability off`.
 - One writable server per graph. A server started without `--readonly` takes
   the same cross-process writer lease as `kglite.open()` *before* it reads the
   graph, and holds it until shutdown, so a second writable server — or a CLI
@@ -214,8 +377,10 @@ switched automatically.
   the holding process instead of racing it to overwrite at save time. The
   refusal is immediate rather than a wait, so a supervisor's restart policy
   governs the retry. `--readonly` servers take no lease and start alongside a
-  live writer.
-- Back up the complete graph before upgrades; see
-  [Import and Export](../python/guides/import-export.md).
+  live writer. Because the lease is exclusive, the graph's write-ahead sidecar
+  has exactly one writer too.
+- Back up the complete graph before upgrades — including the `<graph>-wal`
+  sidecar, or after a `CALL db.checkpoint()` that folds it in; see
+  [Import and Export](../python/guides/import-export.md) and *Durability*.
 - Use release benchmarks/CI reports for performance claims; this operator page
   intentionally avoids unversioned hardware-specific numbers.

--- a/docs/rust/embedding.md
+++ b/docs/rust/embedding.md
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load a graph file written by ANY kglite binding —
     // Python's `kg.save("graph.kgl")`, the bolt-server's
-    // `CALL db.checkpoint("graph.kgl")`, etc. The on-disk
+    // `CALL db.checkpoint()` over Bolt, etc. The on-disk
     // .kgl format is the portable cross-binding contract.
     let graph = load_file("graph.kgl")?;
 
@@ -142,12 +142,17 @@ snapshot/working CoW + OCC live here exactly once.
 - `Session::new(dir)` + `session.begin()` / `session.commit(tx,
   true)` — the snapshot/working CoW transaction model. OCC is
   opt-in per commit; pass `true` for production semantics.
+- `Session::open_durable(dir, path, level)` — the same session with a
+  write-ahead log under it: the sidecar is recovered before the session
+  serves anyone, and each commit's frame is appended before the publish.
 - `CommitOutcome::{NoWritesNoOp, Committed { new_version },
-  ConflictDetected { current_version, base_version }}` — what
-  your binding maps to its consumer-facing error type.
+  ConflictDetected { current_version, base_version },
+  DurabilityFailed { error }}` — what your binding maps to its
+  consumer-facing error type. The enum is `#[non_exhaustive]`, so match a
+  catch-all arm as well.
 
 See `docs/rust/session.md` for the full session
-abstraction guide.
+abstraction guide, including the durable-session contract.
 
 ### Dataset loaders
 

--- a/docs/rust/session.md
+++ b/docs/rust/session.md
@@ -54,6 +54,63 @@ snapshot continue seeing it after commit; new snapshots see the committed graph.
 Pass `check_occ=true` in production so a transaction based on a stale version
 returns `ConflictDetected`. Last-writer-wins is not a safe default.
 
+`CommitOutcome` is `#[non_exhaustive]` — match a catch-all arm, not only the
+variants that existed when you wrote the binding.
+
+## Durable sessions
+
+`Session::open_durable(graph, checkpoint_path, level)` builds a session that
+appends every commit to the path's write-ahead sidecar. It performs the whole
+open ordering, so a binding does not re-derive it: recover the sidecar, replay
+the frames the loaded checkpoint does not already contain, *then* wrap the
+backend for write capture, then open the log for append.
+
+```rust
+use kglite::api::durable::DurabilityLevel;
+
+let session = Session::open_durable(graph, "/data/app.kgl", DurabilityLevel::Normal)?;
+match session.commit(tx, true) {
+    CommitOutcome::DurabilityFailed { error } => { /* IO/backend error, not retriable */ }
+    _ => {}
+}
+session.sync()?;                 // on-demand barrier: what makes `Normal` usable
+session.save("/data/app.kgl", true)?;  // checkpoint: folds the log in and truncates it
+```
+
+Contract points a binding has to honour:
+
+- **The frame is appended between the OCC check and the publish.** A log that
+  cannot be written blocks the commit rather than reporting success over an
+  unlogged write; `CommitOutcome::DurabilityFailed { error }` says so, and the
+  graph, its version and its readers are untouched. Surface it as an
+  IO/backend error, not as a retriable conflict — re-running hits the same
+  wall.
+- **`save` is the checkpoint**: flush the log, stamp `checkpoint_lsn`, write
+  the file, truncate the log. Its signature is unchanged, and it forces
+  `fsync` on a durable session because it destroys the log that would
+  otherwise still describe those commits.
+- **`write()` / `transact` are not logged paths** and are unsupported on a
+  durable session. Taking one anyway latches the session: every later
+  durability operation fails loudly until a checkpoint folds the direct write
+  in. Callers with an error channel check
+  `Session::check_direct_write_allowed` first; bindings should route mutations
+  through `begin`/`commit` instead.
+- **One durable owner per path.** A durable `Session` and a durable
+  `KnowledgeGraph` over the same path are not a supported pair — the split
+  checkpoint/next-LSN state is what the replay gate reads.
+- **Refusals are explicit**, not silent degradation: disk-mode graphs at any
+  logging level, a path another durable owner already wrapped, and — the
+  data-safety one — level `Off` over a sidecar holding commits the checkpoint
+  does not contain. Recovery on open is unconditional; a non-durable open of
+  such a path is an error rather than a graph quietly missing acknowledged
+  writes.
+
+`Session::durability()` reports the level (`None` when the session logs
+nothing). Non-durable sessions are unaffected in behaviour and in cost.
+Levels, per-level loss windows and the measured cost of each are in
+[Bolt server → Durability](../operators/bolt-server.md#durability), whose
+`--durability` flag is this API's only server-side consumer.
+
 ## Binding models
 
 - Python exposes direct `KnowledgeGraph`, explicit `Session`,
@@ -86,6 +143,7 @@ exposing that mode.
 
 - `graph/session/execute.rs` — options/outcome and canonical pipeline.
 - `graph/session/transaction.rs` — `Session`, `Transaction`, OCC, snapshots.
+- `graph/session/durable.rs` — `open_durable`, `sync`, the checkpoint order.
 - `api::session` — supported public re-exports.
 - `crates/kglite-py/src/graph/pyapi/` — Python wrapper.
 - `crates/kglite-bolt-server/src/backend.rs` — Bolt wrapper.

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -817,6 +817,17 @@ def open(
             - ``None`` (default) — ``"full"``, except on ``storage="disk"``
               where it resolves to ``"off"`` rather than raising.
 
+            **Recovery happens at every level, including ``"off"``.** Opening a
+            path is a decision about that path's data, not only about how future
+            writes are logged, so an ``"off"`` open over a ``<path>-wal`` sidecar
+            that still holds commits the checkpoint does not contain raises
+            ``ValueError`` instead of returning a graph that is missing them —
+            the next ``save()`` would truncate the log and destroy those commits.
+            Reopen at ``"full"`` or ``"normal"`` to replay them, or move the
+            sidecar aside to discard them deliberately. Sidecar frames the
+            checkpoint already contains (the residue of a crash between a
+            ``save()`` and its truncation) are harmless and open fine.
+
             **The levels are not uniform across storage modes:**
             ``storage="disk"`` supports only ``"off"``, and both ``"full"`` and
             ``"normal"`` raise ``ValueError`` there. A disk graph commits by

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -3613,6 +3613,18 @@ class KnowledgeGraph:
         Load it back with :func:`kglite.load` (accepts both files and
         directories).
 
+        **A path whose write-ahead log runs ahead of it is refused.** If a
+        ``<path>-wal`` sidecar beside the target still holds commits this graph
+        does not contain — a durable writer that died before its next
+        checkpoint — saving here would strand them: the sidecar outlives the
+        new file, and the next ``kglite.open(path, durable=...)`` replays those
+        commits back over what was just saved. ``save()`` raises ``ValueError``
+        instead, naming the sidecar and the two ways out: reopen the path
+        durably (``kglite.open(path, durable="full")``) to replay the commits
+        first, or move the sidecar aside to discard them deliberately. A graph
+        opened with ``durable=`` is never affected — its own checkpoint folds
+        its log in.
+
         Args:
             path: Output file path (typically ``*.kgl``). May be omitted if the
                 graph was opened via :func:`kglite.open` or :func:`kglite.load`,

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -43,6 +43,11 @@ FINDING CATEGORIES
 ``exact-pin``
     A site pins an ecosystem package at an exact version that has been
     superseded. Not an error; it is the thing that silently rots.
+``citation``
+    Prose that *records* a version — "introduced in X", "the X → Y move",
+    "verified against X on <date>" — rather than requiring one. Classified and
+    listed, never reported as drift: telling a downstream to move a provenance
+    line to the current version asks it to falsify its own record.
 ``site``
     Inventory: a declaration living outside package metadata. Always listed,
     even when consistent, because these are the sites that *can* drift with
@@ -63,8 +68,14 @@ genuinely affected:
 * its declared range **excludes** the new version (blocked), or
 * it pins the upstream at a now-superseded exact version somewhere, or
 * a breaking change in this release touches a symbol the repo actually
-  references (approximated by scanning its sources for the symbols listed in
-  ``--breaking-symbol`` / the release config).
+  references (approximated by scanning its *code* — never comments or prose —
+  for the symbols ``BREAKING_SYMBOLS_BY_VERSION`` records against **this**
+  version, or the ones given with ``--breaking-symbol``).
+
+Each note's "what changed" section is read from the announced release's own
+``## [X.Y.Z]`` CHANGELOG entry. When that entry cannot be resolved the section
+is omitted and a warning goes to stderr: a blurb that is silently a different
+release's is worse than an absent one, and three shipped notes proved it.
 
 When a downstream is unaffected the run prints ``SKIP <repo>: <reason>`` and
 writes nothing. The decision *not* to notify is as much a feature as the note.
@@ -358,6 +369,9 @@ BINDING_SITES = {
 }
 DOC_SITES = {"docs", "docs-install"}
 ADVISORY_SITES = {"script", "source-string"}
+#: Prose that *records* a version rather than requiring one — see
+#: ``is_version_citation``. Reported as an adjudicated class, never as drift.
+CITATION_SITES = {"docs-citation"}
 
 
 @dataclasses.dataclass
@@ -704,6 +718,110 @@ SUPPRESS_MARKER = "version-check: ignore"
 _LEDGER_ROW = re.compile(r"^\|\s*\d{4}-\d{2}-\d{2}\s*\|")
 
 
+# ---- declaration vs citation ----------------------------------------------
+#
+# A version *declaration* — a pin, a documented floor, "requires >= X", an
+# install line — states what you must use, so it goes stale the moment a
+# release lands. A version *citation* — "introduced in X", "the X → Y move",
+# "verified against X", a dated correction — states what happened, and is true
+# forever. Telling a downstream to "move" one of those to the current version
+# asks them to falsify their own record; codingest's PARITY.md provenance line
+# was cited that way in three consecutive release notes.
+#
+# The classifier is deliberately conservative in one direction: anything it
+# cannot recognise as a record stays a finding, because a missed stale pin
+# costs more than a false positive that a human dismisses.
+
+#: Past-tense / provenance cues. Presence of one inside the sentence carrying
+#: the version means the sentence is talking about the past.
+#: The past-tense forms are deliberate. An earlier draft accepted
+#: ``ship(?:ped)? in`` and classified "these crates ship in lockstep" — a
+#: present-tense statement about policy — as a historical record.
+_CITATION_CUES = re.compile(
+    r"\b(introduced|added\s+in|landed\s+in|shipped\s+in|released\s+in|"
+    r"removed\s+in|deleted\s+in|renamed\s+in|fixed\s+in|broke\s+in|changed\s+in|"
+    r"migrat(?:ed|ion|ing)|verified|was|were|used\s+to|since|as\s+of|onwards?|"
+    r"previously|formerly|originally|earlier|historical\w*|history|no\s+longer|"
+    r"already|first\s+appeared|described|correction|moved\s+from|"
+    r"upgraded\s+from|bumped\s+from)\b",
+    re.IGNORECASE,
+)
+#: Cues that make a sentence a live requirement even if it is phrased in prose.
+#: These win over the citation cues, except against an explicit version range.
+_DECLARATION_CUES = re.compile(
+    r"\b(requires?|required|requirement|minimum|floor|pins?|pinned|depends?\s+on|"
+    r"needs?|install(?:s|ing|ation)?|upgrade\s+to|bump\s+to|move\s+to|must\s+be|"
+    r"at\s+least|or\s+newer|or\s+later|supported\s+version)\b",
+    re.IGNORECASE,
+)
+#: ``0.15.8 → 0.15.11``, ``0.15.8 -> 0.15.11``, ``0.15.8 to 0.15.11``. Two
+#: endpoints describe a completed transition; nothing can "move" a range to the
+#: current version without rewriting which move actually happened. This wins
+#: over the declaration cues, because "the engine floor moved 0.15.11 → 0.15.13"
+#: is a record of a bump, not a bump instruction.
+_VERSION_RANGE = re.compile(r"v?\d+\.\d+(?:\.\d+)?\s*(?:→|->|-->|=>|–|—|\bto\b)\s*v?\d+\.\d+")
+#: An ISO date anywhere in the surrounding prose dates the statement.
+_DATED_PROSE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+#: ``0.15.5+`` is a floor written compactly — a declaration, whatever else the
+#: sentence says.
+_FLOOR_SUFFIX = re.compile(r"^\s*\+")
+
+
+def _prose_context(lines: list[str], index: int) -> tuple[str, int]:
+    """The wrapped sentence around ``lines[index]``, and its start offset.
+
+    Markdown wraps sentences across lines, so the verb that dates a statement
+    ("…and it was\\nintroduced in kglite 0.15.5") routinely sits on a different
+    line from the version. Neighbours are joined only while the sentence is
+    unfinished — a preceding line that ends in terminal punctuation starts a new
+    thought and is not evidence about this one.
+    """
+    before: list[str] = []
+    i = index - 1
+    while i >= 0 and len(before) < 2:
+        prev = lines[i].strip()
+        if not prev or prev.endswith((".", "!", "?")) or prev.startswith(("#", "|", "```")):
+            break
+        before.insert(0, prev)
+        i -= 1
+    after: list[str] = []
+    tail = lines[index].strip()
+    j = index + 1
+    while j < len(lines) and len(after) < 2 and not tail.endswith((".", "!", "?")):
+        nxt = lines[j].strip()
+        if not nxt or nxt.startswith(("#", "|", "```")):
+            break
+        after.append(nxt)
+        tail = nxt
+        j += 1
+    head = " ".join(before)
+    line_start = len(head) + 1 if head else 0
+    return " ".join([*before, lines[index].strip(), *after]), line_start
+
+
+def _sentence_at(text: str, index: int) -> str:
+    """The sentence of ``text`` containing offset ``index``."""
+    starts = [m.end() for m in re.finditer(r"[.!?;:]\s+", text[:index])]
+    start = starts[-1] if starts else 0
+    m = re.search(r"[.!?;:]\s+", text[index:])
+    end = index + m.start() + 1 if m else len(text)
+    return text[start:end]
+
+
+def is_version_citation(lines: list[str], index: int, match: re.Match[str]) -> bool:
+    """True when this version mention records history rather than declaring a need."""
+    if _FLOOR_SUFFIX.match(lines[index][match.end() :]):
+        return False  # `0.15.5+` — a floor, not a record
+    context, line_start = _prose_context(lines, index)
+    lead_ws = len(lines[index]) - len(lines[index].lstrip())
+    sentence = _sentence_at(context, line_start + max(0, match.start() - lead_ws))
+    if _VERSION_RANGE.search(sentence):
+        return True
+    if _DECLARATION_CUES.search(sentence):
+        return False
+    return bool(_CITATION_CUES.search(sentence) or _DATED_PROSE.search(context))
+
+
 # ---- Gradle / Maven coordinates -------------------------------------------
 
 #: A Maven coordinate: ``io.github.kkollsga:kglite:0.15.9``. This is how the
@@ -842,7 +960,11 @@ def scan_docs(repo: str, path: Path, tracked: set[str]) -> list[Declaration]:
             if not _tracked(name, tracked) or (i, name.lower()) in seen:
                 continue
             seen.add((i, name.lower()))
-            out.append(Declaration(repo, path, i, name, "=" + m.group("spec"), "docs", s[:200], metadata=False))
+            # Prose is the only site where a version can be a *record* rather
+            # than a requirement, so it is the only site that gets classified.
+            # An install line is a declaration wherever it appears.
+            site = "docs-citation" if is_version_citation(lines, i - 1, m) else "docs"
+            out.append(Declaration(repo, path, i, name, "=" + m.group("spec"), site, s[:200], metadata=False))
     return out
 
 
@@ -1053,6 +1175,27 @@ def analyse(
                     continue
                 iv = d.interval
                 assert iv is not None
+                if d.site in CITATION_SITES:
+                    # Historical prose. Surfaced so the classification is
+                    # auditable — a silent exemption is how a scanner goes
+                    # blind — but never as something to change.
+                    if not iv.contains(current):
+                        findings.append(
+                            Finding(
+                                kind="citation",
+                                severity="info",
+                                repo=repo,
+                                package=pkg,
+                                message=(
+                                    f"{repo} prose records {pkg} {fmt_version(iv.lo)} as history "
+                                    f"(a migration, an introduction, a verified move), not as a "
+                                    f"requirement. Moving it to {fmt_version(current)} would "
+                                    f"falsify the record."
+                                ),
+                                declarations=[d],
+                            )
+                        )
+                    continue
                 is_doc = d.site in DOC_SITES
                 if not iv.contains(current):
                     if id(d) in floor_pins:
@@ -1134,6 +1277,8 @@ def analyse(
 
         # --- 4. inventory of declaration sites outside package metadata
         for d in group:
+            if d.site in CITATION_SITES:
+                continue  # reported as `citation`; not a drift surface
             if not d.metadata and d.site != "cargo-lock":
                 findings.append(
                     Finding(
@@ -1224,6 +1369,7 @@ KIND_TITLE = {
     "exact-pin": "SUPERSEDED EXACT PINS",
     "stale-docs": "STALE DOCUMENTED VERSIONS — prose naming a superseded version",
     "floor-test": "DELIBERATE FLOOR-TEST PINS (not findings; shown for audit)",
+    "citation": "HISTORICAL CITATIONS — prose recording a past version (classified, not flagged)",
     "acknowledged": "ACKNOWLEDGED HISTORICAL REFERENCES (adjudicated, no action)",
     "site": "DECLARATION SITES OUTSIDE PACKAGE METADATA (drift surface)",
 }
@@ -1234,6 +1380,7 @@ KIND_ORDER = [
     "exact-pin",
     "stale-docs",
     "floor-test",
+    "citation",
     "acknowledged",
     "site",
 ]
@@ -1279,33 +1426,140 @@ class NotifyDecision:
     touched_symbols: list[tuple[str, str]] = dataclasses.field(default_factory=list)
 
 
+#: Files a symbol reference can live in at all. Markdown, RST and text are
+#: absent on purpose: prose *naming* an API is not a call site.
+CODE_EXTS = {".rs", ".py", ".pyi", ".toml", ".java", ".kt", ".kts", ".c", ".h", ".cpp", ".hpp", ".go", ".js", ".ts"}
+
+#: Comment syntax per extension: (line marker, has C-style block comments,
+#: has Python triple-quoted strings).
+_COMMENT_STYLE: dict[str, tuple[str, bool, bool]] = {
+    ".rs": ("//", True, False),
+    ".java": ("//", True, False),
+    ".kt": ("//", True, False),
+    ".kts": ("//", True, False),
+    ".c": ("//", True, False),
+    ".h": ("//", True, False),
+    ".cpp": ("//", True, False),
+    ".hpp": ("//", True, False),
+    ".go": ("//", True, False),
+    ".js": ("//", True, False),
+    ".ts": ("//", True, False),
+    ".toml": ("#", False, False),
+    ".py": ("#", False, True),
+    ".pyi": ("#", False, True),
+}
+
+
+def _cut_at_marker(text: str, marker: str) -> str:
+    """Drop everything from an unquoted ``marker`` onwards."""
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            if ch == "\\":
+                out.append(text[i : i + 2])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in "\"'":
+            quote = ch
+        elif text.startswith(marker, i):
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def code_lines(suffix: str, lines: list[str]) -> list[tuple[int, str]]:
+    """``(lineno, code)`` with comments and Python docstrings removed.
+
+    A symbol named in a comment is a *note about* an API, not a use of it — and
+    conflating the two produced the worst kind of evidence: codingest's release
+    note cited a `Cargo.toml` comment describing a finished migration while
+    missing the actual `NodeView` call site in `rev.rs`. The one hit offered was
+    the one that wasn't a reference.
+    """
+    marker, block_comments, docstrings = _COMMENT_STYLE.get(suffix, ("#", False, False))
+    out: list[tuple[int, str]] = []
+    in_block = False
+    in_doc: str | None = None
+    for i, raw in enumerate(lines, 1):
+        text = raw
+        if in_block:
+            end = text.find("*/")
+            if end < 0:
+                continue
+            text = text[end + 2 :]
+            in_block = False
+        if in_doc:
+            end = text.find(in_doc)
+            if end < 0:
+                continue
+            text = text[end + 3 :]
+            in_doc = None
+        if block_comments:
+            while True:
+                start = text.find("/*")
+                if start < 0:
+                    break
+                end = text.find("*/", start + 2)
+                if end < 0:
+                    text = text[:start]
+                    in_block = True
+                    break
+                text = text[:start] + text[end + 2 :]
+        if docstrings:
+            for q in ('"""', "'''"):
+                while True:
+                    start = text.find(q)
+                    if start < 0:
+                        break
+                    end = text.find(q, start + 3)
+                    if end < 0:
+                        text = text[:start]
+                        in_doc = q
+                        break
+                    text = text[:start] + text[end + 3 :]
+                if in_doc:
+                    break
+        text = _cut_at_marker(text, marker)
+        if text.strip():
+            out.append((i, text))
+    return out
+
+
 def find_symbol_uses(root: Path, symbols: list[str]) -> list[tuple[str, str]]:
-    """Which of ``symbols`` this repo's sources actually reference.
+    """Which of ``symbols`` this repo's *code* actually references.
 
     Approximates "a breaking change touches a surface it uses". Deliberately
-    source-only: docs and changelogs mentioning a symbol are not usage.
+    code-only: docs, changelogs and comments mentioning a symbol are not usage,
+    and citing one as evidence sends a maintainer to a line that needs nothing.
+    The hit is reported as ``path:line`` so the claim can be checked.
     """
     hits: list[tuple[str, str]] = []
     if not symbols:
         return hits
-    exts = {".rs", ".py", ".pyi", ".toml"}
     found: dict[str, str] = {}
-    for path in _iter_files(root):
-        if path.suffix not in exts or path.name in {"Cargo.lock", "CHANGELOG.md"}:
+    for path in sorted(_iter_files(root)):
+        if path.suffix not in CODE_EXTS or path.name in {"Cargo.lock"}:
             continue
         lines = _read(path)
         if lines is None:
             continue
-        text = "\n".join(lines)
-        for sym in symbols:
-            if sym in found:
-                continue
-            if sym in text:
-                try:
-                    rel = str(path.relative_to(root))
-                except ValueError:
-                    rel = str(path)
-                found[sym] = rel
+        remaining = [s for s in symbols if s not in found]
+        if not remaining:
+            break
+        try:
+            rel = str(path.relative_to(root))
+        except ValueError:
+            rel = str(path)
+        for lineno, code in code_lines(path.suffix, lines):
+            for sym in remaining:
+                if sym not in found and sym in code:
+                    found[sym] = f"{rel}:{lineno}"
     for sym in symbols:
         if sym in found:
             hits.append((sym, found[sym]))
@@ -1386,6 +1640,125 @@ def decide_notifications(
             )
         decisions.append(NotifyDecision(repo, False, [], skip_reason=skip))
     return decisions
+
+
+# ---- "what changed" — read from the announced release's CHANGELOG entry -----
+
+_CHANGELOG_RELEASE_RE = re.compile(r"^##\s*\[(?P<ver>[^\]]+)\]")
+_CHANGELOG_SUBSECTION_RE = re.compile(r"^###\s+(?P<name>.+?)\s*$")
+_CHANGELOG_BULLET_RE = re.compile(r"^-\s+(?P<text>.*)$")
+_BOLD_LEAD_RE = re.compile(r"^\*\*(?P<lead>.+?)\*\*", re.DOTALL)
+
+#: How many entries a note quotes before pointing at the file. A release with
+#: twenty bullets does not become twenty asks.
+MAX_HIGHLIGHTS = 8
+
+
+def changelog_entry(path: Path, version: tuple[int, int, int]) -> list[str] | None:
+    """The body lines of ``## [<version>]``, or None when there is no such entry.
+
+    None is a meaningful answer and the caller must honour it: a note that
+    cannot resolve its own release's entry carries no "what changed" section at
+    all. The alternative — falling back to whatever text is nearest to hand —
+    is the defect this function replaces.
+    """
+    lines = _read(path)
+    if lines is None:
+        return None
+    body: list[str] | None = None
+    for line in lines:
+        m = _CHANGELOG_RELEASE_RE.match(line)
+        if m:
+            if body is not None:
+                break  # next release heading ends the entry
+            if parse_version(m.group("ver")) == version:
+                body = []
+            continue
+        if body is not None:
+            body.append(line)
+    return body
+
+
+def summarise_changelog_entry(body: list[str], version: str) -> list[str]:
+    """Condense a changelog entry into one line per top-level bullet.
+
+    Each entry in this project's changelog opens with a bold lead sentence that
+    states the change; the paragraphs after it are evidence and measurement.
+    Quoting the lead verbatim keeps the note honest — it is the changelog's own
+    words about the release it names — while staying short enough to read in an
+    inbox. A bullet without a bold lead falls back to its first sentence.
+    """
+    picked: list[tuple[str, str]] = []
+    section = ""
+    current: list[str] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current:
+            text = " ".join(part.strip() for part in current).strip()
+            lead = _lead_sentence(text)
+            if lead:
+                picked.append((section, lead))
+        current = None
+
+    for raw in body:
+        sub = _CHANGELOG_SUBSECTION_RE.match(raw)
+        if sub:
+            flush()
+            section = sub.group("name").strip()
+            continue
+        bullet = _CHANGELOG_BULLET_RE.match(raw)
+        if bullet and not raw[:1].isspace():
+            flush()
+            current = [bullet.group("text")]
+        elif current is not None:
+            if not raw.strip():
+                flush()
+            else:
+                current.append(raw)
+    flush()
+
+    out = [f"{sec}: {lead}" if sec else lead for sec, lead in picked[:MAX_HIGHLIGHTS]]
+    if len(picked) > MAX_HIGHLIGHTS:
+        out.append(f"…and {len(picked) - MAX_HIGHLIGHTS} further entr(ies) in `[{version}]` — read the CHANGELOG.")
+    return out
+
+
+def _lead_sentence(text: str) -> str:
+    m = _BOLD_LEAD_RE.match(text)
+    if m:
+        return " ".join(m.group("lead").split())
+    plain = " ".join(text.split())
+    first = re.split(r"(?<=[.!?])\s", plain, maxsplit=1)[0]
+    return first if len(first) <= 240 else first[:239].rstrip() + "…"
+
+
+def release_highlights(upstream_root: Path, upstream_version: tuple[int, int, int]) -> list[str]:
+    """What the announced release changed, condensed from its own entry.
+
+    Empty when the entry cannot be resolved — and that emptiness is the whole
+    point. Notes for 0.15.11, 0.15.12 and 0.15.13 all shipped 0.15.9's prose
+    because this text came from a constant that no release step had to touch;
+    an absent section is strictly better than a confidently wrong one.
+    """
+    ver = fmt_version(upstream_version)
+    path = upstream_root / "CHANGELOG.md"
+    body = changelog_entry(path, upstream_version)
+    if body is None:
+        print(
+            f"warning: no `## [{ver}]` section in {path} — the release notes will carry "
+            f'no "what changed" section rather than another release\'s.',
+            file=sys.stderr,
+        )
+        return []
+    highlights = summarise_changelog_entry(body, ver)
+    if not highlights:
+        print(
+            f"warning: the `## [{ver}]` entry in {path} has no bullet entries to quote; "
+            f'the release notes will carry no "what changed" section.',
+            file=sys.stderr,
+        )
+    return highlights
 
 
 def compose_note(
@@ -1475,7 +1848,10 @@ def compose_note(
         lines.append("")
 
     if highlights and not docs_only:
-        lines += ["**What changed in this release that can reach you:**", ""]
+        lines += [
+            f"**What changed in this release that can reach you** (lead lines of the `[{ver}]` CHANGELOG entry):",
+            "",
+        ]
         lines += [f"- {h}" for h in highlights]
         lines.append("")
 
@@ -1492,11 +1868,13 @@ def compose_note(
             f"stops needing maintenance). Nothing else here needs to change — your "
             f"manifests are already correct."
         )
-    else:
+    elif sites:
         lines.append(
             f"- Move the sites above to {ver} and refresh the lockfile. They sit outside "
             f"package metadata, so nothing in your own CI will notice they drifted."
         )
+    # A note whose only reason is a referenced breaking symbol has no sites to
+    # move; "move the sites above" pointed at nothing at all in that case.
     if decision.touched_symbols:
         lines.append(
             f"- Check those call sites against the `[{ver}]` CHANGELOG before upgrading; "
@@ -1560,35 +1938,44 @@ def run_notify(
 # Entry point
 # --------------------------------------------------------------------------
 
-#: Symbols whose *breaking* change in the current release could reach a
-#: downstream. Kept here (rather than parsed from CHANGELOG prose, which is not
-#: a machine contract) and refreshed at release time alongside the other
-#: captured constants. Empty is a valid state: a release with no breaking
-#: surface notifies only on range/pin grounds.
-DEFAULT_BREAKING_SYMBOLS: list[str] = [
+#: Symbols whose *breaking* change could reach a downstream, keyed by **the
+#: release that broke them**.
+#:
+#: The key is load-bearing, and it replaces a flat ``DEFAULT_BREAKING_SYMBOLS``
+#: list that was the 0.15.9 set and stayed the 0.15.9 set: every release after
+#: it asserted, in a downstream's inbox, that this release touched `NodeView`.
+#: Three notes shipped that claim about releases containing no such change. A
+#: symbol set that is not tied to the version it describes cannot go stale
+#: *visibly* — it just keeps being right about one release and wrong about all
+#: the others. Keyed, a release with no entry here simply does not fire the
+#: breaking-surface criterion, which is the correct behaviour for the common
+#: case (most releases break nothing).
+#:
+#: Add an entry when a release removes or changes a public symbol; never edit
+#: an existing release's set to mean "the current release".
+BREAKING_SYMBOLS_BY_VERSION: dict[str, list[str]] = {
     # 0.15.9 — D1/D2 Rust-API surgery (semver-major, shipped in a patch per
-    # project policy; Python and C surfaces are additive-only this release).
-    "NodeData::get_property",
-    "NodeData::property_iter",
-    "NodeData::properties_cloned",
-    "DirGraph::column_stores",
-    "NodeView",
-    "GraphBackend::Forked",
-    "GraphRead::node_view",
-    "resolve_node_property",
-]
+    # project policy; Python and C surfaces were additive-only that release).
+    "0.15.9": [
+        "NodeData::get_property",
+        "NodeData::property_iter",
+        "NodeData::properties_cloned",
+        "DirGraph::column_stores",
+        "NodeView",
+        "GraphBackend::Forked",
+        "GraphRead::node_view",
+        "resolve_node_property",
+    ],
+}
 
-DEFAULT_HIGHLIGHTS = [
-    "Saved-graph writes no longer sweep every node of the type: a one-row "
-    "columnar SET/REMOVE mutates one row in place, and MERGE into a saved "
-    "type dropped from 1,789x to 29.6x its fresh-graph cost.",
-    "Holding a query result, freeze(), Session, or open transaction across "
-    "a write no longer copies the graph: first-write cost at 1M nodes fell "
-    "from ~36ms to ~5us on plain graphs, and the fork allocates nothing.",
-    "The Rust API changed shape (NodeData property readers removed, "
-    "NodeView is the read route, DirGraph.column_stores became accessors); "
-    "Python and C surfaces are additive-only.",
-]
+
+def breaking_symbols_for(version: str) -> list[str]:
+    """The symbols this exact release broke, or ``[]``.
+
+    Deliberately an exact-version lookup with no fallback: inheriting the
+    previous release's set is precisely the defect this table exists to remove.
+    """
+    return list(BREAKING_SYMBOLS_BY_VERSION.get(version, []))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1619,7 +2006,7 @@ def main(argv: list[str] | None = None) -> int:
         "--breaking-symbol",
         action="append",
         default=None,
-        help="symbol broken by this release; repeatable (default: the current release's set)",
+        help="symbol broken by this release; repeatable (default: BREAKING_SYMBOLS_BY_VERSION[<version>], or none)",
     )
     p.add_argument("--date", default=None, help="date stamp for notes (default: today)")
     args = p.parse_args(argv)
@@ -1693,10 +2080,14 @@ def main(argv: list[str] | None = None) -> int:
     findings = analyse(decls, package_owner)
 
     if args.notify:
-        symbols = args.breaking_symbol if args.breaking_symbol is not None else DEFAULT_BREAKING_SYMBOLS
+        if args.breaking_symbol is not None:
+            symbols = args.breaking_symbol
+        else:
+            symbols = breaking_symbols_for(fmt_version(upstream_version))
         date = args.date or _dt.date.today().isoformat()
+        highlights = release_highlights(repos[UPSTREAM_REPO], upstream_version)
         decisions = decide_notifications(findings, decls, repos, upstream_version, symbols)
-        return run_notify(decisions, repos, upstream_version, date, DEFAULT_HIGHLIGHTS, args.dry_run)
+        return run_notify(decisions, repos, upstream_version, date, highlights, args.dry_run)
 
     if args.json:
         print(

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -773,6 +773,15 @@ impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
 pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::api::durable::DurabilityLevel
 impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::DurableOpenError
+pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::error::Error for kglite::api::durable::DurableOpenError
+impl core::fmt::Debug for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum kglite::api::durable::SyncMode
 pub kglite::api::durable::SyncMode::Barrier
 pub kglite::api::durable::SyncMode::PageCache
@@ -893,6 +902,9 @@ pub fn kglite::api::durable::WalFrame::serialize<__S>(&self, __serializer: __S) 
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::durable::WalFrame
 pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
+pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -896,6 +896,7 @@ pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, fra
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf
+pub fn kglite::api::durable::wrap_for_durability(dir: &mut kglite::api::DirGraph)
 pub mod kglite::api::embeddings
 pub struct kglite::api::embeddings::EmbeddingIngestReport
 pub kglite::api::embeddings::EmbeddingIngestReport::dimension: usize
@@ -1404,12 +1405,14 @@ pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<a
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
 pub mod kglite::api::session
-pub enum kglite::api::session::CommitOutcome
+#[non_exhaustive] pub enum kglite::api::session::CommitOutcome
 pub kglite::api::session::CommitOutcome::Committed
 pub kglite::api::session::CommitOutcome::Committed::new_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected
 pub kglite::api::session::CommitOutcome::ConflictDetected::base_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected::current_version: u64
+pub kglite::api::session::CommitOutcome::DurabilityFailed
+pub kglite::api::session::CommitOutcome::DurabilityFailed::error: alloc::string::String
 pub kglite::api::session::CommitOutcome::NoWritesNoOp
 impl core::fmt::Debug for kglite::api::session::CommitOutcome
 pub fn kglite::api::session::CommitOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1462,6 +1465,11 @@ pub fn kglite::api::session::Session::snapshot(&self) -> alloc::sync::Arc<kglite
 pub fn kglite::api::session::Session::transact<T, E>(&self, operation: impl core::ops::function::FnOnce(&mut kglite::api::DirGraph) -> core::result::Result<T, E>) -> core::result::Result<T, E>
 pub fn kglite::api::session::Session::version(&self) -> u64
 pub fn kglite::api::session::Session::write(&self) -> kglite::graph::session::transaction::SessionWriteGuard<'_>
+impl kglite::api::session::Session
+pub fn kglite::api::session::Session::check_direct_write_allowed(&self) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::session::Session::durability(&self) -> core::option::Option<kglite::api::durable::DurabilityLevel>
+pub fn kglite::api::session::Session::open_durable(graph: alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &str, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<kglite::api::session::Session, alloc::string::String>
+pub fn kglite::api::session::Session::sync(&self) -> core::result::Result<(), alloc::string::String>
 pub struct kglite::api::session::Transaction
 impl kglite::api::session::Transaction
 pub fn kglite::api::session::Transaction::base_version(&self) -> u64

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -777,6 +777,8 @@ pub enum kglite::api::durable::DurableOpenError
 pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
 impl core::error::Error for kglite::api::durable::DurableOpenError
 impl core::fmt::Debug for kglite::api::durable::DurableOpenError
 pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1213,6 +1215,16 @@ pub kglite::api::io::ProgressEvent::Update::fields: &'a [(&'a str, kglite::api::
 pub kglite::api::io::ProgressEvent::Update::phase: &'a str
 pub enum kglite::api::io::ProgressValue
 pub kglite::api::io::ProgressValue::U64(u64)
+pub enum kglite::api::io::SaveError
+pub kglite::api::io::SaveError::Io(alloc::string::String)
+pub kglite::api::io::SaveError::Refused(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
+impl core::error::Error for kglite::api::io::SaveError
+impl core::fmt::Debug for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::io::Cancelled
 pub struct kglite::api::io::GraphFileIdentity
 impl kglite::api::io::GraphFileIdentity
@@ -1295,8 +1307,8 @@ pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, req
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)
-pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), alloc::string::String>
-pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), kglite::api::io::SaveError>
+pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), kglite::api::io::SaveError>
 pub fn kglite::api::io::save_subset(source: &kglite::api::DirGraph, selection: &kglite::api::CowSelection, out_path: &std::path::Path, _spec: core::option::Option<&kglite::api::io::SubsetSpec>) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::save_subset_streaming_disk(source: &kglite::api::DirGraph, kept_per_type: &std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u32>>, edge_filter: core::option::Option<&[u64]>, out_path: &std::path::Path) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::to_csv(graph: &kglite::api::DirGraph, selection: core::option::Option<&kglite::api::CurrentSelection>) -> core::result::Result<(alloc::string::String, alloc::string::String), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -1303,7 +1303,7 @@ pub fn kglite::api::io::load_kgl_bytes(data: &[u8]) -> core::io::error::Result<a
 pub fn kglite::api::io::load_ntriples(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::NTriplesConfig) -> core::result::Result<kglite::graph::io::ntriples::NTriplesStats, alloc::string::String>
 pub fn kglite::api::io::load_rdf(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::RdfConfig) -> core::result::Result<kglite::api::io::RdfStats, alloc::string::String>
 pub fn kglite::api::io::open_or_create_graph(path: &std::path::Path, create_mode: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
-pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
+pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>, attaching_log: kglite::api::durable::DurabilityLevel) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -904,6 +904,7 @@ pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> 
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
 pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
 pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::ensure_recovered(checkpoint_path: &std::path::Path, checkpoint_lsn: u64) -> core::result::Result<(), kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -777,6 +777,8 @@ pub enum kglite::api::durable::DurableOpenError
 pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
 impl core::error::Error for kglite::api::durable::DurableOpenError
 impl core::fmt::Debug for kglite::api::durable::DurableOpenError
 pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1213,6 +1215,16 @@ pub kglite::api::io::ProgressEvent::Update::fields: &'a [(&'a str, kglite::api::
 pub kglite::api::io::ProgressEvent::Update::phase: &'a str
 pub enum kglite::api::io::ProgressValue
 pub kglite::api::io::ProgressValue::U64(u64)
+pub enum kglite::api::io::SaveError
+pub kglite::api::io::SaveError::Io(alloc::string::String)
+pub kglite::api::io::SaveError::Refused(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
+impl core::error::Error for kglite::api::io::SaveError
+impl core::fmt::Debug for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::io::Cancelled
 pub struct kglite::api::io::GraphFileIdentity
 impl kglite::api::io::GraphFileIdentity
@@ -1280,8 +1292,8 @@ pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, req
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)
-pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), alloc::string::String>
-pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), kglite::api::io::SaveError>
+pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), kglite::api::io::SaveError>
 pub fn kglite::api::io::save_subset(source: &kglite::api::DirGraph, selection: &kglite::api::CowSelection, out_path: &std::path::Path, _spec: core::option::Option<&kglite::api::io::SubsetSpec>) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::save_subset_streaming_disk(source: &kglite::api::DirGraph, kept_per_type: &std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u32>>, edge_filter: core::option::Option<&[u64]>, out_path: &std::path::Path) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::to_csv(graph: &kglite::api::DirGraph, selection: core::option::Option<&kglite::api::CurrentSelection>) -> core::result::Result<(alloc::string::String, alloc::string::String), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -773,6 +773,15 @@ impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
 pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::api::durable::DurabilityLevel
 impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::DurableOpenError
+pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::error::Error for kglite::api::durable::DurableOpenError
+impl core::fmt::Debug for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum kglite::api::durable::SyncMode
 pub kglite::api::durable::SyncMode::Barrier
 pub kglite::api::durable::SyncMode::PageCache
@@ -893,6 +902,9 @@ pub fn kglite::api::durable::WalFrame::serialize<__S>(&self, __serializer: __S) 
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::durable::WalFrame
 pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
+pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -896,6 +896,7 @@ pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, fra
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf
+pub fn kglite::api::durable::wrap_for_durability(dir: &mut kglite::api::DirGraph)
 pub mod kglite::api::embeddings
 pub struct kglite::api::embeddings::EmbeddingIngestReport
 pub kglite::api::embeddings::EmbeddingIngestReport::dimension: usize
@@ -1389,12 +1390,14 @@ pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<a
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
 pub mod kglite::api::session
-pub enum kglite::api::session::CommitOutcome
+#[non_exhaustive] pub enum kglite::api::session::CommitOutcome
 pub kglite::api::session::CommitOutcome::Committed
 pub kglite::api::session::CommitOutcome::Committed::new_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected
 pub kglite::api::session::CommitOutcome::ConflictDetected::base_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected::current_version: u64
+pub kglite::api::session::CommitOutcome::DurabilityFailed
+pub kglite::api::session::CommitOutcome::DurabilityFailed::error: alloc::string::String
 pub kglite::api::session::CommitOutcome::NoWritesNoOp
 impl core::fmt::Debug for kglite::api::session::CommitOutcome
 pub fn kglite::api::session::CommitOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1447,6 +1450,11 @@ pub fn kglite::api::session::Session::snapshot(&self) -> alloc::sync::Arc<kglite
 pub fn kglite::api::session::Session::transact<T, E>(&self, operation: impl core::ops::function::FnOnce(&mut kglite::api::DirGraph) -> core::result::Result<T, E>) -> core::result::Result<T, E>
 pub fn kglite::api::session::Session::version(&self) -> u64
 pub fn kglite::api::session::Session::write(&self) -> kglite::graph::session::transaction::SessionWriteGuard<'_>
+impl kglite::api::session::Session
+pub fn kglite::api::session::Session::check_direct_write_allowed(&self) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::session::Session::durability(&self) -> core::option::Option<kglite::api::durable::DurabilityLevel>
+pub fn kglite::api::session::Session::open_durable(graph: alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &str, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<kglite::api::session::Session, alloc::string::String>
+pub fn kglite::api::session::Session::sync(&self) -> core::result::Result<(), alloc::string::String>
 pub struct kglite::api::session::Transaction
 impl kglite::api::session::Transaction
 pub fn kglite::api::session::Transaction::base_version(&self) -> u64

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -904,6 +904,7 @@ pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> 
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
 pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
 pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::ensure_recovered(checkpoint_path: &std::path::Path, checkpoint_lsn: u64) -> core::result::Result<(), kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -1288,7 +1288,7 @@ pub fn kglite::api::io::load_file(path: &str) -> core::io::error::Result<alloc::
 pub fn kglite::api::io::load_kgl_bytes(data: &[u8]) -> core::io::error::Result<alloc::sync::Arc<kglite::api::DirGraph>>
 pub fn kglite::api::io::load_ntriples(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::NTriplesConfig) -> core::result::Result<kglite::graph::io::ntriples::NTriplesStats, alloc::string::String>
 pub fn kglite::api::io::open_or_create_graph(path: &std::path::Path, create_mode: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
-pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
+pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>, attaching_log: kglite::api::durable::DurabilityLevel) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -777,6 +777,8 @@ pub enum kglite::api::durable::DurableOpenError
 pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
 impl core::error::Error for kglite::api::durable::DurableOpenError
 impl core::fmt::Debug for kglite::api::durable::DurableOpenError
 pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1213,6 +1215,16 @@ pub kglite::api::io::ProgressEvent::Update::fields: &'a [(&'a str, kglite::api::
 pub kglite::api::io::ProgressEvent::Update::phase: &'a str
 pub enum kglite::api::io::ProgressValue
 pub kglite::api::io::ProgressValue::U64(u64)
+pub enum kglite::api::io::SaveError
+pub kglite::api::io::SaveError::Io(alloc::string::String)
+pub kglite::api::io::SaveError::Refused(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
+impl core::error::Error for kglite::api::io::SaveError
+impl core::fmt::Debug for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::io::Cancelled
 pub struct kglite::api::io::GraphFileIdentity
 impl kglite::api::io::GraphFileIdentity
@@ -1280,8 +1292,8 @@ pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, req
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)
-pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), alloc::string::String>
-pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), kglite::api::io::SaveError>
+pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), kglite::api::io::SaveError>
 pub fn kglite::api::io::save_subset(source: &kglite::api::DirGraph, selection: &kglite::api::CowSelection, out_path: &std::path::Path, _spec: core::option::Option<&kglite::api::io::SubsetSpec>) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::save_subset_streaming_disk(source: &kglite::api::DirGraph, kept_per_type: &std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u32>>, edge_filter: core::option::Option<&[u64]>, out_path: &std::path::Path) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::to_csv(graph: &kglite::api::DirGraph, selection: core::option::Option<&kglite::api::CurrentSelection>) -> core::result::Result<(alloc::string::String, alloc::string::String), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -773,6 +773,15 @@ impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
 pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::api::durable::DurabilityLevel
 impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::DurableOpenError
+pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::error::Error for kglite::api::durable::DurableOpenError
+impl core::fmt::Debug for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum kglite::api::durable::SyncMode
 pub kglite::api::durable::SyncMode::Barrier
 pub kglite::api::durable::SyncMode::PageCache
@@ -893,6 +902,9 @@ pub fn kglite::api::durable::WalFrame::serialize<__S>(&self, __serializer: __S) 
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::durable::WalFrame
 pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
+pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -896,6 +896,7 @@ pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, fra
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf
+pub fn kglite::api::durable::wrap_for_durability(dir: &mut kglite::api::DirGraph)
 pub mod kglite::api::embeddings
 pub struct kglite::api::embeddings::EmbeddingIngestReport
 pub kglite::api::embeddings::EmbeddingIngestReport::dimension: usize
@@ -1389,12 +1390,14 @@ pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<a
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
 pub mod kglite::api::session
-pub enum kglite::api::session::CommitOutcome
+#[non_exhaustive] pub enum kglite::api::session::CommitOutcome
 pub kglite::api::session::CommitOutcome::Committed
 pub kglite::api::session::CommitOutcome::Committed::new_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected
 pub kglite::api::session::CommitOutcome::ConflictDetected::base_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected::current_version: u64
+pub kglite::api::session::CommitOutcome::DurabilityFailed
+pub kglite::api::session::CommitOutcome::DurabilityFailed::error: alloc::string::String
 pub kglite::api::session::CommitOutcome::NoWritesNoOp
 impl core::fmt::Debug for kglite::api::session::CommitOutcome
 pub fn kglite::api::session::CommitOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1447,6 +1450,11 @@ pub fn kglite::api::session::Session::snapshot(&self) -> alloc::sync::Arc<kglite
 pub fn kglite::api::session::Session::transact<T, E>(&self, operation: impl core::ops::function::FnOnce(&mut kglite::api::DirGraph) -> core::result::Result<T, E>) -> core::result::Result<T, E>
 pub fn kglite::api::session::Session::version(&self) -> u64
 pub fn kglite::api::session::Session::write(&self) -> kglite::graph::session::transaction::SessionWriteGuard<'_>
+impl kglite::api::session::Session
+pub fn kglite::api::session::Session::check_direct_write_allowed(&self) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::session::Session::durability(&self) -> core::option::Option<kglite::api::durable::DurabilityLevel>
+pub fn kglite::api::session::Session::open_durable(graph: alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &str, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<kglite::api::session::Session, alloc::string::String>
+pub fn kglite::api::session::Session::sync(&self) -> core::result::Result<(), alloc::string::String>
 pub struct kglite::api::session::Transaction
 impl kglite::api::session::Transaction
 pub fn kglite::api::session::Transaction::base_version(&self) -> u64

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -904,6 +904,7 @@ pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> 
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
 pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
 pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::ensure_recovered(checkpoint_path: &std::path::Path, checkpoint_lsn: u64) -> core::result::Result<(), kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -1288,7 +1288,7 @@ pub fn kglite::api::io::load_file(path: &str) -> core::io::error::Result<alloc::
 pub fn kglite::api::io::load_kgl_bytes(data: &[u8]) -> core::io::error::Result<alloc::sync::Arc<kglite::api::DirGraph>>
 pub fn kglite::api::io::load_ntriples(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::NTriplesConfig) -> core::result::Result<kglite::graph::io::ntriples::NTriplesStats, alloc::string::String>
 pub fn kglite::api::io::open_or_create_graph(path: &std::path::Path, create_mode: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
-pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
+pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>, attaching_log: kglite::api::durable::DurabilityLevel) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -777,6 +777,8 @@ pub enum kglite::api::durable::DurableOpenError
 pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
 impl core::error::Error for kglite::api::durable::DurableOpenError
 impl core::fmt::Debug for kglite::api::durable::DurableOpenError
 pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1213,6 +1215,16 @@ pub kglite::api::io::ProgressEvent::Update::fields: &'a [(&'a str, kglite::api::
 pub kglite::api::io::ProgressEvent::Update::phase: &'a str
 pub enum kglite::api::io::ProgressValue
 pub kglite::api::io::ProgressValue::U64(u64)
+pub enum kglite::api::io::SaveError
+pub kglite::api::io::SaveError::Io(alloc::string::String)
+pub kglite::api::io::SaveError::Refused(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
+impl core::error::Error for kglite::api::io::SaveError
+impl core::fmt::Debug for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::io::Cancelled
 pub struct kglite::api::io::GraphFileIdentity
 impl kglite::api::io::GraphFileIdentity
@@ -1280,8 +1292,8 @@ pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, req
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)
-pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), alloc::string::String>
-pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), kglite::api::io::SaveError>
+pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), kglite::api::io::SaveError>
 pub fn kglite::api::io::save_subset(source: &kglite::api::DirGraph, selection: &kglite::api::CowSelection, out_path: &std::path::Path, _spec: core::option::Option<&kglite::api::io::SubsetSpec>) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::save_subset_streaming_disk(source: &kglite::api::DirGraph, kept_per_type: &std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u32>>, edge_filter: core::option::Option<&[u64]>, out_path: &std::path::Path) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::to_csv(graph: &kglite::api::DirGraph, selection: core::option::Option<&kglite::api::CurrentSelection>) -> core::result::Result<(alloc::string::String, alloc::string::String), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -773,6 +773,15 @@ impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
 pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::api::durable::DurabilityLevel
 impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::DurableOpenError
+pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::error::Error for kglite::api::durable::DurableOpenError
+impl core::fmt::Debug for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum kglite::api::durable::SyncMode
 pub kglite::api::durable::SyncMode::Barrier
 pub kglite::api::durable::SyncMode::PageCache
@@ -893,6 +902,9 @@ pub fn kglite::api::durable::WalFrame::serialize<__S>(&self, __serializer: __S) 
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::durable::WalFrame
 pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
+pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -896,6 +896,7 @@ pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, fra
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf
+pub fn kglite::api::durable::wrap_for_durability(dir: &mut kglite::api::DirGraph)
 pub mod kglite::api::embeddings
 pub struct kglite::api::embeddings::EmbeddingIngestReport
 pub kglite::api::embeddings::EmbeddingIngestReport::dimension: usize
@@ -1389,12 +1390,14 @@ pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<a
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
 pub mod kglite::api::session
-pub enum kglite::api::session::CommitOutcome
+#[non_exhaustive] pub enum kglite::api::session::CommitOutcome
 pub kglite::api::session::CommitOutcome::Committed
 pub kglite::api::session::CommitOutcome::Committed::new_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected
 pub kglite::api::session::CommitOutcome::ConflictDetected::base_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected::current_version: u64
+pub kglite::api::session::CommitOutcome::DurabilityFailed
+pub kglite::api::session::CommitOutcome::DurabilityFailed::error: alloc::string::String
 pub kglite::api::session::CommitOutcome::NoWritesNoOp
 impl core::fmt::Debug for kglite::api::session::CommitOutcome
 pub fn kglite::api::session::CommitOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1447,6 +1450,11 @@ pub fn kglite::api::session::Session::snapshot(&self) -> alloc::sync::Arc<kglite
 pub fn kglite::api::session::Session::transact<T, E>(&self, operation: impl core::ops::function::FnOnce(&mut kglite::api::DirGraph) -> core::result::Result<T, E>) -> core::result::Result<T, E>
 pub fn kglite::api::session::Session::version(&self) -> u64
 pub fn kglite::api::session::Session::write(&self) -> kglite::graph::session::transaction::SessionWriteGuard<'_>
+impl kglite::api::session::Session
+pub fn kglite::api::session::Session::check_direct_write_allowed(&self) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::session::Session::durability(&self) -> core::option::Option<kglite::api::durable::DurabilityLevel>
+pub fn kglite::api::session::Session::open_durable(graph: alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &str, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<kglite::api::session::Session, alloc::string::String>
+pub fn kglite::api::session::Session::sync(&self) -> core::result::Result<(), alloc::string::String>
 pub struct kglite::api::session::Transaction
 impl kglite::api::session::Transaction
 pub fn kglite::api::session::Transaction::base_version(&self) -> u64

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -904,6 +904,7 @@ pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> 
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
 pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
 pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::ensure_recovered(checkpoint_path: &std::path::Path, checkpoint_lsn: u64) -> core::result::Result<(), kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -1288,7 +1288,7 @@ pub fn kglite::api::io::load_file(path: &str) -> core::io::error::Result<alloc::
 pub fn kglite::api::io::load_kgl_bytes(data: &[u8]) -> core::io::error::Result<alloc::sync::Arc<kglite::api::DirGraph>>
 pub fn kglite::api::io::load_ntriples(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::NTriplesConfig) -> core::result::Result<kglite::graph::io::ntriples::NTriplesStats, alloc::string::String>
 pub fn kglite::api::io::open_or_create_graph(path: &std::path::Path, create_mode: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
-pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
+pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>, attaching_log: kglite::api::durable::DurabilityLevel) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -773,6 +773,15 @@ impl core::fmt::Debug for kglite::api::durable::DurabilityLevel
 pub fn kglite::api::durable::DurabilityLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::api::durable::DurabilityLevel
 impl core::marker::StructuralPartialEq for kglite::api::durable::DurabilityLevel
+pub enum kglite::api::durable::DurableOpenError
+pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
+pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::error::Error for kglite::api::durable::DurableOpenError
+impl core::fmt::Debug for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::durable::DurableOpenError
+pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum kglite::api::durable::SyncMode
 pub kglite::api::durable::SyncMode::Barrier
 pub kglite::api::durable::SyncMode::PageCache
@@ -893,6 +902,9 @@ pub fn kglite::api::durable::WalFrame::serialize<__S>(&self, __serializer: __S) 
 impl<'de> serde_core::de::Deserialize<'de> for kglite::api::durable::WalFrame
 pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
+pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -896,6 +896,7 @@ pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, fra
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>
 pub fn kglite::api::durable::wal_path(checkpoint: &std::path::Path) -> std::path::PathBuf
+pub fn kglite::api::durable::wrap_for_durability(dir: &mut kglite::api::DirGraph)
 pub mod kglite::api::embeddings
 pub struct kglite::api::embeddings::EmbeddingIngestReport
 pub kglite::api::embeddings::EmbeddingIngestReport::dimension: usize
@@ -1404,12 +1405,14 @@ pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<a
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
 pub mod kglite::api::session
-pub enum kglite::api::session::CommitOutcome
+#[non_exhaustive] pub enum kglite::api::session::CommitOutcome
 pub kglite::api::session::CommitOutcome::Committed
 pub kglite::api::session::CommitOutcome::Committed::new_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected
 pub kglite::api::session::CommitOutcome::ConflictDetected::base_version: u64
 pub kglite::api::session::CommitOutcome::ConflictDetected::current_version: u64
+pub kglite::api::session::CommitOutcome::DurabilityFailed
+pub kglite::api::session::CommitOutcome::DurabilityFailed::error: alloc::string::String
 pub kglite::api::session::CommitOutcome::NoWritesNoOp
 impl core::fmt::Debug for kglite::api::session::CommitOutcome
 pub fn kglite::api::session::CommitOutcome::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1462,6 +1465,11 @@ pub fn kglite::api::session::Session::snapshot(&self) -> alloc::sync::Arc<kglite
 pub fn kglite::api::session::Session::transact<T, E>(&self, operation: impl core::ops::function::FnOnce(&mut kglite::api::DirGraph) -> core::result::Result<T, E>) -> core::result::Result<T, E>
 pub fn kglite::api::session::Session::version(&self) -> u64
 pub fn kglite::api::session::Session::write(&self) -> kglite::graph::session::transaction::SessionWriteGuard<'_>
+impl kglite::api::session::Session
+pub fn kglite::api::session::Session::check_direct_write_allowed(&self) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::session::Session::durability(&self) -> core::option::Option<kglite::api::durable::DurabilityLevel>
+pub fn kglite::api::session::Session::open_durable(graph: alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &str, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<kglite::api::session::Session, alloc::string::String>
+pub fn kglite::api::session::Session::sync(&self) -> core::result::Result<(), alloc::string::String>
 pub struct kglite::api::session::Transaction
 impl kglite::api::session::Transaction
 pub fn kglite::api::session::Transaction::base_version(&self) -> u64

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -777,6 +777,8 @@ pub enum kglite::api::durable::DurableOpenError
 pub kglite::api::durable::DurableOpenError::Io(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Refused(alloc::string::String)
 pub kglite::api::durable::DurableOpenError::Replay(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
 impl core::error::Error for kglite::api::durable::DurableOpenError
 impl core::fmt::Debug for kglite::api::durable::DurableOpenError
 pub fn kglite::api::durable::DurableOpenError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1213,6 +1215,16 @@ pub kglite::api::io::ProgressEvent::Update::fields: &'a [(&'a str, kglite::api::
 pub kglite::api::io::ProgressEvent::Update::phase: &'a str
 pub enum kglite::api::io::ProgressValue
 pub kglite::api::io::ProgressValue::U64(u64)
+pub enum kglite::api::io::SaveError
+pub kglite::api::io::SaveError::Io(alloc::string::String)
+pub kglite::api::io::SaveError::Refused(alloc::string::String)
+impl core::convert::From<kglite::api::durable::DurableOpenError> for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::from(error: kglite::api::durable::DurableOpenError) -> Self
+impl core::error::Error for kglite::api::io::SaveError
+impl core::fmt::Debug for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::api::io::SaveError
+pub fn kglite::api::io::SaveError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct kglite::api::io::Cancelled
 pub struct kglite::api::io::GraphFileIdentity
 impl kglite::api::io::GraphFileIdentity
@@ -1295,8 +1307,8 @@ pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, req
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)
-pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), alloc::string::String>
-pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), alloc::string::String>
+pub fn kglite::api::io::save_graph(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str) -> core::result::Result<(), kglite::api::io::SaveError>
+pub fn kglite::api::io::save_graph_with(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, path: &str, fsync: bool) -> core::result::Result<(), kglite::api::io::SaveError>
 pub fn kglite::api::io::save_subset(source: &kglite::api::DirGraph, selection: &kglite::api::CowSelection, out_path: &std::path::Path, _spec: core::option::Option<&kglite::api::io::SubsetSpec>) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::save_subset_streaming_disk(source: &kglite::api::DirGraph, kept_per_type: &std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u32>>, edge_filter: core::option::Option<&[u64]>, out_path: &std::path::Path) -> core::result::Result<(), alloc::string::String>
 pub fn kglite::api::io::to_csv(graph: &kglite::api::DirGraph, selection: core::option::Option<&kglite::api::CurrentSelection>) -> core::result::Result<(alloc::string::String, alloc::string::String), alloc::string::String>

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -1303,7 +1303,7 @@ pub fn kglite::api::io::load_kgl_bytes(data: &[u8]) -> core::io::error::Result<a
 pub fn kglite::api::io::load_ntriples(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::NTriplesConfig) -> core::result::Result<kglite::graph::io::ntriples::NTriplesStats, alloc::string::String>
 pub fn kglite::api::io::load_rdf(graph: &mut kglite::api::DirGraph, path: &str, config: &kglite::api::io::RdfConfig) -> core::result::Result<kglite::api::io::RdfStats, alloc::string::String>
 pub fn kglite::api::io::open_or_create_graph(path: &std::path::Path, create_mode: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
-pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
+pub fn kglite::api::io::open_or_create_graph_in_mode(path: &std::path::Path, requested: core::option::Option<kglite::api::storage::StorageMode>, attaching_log: kglite::api::durable::DurabilityLevel) -> core::io::error::Result<kglite::api::io::OpenGraphResult>
 pub fn kglite::api::io::pass_a_scan(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec) -> kglite::graph::mutation::subgraph_streaming::PassAResult
 pub fn kglite::api::io::pass_a_scan_to_file(source: &kglite::api::storage::DiskGraph, spec: &kglite::api::io::SubsetSpec, kept_edges_path: &std::path::Path) -> core::result::Result<kglite::graph::mutation::subgraph_streaming::PassAFileResult, alloc::string::String>
 pub fn kglite::api::io::prepare_save(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>)

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -904,6 +904,7 @@ pub fn kglite::api::durable::WalFrame::deserialize<__D>(__deserializer: __D) -> 
 pub fn kglite::api::durable::apply_frames(graph: &mut kglite::api::DirGraph, frames: &[kglite::api::durable::WalFrame], after_lsn: u64) -> core::result::Result<u64, alloc::string::String>
 pub fn kglite::api::durable::checkpoint_epilogue(wal: &mut kglite::api::durable::Wal, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
 pub fn kglite::api::durable::checkpoint_prologue(wal: &mut kglite::api::durable::Wal, next_lsn: u64, graph: &mut kglite::api::DirGraph) -> core::io::error::Result<()>
+pub fn kglite::api::durable::ensure_recovered(checkpoint_path: &std::path::Path, checkpoint_lsn: u64) -> core::result::Result<(), kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::open_log(graph: &mut alloc::sync::Arc<kglite::api::DirGraph>, checkpoint_path: &std::path::Path, level: kglite::api::durable::DurabilityLevel) -> core::result::Result<core::option::Option<(kglite::api::durable::Wal, u64)>, kglite::api::durable::DurableOpenError>
 pub fn kglite::api::durable::recover(path: &std::path::Path) -> core::io::error::Result<alloc::vec::Vec<kglite::api::durable::WalFrame>>
 pub fn kglite::api::durable::resolve_ops(raw: &[kglite::graph::storage::recording::RawOp], graph: &impl kglite::api::GraphRead, interner: &kglite::api::StringInterner, secondary_labels: impl core::ops::function::Fn(petgraph::graph_impl::NodeIndex) -> alloc::vec::Vec<alloc::string::String>) -> alloc::vec::Vec<kglite::graph::wal::MutationOp>

--- a/tests/api-baselines/source-quality.json
+++ b/tests/api-baselines/source-quality.json
@@ -504,15 +504,15 @@
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",
       "qualified_name": "crate::add_connections",
-      "lines": 304,
-      "branches": 41,
+      "lines": 293,
+      "branches": 36,
       "nesting": 3
     },
     {
       "path": "crates/kglite/src/graph/mutation/maintain.rs",
       "qualified_name": "crate::add_nodes",
       "lines": 275,
-      "branches": 32,
+      "branches": 27,
       "nesting": 4
     },
     {

--- a/tests/benchmarks/test_bench_bolt_writers.py
+++ b/tests/benchmarks/test_bench_bolt_writers.py
@@ -9,7 +9,9 @@ Two sweeps live here: `test_contended_writer_sweep` varies the writer count
 at one write per transaction, and `test_batch_size_sweep` varies the writes
 per transaction at a fixed writer count — the measurement behind the
 operator page's "batch more work into each transaction rather than adding
-writers".
+writers". A third cell, `test_checkpoint_under_contention`, holds the
+writer count fixed and adds a `CALL db.checkpoint()` thread — the price of
+durability under load, since a checkpoint pauses committing writers.
 
 The unit of work runs through `session.execute_write`, i.e. the
 driver-managed path that retries a `Neo.TransientError.*` failure by
@@ -47,6 +49,8 @@ Recorded numbers require a **release**-built `kglite-bolt-server`
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import os
+from pathlib import Path
 import shutil
 import threading
 import time
@@ -62,6 +66,15 @@ from tests.conftest import (
 neo4j = pytest.importorskip("neo4j")
 
 pytestmark = [pytest.mark.benchmark, pytest.mark.bolt_stress]
+
+#: Binary every cell spawns. Defaults to the shared newest-of-profile
+#: resolution; setting `KGLITE_BENCH_BOLT_BINARY` pins one explicit
+#: executable for the whole run. Recorded numbers use the pinned form with
+#: a *copy* of the release build, because a concurrent `cargo build` of the
+#: other profile would otherwise flip newest-of-profile mid-run and the
+#: recorded row could not say which profile produced it.
+_PINNED_BINARY = os.environ.get("KGLITE_BENCH_BOLT_BINARY")
+_BENCH_BINARY = Path(_PINNED_BINARY) if _PINNED_BINARY else _BOLT_BINARY
 
 
 #: OCC conflict status code. Classification is by code — never by exception
@@ -79,6 +92,13 @@ BATCH_CELLS = ((4, 1), (4, 10), (4, 100), (1, 1), (1, 100))
 
 #: Measurement window per cell, seconds.
 CELL_SECONDS = 5.0
+
+#: Checkpoint-under-contention cell: writers, and how often the checkpoint
+#: thread fires. N=4 is the contended series the batch sweep is about; ~1 s
+#: over a 5 s window gives four calls, each landing on a graph with writes
+#: since the last one (so the digest-skip never answers).
+CHECKPOINT_WRITERS = 4
+CHECKPOINT_PERIOD_S = 1.0
 
 #: Warmup cell (discarded): pays first-write / page-cache / JIT-ish costs.
 WARMUP_WRITERS = 2
@@ -114,6 +134,18 @@ class CellResult:
     slowest_op_attempts: int = 1
     #: CREATEs per committed transaction (the unit of work's batch size).
     batch: int = 1
+    #: `CALL db.checkpoint()` round-trip times, ms — one per call the
+    #: checkpoint thread made (empty in an un-checkpointed cell). This is
+    #: the writer-pause upper bound: `Session::save` holds the session lock
+    #: for its whole duration, so a contended writer waits at most this.
+    checkpoint_ms: list[float] = field(default_factory=list)
+    #: Calls that wrote the file vs. calls the digest-skip answered without
+    #: writing, classified from the verb's `message` column.
+    checkpoints_written: int = 0
+    checkpoints_skipped: int = 0
+    #: Anything the checkpoint thread saw that was neither: a raised
+    #: exception or an unrecognized message. Asserted empty.
+    checkpoint_errors: list[str] = field(default_factory=list)
 
     @property
     def committed_per_s(self) -> float:
@@ -154,8 +186,8 @@ def _percentile(values: list[float], pct: float) -> float:
 @pytest.fixture(scope="module")
 def _writer_fixture(tmp_path_factory):
     """Build the 10k-node graph once; yield the path each cell copies."""
-    if not _BOLT_BINARY.exists():
-        pytest.skip(f"bolt-server binary not built at {_BOLT_BINARY}")
+    if not _BENCH_BINARY.exists():
+        pytest.skip(f"bolt-server binary not built at {_BENCH_BINARY}")
     import pandas as pd
 
     import kglite
@@ -199,6 +231,7 @@ def _run_cell(
     seconds: float,
     tag: str,
     batch: int | None = None,
+    checkpoint_every: float | None = None,
 ) -> CellResult:
     """One cell: `writers` threads hammering `execute_write` for `seconds`.
 
@@ -209,6 +242,13 @@ def _run_cell(
     bare single-node `CREATE`. An integer K runs `_BATCH_QUERY` with K rows,
     including at K=1 — so the batch sweep's cells differ *only* in K, and
     the K=1 cell carries the same `UNWIND`/parameter overhead as K=100.
+
+    `checkpoint_every`, when set, adds one more thread on its own driver
+    session firing `CALL db.checkpoint()` at that period for the whole
+    window — the durability-under-load arm. It is deliberately *not* in the
+    start barrier: the writers' window must not wait on it, and its first
+    call lands one period into the window with writes already in flight.
+    The verb writes the served path, which is this cell's private copy.
     """
     rows_per_tx = 1 if batch is None else batch
     cell_graph = tmp_dir / f"cell_{tag}.kgl"
@@ -302,7 +342,47 @@ def _run_cell(
             if latencies and max(latencies) >= max(result.latencies_ms or [0.0]):
                 result.slowest_op_attempts = slowest_op_attempts
 
-    proc, url = _spawn_bolt_server(cell_graph)
+    def checkpointer(driver) -> None:
+        """Fire `CALL db.checkpoint()` every `checkpoint_every` seconds until
+        the window closes, timing each round-trip.
+
+        `stop.wait(period)` returns True the moment the window ends, so a
+        checkpoint is never issued after `stop.set()` — the timed calls all
+        overlap live writers, which is the point of the arm. The call is
+        auto-commit: the verb refuses to run inside an explicit transaction.
+        """
+        errors: list[str] = []
+        durations: list[float] = []
+        written = 0
+        skipped = 0
+        try:
+            with driver.session() as session:
+                while not stop.wait(checkpoint_every):
+                    t0 = time.perf_counter()
+                    try:
+                        record = session.run("CALL db.checkpoint() YIELD success, message").single()
+                    except Exception as e:  # noqa: BLE001
+                        errors.append(repr(e))
+                        continue
+                    durations.append((time.perf_counter() - t0) * 1000.0)
+                    message = record["message"]
+                    if not record["success"]:
+                        errors.append(f"success=false: {message!r}")
+                    elif message.startswith("checkpoint written"):
+                        written += 1
+                    elif message.startswith("skipped"):
+                        skipped += 1
+                    else:
+                        errors.append(f"unrecognized message: {message!r}")
+        except Exception as e:  # noqa: BLE001
+            errors.append(f"session: {e!r}")
+        with lock:
+            result.checkpoint_ms.extend(durations)
+            result.checkpoints_written += written
+            result.checkpoints_skipped += skipped
+            result.checkpoint_errors.extend(errors)
+
+    proc, url = _spawn_bolt_server(cell_graph, binary=_BENCH_BINARY)
     try:
         with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password"), **_RETRY_KW) as driver:
             threads = [threading.Thread(target=worker, args=(driver, i), daemon=True) for i in range(writers)]
@@ -313,11 +393,21 @@ def _run_cell(
             except threading.BrokenBarrierError:
                 pass
             t_start = time.perf_counter()
+            ckpt = None
+            if checkpoint_every is not None:
+                ckpt = threading.Thread(target=checkpointer, args=(driver,), daemon=True)
+                ckpt.start()
             time.sleep(seconds)
             stop.set()
             for t in threads:
                 t.join(timeout=120)
+            # Elapsed is read before joining the checkpoint thread on
+            # purpose. A checkpoint in flight when the window closes would
+            # otherwise be added to the denominator and charge the
+            # checkpointed arm a throughput dip it did not have.
             result.elapsed_s = time.perf_counter() - t_start
+            if ckpt is not None:
+                ckpt.join(timeout=120)
 
             with driver.session() as session:
                 record = session.run(
@@ -332,7 +422,7 @@ def _run_cell(
 def _format_table(cells: list[CellResult]) -> str:
     lines = [
         "",
-        f"bolt contended writers — binary: {_BOLT_BINARY}",
+        f"bolt contended writers — binary: {_BENCH_BINARY}",
         f"{'N':>3} {'committed/s':>12} {'committed':>10} {'attempts':>9} {'retry_rate':>11} "
         f"{'p50_ms':>8} {'p95_ms':>8} {'p99_ms':>8} {'max_ms':>9} {'mean_ms':>8} "
         f"{'max_att':>8} {'slow_att':>9} {'exhaust':>8}",
@@ -351,7 +441,7 @@ def _format_table(cells: list[CellResult]) -> str:
 def _format_batch_table(cells: list[CellResult]) -> str:
     lines = [
         "",
-        f"bolt batch-size sweep — binary: {_BOLT_BINARY}",
+        f"bolt batch-size sweep — binary: {_BENCH_BINARY}",
         f"{'N':>3} {'K':>5} {'ops/s':>10} {'tx/s':>9} {'committed':>10} {'attempts':>9} "
         f"{'retry_rate':>11} {'p50_ms':>8} {'p95_ms':>8} {'max_ms':>9} {'exhaust':>8}",
     ]
@@ -363,6 +453,84 @@ def _format_batch_table(cells: list[CellResult]) -> str:
             f"{max(c.latencies_ms or [0.0]):>9.2f} {c.exhausted_conflicts:>8}"
         )
     return "\n".join(lines)
+
+
+def _format_checkpoint_table(cells: list[tuple[str, CellResult]]) -> str:
+    lines = [
+        "",
+        f"bolt checkpoint-under-contention (N={CHECKPOINT_WRITERS}) — binary: {_BENCH_BINARY}",
+        f"{'arm':>14} {'committed/s':>12} {'committed':>10} {'retry_rate':>11} "
+        f"{'p50_ms':>8} {'p95_ms':>8} {'max_ms':>9} "
+        f"{'ckpt_w':>7} {'ckpt_skip':>10} {'ckpt_p50_ms':>12} {'ckpt_max_ms':>12}",
+    ]
+    for arm, c in cells:
+        lines.append(
+            f"{arm:>14} {c.committed_per_s:>12.1f} {c.committed:>10} {c.retry_rate:>11.3f} "
+            f"{_percentile(c.latencies_ms, 50):>8.2f} {_percentile(c.latencies_ms, 95):>8.2f} "
+            f"{max(c.latencies_ms or [0.0]):>9.2f} "
+            f"{c.checkpoints_written:>7} {c.checkpoints_skipped:>10} "
+            f"{_percentile(c.checkpoint_ms, 50):>12.2f} {max(c.checkpoint_ms or [0.0]):>12.2f}"
+        )
+    if len(cells) == 2:
+        base, ckpt = cells[0][1].committed_per_s, cells[1][1].committed_per_s
+        dip = (base - ckpt) / base * 100.0 if base else 0.0
+        lines.append(f"  committed-throughput dip with checkpointing: {dip:+.1f}%")
+    return "\n".join(lines)
+
+
+def test_checkpoint_under_contention(_writer_fixture, tmp_path):
+    """What `CALL db.checkpoint()` costs the writers it interrupts.
+
+    `Session::save` holds the session lock for its whole duration (it
+    mutates the graph: metadata stamp, index keys, columnar consolidation),
+    so a checkpoint pauses committing writers rather than running beside
+    them. This cell prices that pause the only way that matters to an
+    operator: two otherwise-identical windows of N contended managed
+    writers, one with a thread firing the verb about once a second and one
+    without, and the difference in committed throughput.
+
+    Nothing numeric is asserted — same as every cell in this module. The
+    sanity invariants are the ones that would invalidate the number:
+    the landed==committed oracle survives concurrent saving, no
+    non-conflict error escaped, and the checkpointed arm really did write
+    the file more than once (a run where every call hit the digest-skip
+    would be a baseline wearing a checkpoint thread's clothes).
+
+    Recorded in `dev-docs/bench/results/results.csv` under
+    `bolt_checkpoint:*`; the docs' qualitative claim about checkpoint cost
+    is this measurement.
+    """
+    # Warmup cell — discarded.
+    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "ckptwarm")
+
+    baseline = _run_cell(_writer_fixture, tmp_path, CHECKPOINT_WRITERS, CELL_SECONDS, "ckptbase")
+    checkpointed = _run_cell(
+        _writer_fixture,
+        tmp_path,
+        CHECKPOINT_WRITERS,
+        CELL_SECONDS,
+        "ckpton",
+        checkpoint_every=CHECKPOINT_PERIOD_S,
+    )
+
+    print(_format_checkpoint_table([("baseline", baseline), ("checkpointed", checkpointed)]))
+
+    for arm, c in (("baseline", baseline), ("checkpointed", checkpointed)):
+        assert c.hard_errors == [], f"{arm}: non-conflict errors: {c.hard_errors[:3]}"
+        assert c.committed > 0, f"{arm}: no writer committed"
+        # The oracle the whole arm rests on: a save running concurrently
+        # with commits must not lose or duplicate a committed write.
+        assert c.landed == c.committed, f"{arm}: landed {c.landed} != committed {c.committed}"
+        assert c.committed_per_s > 0
+
+    assert baseline.checkpoint_ms == [], "baseline arm must not have checkpointed"
+    assert checkpointed.checkpoint_errors == [], f"checkpoint errors: {checkpointed.checkpoint_errors[:3]}"
+    # Under continuous writes every call should find a new version, so a
+    # skip here means the writers stalled or the digest logic changed.
+    assert checkpointed.checkpoints_written >= 2, (
+        f"expected >=2 real checkpoint writes, got {checkpointed.checkpoints_written} "
+        f"written / {checkpointed.checkpoints_skipped} skipped"
+    )
 
 
 def test_contended_writer_sweep(_writer_fixture, tmp_path):

--- a/tests/benchmarks/test_bench_bolt_writers.py
+++ b/tests/benchmarks/test_bench_bolt_writers.py
@@ -11,7 +11,11 @@ per transaction at a fixed writer count — the measurement behind the
 operator page's "batch more work into each transaction rather than adding
 writers". A third cell, `test_checkpoint_under_contention`, holds the
 writer count fixed and adds a `CALL db.checkpoint()` thread — the price of
-durability under load, since a checkpoint pauses committing writers.
+durability under load, since a checkpoint pauses committing writers. A
+fourth, `test_durability_sweep`, spawns the server at each `--durability`
+level and prices the write-ahead log: `full` puts a device barrier inside
+the session lock every commit already serializes on, so it is the level
+whose cost decides which one ships as the default.
 
 The unit of work runs through `session.execute_write`, i.e. the
 driver-managed path that retries a `Neo.TransientError.*` failure by
@@ -24,6 +28,12 @@ Design notes that matter for reading the numbers:
 - **Fixed wall-clock window per cell.** Committed throughput is the metric;
   a fixed op count would let a heavily-retried cell run far longer and turn
   throughput into a function of the slowest worker.
+- **Committed-in-window is the throughput cell, not committed/elapsed.**
+  Each worker keeps running its current transaction after the window closes,
+  so the harness's `elapsed` carries a drain tail whose length depends on
+  how slow that last transaction was — at `--durability full` the tail is a
+  whole fsync. Counting the commits that *completed inside* the fixed window
+  divides by a constant instead, which is why the recorded rows use it.
 - **Fresh server + fresh copy of the fixture per cell**, so every cell
   starts from an identical 10k-node graph. A write transaction materializes
   a working graph, so starting size is part of the cost being measured.
@@ -93,12 +103,37 @@ BATCH_CELLS = ((4, 1), (4, 10), (4, 100), (1, 1), (1, 100))
 #: Measurement window per cell, seconds.
 CELL_SECONDS = 5.0
 
+#: Durability sweep: `(--durability level, writer count)` cells. N=1 is the
+#: uncontended control — it isolates the log's per-commit cost from what the
+#: session lock does with it once writers queue behind each other. Ordered
+#: level-minor so a machine-drift trend shows up as a within-N pattern.
+DURABILITY_CELLS = tuple((level, n) for n in (1, 4) for level in ("off", "normal", "full"))
+
 #: Checkpoint-under-contention cell: writers, and how often the checkpoint
 #: thread fires. N=4 is the contended series the batch sweep is about; ~1 s
 #: over a 5 s window gives four calls, each landing on a graph with writes
 #: since the last one (so the digest-skip never answers).
 CHECKPOINT_WRITERS = 4
 CHECKPOINT_PERIOD_S = 1.0
+
+#: Sham-thread control for the checkpoint cell. The checkpointed arm
+#: measured *faster* than its baseline; a third arm whose extra session
+#: issues a cheap read at the same period separates "saving consolidates
+#: something" from "an extra session on this driver changes the load
+#: pattern" — if the read arm speeds up too, the speed-up is the thread,
+#: not the checkpoint.
+READ_PROBE_PERIOD_S = CHECKPOINT_PERIOD_S
+READ_PROBE_QUERY = "RETURN 1 AS one"
+
+#: The level every cell *outside* the durability sweep pins explicitly.
+#:
+#: Those three sweeps are the write-path curve, and their rows in
+#: `dev-docs/bench/results/results.csv` go back to before the write-ahead log
+#: existed. The server's default is now `normal`, so spawning without the flag
+#: would silently re-point the cells at a different system and make the old
+#: rows incomparable. What logging costs is `test_durability_sweep`'s question,
+#: and it answers it against this same `off` reference.
+RECORDED_LEVEL = "off"
 
 #: Warmup cell (discarded): pays first-write / page-cache / JIT-ish costs.
 WARMUP_WRITERS = 2
@@ -146,10 +181,51 @@ class CellResult:
     #: Anything the checkpoint thread saw that was neither: a raised
     #: exception or an unrecognized message. Asserted empty.
     checkpoint_errors: list[str] = field(default_factory=list)
+    #: `--durability` level the server was spawned at ("off" when the flag
+    #: was not passed, i.e. whatever the binary's default is).
+    durability: str = "off"
+    #: `perf_counter` stamp of every committed unit of work, used to count
+    #: the commits that landed inside the fixed window (see the module
+    #: docstring) rather than dividing by a drain-inflated elapsed.
+    commit_times: list[float] = field(default_factory=list)
+    #: End of the fixed measurement window, on the same clock.
+    window_end: float = 0.0
+    #: Length of that window, seconds — the fixed denominator.
+    window_s: float = 0.0
+    #: Size of the `<graph>-wal` sidecar when the window closed, bytes. 0
+    #: when the level keeps no log (the file does not exist).
+    wal_bytes: int = 0
+    #: Round-trip times of the sham read-probe thread, ms (empty unless the
+    #: read-probe arm ran), and anything it raised.
+    probe_ms: list[float] = field(default_factory=list)
+    probe_errors: list[str] = field(default_factory=list)
 
     @property
     def committed_per_s(self) -> float:
         return self.committed / self.elapsed_s if self.elapsed_s > 0 else 0.0
+
+    @property
+    def committed_in_window(self) -> int:
+        """Commits that completed before the window closed — the metric.
+
+        See the module docstring: `committed / elapsed` charges a cell for
+        its own drain tail, which is a whole fsync at `--durability full`.
+        """
+        return sum(1 for t in self.commit_times if t <= self.window_end)
+
+    @property
+    def window_per_s(self) -> float:
+        return self.committed_in_window / self.window_s if self.window_s > 0 else 0.0
+
+    @property
+    def wal_bytes_per_commit(self) -> float:
+        """Sidecar bytes per committed transaction — the growth-rate datum.
+
+        Paired with the cell's *total* commits, not the in-window count:
+        the size is read after the writers drain, so every committed
+        transaction contributed a frame to it.
+        """
+        return self.wal_bytes / self.committed if self.committed else 0.0
 
     @property
     def ops_per_s(self) -> float:
@@ -232,6 +308,8 @@ def _run_cell(
     tag: str,
     batch: int | None = None,
     checkpoint_every: float | None = None,
+    durability: str | None = None,
+    read_probe_every: float | None = None,
 ) -> CellResult:
     """One cell: `writers` threads hammering `execute_write` for `seconds`.
 
@@ -249,20 +327,35 @@ def _run_cell(
     start barrier: the writers' window must not wait on it, and its first
     call lands one period into the window with writes already in flight.
     The verb writes the served path, which is this cell's private copy.
+
+    `durability` spawns the server with `--durability <level>`; `None`
+    passes no flag, so the cell measures whatever the binary defaults to.
+    `read_probe_every` is the sham-thread control for `checkpoint_every`:
+    the same extra session at the same period running a trivial read.
     """
     rows_per_tx = 1 if batch is None else batch
     cell_graph = tmp_dir / f"cell_{tag}.kgl"
     shutil.copy(fixture_path, cell_graph)
+    wal_file = Path(f"{cell_graph}-wal")
 
     stop = threading.Event()
     start_barrier = threading.Barrier(writers + 1, timeout=60)
     lock = threading.Lock()
-    result = CellResult(writers=writers, committed=0, attempts=0, elapsed_s=0.0, batch=rows_per_tx)
+    result = CellResult(
+        writers=writers,
+        committed=0,
+        attempts=0,
+        elapsed_s=0.0,
+        batch=rows_per_tx,
+        durability=durability or "default",
+        window_s=seconds,
+    )
 
     def worker(driver, worker_id: int) -> None:
         attempts = 0
         committed = 0
         latencies: list[float] = []
+        commit_times: list[float] = []
         hard: list[str] = []
         exhausted = 0
         max_op_attempts = 1
@@ -320,9 +413,11 @@ def _run_cell(
                             continue
                         hard.append(repr(e))
                         break
-                    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                    t_end = time.perf_counter()
+                    elapsed_ms = (t_end - t0) * 1000.0
                     op_attempts = attempts - attempts_before
                     latencies.append(elapsed_ms)
+                    commit_times.append(t_end)
                     committed += 1
                     max_op_attempts = max(max_op_attempts, op_attempts)
                     if elapsed_ms > slowest_ms:
@@ -336,6 +431,7 @@ def _run_cell(
             result.attempts += attempts
             result.committed += committed
             result.latencies_ms.extend(latencies)
+            result.commit_times.extend(commit_times)
             result.hard_errors.extend(hard)
             result.exhausted_conflicts += exhausted
             result.max_op_attempts = max(result.max_op_attempts, max_op_attempts)
@@ -382,7 +478,34 @@ def _run_cell(
             result.checkpoints_skipped += skipped
             result.checkpoint_errors.extend(errors)
 
-    proc, url = _spawn_bolt_server(cell_graph, binary=_BENCH_BINARY)
+    def read_prober(driver) -> None:
+        """The checkpoint thread's sham twin: same extra session, same
+        period, a trivial read instead of the verb.
+
+        Whatever the checkpointed arm gains from merely having one more
+        session on the driver, this arm gains too — so the difference
+        between the two arms is what saving actually did.
+        """
+        errors: list[str] = []
+        durations: list[float] = []
+        try:
+            with driver.session() as session:
+                while not stop.wait(read_probe_every):
+                    t0 = time.perf_counter()
+                    try:
+                        session.run(READ_PROBE_QUERY).consume()
+                    except Exception as e:  # noqa: BLE001
+                        errors.append(repr(e))
+                        continue
+                    durations.append((time.perf_counter() - t0) * 1000.0)
+        except Exception as e:  # noqa: BLE001
+            errors.append(f"session: {e!r}")
+        with lock:
+            result.probe_ms.extend(durations)
+            result.probe_errors.extend(errors)
+
+    extra_args = ["--durability", durability] if durability is not None else None
+    proc, url = _spawn_bolt_server(cell_graph, binary=_BENCH_BINARY, extra_args=extra_args)
     try:
         with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password"), **_RETRY_KW) as driver:
             threads = [threading.Thread(target=worker, args=(driver, i), daemon=True) for i in range(writers)]
@@ -393,10 +516,15 @@ def _run_cell(
             except threading.BrokenBarrierError:
                 pass
             t_start = time.perf_counter()
+            result.window_end = t_start + seconds
             ckpt = None
             if checkpoint_every is not None:
                 ckpt = threading.Thread(target=checkpointer, args=(driver,), daemon=True)
                 ckpt.start()
+            probe = None
+            if read_probe_every is not None:
+                probe = threading.Thread(target=read_prober, args=(driver,), daemon=True)
+                probe.start()
             time.sleep(seconds)
             stop.set()
             for t in threads:
@@ -406,8 +534,16 @@ def _run_cell(
             # otherwise be added to the denominator and charge the
             # checkpointed arm a throughput dip it did not have.
             result.elapsed_s = time.perf_counter() - t_start
+            # Read once every writer has drained, so the sidecar holds one
+            # frame per *committed* transaction of this cell — the pairing
+            # `wal_bytes_per_commit` assumes. The cell's copy starts with
+            # no sidecar and nothing truncates it unless the cell asked for
+            # a checkpoint, so this is the cell's own growth.
+            result.wal_bytes = wal_file.stat().st_size if wal_file.exists() else 0
             if ckpt is not None:
                 ckpt.join(timeout=120)
+            if probe is not None:
+                probe.join(timeout=120)
 
             with driver.session() as session:
                 record = session.run(
@@ -455,26 +591,61 @@ def _format_batch_table(cells: list[CellResult]) -> str:
     return "\n".join(lines)
 
 
+def _format_durability_table(cells: list[CellResult]) -> str:
+    lines = [
+        "",
+        f"bolt durability sweep — binary: {_BENCH_BINARY}",
+        f"{'level':>7} {'N':>3} {'win_tx/s':>9} {'in_window':>10} {'committed':>10} "
+        f"{'elapsed_tx/s':>13} {'retry_rate':>11} {'p50_ms':>8} {'p95_ms':>8} "
+        f"{'mean_ms':>8} {'max_ms':>9} {'wal_KiB':>9} {'wal_B/tx':>9} {'wal_KiB/s':>10}",
+    ]
+    for c in cells:
+        wal_kib = c.wal_bytes / 1024.0
+        lines.append(
+            f"{c.durability:>7} {c.writers:>3} {c.window_per_s:>9.1f} {c.committed_in_window:>10} "
+            f"{c.committed:>10} {c.committed_per_s:>13.1f} {c.retry_rate:>11.3f} "
+            f"{_percentile(c.latencies_ms, 50):>8.2f} {_percentile(c.latencies_ms, 95):>8.2f} "
+            f"{c.mean_ms:>8.2f} {max(c.latencies_ms or [0.0]):>9.2f} "
+            f"{wal_kib:>9.1f} {c.wal_bytes_per_commit:>9.1f} "
+            f"{(wal_kib / c.elapsed_s if c.elapsed_s else 0.0):>10.1f}"
+        )
+    by_key = {(c.durability, c.writers): c for c in cells}
+    for n in sorted({c.writers for c in cells}):
+        off = by_key.get(("off", n))
+        if off is None or off.committed_in_window == 0:
+            continue
+        for level in ("normal", "full"):
+            cell = by_key.get((level, n))
+            if cell is None:
+                continue
+            cost = (off.committed_in_window - cell.committed_in_window) / off.committed_in_window * 100.0
+            lines.append(f"  N={n} {level} costs {cost:+.1f}% of off's in-window committed throughput")
+    return "\n".join(lines)
+
+
 def _format_checkpoint_table(cells: list[tuple[str, CellResult]]) -> str:
     lines = [
         "",
         f"bolt checkpoint-under-contention (N={CHECKPOINT_WRITERS}) — binary: {_BENCH_BINARY}",
-        f"{'arm':>14} {'committed/s':>12} {'committed':>10} {'retry_rate':>11} "
-        f"{'p50_ms':>8} {'p95_ms':>8} {'max_ms':>9} "
+        f"{'arm':>14} {'win_tx/s':>9} {'in_window':>10} {'committed/s':>12} {'committed':>10} "
+        f"{'retry_rate':>11} {'p50_ms':>8} {'p95_ms':>8} {'max_ms':>9} "
         f"{'ckpt_w':>7} {'ckpt_skip':>10} {'ckpt_p50_ms':>12} {'ckpt_max_ms':>12}",
     ]
     for arm, c in cells:
         lines.append(
-            f"{arm:>14} {c.committed_per_s:>12.1f} {c.committed:>10} {c.retry_rate:>11.3f} "
+            f"{arm:>14} {c.window_per_s:>9.1f} {c.committed_in_window:>10} "
+            f"{c.committed_per_s:>12.1f} {c.committed:>10} {c.retry_rate:>11.3f} "
             f"{_percentile(c.latencies_ms, 50):>8.2f} {_percentile(c.latencies_ms, 95):>8.2f} "
             f"{max(c.latencies_ms or [0.0]):>9.2f} "
             f"{c.checkpoints_written:>7} {c.checkpoints_skipped:>10} "
             f"{_percentile(c.checkpoint_ms, 50):>12.2f} {max(c.checkpoint_ms or [0.0]):>12.2f}"
         )
-    if len(cells) == 2:
-        base, ckpt = cells[0][1].committed_per_s, cells[1][1].committed_per_s
-        dip = (base - ckpt) / base * 100.0 if base else 0.0
-        lines.append(f"  committed-throughput dip with checkpointing: {dip:+.1f}%")
+    # Every arm is compared against the first one (the un-augmented
+    # baseline) on in-window commits, the fixed-denominator cell.
+    base = cells[0][1].committed_in_window if cells else 0
+    for arm, c in cells[1:]:
+        dip = (base - c.committed_in_window) / base * 100.0 if base else 0.0
+        lines.append(f"  committed-throughput dip, {arm} vs baseline: {dip:+.1f}%")
     return "\n".join(lines)
 
 
@@ -489,6 +660,13 @@ def test_checkpoint_under_contention(_writer_fixture, tmp_path):
     writers, one with a thread firing the verb about once a second and one
     without, and the difference in committed throughput.
 
+    A third arm is the sham-thread control: the same extra session at the
+    same period running `RETURN 1`. The first measurement of this cell had
+    the *checkpointed* arm committing more than its baseline, reproducibly
+    and in a reversed-order run; the control separates a real effect of
+    saving from anything an extra session on the driver does to the load
+    pattern.
+
     Nothing numeric is asserted — same as every cell in this module. The
     sanity invariants are the ones that would invalidate the number:
     the landed==committed oracle survives concurrent saving, no
@@ -501,9 +679,11 @@ def test_checkpoint_under_contention(_writer_fixture, tmp_path):
     is this measurement.
     """
     # Warmup cell — discarded.
-    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "ckptwarm")
+    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "ckptwarm", durability=RECORDED_LEVEL)
 
-    baseline = _run_cell(_writer_fixture, tmp_path, CHECKPOINT_WRITERS, CELL_SECONDS, "ckptbase")
+    baseline = _run_cell(
+        _writer_fixture, tmp_path, CHECKPOINT_WRITERS, CELL_SECONDS, "ckptbase", durability=RECORDED_LEVEL
+    )
     checkpointed = _run_cell(
         _writer_fixture,
         tmp_path,
@@ -511,11 +691,22 @@ def test_checkpoint_under_contention(_writer_fixture, tmp_path):
         CELL_SECONDS,
         "ckpton",
         checkpoint_every=CHECKPOINT_PERIOD_S,
+        durability=RECORDED_LEVEL,
+    )
+    read_probed = _run_cell(
+        _writer_fixture,
+        tmp_path,
+        CHECKPOINT_WRITERS,
+        CELL_SECONDS,
+        "ckptprobe",
+        read_probe_every=READ_PROBE_PERIOD_S,
+        durability=RECORDED_LEVEL,
     )
 
-    print(_format_checkpoint_table([("baseline", baseline), ("checkpointed", checkpointed)]))
+    arms = [("baseline", baseline), ("checkpointed", checkpointed), ("read-probe", read_probed)]
+    print(_format_checkpoint_table(arms))
 
-    for arm, c in (("baseline", baseline), ("checkpointed", checkpointed)):
+    for arm, c in arms:
         assert c.hard_errors == [], f"{arm}: non-conflict errors: {c.hard_errors[:3]}"
         assert c.committed > 0, f"{arm}: no writer committed"
         # The oracle the whole arm rests on: a save running concurrently
@@ -525,6 +716,10 @@ def test_checkpoint_under_contention(_writer_fixture, tmp_path):
 
     assert baseline.checkpoint_ms == [], "baseline arm must not have checkpointed"
     assert checkpointed.checkpoint_errors == [], f"checkpoint errors: {checkpointed.checkpoint_errors[:3]}"
+    # The control is only a control if its extra session really ran.
+    assert read_probed.checkpoint_ms == [], "read-probe arm must not have checkpointed"
+    assert read_probed.probe_errors == [], f"read-probe errors: {read_probed.probe_errors[:3]}"
+    assert len(read_probed.probe_ms) >= 2, f"read-probe thread barely ran: {read_probed.probe_ms}"
     # Under continuous writes every call should find a new version, so a
     # skip here means the writers stalled or the digest logic changed.
     assert checkpointed.checkpoints_written >= 2, (
@@ -537,9 +732,11 @@ def test_contended_writer_sweep(_writer_fixture, tmp_path):
     """Sweep N ∈ {1,2,4,8} managed writers; record the curve, assert only
     that the system stayed correct (see module docstring)."""
     # Warmup cell — discarded.
-    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "warm")
+    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "warm", durability=RECORDED_LEVEL)
 
-    cells = [_run_cell(_writer_fixture, tmp_path, n, CELL_SECONDS, f"n{n}") for n in WRITER_COUNTS]
+    cells = [
+        _run_cell(_writer_fixture, tmp_path, n, CELL_SECONDS, f"n{n}", durability=RECORDED_LEVEL) for n in WRITER_COUNTS
+    ]
 
     print(_format_table(cells))
 
@@ -565,9 +762,14 @@ def test_batch_size_sweep(_writer_fixture, tmp_path):
     `dev-docs/bench/results/results.csv`.
     """
     # Warmup cell — discarded.
-    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "batchwarm", batch=10)
+    _run_cell(
+        _writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "batchwarm", batch=10, durability=RECORDED_LEVEL
+    )
 
-    cells = [_run_cell(_writer_fixture, tmp_path, n, CELL_SECONDS, f"b{k}n{n}", batch=k) for n, k in BATCH_CELLS]
+    cells = [
+        _run_cell(_writer_fixture, tmp_path, n, CELL_SECONDS, f"b{k}n{n}", batch=k, durability=RECORDED_LEVEL)
+        for n, k in BATCH_CELLS
+    ]
 
     print(_format_batch_table(cells))
 
@@ -581,3 +783,48 @@ def test_batch_size_sweep(_writer_fixture, tmp_path):
         # contributed none.
         assert c.landed == c.committed * c.batch, f"{label}: landed {c.landed} != committed*K {c.committed * c.batch}"
         assert c.ops_per_s > 0
+
+
+def test_durability_sweep(_writer_fixture, tmp_path):
+    """What the write-ahead log costs a Bolt writer, per level and per N.
+
+    Every Bolt commit already serializes on the session lock. `full` puts a
+    device barrier (`F_FULLFSYNC` on macOS) *inside* that lock, so its cost
+    is paid by every writer waiting behind the one committing, not just by
+    the committer; `normal` writes the same frame but stops at the page
+    cache. This cell prices both against `off` at an uncontended N=1 and a
+    contended N=4, and records how fast the `<graph>-wal` sidecar grows,
+    which is what tells an operator how often to checkpoint.
+
+    Committed-in-window is the throughput cell here (see the module
+    docstring): a `full` cell's drain tail after the window closes is a
+    whole fsync per writer, which `committed / elapsed` would charge to the
+    level being measured.
+
+    Nothing numeric is asserted — the sanity invariants are the ones that
+    would invalidate the numbers: the landed==committed oracle holds at
+    every level (a logged commit must be exactly as present as an unlogged
+    one), no non-conflict error escaped, and a logging level really did
+    write a sidecar while `off` really did not.
+    """
+    # Warmup cell — discarded.
+    _run_cell(_writer_fixture, tmp_path, WARMUP_WRITERS, WARMUP_SECONDS, "durwarm", durability="off")
+
+    cells = [
+        _run_cell(_writer_fixture, tmp_path, n, CELL_SECONDS, f"dur{level}n{n}", durability=level)
+        for level, n in DURABILITY_CELLS
+    ]
+
+    print(_format_durability_table(cells))
+
+    for c in cells:
+        label = f"--durability {c.durability} N={c.writers}"
+        assert c.hard_errors == [], f"{label}: non-conflict errors: {c.hard_errors[:3]}"
+        assert c.committed > 0, f"{label}: no writer committed"
+        # The oracle: logging must not lose, duplicate or delay a write.
+        assert c.landed == c.committed, f"{label}: landed {c.landed} != committed {c.committed}"
+        assert c.committed_in_window > 0, f"{label}: nothing committed inside the window"
+        if c.durability == "off":
+            assert c.wal_bytes == 0, f"{label}: an unlogged server wrote a {c.wal_bytes}-byte sidecar"
+        else:
+            assert c.wal_bytes > 0, f"{label}: a logging server wrote no sidecar"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for kglite test suite."""
 
 import importlib.util
+import os
 from pathlib import Path
 import socket
 import subprocess
@@ -174,11 +175,17 @@ def _build_bolt_fixture_graph(path: Path) -> None:
     g.save(str(path))
 
 
-def _spawn_bolt_server(fixture_path: Path, readonly: bool = False, extra_args: list[str] | None = None):
+def _spawn_bolt_server(
+    fixture_path: Path,
+    readonly: bool = False,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+):
     """Spawn `kglite-bolt-server` on an ephemeral port; return (proc, url).
     Caller is responsible for kill+wait on teardown via
     `_teardown_bolt_server`. The `extra_args` list is appended verbatim
-    to the command line (e.g. ["--max-message-size", "1024"]).
+    to the command line (e.g. ["--max-message-size", "1024"]); `env` is
+    overlaid on the inherited environment (for the flags' env mirrors).
     """
     port = _find_free_port()
     cmd = [
@@ -194,7 +201,12 @@ def _spawn_bolt_server(fixture_path: Path, readonly: bool = False, extra_args: l
         cmd.append("--readonly")
     if extra_args:
         cmd.extend(extra_args)
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, **env} if env else None,
+    )
     url = f"bolt://127.0.0.1:{port}"
     try:
         _wait_for_listener("127.0.0.1", port, deadline_s=10.0)
@@ -212,6 +224,31 @@ def _teardown_bolt_server(proc) -> None:
     except subprocess.TimeoutExpired:
         proc.terminate()
         proc.wait(timeout=2)
+
+
+def _graceful_stop_bolt_server(proc, sig=None, timeout: float = 20.0) -> int:
+    """Ask the server to shut down the way a supervisor does, and wait.
+
+    POSIX only (Windows has no SIGINT/SIGTERM delivery to a child that means
+    "shut down gracefully"); callers gate on ``os.name == "posix"``.
+
+    Deliberately NOT a variant of `_teardown_bolt_server`, which SIGKILLs
+    first: a killed server never runs its shutdown path, so it cannot test
+    anything that happens *during* one. On timeout the process is killed and
+    the failure is raised — an exit-hook that hangs must fail the test, not
+    quietly become a leaked process.
+
+    Returns the exit status.
+    """
+    import signal as _signal
+
+    proc.send_signal(_signal.SIGINT if sig is None else sig)
+    try:
+        return proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+        raise
 
 
 def _bolt_binary_available() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,16 +180,24 @@ def _spawn_bolt_server(
     readonly: bool = False,
     extra_args: list[str] | None = None,
     env: dict[str, str] | None = None,
+    binary: Path | None = None,
 ):
     """Spawn `kglite-bolt-server` on an ephemeral port; return (proc, url).
     Caller is responsible for kill+wait on teardown via
     `_teardown_bolt_server`. The `extra_args` list is appended verbatim
     to the command line (e.g. ["--max-message-size", "1024"]); `env` is
     overlaid on the inherited environment (for the flags' env mirrors).
+
+    `binary` overrides which executable is spawned. It exists for the
+    benchmark suites, which pin an explicit copy of a release build: with
+    the default (`_BOLT_BINARY`) a concurrent `cargo build` of the other
+    profile flips `workspace_binary`'s newest-of-profile answer, so a
+    recorded number could silently come from a different profile than the
+    one the run reports.
     """
     port = _find_free_port()
     cmd = [
-        str(_BOLT_BINARY),
+        str(binary or _BOLT_BINARY),
         "--graph",
         str(fixture_path),
         "--bind",

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -1,5 +1,5 @@
 """Durability surface of kglite-bolt-server — `--save-on-exit`, the signals
-that trigger it, and the `CALL db.checkpoint()` verb.
+that trigger it, the `CALL db.checkpoint()` verb, and `--checkpoint-interval`.
 
 The server's writes are process-local: they live in the served graph's
 in-memory state and reach the `.kgl` file only when something checkpoints
@@ -12,9 +12,13 @@ POSIX-gated: the graceful-stop helper delivers SIGINT/SIGTERM, which have no
 Windows equivalent that means "shut down cleanly".
 """
 
+import hashlib
 import os
+import shutil
 import signal
 import subprocess
+import time
+from uuid import uuid4
 
 import pytest
 
@@ -65,6 +69,45 @@ def _marker_count_on_disk(path, title: str = "Zed") -> int:
     """Reopen the served `.kgl` in-process and count the marker node."""
     g = kglite.open(str(path))
     return g.cypher(_named_count_query(title)).scalar()
+
+
+def _snapshot(served, tmp_path):
+    """Copy the served file so it can be opened while the server still runs.
+
+    The running server holds the graph's writer lease, so `kglite.open` on the
+    served path itself would contend with it. Every checkpoint is an atomic
+    temp+rename, so a copy is always a whole file, never a half-written one.
+    """
+    snap = tmp_path / f"snapshot-{uuid4().hex}.kgl"
+    shutil.copyfile(served, snap)
+    return snap
+
+
+def _marker_count_in_snapshot(served, tmp_path, title: str = "Zed") -> int:
+    return _marker_count_on_disk(_snapshot(served, tmp_path), title)
+
+
+def _digest(path) -> str:
+    """Content hash of the served file.
+
+    Content, not mtime: this suite runs on filesystems whose timestamp
+    granularity is coarse enough that two writes a tick apart can share an
+    mtime, which would turn an idle-skip assertion into a coin flip.
+    """
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _wait_until(predicate, timeout: float, what: str):
+    """Poll `predicate` until it returns a truthy value, or fail saying what
+    was being waited for. Bounded well inside the suite's 120 s ceiling."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(0.2)
+    raise AssertionError(f"timed out after {timeout}s waiting for {what} (last value: {last!r})")
 
 
 def _run_server_binary(bolt_binary_path, args, env=None) -> subprocess.CompletedProcess:
@@ -405,3 +448,273 @@ def test_checkpoint_is_refused_inside_an_explicit_transaction(tmp_path):
     assert excinfo.value.code == "Neo.ClientError.Request.Invalid"
     assert "explicit transaction" in excinfo.value.message
     assert _marker_count_on_disk(fixture) == 1
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# --checkpoint-interval — the periodic task
+#
+# Every test here uses a 1-second interval and a bounded poll: the point is
+# that a tick happens and what it does, never how fast it is.
+# ────────────────────────────────────────────────────────────────────────────
+
+INTERVAL_ARGS = ["--checkpoint-interval", "1"]
+
+
+def test_checkpoint_interval_writes_a_committed_write_without_any_other_trigger(tmp_path):
+    """A write committed over Bolt reaches the file on its own — no verb call,
+    no shutdown. The server is SIGKILLed afterwards, so nothing but a tick can
+    have written it (the baseline test at the top of this file pins that a
+    server without any checkpointing writes nothing at all)."""
+    _require_binary()
+    fixture = tmp_path / "interval-write.kgl"
+    _build_bolt_fixture_graph(fixture)
+    assert _marker_count_on_disk(fixture) == 0
+    proc, url = _spawn_bolt_server(fixture, extra_args=INTERVAL_ARGS)
+    try:
+        _write_marker(url)
+        _wait_until(
+            lambda: _marker_count_in_snapshot(fixture, tmp_path) == 1,
+            timeout=25.0,
+            what="the periodic checkpoint to write the committed graph",
+        )
+    finally:
+        _teardown_bolt_server(proc)  # SIGKILL: no exit save, no shutdown path
+    assert _marker_count_on_disk(fixture) == 1
+
+
+def test_checkpoint_interval_env_mirror_writes_a_committed_write(tmp_path):
+    """`KGLITE_BOLT_CHECKPOINT_INTERVAL=1` does what the flag does."""
+    _require_binary()
+    fixture = tmp_path / "interval-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, env={"KGLITE_BOLT_CHECKPOINT_INTERVAL": "1"})
+    try:
+        _write_marker(url)
+        _wait_until(
+            lambda: _marker_count_in_snapshot(fixture, tmp_path) == 1,
+            timeout=25.0,
+            what="the env-configured periodic checkpoint to write",
+        )
+    finally:
+        _teardown_bolt_server(proc)
+
+
+def test_checkpoint_interval_skips_ticks_while_the_graph_is_idle(tmp_path):
+    """After the graph is on disk, further ticks on an unchanged graph write
+    nothing — the file is byte-identical across several tick windows."""
+    _require_binary()
+    fixture = tmp_path / "interval-idle.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=INTERVAL_ARGS)
+    try:
+        _write_marker(url)
+        _wait_until(
+            lambda: _marker_count_in_snapshot(fixture, tmp_path) == 1,
+            timeout=25.0,
+            what="the first checkpoint of the written graph",
+        )
+        settled = _digest(fixture)
+        # No client writes from here: at least three further ticks pass.
+        time.sleep(3.5)
+        assert _digest(fixture) == settled, "ticks over an unchanged graph must not rewrite the served file"
+        # Mutation check on the skip itself: a further write makes the next
+        # tick save again, so the stability above is a skip, not a dead task.
+        _write_marker(url, "Later")
+        _wait_until(
+            lambda: _digest(fixture) != settled,
+            timeout=25.0,
+            what="a tick after a new write to rewrite the file",
+        )
+    finally:
+        _teardown_bolt_server(proc)
+    assert _marker_count_on_disk(fixture, "Later") == 1
+
+
+def test_first_tick_rewrites_a_file_that_predates_the_process(tmp_path):
+    """The first tick saves unconditionally. The served file is replaced *on
+    disk* with a different graph after the server loaded it — the state the
+    server serves and the state on disk have now diverged with no version bump
+    to notice — and the first tick must restore what is being served. A
+    digest-skip seeded from the graph as loaded would leave the stale file
+    there forever."""
+    _require_binary()
+    fixture = tmp_path / "interval-stale.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=INTERVAL_ARGS)
+    try:
+        # A graph the server has never seen, written under the served path.
+        stale = tmp_path / "stale-source.kgl"
+        _build_bolt_fixture_graph(stale)
+        g = kglite.open(str(stale))
+        g.cypher("CREATE (:Person {id: 77, title: 'Stale', city: 'Nowhere'})")
+        g.save(str(stale))
+        del g
+        os.replace(shutil.copyfile(stale, tmp_path / "stale-copy.kgl"), fixture)
+        assert _marker_count_on_disk(_snapshot(fixture, tmp_path), "Stale") == 1
+
+        # No client writes at all — only the unconditional first tick can undo
+        # this, and it must, because the file no longer matches what is served.
+        _wait_until(
+            lambda: _marker_count_in_snapshot(fixture, tmp_path, "Stale") == 0,
+            timeout=25.0,
+            what="the first tick to overwrite the stale file with the served state",
+        )
+        snapshot = _snapshot(fixture, tmp_path)
+        assert kglite.open(str(snapshot)).cypher("MATCH (p:Person) RETURN count(p) AS c").scalar() == 4, (
+            "the rewritten file must be the served state, not a merge of the two"
+        )
+    finally:
+        _teardown_bolt_server(proc)
+
+
+def test_shutdown_stays_prompt_and_ordered_with_the_interval_armed(tmp_path):
+    """The periodic task cannot delay or outlive shutdown: SIGINT still exits
+    cleanly and well inside the timeout, and the task is stopped *before* the
+    exit save runs — the exit save must be the last write to the file."""
+    _require_binary()
+    fixture = tmp_path / "interval-shutdown.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=[*INTERVAL_ARGS, "--save-on-exit"])
+    try:
+        _write_marker(url)
+        started = time.monotonic()
+        status = _graceful_stop_bolt_server(proc, signal.SIGINT, timeout=20.0)
+        elapsed = time.monotonic() - started
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    assert status == 0, "an armed checkpoint task must not break the clean stop"
+    assert elapsed < 10.0, f"shutdown took {elapsed:.1f}s with the checkpoint task armed"
+    logs = proc.stdout.read().decode("utf-8", errors="replace") + proc.stderr.read().decode("utf-8", errors="replace")
+    stopped = logs.find("checkpoint-interval: stopped")
+    saved = logs.find("save-on-exit complete")
+    assert stopped != -1 and saved != -1, logs
+    assert stopped < saved, f"the periodic task must be stopped before the exit save runs:\n{logs}"
+    assert _marker_count_on_disk(fixture) == 1
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# --checkpoint-interval — startup validation
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["0", "abc", "5s", "-1"], ids=["zero", "junk", "units", "negative"])
+def test_checkpoint_interval_rejects_a_value_it_cannot_honour(bolt_binary_path, tmp_path, value):
+    """A mistyped interval fails startup rather than starting a server that
+    silently never checkpoints.
+
+    `--flag=value` rather than `--flag value` so every case reaches the value
+    parser: a bare `-1` in the next argv slot is read by clap as an unknown
+    *flag*, which is still a refusal but a different one. The spaced spelling
+    is what every other test here spawns with.
+    """
+    _require_binary()
+    fixture = tmp_path / "bad-interval.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", f"--checkpoint-interval={value}"],
+    )
+    assert result.returncode != 0, f"--checkpoint-interval {value} must not start a server"
+    combined = result.stdout + result.stderr
+    assert "--checkpoint-interval" in combined, combined
+    if value == "0":
+        assert "at least 1 second" in combined, combined
+
+
+def test_checkpoint_interval_env_mirror_rejects_a_bad_value(bolt_binary_path, tmp_path):
+    """The environment spelling gets the same parse — and the error names the
+    variable, since the operator never typed a flag."""
+    _require_binary()
+    fixture = tmp_path / "bad-interval-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0"],
+        env={"KGLITE_BOLT_CHECKPOINT_INTERVAL": "0"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "KGLITE_BOLT_CHECKPOINT_INTERVAL" in combined and "at least 1 second" in combined, combined
+
+
+def test_checkpoint_interval_conflicts_with_readonly_flag(bolt_binary_path, tmp_path):
+    """clap rejects the flag pair before anything is opened."""
+    _require_binary()
+    fixture = tmp_path / "ro-interval.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly", "--checkpoint-interval", "60"],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "cannot be used with" in combined, combined
+    assert "--readonly" in combined and "--checkpoint-interval" in combined, combined
+
+
+def test_checkpoint_interval_env_mirror_is_refused_with_readonly(bolt_binary_path, tmp_path):
+    """clap cannot see the environment, so the server checks it itself."""
+    _require_binary()
+    fixture = tmp_path / "ro-interval-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly"],
+        env={"KGLITE_BOLT_CHECKPOINT_INTERVAL": "60"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--readonly" in combined and "nothing to write back" in combined, combined
+
+
+def test_checkpoint_interval_is_refused_for_a_disk_graph(bolt_binary_path, tmp_path):
+    """Disk graphs are excluded for the same unbounded-generation reason
+    `--save-on-exit` refuses them — and periodic checkpointing is the shape
+    that would grow the directory fastest."""
+    _require_binary()
+    disk_dir = tmp_path / "disk-interval"
+    g = kglite.KnowledgeGraph(storage="disk", path=str(disk_dir))
+    g.cypher("CREATE (:Person {id: 1, title: 'Alice'})")
+    g.save(str(disk_dir))
+    del g
+
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(disk_dir), "--port", "0", "--checkpoint-interval", "60"],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "disk-mode" in combined and "generation" in combined, combined
+
+
+def test_checkpoint_interval_and_the_verb_share_one_skip_state(tmp_path):
+    """One recorded version, two routes to it: a `db.checkpoint()` that wrote
+    version N makes the next tick a skip, and a tick that wrote version N makes
+    the next verb call report the skip. Two independent counters would each
+    re-save what the other had just written."""
+    _require_binary()
+    fixture = tmp_path / "shared-state.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=INTERVAL_ARGS)
+    try:
+        _write_marker(url)
+        # The verb writes first; the tick then finds nothing to do, so the file
+        # stays byte-identical across several tick windows.
+        assert _checkpoint(url)["message"].startswith("checkpoint written: version ")
+        after_verb = _digest(fixture)
+        time.sleep(3.5)
+        assert _digest(fixture) == after_verb, "a tick must skip what the verb just wrote"
+
+        # Now the other direction: a tick writes the next version, and the verb
+        # that follows reports the skip instead of re-saving.
+        _write_marker(url, "Later")
+        _wait_until(
+            lambda: _digest(fixture) != after_verb,
+            timeout=25.0,
+            what="a tick to write the new version",
+        )
+        message = _checkpoint(url)["message"]
+        assert message.startswith("skipped: graph unchanged since version "), message
+    finally:
+        _teardown_bolt_server(proc)

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -835,9 +835,9 @@ def test_the_env_mirror_logs_the_same_way(tmp_path):
 
 
 def test_without_the_log_the_same_commit_is_lost(tmp_path):
-    """The control for the two tests above, and the pinned default: `off` — the
-    level an invocation with no `--durability` gets — loses a committed write to
-    a SIGKILL, because nothing but a checkpoint ever writes the graph back."""
+    """The control for the two tests above: `off` — which has to be asked for,
+    the default being `normal` — loses a committed write to a SIGKILL, because
+    without a log nothing but a checkpoint ever writes the graph back."""
     _require_binary()
     fixture = tmp_path / "wal-off.kgl"
     _build_bolt_fixture_graph(fixture)

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -1,5 +1,5 @@
-"""Durability surface of kglite-bolt-server — `--save-on-exit` and the
-signals that trigger it.
+"""Durability surface of kglite-bolt-server — `--save-on-exit`, the signals
+that trigger it, and the `CALL db.checkpoint()` verb.
 
 The server's writes are process-local: they live in the served graph's
 in-memory state and reach the `.kgl` file only when something checkpoints
@@ -44,23 +44,27 @@ def _require_binary():
         pytest.skip(_BOLT_SKIP_REASON)
 
 
-def _write_marker(url: str) -> None:
+def _named_count_query(title: str) -> str:
+    return f"MATCH (p:Person {{title: '{title}'}}) RETURN count(p) AS c"
+
+
+def _write_marker(url: str, title: str = "Zed") -> None:
     """Commit one node through an explicit transaction, so the write is
     definitely committed (not merely sent) before the server is signalled."""
     with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
         with driver.session() as session:
             tx = session.begin_transaction()
-            tx.run("CREATE (:Person {id: 99, title: 'Zed', city: 'Tromso'})")
+            tx.run(f"CREATE (:Person {{id: 99, title: '{title}', city: 'Tromso'}})")
             tx.commit()
         # Read it back on a fresh session: the write is live in the server.
         with driver.session() as session:
-            assert session.run(MARKER_QUERY).single()["c"] == 1
+            assert session.run(_named_count_query(title)).single()["c"] == 1
 
 
-def _marker_count_on_disk(path) -> int:
+def _marker_count_on_disk(path, title: str = "Zed") -> int:
     """Reopen the served `.kgl` in-process and count the marker node."""
     g = kglite.open(str(path))
-    return g.cypher(MARKER_QUERY).scalar()
+    return g.cypher(_named_count_query(title)).scalar()
 
 
 def _run_server_binary(bolt_binary_path, args, env=None) -> subprocess.CompletedProcess:
@@ -216,3 +220,188 @@ def test_save_on_exit_is_refused_for_a_disk_graph(bolt_binary_path, tmp_path):
     assert result.returncode != 0
     combined = result.stdout + result.stderr
     assert "disk-mode" in combined and "generation" in combined, combined
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CALL db.checkpoint() — the on-demand verb (bolt-only; see p2-red.txt for
+# what this query did before the intercept existed)
+# ────────────────────────────────────────────────────────────────────────────
+
+CHECKPOINT = "CALL db.checkpoint()"
+
+
+def _checkpoint(url: str, query: str = CHECKPOINT):
+    """Run the verb on a fresh driver session and return the single record."""
+    with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+        with driver.session() as session:
+            return session.run(query).single()
+
+
+def test_checkpoint_returns_the_neo4j_result_shape(tmp_path):
+    """Columns `success, message` with one record — the shape Neo4j's own
+    `db.checkpoint()` yields, so a client can consume it identically."""
+    _require_binary()
+    fixture = tmp_path / "shape.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        record = _checkpoint(url)
+        assert list(record.keys()) == ["success", "message"]
+        assert record["success"] is True
+        assert record["message"].startswith("checkpoint written: version "), record["message"]
+        # An explicit YIELD projects exactly what it asked for, in its order.
+        yielded = _checkpoint(url, "CALL db.checkpoint() YIELD message, success")
+        assert list(yielded.keys()) == ["message", "success"]
+        assert yielded["success"] is True
+    finally:
+        _teardown_bolt_server(proc)
+
+
+def test_checkpoint_writes_the_committed_graph_to_the_served_file(tmp_path):
+    """The point of the verb. The server is then SIGKILLed — a killed process
+    runs no exit hook, so the write can only have reached the file through the
+    checkpoint."""
+    _require_binary()
+    fixture = tmp_path / "verb-write.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        _write_marker(url)
+        assert _checkpoint(url)["success"] is True
+    finally:
+        _teardown_bolt_server(proc)
+    assert _marker_count_on_disk(fixture) == 1, "the checkpoint must write the committed graph back"
+
+
+def test_checkpoint_bounds_the_loss_window_across_a_sigkill(tmp_path):
+    """The documented loss window, proven in both directions: a write made
+    *before* `db.checkpoint()` survives a SIGKILL and a restart on the same
+    file; a write made *after* it is gone. Neither half alone is evidence —
+    the first without the second would also pass on a server that saved
+    everything continuously."""
+    _require_binary()
+    fixture = tmp_path / "loss-window.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        _write_marker(url, "Before")
+        assert _checkpoint(url)["success"] is True
+        _write_marker(url, "After")
+    finally:
+        _teardown_bolt_server(proc)  # SIGKILL: no shutdown path, no exit save
+
+    # Restart on the same file — the server is the reader, so this also proves
+    # the checkpointed file is servable and the dead process's lease is gone.
+    restarted, restarted_url = _spawn_bolt_server(fixture)
+    try:
+        with neo4j.GraphDatabase.driver(restarted_url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                before = session.run(_named_count_query("Before")).single()["c"]
+                after = session.run(_named_count_query("After")).single()["c"]
+    finally:
+        _teardown_bolt_server(restarted)
+    assert before == 1, "a write committed before the checkpoint must survive the crash"
+    assert after == 0, "a write committed after the checkpoint is the documented loss window"
+
+
+def test_checkpoint_skips_when_the_graph_has_not_changed(tmp_path):
+    """Digest-skip: the second checkpoint of an unchanged graph reports the
+    skip and leaves the file untouched (mtime, byte-for-byte)."""
+    _require_binary()
+    fixture = tmp_path / "skip.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        _write_marker(url)
+        first = _checkpoint(url)
+        assert first["message"].startswith("checkpoint written: version "), first["message"]
+        stat_after_write = fixture.stat()
+
+        second = _checkpoint(url)
+        assert second["success"] is True
+        assert second["message"].startswith("skipped: graph unchanged since version "), second["message"]
+        assert fixture.stat().st_mtime_ns == stat_after_write.st_mtime_ns, (
+            "a skipped checkpoint must not rewrite the served file"
+        )
+
+        # Mutation check: a further write makes the next checkpoint save again.
+        _write_marker(url, "Later")
+        third = _checkpoint(url)
+        assert third["message"].startswith("checkpoint written: version "), third["message"]
+    finally:
+        _teardown_bolt_server(proc)
+    assert _marker_count_on_disk(fixture, "Later") == 1
+
+
+def test_checkpoint_is_refused_on_a_readonly_server(tmp_path):
+    """`--readonly` refuses the verb with the exact Neo4j security code, and
+    writes nothing."""
+    _require_binary()
+    fixture = tmp_path / "readonly.kgl"
+    _build_bolt_fixture_graph(fixture)
+    before = fixture.stat().st_mtime_ns
+    proc, url = _spawn_bolt_server(fixture, readonly=True)
+    try:
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                with pytest.raises(neo4j.exceptions.Forbidden) as excinfo:
+                    session.run(CHECKPOINT).single()
+    finally:
+        _teardown_bolt_server(proc)
+    assert excinfo.value.code == "Neo.ClientError.Security.Forbidden"
+    assert "--readonly" in excinfo.value.message
+    assert fixture.stat().st_mtime_ns == before, "a refused checkpoint writes nothing"
+
+
+def test_checkpoint_is_refused_for_a_disk_graph_over_the_wire(tmp_path):
+    """A disk graph serves normally; only the checkpoint verb is refused, for
+    the same unbounded-generation reason `--save-on-exit` refuses at startup."""
+    _require_binary()
+    disk_dir = tmp_path / "disk-verb"
+    g = kglite.KnowledgeGraph(storage="disk", path=str(disk_dir))
+    g.cypher("CREATE (:Person {id: 1, title: 'Alice'})")
+    g.save(str(disk_dir))
+    del g
+
+    proc, url = _spawn_bolt_server(disk_dir)
+    try:
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                # The graph itself is perfectly queryable — the refusal is
+                # specific to the verb, not to serving a disk graph.
+                assert session.run("MATCH (n:Person) RETURN count(n) AS c").single()["c"] == 1
+                with pytest.raises(neo4j.exceptions.Forbidden) as excinfo:
+                    session.run(CHECKPOINT).single()
+    finally:
+        _teardown_bolt_server(proc)
+    assert excinfo.value.code == "Neo.ClientError.Security.Forbidden"
+    assert "generation" in excinfo.value.message
+
+
+def test_checkpoint_is_refused_inside_an_explicit_transaction(tmp_path):
+    """A checkpoint writes the *committed* graph, which by definition excludes
+    the calling transaction's uncommitted writes — so running it there would
+    report success over a file missing the work just done. Refused, and the
+    transaction is still usable afterwards."""
+    _require_binary()
+    fixture = tmp_path / "in-tx.kgl"
+    _build_bolt_fixture_graph(fixture)
+    before = fixture.stat().st_mtime_ns
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                tx = session.begin_transaction()
+                tx.run("CREATE (:Person {id: 99, title: 'Zed'})")
+                with pytest.raises(neo4j.exceptions.ClientError) as excinfo:
+                    tx.run(CHECKPOINT).single()
+                tx.rollback()
+        assert fixture.stat().st_mtime_ns == before, "a refused checkpoint writes nothing"
+        # COMMIT-then-checkpoint is the supported spelling, and still works.
+        _write_marker(url)
+        assert _checkpoint(url)["success"] is True
+    finally:
+        _teardown_bolt_server(proc)
+    assert excinfo.value.code == "Neo.ClientError.Request.Invalid"
+    assert "explicit transaction" in excinfo.value.message
+    assert _marker_count_on_disk(fixture) == 1

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -1,12 +1,18 @@
 """Durability surface of kglite-bolt-server — `--save-on-exit`, the signals
 that trigger it, the `CALL db.checkpoint()` verb, and `--checkpoint-interval`.
 
-The server's writes are process-local: they live in the served graph's
-in-memory state and reach the `.kgl` file only when something checkpoints
-them. `test_write_over_bolt_does_not_reach_the_file_without_save_on_exit`
-pins that baseline — every other test here measures against it, and without
-it a passing save-on-exit test could just be reading a write the server had
-persisted anyway.
+The server's writes are process-local *as far as the `.kgl` goes*: they live
+in the served graph's in-memory state and reach the file only when something
+checkpoints them. `test_write_over_bolt_does_not_reach_the_file_without_save_
+on_exit` pins that baseline at `--durability off` — every checkpoint test
+here measures against it, and without it a passing save-on-exit test could
+just be reading a write the server had persisted anyway.
+
+What a commit survives is the other axis, and the default moved along it:
+`--durability` defaults to `normal`, so an acknowledged commit outlives the
+server process even with nothing checkpointing. Tests about the *file* pass
+`--durability off` explicitly; tests about the *default* say so in their
+name.
 
 POSIX-gated: the graceful-stop helper delivers SIGINT/SIGTERM, which have no
 Windows equivalent that means "shut down cleanly".
@@ -132,11 +138,18 @@ def _run_server_binary(bolt_binary_path, args, env=None) -> subprocess.Completed
 
 def test_write_over_bolt_does_not_reach_the_file_without_save_on_exit(tmp_path):
     """The process-local baseline. A graceful SIGINT shutdown with no
-    `--save-on-exit` leaves the served file exactly as it was."""
+    `--save-on-exit` leaves the served file exactly as it was.
+
+    Pinned at an explicit `--durability off` because that is the model this
+    baseline is about: with no log, a write that never reached the file is
+    gone. The default level is `normal`, where the same write is in the
+    sidecar and comes back on the next start — a different property, tested
+    at `test_a_default_server_logs_at_normal`.
+    """
     _require_binary()
     fixture = tmp_path / "baseline.kgl"
     _build_bolt_fixture_graph(fixture)
-    proc, url = _spawn_bolt_server(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", "off"])
     try:
         _write_marker(url)
         status = _graceful_stop_bolt_server(proc, signal.SIGINT)
@@ -326,11 +339,19 @@ def test_checkpoint_bounds_the_loss_window_across_a_sigkill(tmp_path):
     *before* `db.checkpoint()` survives a SIGKILL and a restart on the same
     file; a write made *after* it is gone. Neither half alone is evidence —
     the first without the second would also pass on a server that saved
-    everything continuously."""
+    everything continuously.
+
+    At `--durability off`, which is the level this window belongs to: with a
+    log the post-checkpoint write is *not* lost — it is replayed at the next
+    start, which is what `test_a_checkpoint_truncates_the_log_and_later_
+    commits_start_a_fresh_one` proves. Checkpointing bounds the loss window;
+    the log removes it.
+    """
     _require_binary()
     fixture = tmp_path / "loss-window.kgl"
     _build_bolt_fixture_graph(fixture)
-    proc, url = _spawn_bolt_server(fixture)
+    off = ["--durability", "off"]
+    proc, url = _spawn_bolt_server(fixture, extra_args=off)
     try:
         _write_marker(url, "Before")
         assert _checkpoint(url)["success"] is True
@@ -340,7 +361,7 @@ def test_checkpoint_bounds_the_loss_window_across_a_sigkill(tmp_path):
 
     # Restart on the same file — the server is the reader, so this also proves
     # the checkpointed file is servable and the dead process's lease is gone.
-    restarted, restarted_url = _spawn_bolt_server(fixture)
+    restarted, restarted_url = _spawn_bolt_server(fixture, extra_args=off)
     try:
         with neo4j.GraphDatabase.driver(restarted_url, auth=("neo4j", "password")) as driver:
             with driver.session() as session:
@@ -835,21 +856,35 @@ def test_without_the_log_the_same_commit_is_lost(tmp_path):
         _teardown_bolt_server(restarted)
 
 
-def test_a_default_server_does_not_log(tmp_path):
-    """The default is `off`: an invocation that says nothing about durability
-    behaves exactly as it did before the flag existed. Pinned separately from
-    the `off` test above because flipping the default is a decision, not an
-    implementation detail — see `DEFAULT_DURABILITY` in main.rs."""
+def test_a_default_server_logs_at_normal(tmp_path):
+    """The default is `normal`: an invocation that says nothing about
+    durability still keeps a committed write across the process dying.
+
+    Pinned separately from the parametrized `normal` test above because the
+    default is a decision, not an implementation detail — see
+    `DEFAULT_DURABILITY` in main.rs, and R3.3 for the measurement that chose
+    it. The `.kgl` itself is still untouched: the default bounds what a crash
+    costs, it does not checkpoint continuously.
+    """
     _require_binary()
     fixture = tmp_path / "wal-default.kgl"
     _build_bolt_fixture_graph(fixture)
+    untouched = _digest(fixture)
     proc, url = _spawn_bolt_server(fixture)
     try:
         _write_marker(url)
-        assert _wal_size(fixture) == 0, "the default must not attach a log"
+        assert _wal_size(fixture) > WAL_HEADER_BYTES, "the default must attach a log"
     finally:
-        _teardown_bolt_server(proc)
-    assert _marker_count_on_disk(fixture) == 0
+        _teardown_bolt_server(proc)  # SIGKILL: no shutdown path, no exit save
+    assert _digest(fixture) == untouched, "writes stay process-local until something checkpoints"
+
+    restarted, restarted_url = _spawn_bolt_server(fixture)
+    try:
+        assert _count_over_bolt(restarted_url, "Zed") == 1, (
+            "a commit acknowledged by a default server must survive that server dying"
+        )
+    finally:
+        _teardown_bolt_server(restarted)
 
 
 # ── Recovery on open is unconditional ───────────────────────────────────────
@@ -858,8 +893,13 @@ def test_a_default_server_does_not_log(tmp_path):
 def test_starting_at_off_over_an_unreplayed_log_is_refused(tmp_path, bolt_binary_path):
     """A logged commit that no checkpoint has folded in is *data*, and starting
     a server that neither replays nor keeps it would lose it at the next
-    checkpoint. Both spellings of "no log" are refused: the explicit `off` and
-    the default."""
+    checkpoint. Asking for `off` over such a log is therefore refused.
+
+    The default is not one of the ways to ask: it logs at `normal`, so the
+    same path started with no flag replays the commit instead — asserted here
+    beside the refusal, because "refused" is only the right answer for an
+    operator who typed `off`.
+    """
     _require_binary()
     fixture = tmp_path / "unreplayed.kgl"
     _build_bolt_fixture_graph(fixture)
@@ -869,15 +909,23 @@ def test_starting_at_off_over_an_unreplayed_log_is_refused(tmp_path, bolt_binary
     finally:
         _teardown_bolt_server(proc)
 
-    for args in (["--durability", "off"], []):
-        result = _run_server_binary(
-            bolt_binary_path,
-            ["--graph", str(fixture), "--port", "0", *args],
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--durability", "off"],
+    )
+    assert result.returncode != 0, f"off must refuse: {result.stdout}{result.stderr}"
+    combined = result.stdout + result.stderr
+    assert "-wal" in combined, combined
+    assert "'full' or 'normal'" in combined, combined
+
+    # The default recovers rather than refusing — the flip's whole point.
+    default_started, default_url = _spawn_bolt_server(fixture)
+    try:
+        assert _count_over_bolt(default_url, "Zed") == 1, (
+            "a default server must replay the unreplayed log, not refuse it"
         )
-        assert result.returncode != 0, f"args={args} must refuse: {result.stdout}{result.stderr}"
-        combined = result.stdout + result.stderr
-        assert "-wal" in combined, combined
-        assert "'full' or 'normal'" in combined, combined
+    finally:
+        _teardown_bolt_server(default_started)
 
     # Non-vacuity: the refusal is about the level, not a broken file — the same
     # path serves fine at a logging level, with the write.

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -52,13 +52,18 @@ def _named_count_query(title: str) -> str:
     return f"MATCH (p:Person {{title: '{title}'}}) RETURN count(p) AS c"
 
 
-def _write_marker(url: str, title: str = "Zed") -> None:
+def _write_marker(url: str, title: str = "Zed", node_id: int = 99) -> None:
     """Commit one node through an explicit transaction, so the write is
-    definitely committed (not merely sent) before the server is signalled."""
+    definitely committed (not merely sent) before the server is signalled.
+
+    `node_id` is distinct per marker wherever two markers must coexist *after a
+    WAL replay*: the log records a mutation as an upsert keyed by `(type, id)`,
+    so two `CREATE`s sharing an id are two nodes live and one node replayed.
+    """
     with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
         with driver.session() as session:
             tx = session.begin_transaction()
-            tx.run(f"CREATE (:Person {{id: 99, title: '{title}', city: 'Tromso'}})")
+            tx.run(f"CREATE (:Person {{id: {node_id}, title: '{title}', city: 'Tromso'}})")
             tx.commit()
         # Read it back on a fresh session: the write is live in the server.
         with driver.session() as session:
@@ -718,3 +723,356 @@ def test_checkpoint_interval_and_the_verb_share_one_skip_state(tmp_path):
         assert message.startswith("skipped: graph unchanged since version "), message
     finally:
         _teardown_bolt_server(proc)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# --durability: the write-ahead log
+#
+# The three features above bound the loss window by *rewriting the whole
+# graph*; the log bounds it per commit. What every test here measures is what
+# survives a SIGKILL with **no checkpoint of any kind in between** — the
+# baseline test at the top of this file is the control: at `off`, that write is
+# gone.
+# ────────────────────────────────────────────────────────────────────────────
+
+# magic (4 bytes) + format version (1 byte). A truncated log is exactly this
+# long; anything more is at least one frame.
+WAL_HEADER_BYTES = 5
+
+
+def _wal_path(served):
+    """The sidecar beside `served`, derived the way the engine derives it."""
+    return served.parent / (served.name + "-wal")
+
+
+def _wal_size(served) -> int:
+    path = _wal_path(served)
+    return path.stat().st_size if path.exists() else 0
+
+
+def _count_over_bolt(url: str, title: str) -> int:
+    with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+        with driver.session() as session:
+            return session.run(_named_count_query(title)).single()["c"]
+
+
+@pytest.mark.parametrize("level", ["full", "normal"])
+def test_a_logged_commit_survives_a_sigkill_with_no_checkpoint(tmp_path, level):
+    """The rung's headline. Commit over Bolt, SIGKILL the server — no exit
+    hook, no `db.checkpoint()`, no interval — and restart at the same level:
+    the write comes back out of the log.
+
+    `normal` is tested against a *process* kill, which is exactly what it
+    promises (the frame is in the kernel's page cache). Its OS-crash/power-loss
+    window is documented, not tested: nothing in a user-space test can take the
+    page cache away.
+    """
+    _require_binary()
+    fixture = tmp_path / f"wal-{level}.kgl"
+    _build_bolt_fixture_graph(fixture)
+    untouched = _digest(fixture)
+
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", level])
+    try:
+        _write_marker(url)
+        assert _wal_size(fixture) > WAL_HEADER_BYTES, "the commit must reach the log"
+    finally:
+        _teardown_bolt_server(proc)  # SIGKILL: no shutdown path, no exit save
+
+    assert _digest(fixture) == untouched, (
+        "no checkpoint ran, so the .kgl must be byte-identical — otherwise this test would prove nothing about the log"
+    )
+
+    restarted, restarted_url = _spawn_bolt_server(fixture, extra_args=["--durability", level])
+    try:
+        assert _count_over_bolt(restarted_url, "Zed") == 1, (
+            f"--durability {level} must replay the committed write at startup"
+        )
+    finally:
+        _teardown_bolt_server(restarted)
+
+
+def test_the_env_mirror_logs_the_same_way(tmp_path):
+    """`KGLITE_BOLT_DURABILITY=full` does what the flag does — the spelling a
+    Compose file or unit file can set."""
+    _require_binary()
+    fixture = tmp_path / "wal-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    env = {"KGLITE_BOLT_DURABILITY": "full"}
+
+    proc, url = _spawn_bolt_server(fixture, env=env)
+    try:
+        _write_marker(url)
+    finally:
+        _teardown_bolt_server(proc)
+
+    restarted, restarted_url = _spawn_bolt_server(fixture, env=env)
+    try:
+        assert _count_over_bolt(restarted_url, "Zed") == 1
+    finally:
+        _teardown_bolt_server(restarted)
+
+
+def test_without_the_log_the_same_commit_is_lost(tmp_path):
+    """The control for the two tests above, and the pinned default: `off` — the
+    level an invocation with no `--durability` gets — loses a committed write to
+    a SIGKILL, because nothing but a checkpoint ever writes the graph back."""
+    _require_binary()
+    fixture = tmp_path / "wal-off.kgl"
+    _build_bolt_fixture_graph(fixture)
+
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", "off"])
+    try:
+        _write_marker(url)
+        assert _wal_size(fixture) == 0, "level off must not create a log at all"
+    finally:
+        _teardown_bolt_server(proc)
+
+    restarted, restarted_url = _spawn_bolt_server(fixture, extra_args=["--durability", "off"])
+    try:
+        assert _count_over_bolt(restarted_url, "Zed") == 0
+    finally:
+        _teardown_bolt_server(restarted)
+
+
+def test_a_default_server_does_not_log(tmp_path):
+    """The default is `off`: an invocation that says nothing about durability
+    behaves exactly as it did before the flag existed. Pinned separately from
+    the `off` test above because flipping the default is a decision, not an
+    implementation detail — see `DEFAULT_DURABILITY` in main.rs."""
+    _require_binary()
+    fixture = tmp_path / "wal-default.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        _write_marker(url)
+        assert _wal_size(fixture) == 0, "the default must not attach a log"
+    finally:
+        _teardown_bolt_server(proc)
+    assert _marker_count_on_disk(fixture) == 0
+
+
+# ── Recovery on open is unconditional ───────────────────────────────────────
+
+
+def test_starting_at_off_over_an_unreplayed_log_is_refused(tmp_path, bolt_binary_path):
+    """A logged commit that no checkpoint has folded in is *data*, and starting
+    a server that neither replays nor keeps it would lose it at the next
+    checkpoint. Both spellings of "no log" are refused: the explicit `off` and
+    the default."""
+    _require_binary()
+    fixture = tmp_path / "unreplayed.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", "full"])
+    try:
+        _write_marker(url)
+    finally:
+        _teardown_bolt_server(proc)
+
+    for args in (["--durability", "off"], []):
+        result = _run_server_binary(
+            bolt_binary_path,
+            ["--graph", str(fixture), "--port", "0", *args],
+        )
+        assert result.returncode != 0, f"args={args} must refuse: {result.stdout}{result.stderr}"
+        combined = result.stdout + result.stderr
+        assert "-wal" in combined, combined
+        assert "'full' or 'normal'" in combined, combined
+
+    # Non-vacuity: the refusal is about the level, not a broken file — the same
+    # path serves fine at a logging level, with the write.
+    recovered, recovered_url = _spawn_bolt_server(fixture, extra_args=["--durability", "full"])
+    try:
+        assert _count_over_bolt(recovered_url, "Zed") == 1
+    finally:
+        _teardown_bolt_server(recovered)
+
+
+# ── Checkpoints and the log ─────────────────────────────────────────────────
+
+
+def test_a_checkpoint_truncates_the_log_and_later_commits_start_a_fresh_one(tmp_path):
+    """The four-step checkpoint order, observed from outside: flush → stamp →
+    write the `.kgl` → truncate the log. After `db.checkpoint()` the file holds
+    the write and the log is back to its header; the next commit lands in the
+    fresh log and is itself recovered by a restart."""
+    _require_binary()
+    fixture = tmp_path / "checkpoint-wal.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", "full"])
+    try:
+        _write_marker(url, "Before", node_id=101)
+        assert _wal_size(fixture) > WAL_HEADER_BYTES
+
+        assert _checkpoint(url)["success"] is True
+        assert _wal_size(fixture) == WAL_HEADER_BYTES, "a checkpoint folds the log into the .kgl and truncates it"
+        # The truncated sidecar is also what makes the file plainly openable
+        # again: nothing is left in front of the checkpoint.
+        assert _marker_count_on_disk(_snapshot(fixture, tmp_path), "Before") == 1
+
+        _write_marker(url, "After", node_id=102)
+        assert _wal_size(fixture) > WAL_HEADER_BYTES, "post-checkpoint commits use the fresh log"
+    finally:
+        _teardown_bolt_server(proc)  # SIGKILL: only the log can carry "After"
+
+    restarted, restarted_url = _spawn_bolt_server(fixture, extra_args=["--durability", "full"])
+    try:
+        assert _count_over_bolt(restarted_url, "Before") == 1, "the checkpointed write"
+        assert _count_over_bolt(restarted_url, "After") == 1, (
+            "with a log, the post-checkpoint write is no longer the loss window"
+        )
+    finally:
+        _teardown_bolt_server(restarted)
+
+
+def test_save_on_exit_flushes_and_truncates_the_log(tmp_path):
+    """A graceful stop under a log: the exit path flushes the log, the exit
+    save folds it into the `.kgl`, and the log is left truncated — so the next
+    start needs no recovery and the graph opens with no durability argument at
+    all."""
+    _require_binary()
+    fixture = tmp_path / "exit-save-wal.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--durability", "normal", "--save-on-exit"])
+    try:
+        _write_marker(url)
+        status = _graceful_stop_bolt_server(proc, signal.SIGTERM)
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    assert status == 0, "a successful flush + exit save exits zero"
+    logs = proc.stdout.read().decode("utf-8", errors="replace") + proc.stderr.read().decode("utf-8", errors="replace")
+    assert "write-ahead log flushed" in logs, logs
+    assert _wal_size(fixture) == WAL_HEADER_BYTES
+    assert _marker_count_on_disk(fixture) == 1
+
+
+# ── Refusal matrix ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("level", ["full", "normal"])
+def test_a_logging_level_is_refused_with_readonly(bolt_binary_path, tmp_path, level):
+    """A read-only server never commits, so a log would only ever be empty."""
+    _require_binary()
+    fixture = tmp_path / "ro-wal.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly", "--durability", level],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--readonly" in combined and "nothing to log" in combined, combined
+
+
+def test_the_env_mirror_is_refused_with_readonly(bolt_binary_path, tmp_path):
+    """The environment spelling too — the level is what conflicts, so a clap
+    `conflicts_with` on the argument could not express this rule anyway."""
+    _require_binary()
+    fixture = tmp_path / "ro-wal-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly"],
+        env={"KGLITE_BOLT_DURABILITY": "full"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--readonly" in combined and "KGLITE_BOLT_DURABILITY" in combined, combined
+
+
+def test_readonly_serves_fine_at_off(tmp_path):
+    """The other side of that rule: `off` is not a conflict, it is what every
+    read-only server already runs at."""
+    _require_binary()
+    fixture = tmp_path / "ro-off.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, readonly=True, extra_args=["--durability", "off"])
+    try:
+        with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+            with driver.session() as session:
+                assert session.run("MATCH (p:Person) RETURN count(p) AS c").single()["c"] == 4
+    finally:
+        _teardown_bolt_server(proc)
+
+
+def test_durability_is_refused_for_a_disk_graph(bolt_binary_path, tmp_path):
+    """A disk graph commits by publishing an immutable generation, so it keeps
+    no logical log at any level. The refusal is the engine's; what matters here
+    is that it reaches the operator as a clean startup error."""
+    _require_binary()
+    disk_dir = tmp_path / "disk-graph"
+    g = kglite.KnowledgeGraph(storage="disk", path=str(disk_dir))
+    g.cypher("CREATE (:Person {id: 1, title: 'Alice'})")
+    g.save(str(disk_dir))
+    del g
+
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(disk_dir), "--port", "0", "--durability", "full"],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "storage='disk'" in combined, combined
+    assert "panicked" not in combined.lower(), combined
+
+
+@pytest.mark.parametrize("value", ["sometimes", "1", "true", "fsync", ""])
+def test_an_unknown_durability_level_is_a_startup_error(bolt_binary_path, tmp_path, value):
+    """A mistyped level fails startup rather than quietly logging nothing —
+    the same treatment `--checkpoint-interval` gives a malformed number."""
+    _require_binary()
+    fixture = tmp_path / "bad-level.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--durability", value],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "full" in combined and "normal" in combined and "off" in combined, combined
+
+
+def test_an_unknown_env_durability_level_is_a_startup_error(bolt_binary_path, tmp_path):
+    _require_binary()
+    fixture = tmp_path / "bad-level-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0"],
+        env={"KGLITE_BOLT_DURABILITY": "sometimes"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "KGLITE_BOLT_DURABILITY" in combined, combined
+
+
+def test_a_storage_conversion_keeps_the_log_recoverable(tmp_path):
+    """`--storage` converts the graph *in memory*, before the session exists, so
+    the `.kgl` on disk — and the `checkpoint_lsn` the replay is gated on — is
+    untouched until the first checkpoint. A converted server therefore logs and
+    recovers exactly like an unconverted one, and the checkpoint writes the
+    converted mode and truncates the log together."""
+    _require_binary()
+    fixture = tmp_path / "converted.kgl"
+    _build_bolt_fixture_graph(fixture)  # saved in memory mode
+    args = ["--storage", "mapped", "--durability", "full"]
+
+    proc, url = _spawn_bolt_server(fixture, extra_args=args)
+    try:
+        _write_marker(url)
+        assert _wal_size(fixture) > WAL_HEADER_BYTES
+    finally:
+        _teardown_bolt_server(proc)  # SIGKILL: only the log carries the write
+
+    restarted, restarted_url = _spawn_bolt_server(fixture, extra_args=args)
+    try:
+        assert _count_over_bolt(restarted_url, "Zed") == 1
+        assert _checkpoint(restarted_url)["success"] is True
+    finally:
+        _teardown_bolt_server(restarted)
+    assert _wal_size(fixture) == WAL_HEADER_BYTES
+    assert _marker_count_on_disk(fixture) == 1
+    assert kglite.open(str(fixture)).graph_info()["storage_mode"] == "mapped", (
+        "the checkpoint must record the mode the operator converted to"
+    )

--- a/tests/test_bolt_server_durability.py
+++ b/tests/test_bolt_server_durability.py
@@ -1,0 +1,218 @@
+"""Durability surface of kglite-bolt-server — `--save-on-exit` and the
+signals that trigger it.
+
+The server's writes are process-local: they live in the served graph's
+in-memory state and reach the `.kgl` file only when something checkpoints
+them. `test_write_over_bolt_does_not_reach_the_file_without_save_on_exit`
+pins that baseline — every other test here measures against it, and without
+it a passing save-on-exit test could just be reading a write the server had
+persisted anyway.
+
+POSIX-gated: the graceful-stop helper delivers SIGINT/SIGTERM, which have no
+Windows equivalent that means "shut down cleanly".
+"""
+
+import os
+import signal
+import subprocess
+
+import pytest
+
+import kglite
+
+neo4j = pytest.importorskip("neo4j")
+
+from tests.conftest import (  # noqa: E402
+    _BOLT_SKIP_REASON,
+    _bolt_binary_available,
+    _build_bolt_fixture_graph,
+    _graceful_stop_bolt_server,
+    _spawn_bolt_server,
+    _teardown_bolt_server,
+)
+
+pytestmark = [
+    pytest.mark.bolt,
+    pytest.mark.skipif(os.name != "posix", reason="SIGINT/SIGTERM shutdown is POSIX-only"),
+]
+
+MARKER_QUERY = "MATCH (p:Person {title: 'Zed'}) RETURN count(p) AS c"
+
+
+def _require_binary():
+    if not _bolt_binary_available():
+        pytest.skip(_BOLT_SKIP_REASON)
+
+
+def _write_marker(url: str) -> None:
+    """Commit one node through an explicit transaction, so the write is
+    definitely committed (not merely sent) before the server is signalled."""
+    with neo4j.GraphDatabase.driver(url, auth=("neo4j", "password")) as driver:
+        with driver.session() as session:
+            tx = session.begin_transaction()
+            tx.run("CREATE (:Person {id: 99, title: 'Zed', city: 'Tromso'})")
+            tx.commit()
+        # Read it back on a fresh session: the write is live in the server.
+        with driver.session() as session:
+            assert session.run(MARKER_QUERY).single()["c"] == 1
+
+
+def _marker_count_on_disk(path) -> int:
+    """Reopen the served `.kgl` in-process and count the marker node."""
+    g = kglite.open(str(path))
+    return g.cypher(MARKER_QUERY).scalar()
+
+
+def _run_server_binary(bolt_binary_path, args, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(bolt_binary_path), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, **env} if env else None,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Baseline: without the flag, a committed write never reaches the file
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_write_over_bolt_does_not_reach_the_file_without_save_on_exit(tmp_path):
+    """The process-local baseline. A graceful SIGINT shutdown with no
+    `--save-on-exit` leaves the served file exactly as it was."""
+    _require_binary()
+    fixture = tmp_path / "baseline.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture)
+    try:
+        _write_marker(url)
+        status = _graceful_stop_bolt_server(proc, signal.SIGINT)
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    assert status == 0, "a SIGINT shutdown is a clean stop"
+    assert _marker_count_on_disk(fixture) == 0, (
+        "without --save-on-exit the server must not write the graph back — "
+        "if this ever passes with 1 the save-on-exit tests below prove nothing"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# --save-on-exit round-trips, on both shutdown signals
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM], ids=["sigint", "sigterm"])
+def test_save_on_exit_persists_a_committed_write(tmp_path, sig):
+    """Spawn with `--save-on-exit`, commit over Bolt, signal, and find the
+    write in the file. SIGTERM is the one a supervisor actually sends."""
+    _require_binary()
+    fixture = tmp_path / f"exit-save-{sig}.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--save-on-exit"])
+    try:
+        _write_marker(url)
+        status = _graceful_stop_bolt_server(proc, sig)
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    assert status == 0, "a successful exit save exits zero"
+    assert _marker_count_on_disk(fixture) == 1, f"--save-on-exit must write the committed graph back on {sig.name}"
+
+
+def test_save_on_exit_env_mirror_persists_a_committed_write(tmp_path):
+    """`KGLITE_BOLT_SAVE_ON_EXIT=1` does what the flag does — the spelling a
+    Compose file or unit file can set."""
+    _require_binary()
+    fixture = tmp_path / "exit-save-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, env={"KGLITE_BOLT_SAVE_ON_EXIT": "1"})
+    try:
+        _write_marker(url)
+        status = _graceful_stop_bolt_server(proc, signal.SIGTERM)
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    assert status == 0
+    assert _marker_count_on_disk(fixture) == 1
+
+
+def test_exit_save_reports_the_saved_graph_version(tmp_path):
+    """The version is logged next to the path: shutdown does not drain
+    connections, so an operator needs to be able to tell a save that ran from
+    a commit that landed after it."""
+    _require_binary()
+    fixture = tmp_path / "exit-save-log.kgl"
+    _build_bolt_fixture_graph(fixture)
+    proc, url = _spawn_bolt_server(fixture, extra_args=["--save-on-exit"])
+    try:
+        _write_marker(url)
+        _graceful_stop_bolt_server(proc, signal.SIGINT)
+    finally:
+        if proc.poll() is None:
+            _teardown_bolt_server(proc)
+    # `tracing_subscriber::fmt()` writes to stdout; read both so the assertion
+    # does not silently depend on which stream the subscriber picks.
+    logs = proc.stdout.read().decode("utf-8", errors="replace") + proc.stderr.read().decode("utf-8", errors="replace")
+    assert "save-on-exit complete" in logs, logs
+    assert "graph_version" in logs, logs
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Startup refusals
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_save_on_exit_conflicts_with_readonly_flag(bolt_binary_path, tmp_path):
+    """clap rejects the flag pair before anything is opened."""
+    _require_binary()
+    fixture = tmp_path / "ro.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly", "--save-on-exit"],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    # "cannot be used with" is clap's conflict phrasing — asserting on the two
+    # flag names alone would also pass against a build where `--save-on-exit`
+    # does not exist at all (its "unexpected argument" error names both).
+    assert "cannot be used with" in combined, combined
+    assert "--readonly" in combined and "--save-on-exit" in combined, combined
+
+
+def test_save_on_exit_env_mirror_is_refused_with_readonly(bolt_binary_path, tmp_path):
+    """The environment spelling is invisible to clap's `conflicts_with`, so
+    the server checks it itself — and fails startup rather than serving a
+    read-only server that silently never saves."""
+    _require_binary()
+    fixture = tmp_path / "ro-env.kgl"
+    _build_bolt_fixture_graph(fixture)
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(fixture), "--port", "0", "--readonly"],
+        env={"KGLITE_BOLT_SAVE_ON_EXIT": "1"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--readonly" in combined and "nothing to write back" in combined, combined
+
+
+def test_save_on_exit_is_refused_for_a_disk_graph(bolt_binary_path, tmp_path):
+    """Disk graphs are excluded: every disk save publishes a new generation
+    and nothing prunes them, so exit checkpoints would grow the directory."""
+    _require_binary()
+    disk_dir = tmp_path / "disk-graph"
+    g = kglite.KnowledgeGraph(storage="disk", path=str(disk_dir))
+    g.cypher("CREATE (:Person {id: 1, title: 'Alice'})")
+    g.save(str(disk_dir))
+    del g
+
+    result = _run_server_binary(
+        bolt_binary_path,
+        ["--graph", str(disk_dir), "--port", "0", "--save-on-exit"],
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "disk-mode" in combined and "generation" in combined, combined

--- a/tests/test_bolt_server_robustness.py
+++ b/tests/test_bolt_server_robustness.py
@@ -261,6 +261,7 @@ def test_server_binary_help_flag(bolt_binary_path):
     assert "--port" in result.stdout
     assert "--readonly" in result.stdout
     assert "--save-on-exit" in result.stdout
+    assert "--durability" in result.stdout
     assert "--auth" in result.stdout
 
 

--- a/tests/test_bolt_server_robustness.py
+++ b/tests/test_bolt_server_robustness.py
@@ -260,6 +260,7 @@ def test_server_binary_help_flag(bolt_binary_path):
     assert "--bind" in result.stdout
     assert "--port" in result.stdout
     assert "--readonly" in result.stdout
+    assert "--save-on-exit" in result.stdout
     assert "--auth" in result.stdout
 
 

--- a/tests/test_cypher_ddl_constraints.py
+++ b/tests/test_cypher_ddl_constraints.py
@@ -183,11 +183,36 @@ def test_not_null_on_the_id_field_is_still_accepted(graph) -> None:
 
 
 def test_the_primary_key_route_actually_enforces_identity_uniqueness(graph) -> None:
-    """The route the rejection message names must work, under both spellings."""
+    """The route the rejection message names must work — under the `id` spelling."""
     graph.define_schema({"nodes": {"Person": {"primary_key": "id"}}})
-    for duplicate in ["CREATE (p:Person {id: 1})", "CREATE (p:Person {person_id: 1})"]:
-        with pytest.raises(Exception, match="duplicate primary key"):
-            graph.cypher(duplicate)
+    with pytest.raises(Exception, match="duplicate primary key"):
+        graph.cypher("CREATE (p:Person {id: 1})")
+
+
+def test_the_id_alias_spelling_does_not_reach_the_identity_field_on_create(graph) -> None:
+    """**Known gap, pinned deliberately** — the aliased spelling is not enforced,
+    because on `CREATE` it never becomes the identity in the first place.
+
+    `add_nodes(unique_id_field="person_id")` makes `person_id` the identity, and
+    reads honour that: `MATCH (p:Person {person_id: 1})` finds Alice and
+    `p.person_id` returns the identity. `CREATE` does not close the loop — it
+    only ever promotes a literal `id` property, so `{person_id: 99}` leaves the
+    node with an engine-minted id and the supplied key is silently dropped.
+
+    This assertion previously read as "both spellings are rejected" and passed
+    for an accidental reason: the fixture's ids are the dense `1, 2, 3`, and the
+    engine's auto-id was `node_bound()` — which for a 3-node graph is `3`, an id
+    that already existed. So the rejection came from the *auto* id colliding,
+    not from the alias resolving. Re-seat the fixture on non-dense ids (or fix
+    the allocator, as `next_auto_node_id` now does) and the old assertion fails.
+    Pinned in its true shape so the gap cannot close or widen unnoticed.
+    """
+    graph.define_schema({"nodes": {"Person": {"primary_key": "id"}}})
+    graph.cypher("CREATE (p:Person {person_id: 99})")
+
+    ids = sorted(d["id"] for d in graph.cypher("MATCH (p:Person) RETURN p.id AS id").to_dicts())
+    assert len(set(ids)) == len(ids), "the engine must not mint a duplicate identity"
+    assert 99 not in ids, "known gap changed — CREATE now honours the id alias; re-read the docstring"
 
 
 def test_relationship_constraint_is_rejected_by_name(graph) -> None:

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -652,6 +652,120 @@ def test_off_accepts_a_log_the_checkpoint_already_contains(tmp_path, level):
     assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"
 
 
+# ── the save side of the same rule ───────────────────────────────────
+#
+# ``kglite.load()`` is deliberately NOT guarded: it is the primitive durable
+# recovery is itself built on, and the documented way to read a graph another
+# process is writing durably, where a sidecar ahead of the checkpoint is the
+# steady state rather than a fault. So the hazard still reaches the disk from
+# the other end — load, mutate, ``save()`` back over the path — and is refused
+# there instead, which closes it without taking the read away.
+
+
+def _crashed_writer_leaves_a_commit(tmp_path) -> None:
+    """Seed ``app.kgl`` with ``age=1``, then leave a committed ``age=2`` in the
+    sidecar that no checkpoint contains — a durable writer that died between a
+    commit and its next ``save()``."""
+    g = _open(tmp_path / "app.kgl", "memory", durable="full")
+    g.cypher("CREATE (:Person {id: 1, name: 'Alice', age: 1})")
+    g.save()
+    del g  # release the single-writer lease before the child opens it
+
+    _crash_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("MATCH (p:Person {id: 1}) SET p.age = 2")
+        """,
+    )
+    assert (tmp_path / "app.kgl-wal").exists()
+
+
+def test_save_over_an_unreplayed_log_is_refused(tmp_path):
+    """The third route into the same corruption, measured end-to-end before
+    this refusal existed: ``kglite.load()`` returns the checkpoint (silently
+    missing ``age=2``), the caller writes ``age=3`` and saves — and because
+    that save neither stamps ``checkpoint_lsn`` nor truncates the sidecar, the
+    next durable open replayed the stale frame OVER it and ``age`` came back
+    as ``2``. Saved data, rolled back to an older commit, with no error
+    anywhere.
+
+    The save is now refused, and the refusal must name both ways out. Both are
+    then exercised below, because a refusal whose advertised remedy does not
+    work is worse than none."""
+    _crashed_writer_leaves_a_commit(tmp_path)
+    path = tmp_path / "app.kgl"
+
+    g = kglite.load(str(path))
+    assert g.cypher("MATCH (p:Person) RETURN p.age AS a").scalar() == 1, (
+        "load() reads the checkpoint alone — the committed frame is invisible to it"
+    )
+    g.cypher("MATCH (p:Person {id: 1}) SET p.age = 3")
+    with pytest.raises(ValueError) as excinfo:
+        g.save()
+    message = str(excinfo.value)
+    assert "app.kgl-wal" in message, "must name the sidecar that holds the commits"
+    assert "'full'" in message and "'normal'" in message, "must name the replaying levels"
+    assert "move the sidecar aside" in message, "must name the deliberate-discard exit"
+    del g
+
+    # Nothing was written and nothing was consumed: the checkpoint still holds
+    # what it did, and the commit is still there for the advertised route.
+    assert kglite.load(str(path)).cypher("MATCH (p:Person) RETURN p.age AS a").scalar() == 1
+    g = kglite.open(str(path), durable="full")
+    assert g.cypher("MATCH (p:Person) RETURN p.age AS a").scalar() == 2
+    g.cypher("MATCH (p:Person {id: 1}) SET p.age = 3")
+    g.save()  # the durable owner's checkpoint folds the log in and truncates it
+    del g
+
+    # …and once recovered, the same load → write → save round trip goes
+    # through, and survives a durable reopen.
+    g = kglite.load(str(path))
+    g.cypher("MATCH (p:Person {id: 1}) SET p.age = 4")
+    g.save()
+    del g
+    assert kglite.open(str(path), durable="full").cypher("MATCH (p:Person) RETURN p.age AS a").scalar() == 4
+
+
+def test_save_as_onto_a_path_whose_log_runs_ahead_is_refused(tmp_path):
+    """The target path's sidecar is what matters, not the origin's. Writing a
+    graph loaded from somewhere else over a path with unreplayed frames
+    orphans them in exactly the same way — the new checkpoint knows nothing
+    about them, and the next durable open replays them over it."""
+    _crashed_writer_leaves_a_commit(tmp_path)
+
+    other = kglite.KnowledgeGraph()
+    other.cypher("CREATE (:Person {id: 9, name: 'Elsewhere'})")
+    with pytest.raises(ValueError) as excinfo:
+        other.save(str(tmp_path / "app.kgl"))
+    assert "app.kgl-wal" in str(excinfo.value)
+
+    # A path with no sidecar at all is the common case and is untouched.
+    other.save(str(tmp_path / "fresh.kgl"))
+    assert (tmp_path / "fresh.kgl").exists()
+
+
+def test_save_over_crash_residue_still_works(tmp_path):
+    """What keeps the refusal non-vacuous in the other direction: frames the
+    checkpoint already folded in are the harmless residue of a crash between
+    the ``.kgl`` write and the log truncation. A refusal keyed on "the sidecar
+    is non-empty" would strand every such graph behind an error."""
+    path = tmp_path / "app.kgl"
+    wal = tmp_path / "app.kgl-wal"
+
+    g = _open(path, "memory", durable="full")
+    g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+    residue = wal.read_bytes()  # the log one instant before the checkpoint
+    g.save()
+    del g
+    wal.write_bytes(residue)  # crash between the .kgl write and the truncation
+
+    g = kglite.load(str(path))
+    g.cypher("CREATE (:Person {id: 2, name: 'Bob'})")
+    g.save()
+    assert kglite.load(str(path)).cypher("MATCH (p:Person) RETURN count(*) AS c").scalar() == 2
+
+
 # ── durability levels ────────────────────────────────────────────────
 #
 # ``durable="normal"`` logs every commit but skips the per-commit barrier.

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -1103,3 +1103,121 @@ def test_sync_flushes_pending_ops_into_the_log(tmp_path):
     )
     g = _open(tmp_path / "app.kgl", "memory", durable="normal")
     assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"
+
+
+# ── recovery fidelity: the live graph is the oracle ──────────────────
+#
+# Every test above asks "did the data survive?". These ask the stronger
+# question the WAL actually promises: is the recovered graph the *same
+# graph* the crashed process had? Recovery folds ops by ``(node_type,
+# id)``, so anything that lets two live nodes share one id is silently
+# merged on replay — a node count that drops between the live session and
+# the recovered one.
+
+
+def _live_and_recovered(tmp_path, body, storage="memory"):
+    """Run *body* in a crashing child, returning ``(live, recovered)`` rows.
+
+    The child prints its own final state before dying, so the comparison is
+    against what the process actually had — not against what the test
+    author believed it would have. ``flush=True`` is load-bearing:
+    ``os._exit`` skips stdio flushing, so an unflushed print would silently
+    hand back an empty "live" side and make the oracle vacuous.
+    """
+    probe = "MATCH (n:T) RETURN n.id AS id, n.tag AS tag"
+    # Dedent *before* appending: `_child_script` dedents what it is given, and
+    # an unindented tail line would make the common prefix empty and leave the
+    # body's own indentation in the generated source.
+    script = _child_script(
+        tmp_path,
+        textwrap.dedent(body).strip()
+        + f"\nprint(sorted((d['id'], d['tag']) for d in g.cypher({probe!r}).to_dicts()), flush=True)",
+        storage,
+        "os._exit(0)",
+    )
+    done = subprocess.run([PYBIN, "-c", script], check=True, capture_output=True, env=dict(os.environ))
+    live = done.stdout.decode().strip().splitlines()[-1]
+    g = _open(tmp_path / "app.kgl", storage)
+    recovered = sorted((d["id"], d["tag"]) for d in g.cypher(probe).to_dicts())
+    return live, repr(recovered)
+
+
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_recovery_matches_live_across_delete_then_create(tmp_path, storage):
+    """``DELETE`` then ``CREATE`` must recover node-for-node.
+
+    This shape collides on a plain in-memory graph (covered in Rust by
+    ``test_auto_assigned_ids_are_never_reused_after_delete``) but happened
+    *not* to collide through a durable session, whose per-commit fork
+    reshapes the index space. It is pinned here anyway: the collision it
+    guards against depends on allocator internals, not on anything a caller
+    can see, so "durable mode is currently lucky" is not a property to leave
+    untested. The genuinely red case is the checkpoint test below.
+    """
+    live, recovered = _live_and_recovered(
+        tmp_path,
+        """
+        g = open_durable()
+        for i in range(5):
+            g.cypher("CREATE (:T {tag: 'a%d'})" % i)
+        g.cypher("MATCH (n:T) WHERE n.tag IN ['a3','a4'] DELETE n")
+        for i in range(3):
+            g.cypher("CREATE (:T {tag: 'b%d'})" % i)
+        """,
+        storage,
+    )
+    assert recovered == live
+
+
+@pytest.mark.parametrize("storage", DURABLE_STORAGE_MODES)
+def test_recovery_matches_live_across_checkpoint_then_create(tmp_path, storage):
+    """Same oracle across a checkpoint, which is where the id allocator has
+    to re-seed itself: the reopened graph must keep minting ids above the
+    ones the ``.kgl`` already holds. Before the fix this history put *three*
+    nodes on one id, and recovery kept one of them."""
+    live, recovered = _live_and_recovered(
+        tmp_path,
+        """
+        g = open_durable()
+        for i in range(6):
+            g.cypher("CREATE (:T {tag: 'a%d'})" % i)
+        g.cypher("MATCH (n:T) WHERE n.tag IN ['a1','a2'] DELETE n")
+        g.save()
+        del g
+        g = open_durable()
+        for i in range(3):
+            g.cypher("CREATE (:T {tag: 'c%d'})" % i)
+        """,
+        storage,
+    )
+    assert recovered == live
+
+
+def test_caller_supplied_duplicate_ids_are_merged_by_recovery(tmp_path):
+    """**Known limitation, pinned deliberately** — not an endorsement.
+
+    ``id`` uniqueness is opt-in (CYPHER.md: "two ``CREATE (:T {id: 'k'})``
+    make two nodes"), but the WAL names every entity — nodes, and both
+    endpoints of every edge — by its logical ``(node_type, id)``. A log in
+    which one id denotes two nodes is therefore not merely folded wrongly,
+    it is *unwritable*: there is no discriminator to carry. So a history
+    that duplicates a caller-supplied id recovers as one node.
+
+    This is asserted rather than left silent so the behaviour cannot change
+    unnoticed in either direction. The fix is a decision, not a patch —
+    either durable mode refuses the write it cannot log, or the WAL gains a
+    node identity independent of ``id`` — and until one is made, a durable
+    application that supplies its own ids should declare a primary key
+    (``define_schema``) or use ``MERGE``, both of which make the shape
+    unreachable.
+    """
+    live, recovered = _live_and_recovered(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:T {id: 1, tag: 'first'})")
+        g.cypher("CREATE (:T {id: 1, tag: 'second'})")
+        """,
+    )
+    assert live == "[(1, 'first'), (1, 'second')]"
+    assert recovered == "[(1, 'second')]", "known limitation changed — re-read the docstring"

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -590,6 +590,68 @@ def test_non_durable_open_writes_no_wal(tmp_path):
     assert not (tmp_path / "app.kgl-wal").exists()
 
 
+# ── recovery-on-open is unconditional ────────────────────────────────
+#
+# Opening a path is a decision about *that path's data*, not only about how
+# future writes will be logged. A sidecar holding commits the checkpoint does
+# not contain is unrecovered data at every level, so `off` — which would
+# neither replay them nor keep them past the next `save()` — is refused rather
+# than silently handing back a graph that is missing committed writes.
+
+
+@pytest.mark.parametrize("level", [False, "off"])
+def test_off_refuses_to_open_over_an_unreplayed_log(tmp_path, level):
+    """The data-loss shape this refusal exists for: a crashed durable session
+    leaves committed frames in the sidecar, and opening `off` used to ignore
+    them — the first later `save()` then truncated the log and the commits were
+    gone, with no error anywhere.
+
+    The refusal must name the sidecar and both ways out, and the recovery route
+    it advertises must actually work (asserted below the refusal)."""
+    _crash_child(
+        tmp_path,
+        """
+        g = open_durable()
+        g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+        """,
+        "memory",
+    )
+    assert (tmp_path / "app.kgl-wal").exists()
+    assert not (tmp_path / "app.kgl").exists(), "the child never checkpointed"
+
+    with pytest.raises(ValueError) as excinfo:
+        kglite.open(str(tmp_path / "app.kgl"), durable=level)
+    message = str(excinfo.value)
+    assert "app.kgl-wal" in message, "must name the sidecar that holds the commits"
+    assert "'full'" in message and "'normal'" in message, "must name the replaying levels"
+
+    # The advertised route back: open at a logging level and the commits return.
+    g = kglite.open(str(tmp_path / "app.kgl"), durable="full")
+    assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"
+
+
+@pytest.mark.parametrize("level", [False, "off"])
+def test_off_accepts_a_log_the_checkpoint_already_contains(tmp_path, level):
+    """The other direction, and what keeps the refusal non-vacuous: a sidecar
+    whose frames are all at or below the checkpoint's `checkpoint_lsn` is the
+    *harmless residue* of a crash between the `.kgl` write and the log
+    truncation. Nothing is unrecovered, so `off` must still open — a refusal
+    keyed on "the sidecar is non-empty" would strand those graphs."""
+    path = tmp_path / "app.kgl"
+    wal = tmp_path / "app.kgl-wal"
+
+    g = _open(path, "memory", durable="full")
+    g.cypher("CREATE (:Person {id: 1, name: 'Alice'})")
+    residue = wal.read_bytes()  # the log as it stood one instant before save()
+    g.save()  # folds 'Alice' in, stamps checkpoint_lsn, truncates the log
+    del g  # release the single-writer lease
+
+    wal.write_bytes(residue)  # crash between the .kgl write and the truncation
+
+    g = kglite.open(str(path), durable=level)
+    assert g.cypher("MATCH (p:Person) RETURN p.name AS n").scalar() == "Alice"
+
+
 # ── durability levels ────────────────────────────────────────────────
 #
 # ``durable="normal"`` logs every commit but skips the per-commit barrier.

--- a/tests/test_id_parity.py
+++ b/tests/test_id_parity.py
@@ -87,3 +87,55 @@ def test_prefix_string_false_positive_gone(mode, tmp_path):
     kg = _load(mode, tmp_path)
     assert _one(kg, "MATCH (n {id: 'a1'}) RETURN n.title AS t") == []
     assert _one(kg, "MATCH (n {id: 'x1'}) RETURN n.title AS t") == []
+
+
+# ── engine-minted ids ────────────────────────────────────────────────
+#
+# The tests above are about how a *loaded* id is represented. These are
+# about the ids the engine hands out when a `CREATE` supplies none, which
+# is a different contract: uniqueness there is not opt-in, because the
+# caller has asked the engine for an identity rather than declared one.
+# (Caller-supplied ids stay permissive by design — CYPHER.md, "Uniqueness
+# is opt-in".)
+
+
+def test_auto_ids_stay_unique_across_save_and_load(tmp_path):
+    """Reopening a graph must not restart the id allocator underneath it.
+
+    The allocator was ``Value::UniqueId(node_bound())``, an index-space
+    bound rather than a counter: after a load whose index space still held
+    the holes left by earlier deletes, ``node_bound()`` stopped advancing
+    as new nodes refilled them, so three consecutive ``CREATE``s were all
+    handed the *same* id. Duplicate ids are then invisible to
+    ``MATCH (n {id: …})`` (one node per id) and are merged outright by WAL
+    replay, so this is silent corruption in both directions.
+    """
+    path = tmp_path / "g.kgl"
+    g = KnowledgeGraph()
+    for i in range(6):
+        g.cypher("CREATE (:T {tag: 'a%d'})" % i)
+    g.cypher("MATCH (n:T) WHERE n.tag IN ['a1','a2'] DELETE n")
+    g.save(str(path))
+
+    import kglite
+
+    g2 = kglite.load(str(path))
+    for i in range(3):
+        g2.cypher("CREATE (:T {tag: 'c%d'})" % i)
+
+    ids = [d["id"] for d in g2.cypher("MATCH (n:T) RETURN n.id AS id").to_dicts()]
+    assert len(set(ids)) == len(ids), f"engine minted a duplicate id: {sorted(ids)}"
+
+
+def test_auto_id_does_not_collide_with_a_caller_supplied_id(tmp_path):
+    """A caller-supplied id raises the allocator's high-water mark, so the
+    engine cannot later mint the same value. Without this, loading one row
+    with a sparse id (``5``) and then creating nodes walks the counter up
+    onto it."""
+    g = KnowledgeGraph()
+    g.cypher("CREATE (:T {id: 3, tag: 'explicit'})")
+    for i in range(5):
+        g.cypher("CREATE (:T {tag: 'auto%d'})" % i)
+
+    ids = [d["id"] for d in g.cypher("MATCH (n:T) RETURN n.id AS id").to_dicts()]
+    assert len(set(ids)) == len(ids), f"auto id collided with a caller id: {sorted(ids)}"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -81,6 +81,43 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+#: The upstream changelog every note's "what changed" section must be read from.
+#: Three distinct releases, each with a lead sentence that appears nowhere else,
+#: so a note quoting the wrong one is detectable by string alone. Bold leads wrap
+#: across lines exactly as the real file's do — that wrapping is the reason a
+#: naive first-line read produces a truncated quote.
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+## [0.17.0] - 2026-08-12
+
+### Fixed
+
+- **A join filtered on a type's title field is no longer planned as if the
+  filter matched everything.** The planner estimated a non-indexed equality
+  filter as `type_count / distinct_values` and the scan read the property map
+  only.
+
+- **`.statistics()` on a type's own title field returned nothing.** Same root
+  cause, same fix.
+
+## [0.16.0] - 2026-08-01
+
+### Changed
+
+- **A lost Bolt write conflict is now retriable.** The server returned a bare
+  failure where the driver expected a transient error.
+
+## [0.15.0] - 2026-07-27
+
+### Added
+
+- **Durability rungs land behind `save(durability=...)`.** Three rungs, one
+  knob.
+"""
+
+
 @pytest.fixture()
 def ecosystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """A minimal, fully consistent two-repo ecosystem at kglite 0.15.0."""
@@ -96,6 +133,7 @@ def ecosystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     root = tmp_path / "eco"
     _write(root / "KGLite" / "Cargo.toml", '[workspace.package]\nversion = "0.15.0"\n')
+    _write(root / "KGLite" / "CHANGELOG.md", CHANGELOG)
     _write(
         root / "downstream" / "Cargo.toml",
         '[workspace.package]\nversion = "1.0.0"\n\n[workspace.dependencies]\nkglite = { version = "0.15.0" }\n',
@@ -503,7 +541,217 @@ def test_notify_is_idempotent_for_a_given_release(ecosystem: Path) -> None:
 
 
 # --------------------------------------------------------------------------
-# 7. Degradation when siblings are absent
+# 7. "What changed in this release" comes from the named release's CHANGELOG
+#
+# The defect these cover shipped three times: 0.15.11, 0.15.12 and 0.15.13 all
+# carried a byte-identical blurb describing 0.15.9's Rust-API break, because the
+# section was rendered from a hand-maintained constant that nothing forced to
+# move. A downstream reading it at face value plans a migration that does not
+# exist in the release it names — the failure manufactures work.
+# --------------------------------------------------------------------------
+
+
+def test_what_changed_quotes_the_named_releases_changelog_entry(ecosystem: Path) -> None:
+    code, out = run(ecosystem, "--upstream-version", "0.17.0", "--notify", "--dry-run")
+    assert code == 0, out
+    assert "What changed in this release" in out
+    assert "A join filtered on a type's title field is no longer planned" in out
+    assert "`.statistics()` on a type's own title field returned nothing." in out
+    # The neighbouring releases' entries must not leak in.
+    assert "retriable" not in out, out
+    assert "Durability rungs" not in out, out
+
+
+def test_a_different_release_gets_its_own_entry(ecosystem: Path) -> None:
+    """The other direction of the same proof: the quote tracks the version."""
+    code, out = run(ecosystem, "--upstream-version", "0.16.0", "--notify", "--dry-run")
+    assert code == 0, out
+    assert "A lost Bolt write conflict is now retriable." in out
+    assert "A join filtered on a type's title field" not in out, out
+
+
+def test_an_unresolvable_version_emits_no_what_changed_section(ecosystem: Path) -> None:
+    """The report's explicit ask: an absent blurb beats a silently wrong one."""
+    code, out = run(ecosystem, "--upstream-version", "0.18.0", "--notify", "--dry-run")
+    assert code == 0, out
+    assert "NOTIFY downstream" in out
+    assert "What changed in this release" not in out, out
+    assert "warning:" in out and "0.18.0" in out
+
+
+def test_a_note_never_carries_a_previous_releases_breaking_prose(ecosystem: Path) -> None:
+    """The staleness trap itself, as a contract.
+
+    Nothing in a note announcing 0.17.0 may quote 0.15.9's API-break prose —
+    the exact text three shipped notes carried. This fails on any design that
+    keeps a hand-edited highlight list, whatever its current contents.
+    """
+    _, out = run(ecosystem, "--upstream-version", "0.17.0", "--notify", "--dry-run")
+    for stale in (
+        "NodeData property readers removed",
+        "column_stores became accessors",
+        "1,789x",
+        "Saved-graph writes no longer sweep",
+    ):
+        assert stale not in out, f"note announcing 0.17.0 quoted 0.15.9 prose: {stale!r}"
+
+
+def test_breaking_symbols_are_scoped_to_the_release_that_broke_them(ecosystem: Path) -> None:
+    """Criterion 4 must not fire with a previous release's symbol set.
+
+    A repo referencing `NodeView` is affected by 0.15.9 and by no later release
+    that did not touch it; asserting otherwise is the same manufactured work as
+    the stale blurb, wearing the evidence section's clothes.
+    """
+    assert "NodeView" in vc.breaking_symbols_for("0.15.9")
+    assert vc.breaking_symbols_for("0.17.0") == []
+
+    _write(
+        ecosystem / "downstream" / "src" / "lib.rs",
+        "fn f(node: &kglite::api::NodeView<'_>) -> bool { node.title().is_some() }\n",
+    )
+    _, out = run(ecosystem, "--upstream-version", "0.17.0", "--notify", "--dry-run")
+    assert "touched by a breaking change" not in out, out
+
+
+# --------------------------------------------------------------------------
+# 8. Declaration vs citation — a version *pin* must move, a version *record*
+#    must not. Following the scan's advice on a provenance line falsifies it.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        # codingest/PARITY.md — a completed, verified migration record.
+        "The kglite 0.14.1 → 0.14.5 engine move and the NodeView/`set_node_property`\n"
+        "API migration left every digest byte-identical — verified, not assumed.",
+        # codingest/docs/mcp.md:63 — when a behaviour was introduced.
+        "Containment is `sandbox_root`, it is **opt-in**, and it was\n"
+        "introduced in kglite 0.14.5: with it, a swap outside the boundary is\n"
+        "refused and the active root does not move.",
+        # codingest/docs/mcp.md:73 — the same fact, phrased as a floor in prose.
+        # The cue ("onward") wraps onto the *next* line, which is why the
+        # classifier reads the whole sentence rather than the matched line.
+        "The boundary is real only from kglite 0.14.5\nonward, and only when you set `sandbox_root`.",
+        # A dated correction block.
+        "> **Correction (2026-07-31).** Earlier revisions of this page described\n"
+        "> the kglite 0.14.5 behaviour incorrectly.",
+        "We migrated at kglite 0.14.5 and the digests were unchanged.",
+        # A range wins over the word "floor": nothing can move a two-ended
+        # transition to the current version without rewriting which move
+        # actually happened. codingest/PARITY.md:13 is exactly this shape.
+        "The engine floor moved kglite 0.14.1 → 0.14.5, which the corpus verified.",
+    ],
+)
+def test_historical_citations_are_not_flagged_as_drift(ecosystem: Path, prose: str) -> None:
+    _write(ecosystem / "downstream" / "PARITY.md", f"# Parity\n\n{prose}\n")
+    code, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" not in out, out
+    assert code == 0, out
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "A thin KGLite 0.14.3 frontend.",
+        "Requires kglite 0.14.3 or newer.",
+        "The engine floor is kglite 0.14.3.",
+        "Install it with `pip install kglite==0.14.3`.",  # version-check: ignore
+        "Set the pin to kglite 0.14.3 before building.",
+        # `X+` is a floor written compactly, so it stays a declaration even
+        # inside a past-tense sentence that would otherwise read as a record.
+        "It was gated on kglite 0.14.3+ here.",
+    ],
+)
+def test_declarations_are_still_flagged(ecosystem: Path, prose: str) -> None:
+    """Non-vacuity in the other direction: the classifier must not exempt a pin.
+
+    A missed stale pin is worse than a false positive, so anything that is not
+    recognisably a record stays a finding.
+    """
+    _write(ecosystem / "downstream" / "README.md", f"# downstream\n\n{prose}\n")
+    _, out = run(ecosystem)
+    assert "STALE DOCUMENTED VERSIONS" in out, out
+    assert "0.14.3" in out
+
+
+def test_a_citation_is_classified_out_loud_not_dropped_silently(ecosystem: Path) -> None:
+    """A silent exemption is how a scanner goes quietly blind; it gets a class."""
+    _write(
+        ecosystem / "downstream" / "PARITY.md",
+        "# Parity\n\nThe kglite 0.14.1 → 0.14.5 engine move left every digest byte-identical.\n",
+    )
+    _, out = run(ecosystem)
+    assert "HISTORICAL CITATIONS" in out, out
+    assert "PARITY.md" in out
+
+
+def test_a_citation_alone_does_not_earn_a_note(ecosystem: Path) -> None:
+    """The delivered defect: three notes told codingest to rewrite its history."""
+    _write(
+        ecosystem / "downstream" / "PARITY.md",
+        "# Parity\n\nThe kglite 0.14.1 → 0.14.5 engine move left every digest byte-identical.\n",
+    )
+    _, out = run(ecosystem, "--notify", "--dry-run")
+    assert "NOTIFY" not in out, out
+    assert "SKIP   downstream" in out
+
+
+# --------------------------------------------------------------------------
+# 9. "Surface you actually reference" must cite code, not prose
+# --------------------------------------------------------------------------
+
+
+def test_symbol_evidence_cites_the_code_site_not_a_comment(ecosystem: Path) -> None:
+    """codingest's shape exactly: a `Cargo.toml` comment naming the migration,
+    and the real use in a `.rs` file the scan never reached."""
+    _write(
+        ecosystem / "downstream" / "Cargo.toml",
+        '[workspace.package]\nversion = "1.0.0"\n\n'
+        "# The `NodeData` -> `NodeView` API break from 0.15.9, migrated here.\n"
+        '[workspace.dependencies]\nkglite = { version = "0.15.0" }\n',
+    )
+    _write(
+        ecosystem / "downstream" / "src" / "rev.rs",
+        "/// Reads the node title.\n"
+        "fn title_is(node: &kglite::api::NodeView<'_>, name: &str) -> bool {\n"
+        "    node.title().as_ref() == name\n}\n",
+    )
+
+    code, out = run(ecosystem, "--notify", "--dry-run", "--breaking-symbol", "NodeView")
+    assert code == 0, out
+    assert "Breaking-change surface you actually reference" in out
+    assert "`NodeView` — in `src/rev.rs:2`" in out, out
+    assert "in `Cargo.toml`" not in out, out
+    # There are no declaration sites in this note, so it must not ask for any
+    # to be moved — the ask has to match the evidence it is based on.
+    assert "Move the sites above" not in out, out
+
+
+def test_a_symbol_only_ever_in_comments_is_not_a_reference(ecosystem: Path) -> None:
+    _write(
+        ecosystem / "downstream" / "Cargo.toml",
+        '[workspace.package]\nversion = "1.0.0"\n\n'
+        "# The `NodeData` -> `NodeView` API break from 0.15.9, migrated here.\n"
+        '[workspace.dependencies]\nkglite = { version = "0.15.0" }\n',
+    )
+    _write(
+        ecosystem / "downstream" / "src" / "rev.rs",
+        "// We used to call NodeView here.\n/* NodeView again */\nfn f() {}\n",
+    )
+    _write(
+        ecosystem / "downstream" / "notes.py",
+        '"""Historical note: NodeView replaced NodeData."""\n\n\ndef f() -> None:\n    pass\n',
+    )
+
+    _, out = run(ecosystem, "--notify", "--dry-run", "--breaking-symbol", "NodeView")
+    assert "touched by a breaking change" not in out, out
+    assert "SKIP   downstream" in out, out
+
+
+# --------------------------------------------------------------------------
+# 10. Degradation when siblings are absent
 # --------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Bolt-server durability program — complete. Plan: `dev-docs/plans/bolt-durability-rungs.md` (local); design base: Neo4j/Memgraph/ArcadeDB/Grafeo/Kùzu source investigation.

- [x] **P1** `--save-on-exit` + SIGTERM-aware graceful shutdown; refusals; fail-closed exit.
- [x] **P2** `CALL db.checkpoint()` — digest-skip, refusal codes, SIGKILL loss-boundary proof.
- [x] **P3** `--checkpoint-interval` — shared skip-state, abort+join ordering.
- [x] **P4** Checkpoint-stall measurement: no throughput cost; pause p50 13.5 ms.
- [x] **P5** Engine lift: `Session::open_durable`, append-before-publish, `DurabilityFailed`, 4-step checkpoint — ordering guards mutation-checked.
- [x] **P6** Wheel consumes lifted helpers; fixed `durable="off"` silently ignoring unreplayed WAL.
- [x] **P6b** (inserted) fixed stale-replay-over-newer-save via non-durable opens (MCP path).
- [x] **P6c** (inserted) fixed the save-side door — unconditional guard, durable owner passes by ordering.
- [x] **P7** Bolt `--durability {full,normal,off}`; unconditional recovery; per-level SIGKILL/restart survival tests; caller-declared open guard.
- [x] **P7b** (inserted) fixed engine-minted duplicate auto-ids after deletes (monotonic HWM); false-green uniqueness test honest; two id-semantics gaps test-pinned.
- [x] **P8** Cliff measured: `full` costs 88% throughput under the serialized commit lock → **default ships `normal`**, full opt-in; defaults degrade, explicit requests refuse; P4's attribution settled by sham probe.
- [x] **P9** Durability docs: levels, loss windows (survives-X-not-Y phrasing), refusal matrix, every claim test-mapped; 2 doc defects fixed (rendered-table column loss; nonexistent verb spelling).

Final gate: workspace clippy, full default pytest (5302), parity (111), bolt (446), bolt_stress (13), `bench-check` 27 cells no regressions, `make gate` — all green. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)