### PR TITLE
fix: .kgl digest load cost (+105% → +5.3%) + perf-gate hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Non-vacuity checked against the shipped regression — 0.16.6 reads +72% on
   this fixture, well outside the 20% gate.
 
+  The other persistence surface is closed in the same pass:
+  `test_bench_disk_dir_reopen_fresh` publishes a disk-mode directory with the
+  build under test and times `open()` on it — the reload path had no cell at
+  all, fresh artifact or stored — and a `PERSISTENCE_SURFACES` table now pairs
+  every writer cell in that harness with the cell reading a freshly written
+  artifact back, with a meta-test that goes red, naming the surface, when
+  either half of a pair is missing.
+
 ## [0.16.8] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Loading a `.kgl` written by 0.16.6 took twice as long, and the 0.16.6 entry
+  said loads were unmoved.** That claim is wrong and is corrected here: the
+  section-integrity digests 0.16.6 added were computed with a hand-rolled
+  software CRC32 table running at roughly 0.5 GB/s, and every section of the
+  container is verified before decode, so the whole compressed payload was
+  passed through it on every `load()`. Reproduced against the published wheels
+  on a 180 MB / 157 742-node / 1 008 891-edge graph (release, macOS arm64, min
+  of 5): the same file content loaded in **402 ms** when 0.16.5 had written it
+  and **729 ms** when 0.16.6 had — the file only pays if it carries digests,
+  which is why a digest-free fixture showed nothing. The digests now go through
+  `crc32fast`, which dispatches to the CPU's CRC instructions, and the same
+  0.16.6-written file loads in **446 ms** — a **1.63x** recovery against the
+  published wheel. Attributed by layer on a local release build, which reads
+  the digest-free file in 423 ms (its own control; it runs ~6% behind the
+  wheel, so the wheel comparison above understates the recovery): the CRC pass
+  cost **+360 ms (+85%)** and now costs **+14 ms**, and the zstd frame content
+  checksum costs **+20 ms (+4.7%)**. Full eager verification of a file this
+  build wrote is now **+5.3%** over a digest-free load of the same graph,
+  rather than +85%. Both layers are kept — at ~5% combined the second check is
+  worth its price, and it is the only one protecting bytes a reader skips.
+
+  The digest *values* are unchanged: `crc32fast` computes the same CRC-32/IEEE
+  as the table it replaced (both pinned by `crc32_matches_known_vector`), so
+  this is not a format change in any direction. A `.kgl` written by this build
+  is byte-identical to one written by 0.16.6 from the same graph; a file
+  written by the published 0.16.6 wheel verifies here (25 of 25 single-byte
+  flips still rejected, 0 silent loads), and a file written here verifies on
+  that wheel. The `.kgl` golden digest does not move.
+
+  Reported by the MCP-servers operator, who measured it on two production
+  graphs after `/update_kglite` rewrote them with the new writer.
+
+### Changed
+
+- **The benchmark gate now loads a file written by the build under test.** The
+  0.16.6 load regression above shipped because no tracked cell loaded a
+  freshly-written `.kgl`: `make bench-check` runs `test_bench_core.py`, whose
+  only container cells were the two save cells, so a cost that exists solely
+  in files *carrying* the new metadata was invisible by construction — the
+  release measured "+11-15% on save, loads unmoved" and was half right. The
+  new `test_bench_load_kgl` cell writes a ~4 MB graph in its fixture and times
+  the load alone. It is version-independent, so the frozen CI harness runs it
+  unchanged against the 0.13.2 reference wheel: each version writes and reads
+  through its own path, which is exactly the quantity that went unmeasured.
+  Non-vacuity checked against the shipped regression — 0.16.6 reads +72% on
+  this fixture, well outside the 20% gate.
+
 ## [0.16.8] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   artifact back, with a meta-test that goes red, naming the surface, when
   either half of a pair is missing.
 
+  The same gate now also *reports* the cells it is about to catch: any passing
+  cell within 8 percentage points of the threshold prints in an `APPROACHING`
+  block (exit code unchanged, silent when the band is empty), and each local
+  `make bench-check` appends one verdict/worst-cell/watch-band row to a
+  recurrence record, so a cell that sits at +17-19% for three releases is
+  visible before the release it finally crosses in.
+
 ## [0.16.8] - 2026-08-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ version = "0.16.8"
 dependencies = [
  "bzip2",
  "chrono",
+ "crc32fast",
  "csv",
  "fastembed",
  "flate2",

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ bench-compare:
 ## Apple Silicon for these benchmarks (same source, different
 ## hardware).
 ## Refresh the baseline at release time via `make refresh-release-constants`.
+## Each run also appends one summary row (verdict, worst cell, watch band) to
+## the local recurrence record `dev-docs/bench/results/gate-history.csv`, so a
+## cell that approaches the gate three runs running is visible without
+## archaeology. That folder is local working state: CI never runs this target
+## (its perf job calls scripts/compare_bench.py directly, without
+## --record-history) and the script skips the append when the folder is absent.
 bench-check:
 	$(ACTIVATE) && maturin develop --release --quiet \
 		&& pytest tests/benchmarks/test_bench_core.py -m benchmark \
@@ -99,7 +105,8 @@ bench-check:
 		&& BASELINE=tests/benchmarks/baselines/current$$( [ "$$(uname)" = "Linux" ] && echo ".linux" )$$( [ "$$(uname)" = "Darwin" ] && echo "" ).json \
 		&& EXACT_SET=$$( [ "$$(uname)" = "Linux" ] && echo "--require-exact-set" || true ) \
 		&& python scripts/compare_bench.py $$BASELINE .bench-current.json \
-			--metric min --threshold 20 $$EXACT_SET
+			--metric min --threshold 20 $$EXACT_SET \
+			--record-history dev-docs/bench/results/gate-history.csv
 
 ## Cumulative perf-drift gate: newest per-release baseline vs the anchor
 ## ~3 releases back at +30% (min). Catches slow drift the per-release 20%

--- a/crates/kglite/Cargo.toml
+++ b/crates/kglite/Cargo.toml
@@ -99,6 +99,14 @@ wkt = "0.14"
 # direct-minimal-versions select regex 1.0.0 for the whole tree.
 regex = "1.10"
 rayon = "1.12"
+# 1.5 is a real floor, not a rounding-up: this drives the CRC32 over every
+# `.kgl` section's compressed bytes on load (`graph::wal::crc32`), and 1.5.0
+# is the first release whose aarch64 hardware-CRC path is gated on a stable
+# build cfg rather than the `nightly` feature. Below it, every arm64 build --
+# which is every macOS wheel -- silently falls back to the software table and
+# the ~25x speedup of that CRC pass, which is the whole reason for the
+# dependency, disappears.
+crc32fast = "1.5"
 flate2 = "1.0.22"
 zstd = "0.13"
 memmap2 = "0.9"

--- a/crates/kglite/src/graph/io/file.rs
+++ b/crates/kglite/src/graph/io/file.rs
@@ -91,6 +91,13 @@ const EMBED_PROVENANCE_MIN_VERSION: u32 = 3;
 //  2. `FileMetadata::section_digests` records a CRC32 of the *compressed*
 //     bytes, verified in `SectionCursor::take` before a byte reaches zstd.
 //
+// Both are cheap enough to run eagerly on every load, but only because the
+// CRC is hardware-accelerated: measured on a 180 MB `.kgl` (release, arm64,
+// min of 5), layer 1 costs ~20 ms (+4.7%) and layer 2 ~14 ms over a
+// digest-free 423 ms load. The software-table CRC that 0.16.6 shipped cost
+// ~360 ms (+85%) on its own, which is the regression this note now guards
+// against: keep `section_digest` on an accelerated implementation.
+//
 // Layer 2 exists because layer 1 only protects what a decoder chooses to
 // decode: a flipped bit that lands where the section *boundaries* are read
 // from, or in a section a reader skips, never reaches an XXH64 check. It also
@@ -120,8 +127,9 @@ fn column_section_key(type_name: &str) -> String {
 }
 
 /// CRC32 (IEEE) of one section's compressed bytes. Shares the WAL's
-/// table-backed implementation so both integrity checks in this crate agree on
-/// what a digest of the same bytes is.
+/// implementation so both integrity checks in this crate agree on what a
+/// digest of the same bytes is; see [`crate::graph::wal::crc32`] for why that
+/// implementation is hardware-accelerated rather than a software table.
 fn section_digest(compressed: &[u8]) -> u32 {
     crate::graph::wal::crc32(compressed)
 }

--- a/crates/kglite/src/graph/wal.rs
+++ b/crates/kglite/src/graph/wal.rs
@@ -70,7 +70,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -273,40 +272,30 @@ pub struct WalFrame {
     pub ops: Vec<MutationOp>,
 }
 
-// CRC32 (IEEE 802.3, polynomial 0xEDB88320), dependency-free and table-backed.
-// Deterministic across processes/builds (unlike DefaultHasher), which the
-// torn-frame check relies on.
-fn crc32_table() -> &'static [u32; 256] {
-    static TABLE: OnceLock<[u32; 256]> = OnceLock::new();
-    TABLE.get_or_init(|| {
-        let mut table = [0u32; 256];
-        let mut n = 0;
-        while n < 256 {
-            let mut c = n as u32;
-            let mut k = 0;
-            while k < 8 {
-                c = if c & 1 != 0 {
-                    0xEDB8_8320 ^ (c >> 1)
-                } else {
-                    c >> 1
-                };
-                k += 1;
-            }
-            table[n] = c;
-            n += 1;
-        }
-        table
-    })
-}
+// ─────────────────────────────────────────────────────────────────────
+// CRC32 (IEEE 802.3, polynomial 0xEDB88320)
+// ─────────────────────────────────────────────────────────────────────
 
-/// CRC32 (IEEE) of `data`. Used as the per-frame integrity check.
+/// CRC32 (IEEE) of `data`.
+///
+/// The single CRC32 in this crate: the per-frame integrity check here, and
+/// the per-section digest over a `.kgl`'s compressed bytes
+/// (`graph::io::file::section_digest`). Deterministic across processes and
+/// builds (unlike `DefaultHasher`), which the torn-frame check relies on.
+///
+/// Backed by `crc32fast`, which dispatches to the CPU's CRC instructions
+/// (aarch64 `crc32*`, x86 `pclmulqdq`) and falls back to a software table
+/// elsewhere. The values are identical to the hand-rolled table this
+/// replaced — `crc32_matches_known_vector` pins them — so digests written
+/// by any previous build still verify, and digests written here still verify
+/// on one. It replaced that table because the software path runs at
+/// ~0.5 GB/s: on a 180 MB `.kgl` that is ~360 ms added to every load, which
+/// is what 0.16.6 shipped. The accelerated path costs ~14 ms for the same
+/// bytes.
 pub fn crc32(data: &[u8]) -> u32 {
-    let table = crc32_table();
-    let mut crc = 0xFFFF_FFFFu32;
-    for &b in data {
-        crc = table[((crc ^ b as u32) & 0xFF) as usize] ^ (crc >> 8);
-    }
-    crc ^ 0xFFFF_FFFF
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(data);
+    hasher.finalize()
 }
 
 /// Write the WAL file header (magic + format version) to a freshly

--- a/docs/_generated/project-facts.md
+++ b/docs/_generated/project-facts.md
@@ -65,4 +65,4 @@ Regenerate with `python scripts/render_docs_facts.py`. CI checks this file for d
 - CPU: `Apple M4`
 - Python: `CPython 3.14.3`
 - pytest-benchmark schema/plugin version: `5.2.3`
-- Recorded benchmarks: `32`
+- Recorded benchmarks: `33`

--- a/docs/_generated/project-facts.md
+++ b/docs/_generated/project-facts.md
@@ -65,4 +65,4 @@ Regenerate with `python scripts/render_docs_facts.py`. CI checks this file for d
 - CPU: `Apple M4`
 - Python: `CPython 3.14.3`
 - pytest-benchmark schema/plugin version: `5.2.3`
-- Recorded benchmarks: `33`
+- Recorded benchmarks: `34`

--- a/scripts/compare_bench.py
+++ b/scripts/compare_bench.py
@@ -10,7 +10,8 @@ Usage:
         [--metric min|mean|median] \\
         [--threshold PERCENT] \\
         [--require-exact-set] \\
-        [--quiet]
+        [--quiet] \\
+        [--record-history PATH]
 
 By default, `min` is the gating metric (per CLAUDE.md performance protocol:
 "Trust `min` over `median` for sub-millisecond benches"). Threshold defaults
@@ -20,6 +21,15 @@ GitHub-runner variance the tracked benchmarks see in practice.
 The summary table is always printed so a passing gate still gives an
 "at-a-glance, am I trending in the right direction" view. `--quiet` drops
 it.
+
+Cells that pass but sit just under the threshold are reported separately as
+an APPROACHING watch band (see `WATCH_BAND_WIDTH_PCT`). The band never
+changes the exit code; it exists so a cell that creeps up release after
+release is visible the release *before* it crosses.
+
+`--record-history PATH` appends one summary row per run to a CSV recurrence
+record (verdict, worst cell, watch band). It is a local developer aid wired
+into `make bench-check`; CI does not pass it.
 
 A benchmark newly present in the current file is informational until the next
 baseline refresh. A benchmark present in the baseline but missing from the
@@ -31,9 +41,39 @@ must also have a committed baseline row before the gate can pass.
 from __future__ import annotations
 
 import argparse
+import csv
+import datetime
 import json
 from pathlib import Path
+import subprocess
 import sys
+
+# Width of the "APPROACHING" watch band, in percentage points below the gate
+# threshold: a +20% gate reports every passing cell in +12%..+20%.
+#
+# Why a band at all: the 0.16.6 leg-1 "flake" sat at +17-19% for several
+# releases and only became visible when it finally crossed 20%. Nothing in a
+# green run said the cell had been sitting one bad round from red — the gate's
+# only two states were silence and failure. The band adds the missing third
+# state without touching the exit code.
+#
+# Why 8pp: wide enough that a cell has to have moved most of the way to the
+# gate before it is named (a fresh cell at +5% stays silent), narrow enough
+# that a healthy run prints nothing at all — silence has to keep meaning
+# something, or the block becomes noise everyone scrolls past.
+WATCH_BAND_WIDTH_PCT = 8.0
+
+# Column header for the recurrence record written by --record-history.
+GATE_HISTORY_HEADER = (
+    "date",
+    "sha",
+    "verdict",
+    "metric",
+    "threshold_pct",
+    "worst_cell",
+    "worst_delta_pct",
+    "approaching",
+)
 
 
 def _load(path: Path) -> dict[str, float]:
@@ -42,6 +82,88 @@ def _load(path: Path) -> dict[str, float]:
     benchmark so the caller picks the metric without re-reading."""
     data = json.loads(path.read_text(encoding="utf-8"))
     return {b["name"]: b["stats"] for b in data["benchmarks"]}
+
+
+def _watch_band(rows: list[tuple[str, float, float, float]], threshold: float) -> list[tuple[str, float, float, float]]:
+    """Passing cells within `WATCH_BAND_WIDTH_PCT` of the gate threshold.
+
+    Regressions (delta > threshold) are excluded — they are the FAIL list, not
+    the watch band. `rows` is already sorted worst-first, so the result is too.
+    """
+    floor = threshold - WATCH_BAND_WIDTH_PCT
+    return [r for r in rows if floor <= r[3] <= threshold]
+
+
+def _print_watch_band(band: list[tuple[str, float, float, float]], threshold: float, name_w: int) -> None:
+    """Print the APPROACHING block. Callers skip an empty band: a run with
+    nothing near the gate must stay byte-identical to the pre-band output."""
+    floor = threshold - WATCH_BAND_WIDTH_PCT
+    print(f"\nAPPROACHING ({floor:+.1f}%..{threshold:+.1f}%)")
+    print(f"  {'benchmark':<{name_w}}  {'baseline':>14}  {'current':>14}  {'delta':>8}")
+    print(f"  {'-' * name_w}  {'-' * 14}  {'-' * 14}  {'-' * 8}")
+    for name, b, c, delta in band:
+        print(f"  {name:<{name_w}}  {b:>14.3e}  {c:>14.3e}  {delta:>+7.1f}%")
+    print(
+        f"\n{len(band)} cell(s) approaching the {threshold:+.1f}% threshold — "
+        "a crossing next release is likely drift, not noise."
+    )
+
+
+def _git_short_sha() -> str:
+    """Short HEAD sha, or "unknown" outside a work tree / without git."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    return out.stdout.strip() or "unknown"
+
+
+def _append_gate_history(
+    path: Path,
+    *,
+    verdict: str,
+    metric: str,
+    threshold: float,
+    rows: list[tuple[str, float, float, float]],
+    band: list[tuple[str, float, float, float]],
+) -> None:
+    """Append one summary row to the recurrence record at `path`.
+
+    Best-effort by design: the record is a local working file and a gate must
+    never fail (or pass) because writing it did or did not work. A missing
+    parent directory means the local working folder is not present (fresh
+    clone, CI checkout) — say so once and move on.
+    """
+    if not path.parent.is_dir():
+        print(f"\ninfo: recurrence record skipped, {path.parent} does not exist.")
+        return
+    worst = rows[0] if rows else None
+    row = [
+        datetime.date.today().isoformat(),
+        _git_short_sha(),
+        verdict,
+        metric,
+        f"{threshold:.1f}",
+        worst[0] if worst else "",
+        f"{worst[3]:+.1f}" if worst else "",
+        ";".join(f"{name}:{delta:+.1f}%" for name, _, _, delta in band),
+    ]
+    try:
+        exists = path.exists()
+        with path.open("a", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            if not exists:
+                writer.writerow(GATE_HISTORY_HEADER)
+            writer.writerow(row)
+    except OSError as exc:  # pragma: no cover - local filesystem failure
+        print(f"\nwarning: could not append to the recurrence record {path}: {exc}")
+        return
+    print(f"\nrecorded: {path} <- {','.join(row)}")
 
 
 def main() -> int:
@@ -56,6 +178,13 @@ def main() -> int:
         help="Fail when the current run contains benchmarks absent from the baseline.",
     )
     p.add_argument("--quiet", action="store_true", help="Suppress the summary table on pass.")
+    p.add_argument(
+        "--record-history",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Append one summary row per run (verdict, worst cell, watch band) to this CSV.",
+    )
     args = p.parse_args()
 
     if not args.baseline.exists():
@@ -94,20 +223,27 @@ def main() -> int:
     rows.sort(key=lambda r: -r[3])
 
     regressions = [r for r in rows if r[3] > args.threshold]
+    band = _watch_band(rows, args.threshold)
+    name_w = max((len(r[0]) for r in rows), default=20)
 
     if not args.quiet or regressions:
         print(f"\nperf comparison ({args.metric}, threshold {args.threshold:+.1f}%)")
         print(f"baseline: {args.baseline}")
         print(f"current:  {args.current}\n")
-        name_w = max((len(r[0]) for r in rows), default=20)
         print(f"  {'benchmark':<{name_w}}  {'baseline':>14}  {'current':>14}  {'delta':>8}")
         print(f"  {'-' * name_w}  {'-' * 14}  {'-' * 14}  {'-' * 8}")
         for name, b, c, delta in rows:
             flag = " <<" if delta > args.threshold else ""
             print(f"  {name:<{name_w}}  {b:>14.3e}  {c:>14.3e}  {delta:>+7.1f}%{flag}")
 
+    # The watch band prints in every run, quiet or not: it is the whole point
+    # of the band that a *passing* run carries the warning.
+    if band:
+        _print_watch_band(band, args.threshold, name_w)
+
     unbaselined = only_current if args.require_exact_set else []
-    if regressions or only_baseline or unbaselined:
+    failed = bool(regressions or only_baseline or unbaselined)
+    if failed:
         if only_baseline:
             print(
                 f"\nFAIL: {len(only_baseline)} tracked benchmark(s) were not collected. "
@@ -131,7 +267,17 @@ def main() -> int:
             "refresh the baseline via `make refresh-release-constants` and explain in "
             "the CHANGELOG entry. Otherwise investigate before merging."
         )
-    if regressions or only_baseline or unbaselined:
+    if args.record_history is not None:
+        _append_gate_history(
+            args.record_history,
+            verdict="FAIL" if failed else "OK",
+            metric=args.metric,
+            threshold=args.threshold,
+            rows=rows,
+            band=band,
+        )
+
+    if failed:
         return 1
 
     print(f"\nOK: no regressions > {args.threshold:+.1f}% on {args.metric} across {len(common)} benchmark(s).")

--- a/tests/benchmarks/baselines/current.json
+++ b/tests/benchmarks/baselines/current.json
@@ -848,6 +848,43 @@
     },
     {
       "group": null,
+      "name": "test_bench_load_kgl",
+      "fullname": "tests/benchmarks/test_bench_core.py::test_bench_load_kgl",
+      "params": null,
+      "param": null,
+      "extra_info": {
+        "capture": "Release profile, macOS/M4 Mac mini, from the slower of two agreeing `make bench-check` runs (10.539 ms and 10.603 ms min). Captured 2026-08-22 under ordinary desktop load, per the relaxed idle-benchmark rule."
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 100,
+        "max_time": 1.0,
+        "min_time": 5e-06,
+        "warmup": 20
+      },
+      "stats": {
+        "min": 0.010602875030599535,
+        "max": 0.011543124972376972,
+        "mean": 0.01085415581939742,
+        "stddev": 0.00017290863627687517,
+        "rounds": 100,
+        "median": 0.010824520519236103,
+        "iqr": 0.00023766601225361228,
+        "q1": 0.01072414600639604,
+        "q3": 0.010961812018649653,
+        "iqr_outliers": 2,
+        "stddev_outliers": 29,
+        "outliers": "29;2",
+        "ld15iqr": 0.010602875030599535,
+        "hd15iqr": 0.011472292011603713,
+        "ops": 92.1306103062298,
+        "total": 1.085415581939742,
+        "iterations": 1
+      }
+    },
+    {
+      "group": null,
       "name": "test_bench_return_node_10k",
       "fullname": "tests/benchmarks/test_bench_core.py::test_bench_return_node_10k",
       "params": null,

--- a/tests/benchmarks/baselines/current.json
+++ b/tests/benchmarks/baselines/current.json
@@ -885,6 +885,43 @@
     },
     {
       "group": null,
+      "name": "test_bench_disk_dir_reopen_fresh",
+      "fullname": "tests/benchmarks/test_bench_core.py::test_bench_disk_dir_reopen_fresh",
+      "params": null,
+      "param": null,
+      "extra_info": {
+        "capture": "Release profile, macOS/M4 Mac mini, from the slower of two agreeing `make bench-check` runs (0.880 ms and 0.927 ms min). Captured 2026-08-22 under ordinary desktop load, per the relaxed idle-benchmark rule."
+      },
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 100,
+        "max_time": 1.0,
+        "min_time": 5e-06,
+        "warmup": 20
+      },
+      "stats": {
+        "min": 0.0009272090392187238,
+        "max": 0.001080874993931502,
+        "mean": 0.0009527812543092296,
+        "stddev": 2.556161639751165e-05,
+        "rounds": 100,
+        "median": 0.0009460625005885959,
+        "iqr": 1.3583456166088581e-05,
+        "q1": 0.0009398545371368527,
+        "q3": 0.0009534379933029413,
+        "iqr_outliers": 12,
+        "stddev_outliers": 10,
+        "outliers": "10;12",
+        "ld15iqr": 0.0009272090392187238,
+        "hd15iqr": 0.0009744589915499091,
+        "ops": 1049.5588525458597,
+        "total": 0.09527812543092296,
+        "iterations": 1
+      }
+    },
+    {
+      "group": null,
       "name": "test_bench_return_node_10k",
       "fullname": "tests/benchmarks/test_bench_core.py::test_bench_return_node_10k",
       "params": null,

--- a/tests/benchmarks/baselines/current.linux.json
+++ b/tests/benchmarks/baselines/current.linux.json
@@ -1011,6 +1011,41 @@
     },
     {
       "group": null,
+      "name": "test_bench_disk_dir_reopen_fresh",
+      "fullname": "test_bench_core.py::test_bench_disk_dir_reopen_fresh",
+      "params": null,
+      "param": null,
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 100,
+        "max_time": 1.0,
+        "min_time": 5e-06,
+        "warmup": 20
+      },
+      "stats": {
+        "min": 0.014558376360218972,
+        "max": 0.01695947368280031,
+        "mean": 0.015270674288040026,
+        "stddev": 0.0004567163077245971,
+        "rounds": 100,
+        "median": 0.015096332677057943,
+        "iqr": 0.00051049436442554,
+        "q1": 0.014990055619273334,
+        "q3": 0.015500549983698875,
+        "iqr_outliers": 4,
+        "stddev_outliers": 25,
+        "outliers": "25;4",
+        "ld15iqr": 0.014558376360218972,
+        "hd15iqr": 0.016279414971359072,
+        "ops": 65.4849930748113,
+        "total": 1.5270674288040027,
+        "iterations": 1
+      }
+    },
+    {
+      "group": null,
       "name": "test_bench_return_node_10k",
       "fullname": "test_bench_core.py::test_bench_return_node_10k",
       "params": null,
@@ -1693,7 +1728,8 @@
       "test_bench_exists_var_length_witness": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-21, scaled by 3.9x (the widest Linux/macOS ratio observed across the 25 cells both files already share; median 2.83, range 1.90-3.88). Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates these cells until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
       "test_bench_exists_fixed_hop": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-21, scaled by 3.9x (the widest Linux/macOS ratio observed across the 25 cells both files already share; median 2.83, range 1.90-3.88). Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates these cells until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
       "test_bench_var_length_1_8_count_distinct": "PROVISIONAL ESTIMATE, not a Linux measurement: this tree captured on macOS/M4 2026-08-21 (two agreeing release runs), scaled by 3.9x \u2014 the same factor and the same reasoning as the five V1 cells above: the widest Linux/macOS ratio observed across the 25 cells both files already share (median 2.83, range 1.90-3.88), chosen generous so an estimate cannot fire a false red on the 30% leg-2 gate. Leg 1 (same-runner reference, 20%) is what actually gates this cell meanwhile. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
-      "test_bench_load_kgl": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-22 (10.791 ms min, harness unmodified -- the cell runs as-written on the reference wheel, which is what makes it usable as a reference row), scaled by 3.9x on the same basis as the khop cells: the widest Linux/macOS ratio observed across the cells both files share. Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates this cell until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file."
+      "test_bench_load_kgl": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-22 (10.791 ms min, harness unmodified -- the cell runs as-written on the reference wheel, which is what makes it usable as a reference row), scaled by 3.9x on the same basis as the khop cells: the widest Linux/macOS ratio observed across the cells both files share. Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates this cell until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
+      "test_bench_disk_dir_reopen_fresh": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-22 (3.733 ms min, the slower of two agreeing runs [3.725 ms]; the harness ran unmodified on the reference wheel, which is what makes it usable as a reference row), scaled by 3.9x on the same basis as the other estimated rows in this file: the widest Linux/macOS ratio observed across the cells both files share. Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates this cell until the real value lands, and this build reopens the fixture roughly 4x faster than 0.13.2 does. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file."
     }
   }
 }

--- a/tests/benchmarks/baselines/current.linux.json
+++ b/tests/benchmarks/baselines/current.linux.json
@@ -976,6 +976,41 @@
     },
     {
       "group": null,
+      "name": "test_bench_load_kgl",
+      "fullname": "test_bench_core.py::test_bench_load_kgl",
+      "params": null,
+      "param": null,
+      "extra_info": {},
+      "options": {
+        "disable_gc": false,
+        "timer": "perf_counter",
+        "min_rounds": 100,
+        "max_time": 1.0,
+        "min_time": 5e-06,
+        "warmup": 20
+      },
+      "stats": {
+        "min": 0.04208522363333032,
+        "max": 0.04557377772289328,
+        "mean": 0.0433827208718285,
+        "stddev": 0.0007046617412233795,
+        "rounds": 100,
+        "median": 0.043244418699759986,
+        "iqr": 0.0009397381480084732,
+        "q1": 0.04282792992016766,
+        "q3": 0.043767668068176134,
+        "iqr_outliers": 1,
+        "stddev_outliers": 30,
+        "outliers": "30;1",
+        "ld15iqr": 0.04208522363333032,
+        "hd15iqr": 0.04557377772289328,
+        "ops": 23.05065196243538,
+        "total": 4.338272087182849,
+        "iterations": 1
+      }
+    },
+    {
+      "group": null,
       "name": "test_bench_return_node_10k",
       "fullname": "test_bench_core.py::test_bench_return_node_10k",
       "params": null,
@@ -1657,7 +1692,8 @@
       "test_bench_fixed_two_hop_count_star": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-21, scaled by 3.9x (the widest Linux/macOS ratio observed across the 25 cells both files already share; median 2.83, range 1.90-3.88). Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates these cells until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
       "test_bench_exists_var_length_witness": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-21, scaled by 3.9x (the widest Linux/macOS ratio observed across the 25 cells both files already share; median 2.83, range 1.90-3.88). Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates these cells until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
       "test_bench_exists_fixed_hop": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-21, scaled by 3.9x (the widest Linux/macOS ratio observed across the 25 cells both files already share; median 2.83, range 1.90-3.88). Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates these cells until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
-      "test_bench_var_length_1_8_count_distinct": "PROVISIONAL ESTIMATE, not a Linux measurement: this tree captured on macOS/M4 2026-08-21 (two agreeing release runs), scaled by 3.9x \u2014 the same factor and the same reasoning as the five V1 cells above: the widest Linux/macOS ratio observed across the 25 cells both files already share (median 2.83, range 1.90-3.88), chosen generous so an estimate cannot fire a false red on the 30% leg-2 gate. Leg 1 (same-runner reference, 20%) is what actually gates this cell meanwhile. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file."
+      "test_bench_var_length_1_8_count_distinct": "PROVISIONAL ESTIMATE, not a Linux measurement: this tree captured on macOS/M4 2026-08-21 (two agreeing release runs), scaled by 3.9x \u2014 the same factor and the same reasoning as the five V1 cells above: the widest Linux/macOS ratio observed across the 25 cells both files already share (median 2.83, range 1.90-3.88), chosen generous so an estimate cannot fire a false red on the 30% leg-2 gate. Leg 1 (same-runner reference, 20%) is what actually gates this cell meanwhile. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file.",
+      "test_bench_load_kgl": "PROVISIONAL ESTIMATE, not a Linux measurement: kglite 0.13.2 captured on macOS/M4 2026-08-22 (10.791 ms min, harness unmodified -- the cell runs as-written on the reference wheel, which is what makes it usable as a reference row), scaled by 3.9x on the same basis as the khop cells: the widest Linux/macOS ratio observed across the cells both files share. Deliberately generous so an estimate cannot fire a false red on the 30% leg-2 gate; leg 1 (same-runner 0.13.2 reference, 20%) is what actually gates this cell until the real value lands. Replace from the first CI perf run's reference artifact, or let the next release's promote_linux_benchmark overwrite the file."
     }
   }
 }

--- a/tests/benchmarks/test_bench_core.py
+++ b/tests/benchmarks/test_bench_core.py
@@ -4,6 +4,10 @@ These benchmarks measure the key operations and are tracked over time.
 Run with: make bench-save (to save a baseline) or make bench-compare (to compare).
 """
 
+import inspect
+import sys
+from typing import NamedTuple
+
 import pandas as pd
 import pytest
 
@@ -636,6 +640,188 @@ def test_bench_load_kgl(benchmark, written_kgl_path):
     """
     graph = benchmark(kglite.load, written_kgl_path)
     assert graph.cypher("MATCH (n:Doc) RETURN count(n) AS c").to_list() == [{"c": 20_000}]
+
+
+@pytest.fixture(scope="module")
+def written_disk_dir(tmp_path_factory):
+    """A disk-mode graph directory published by the build under test.
+
+    Same 20k/40k shape and the same high-entropy payload as
+    :func:`written_kgl_path`, for the same reason — the reopen cost below
+    tracks the published bytes, not a fixed header — but a different seed, so
+    neither fixture can be mistaken for the other's artifact.
+
+    The graph handle is dropped when this fixture returns, which releases the
+    single-writer lease the disk directory holds. Without that, the first
+    ``open()`` in the cell below would be refused by this same process.
+    """
+    nodes, edges = 20_000, 40_000
+    root = tmp_path_factory.mktemp("disk_reopen_bench") / "graph"
+    graph = KnowledgeGraph(storage="disk", path=str(root))
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "nid": list(range(nodes)),
+                "name": [f"N{i}" for i in range(nodes)],
+                "body": _entropic_strings(nodes, 200, 20_260_824),
+            }
+        ),
+        "Doc",
+        "nid",
+        "name",
+    )
+    graph.add_connections(
+        pd.DataFrame(
+            {
+                "s": [i % nodes for i in range(edges)],
+                "d": [(i * 7919 + 13) % nodes for i in range(edges)],
+                "note": _entropic_strings(edges, 24, 20_260_825),
+            }
+        ),
+        "CITES",
+        "Doc",
+        "s",
+        "Doc",
+        "d",
+        columns=["note"],
+    )
+    graph.save(str(root), fsync=False)
+    return str(root)
+
+
+@pytest.mark.benchmark
+def test_bench_disk_dir_reopen_fresh(benchmark, written_disk_dir):
+    """Reopen a disk directory this build published — the reload path.
+
+    The other half of the class `test_bench_load_kgl` covers: a disk graph is
+    reopened by resolving the newest generation and mapping its segments, and
+    that path — the one the "reload instead of rebuild" story is about — had no
+    gating cell at all, on an artifact written by any build, fresh or stored.
+
+    `pedantic` with a setup step rather than a plain `benchmark(...)` call:
+    `open()` takes the directory's single-writer lease, and pytest-benchmark
+    holds the previous round's return value across the next round's call, so a
+    plain call would ask this same process to reopen a directory it has not let
+    go of yet and be refused. The setup drops the previous handle *outside* the
+    timed region, which leaves the timed region as the open alone. Rounds and
+    warmup match what `make bench-check` passes the plain cells.
+    """
+    handle: dict[str, KnowledgeGraph] = {}
+
+    def release_previous_handle():
+        handle.pop("graph", None)
+
+    def reopen():
+        handle["graph"] = kglite.open(written_disk_dir)
+
+    benchmark.pedantic(reopen, setup=release_previous_handle, rounds=100, warmup_rounds=20, iterations=1)
+    assert handle["graph"].cypher("MATCH (n:Doc) RETURN count(n) AS c").to_list() == [{"c": 20_000}]
+
+
+# ---------------------------------------------------------------------------
+# Persistence-surface coverage registry
+# ---------------------------------------------------------------------------
+#
+# 0.16.6 measured its saves honestly and still shipped a +85% load regression,
+# because no cell anywhere read back an artifact the build under test had just
+# written: the read half of every persistence surface was structurally
+# invisible. Adding a load cell fixes one instance. This registry is what
+# stops the *class* from recurring — it pairs each persisted artifact kind with
+# the cell that reads a freshly written one, and the meta-test below fails when
+# a writer or reader cell in this module is missing from it. A new
+# `test_bench_save_foo` therefore cannot land read-blind: the gate names the
+# surface.
+
+
+class PersistenceSurface(NamedTuple):
+    """One persisted artifact kind: its writer cells and its fresh reader."""
+
+    #: Benchmark cells in this module that *write* the artifact.
+    writers: tuple[str, ...]
+    #: The cell that reads one back. Non-optional by construction: a surface
+    #: entry exists to name this cell.
+    reader: str
+    #: The fixture the reader takes, which must be the one that writes the
+    #: artifact with the build under test. That provenance is the whole
+    #: property — a reader repointed at a stored fixture keeps its name, keeps
+    #: passing, and stops being able to see a write-format change.
+    fresh_fixture: str
+
+
+PERSISTENCE_SURFACES: dict[str, PersistenceSurface] = {
+    "kgl_file": PersistenceSurface(
+        writers=("test_bench_save_kgl", "test_bench_save_kgl_new_file"),
+        reader="test_bench_load_kgl",
+        fresh_fixture="written_kgl_path",
+    ),
+    "disk_dir": PersistenceSurface(
+        # Empty on purpose, and not a gap this table is hiding: no cell in this
+        # module publishes a disk directory (the fixture does, untimed). The
+        # rule enforced below is one-directional — a writer cell *here* needs a
+        # reader *here* — so an empty tuple claims nothing that is not true. A
+        # disk publish cell added to this module has to land in this tuple.
+        writers=(),
+        reader="test_bench_disk_dir_reopen_fresh",
+        fresh_fixture="written_disk_dir",
+    ),
+}
+
+#: Underscore-separated name components that mark a cell as writing, or as
+#: reading, a persistence artifact. Whole components, never substrings: a
+#: substring test drags in every unrelated cell whose name happens to contain
+#: the letters, and the resulting noise is what gets a gate switched off.
+WRITER_NAME_COMPONENTS = frozenset({"save", "write", "persist", "checkpoint"})
+READER_NAME_COMPONENTS = frozenset({"load", "reopen", "restore"})
+
+
+def _benchmark_cells() -> dict[str, object]:
+    """Every benchmark cell defined in this module, by name."""
+    return {
+        name: obj
+        for name, obj in vars(sys.modules[__name__]).items()
+        if name.startswith("test_bench_") and callable(obj)
+    }
+
+
+# Unmarked on purpose, like the var-length companion tests at the end of this
+# file: `-m benchmark` deselects it, so it never runs inside `make bench-check`
+# or CI's 0.13.2 reference leg, while `make test` runs it on every change.
+
+
+def test_every_persistence_cell_is_registered_with_its_counterpart():
+    """The registry names a fresh reader for every persistence cell here.
+
+    Red in both directions, which is what makes it worth having: an
+    unregistered writer cell (someone adds `test_bench_save_foo` and no reader)
+    fails naming the cell, and a deleted registry entry fails naming its
+    now-unregistered reader.
+    """
+    cells = _benchmark_cells()
+
+    for surface, entry in PERSISTENCE_SURFACES.items():
+        for name in (*entry.writers, entry.reader):
+            assert name in cells, f"{surface}: {name} is not a benchmark cell in this module"
+            marks = getattr(cells[name], "pytestmark", [])
+            assert any(mark.name == "benchmark" for mark in marks), f"{surface}: {name} is not benchmark-marked"
+        parameters = inspect.signature(cells[entry.reader]).parameters
+        assert entry.fresh_fixture in parameters, (
+            f"{surface}: {entry.reader} does not take {entry.fresh_fixture}, the fixture that writes the "
+            "artifact with the build under test — a reader reading a stored artifact cannot see a "
+            "write-path change"
+        )
+
+    registered_writers = {name for entry in PERSISTENCE_SURFACES.values() for name in entry.writers}
+    registered_readers = {entry.reader for entry in PERSISTENCE_SURFACES.values()}
+    for components, registered, role in (
+        (WRITER_NAME_COMPONENTS, registered_writers, "writer"),
+        (READER_NAME_COMPONENTS, registered_readers, "reader"),
+    ):
+        unregistered = sorted(name for name in cells if components & set(name.split("_")) and name not in registered)
+        assert not unregistered, (
+            f"persistence {role} cells missing from PERSISTENCE_SURFACES: {unregistered}. "
+            f"Every {role} cell belongs to a surface entry pairing it with its counterpart — an unpaired "
+            "persistence cell is exactly how the 0.16.6 load regression shipped."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/benchmarks/test_bench_core.py
+++ b/tests/benchmarks/test_bench_core.py
@@ -7,6 +7,7 @@ Run with: make bench-save (to save a baseline) or make bench-compare (to compare
 import pandas as pd
 import pytest
 
+import kglite
 from kglite import KnowledgeGraph
 
 # ---------------------------------------------------------------------------
@@ -537,6 +538,104 @@ def test_bench_save_kgl_new_file(benchmark, bench_graph, tmp_path):
         counter[0] += 1
 
     benchmark(save)
+
+
+# ---------------------------------------------------------------------------
+# Load throughput
+# ---------------------------------------------------------------------------
+#
+# The file under test is written by the build under test, and that is the
+# whole point of the cell. 0.16.6 added two integrity layers that only a file
+# *carrying* them pays for, and every load-shaped benchmark this repo had read
+# either a stored fixture or a directory, so the class was invisible: the
+# release measured "+11-15% on save, loads unmoved" and shipped a +85% load
+# regression, reported from downstream two days later. A cell whose fixture
+# predates the change under test cannot see the change under test.
+#
+# Version-independent by construction, which the frozen CI harness needs: it
+# times each version's own write-then-read path, with no argument or format
+# assumption. A 0.13.2 reference writes a digest-free file and reads it back;
+# this tree writes digests and verifies them. That difference is exactly the
+# quantity being gated.
+
+#: Alphabet for `_entropic_strings` — 64 symbols, so six LCG bits index it.
+_ENTROPY_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/"
+
+
+def _entropic_strings(count: int, width: int, seed: int) -> list[str]:
+    """`count` deterministic, poorly-compressible strings of `width` chars.
+
+    High entropy on purpose. Sections are zstd-compressed and the integrity
+    digest runs over the *compressed* bytes, so a fixture built from
+    templated text (`f"Node_{i}"`) collapses to a fraction of a megabyte and
+    measures fixed overhead rather than throughput — the 157k-node graph this
+    cell was sized against compressed 195 MB of real text to 13 MB of
+    `f`-strings. An inlined LCG rather than `random.Random` for the same
+    reason as `_scale_free_edges`: the fixture must be byte-identical on every
+    interpreter this harness runs under.
+    """
+    state = seed
+    out = []
+    for _ in range(count):
+        chars = []
+        for _ in range(width):
+            state = (state * 1_103_515_245 + 12_345) & 0x7FFF_FFFF
+            chars.append(_ENTROPY_ALPHABET[(state >> 16) & 63])
+        out.append("".join(chars))
+    return out
+
+
+@pytest.fixture(scope="module")
+def written_kgl_path(tmp_path_factory):
+    """A ~4 MB `.kgl` written by the build under test; ~10 ms to load.
+
+    Sized so the container payload dominates: at this scale the digest layers
+    0.16.6 introduced cost +72% against a digest-free write of the same graph,
+    which is comfortably outside the 20% gate, while 100 rounds still finish
+    in about a second.
+    """
+    nodes, edges = 20_000, 40_000
+    graph = KnowledgeGraph()
+    graph.add_nodes(
+        pd.DataFrame(
+            {
+                "nid": list(range(nodes)),
+                "name": [f"N{i}" for i in range(nodes)],
+                "body": _entropic_strings(nodes, 200, 20_260_822),
+            }
+        ),
+        "Doc",
+        "nid",
+        "name",
+    )
+    graph.add_connections(
+        pd.DataFrame(
+            {
+                "s": [i % nodes for i in range(edges)],
+                "d": [(i * 7919 + 13) % nodes for i in range(edges)],
+                "note": _entropic_strings(edges, 24, 20_260_823),
+            }
+        ),
+        "CITES",
+        "Doc",
+        "s",
+        "Doc",
+        "d",
+        columns=["note"],
+    )
+    path = str(tmp_path_factory.mktemp("load_bench") / "written.kgl")
+    graph.save(path)
+    return path
+
+
+@pytest.mark.benchmark
+def test_bench_load_kgl(benchmark, written_kgl_path):
+    """Deserialize a `.kgl` this build wrote — the process-start latency.
+
+    The timed region is the load alone; writing happens once in the fixture.
+    """
+    graph = benchmark(kglite.load, written_kgl_path)
+    assert graph.cypher("MATCH (n:Doc) RETURN count(n) AS c").to_list() == [{"c": 20_000}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/rust-embed-consumer/Cargo.lock
+++ b/tests/fixtures/rust-embed-consumer/Cargo.lock
@@ -701,6 +701,7 @@ version = "0.16.8"
 dependencies = [
  "bzip2",
  "chrono",
+ "crc32fast",
  "csv",
  "flate2",
  "fs2",

--- a/tests/test_compare_bench.py
+++ b/tests/test_compare_bench.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import datetime
 import json
 from pathlib import Path
 import subprocess
@@ -11,31 +13,52 @@ ROOT = Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts" / "compare_bench.py"
 
 
-def _write_result(path: Path, names: list[str]) -> None:
+def _write_result(path: Path, names: list[str] | dict[str, float]) -> None:
+    values = {name: 1.0 for name in names} if isinstance(names, list) else names
     path.write_text(
         json.dumps(
-            {"benchmarks": [{"name": name, "stats": {"min": 1.0, "mean": 1.0, "median": 1.0}} for name in names]}
+            {
+                "benchmarks": [
+                    {"name": name, "stats": {"min": value, "mean": value, "median": value}}
+                    for name, value in values.items()
+                ]
+            }
         ),
         encoding="utf-8",
     )
 
 
 def _compare(
-    tmp_path: Path, baseline: list[str], current: list[str], *, require_exact_set: bool = False
+    tmp_path: Path,
+    baseline: list[str] | dict[str, float],
+    current: list[str] | dict[str, float],
+    *,
+    require_exact_set: bool = False,
+    quiet: bool = True,
+    extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     baseline_path = tmp_path / "baseline.json"
     current_path = tmp_path / "current.json"
     _write_result(baseline_path, baseline)
     _write_result(current_path, current)
-    command = [sys.executable, str(SCRIPT), str(baseline_path), str(current_path), "--quiet"]
+    command = [sys.executable, str(SCRIPT), str(baseline_path), str(current_path)]
+    if quiet:
+        command.append("--quiet")
     if require_exact_set:
         command.append("--require-exact-set")
+    command.extend(extra_args or [])
     return subprocess.run(
         command,
         check=False,
         capture_output=True,
         text=True,
     )
+
+
+def _current_at(deltas: dict[str, float]) -> dict[str, float]:
+    """Current-run values producing the requested percentage deltas against a
+    baseline of 1.0 per cell."""
+    return {name: 1.0 + pct / 100 for name, pct in deltas.items()}
 
 
 def test_missing_tracked_benchmark_fails(tmp_path: Path) -> None:
@@ -56,3 +79,117 @@ def test_exact_set_rejects_benchmark_without_baseline_row(tmp_path: Path) -> Non
     assert result.returncode == 1
     assert "collected benchmark(s) have no baseline row" in result.stdout
     assert "new" in result.stdout
+
+
+def test_watch_band_names_a_cell_just_under_the_threshold(tmp_path: Path) -> None:
+    """A passing cell one point below the gate is reported, exit code unchanged."""
+    result = _compare(tmp_path, ["creeping", "steady"], _current_at({"creeping": 19.0, "steady": 0.0}))
+    assert result.returncode == 0
+    assert "APPROACHING (+12.0%..+20.0%)" in result.stdout
+    assert "creeping" in result.stdout.split("APPROACHING")[1]
+    assert "steady" not in result.stdout.split("APPROACHING")[1]
+    assert "1 cell(s) approaching the +20.0% threshold" in result.stdout
+    assert "FAIL" not in result.stdout
+
+
+def test_watch_band_ignores_a_cell_below_the_band_floor(tmp_path: Path) -> None:
+    """One point under the band floor (+12% on a 20% gate) stays silent."""
+    result = _compare(tmp_path, ["quiet_cell"], _current_at({"quiet_cell": 11.0}))
+    assert result.returncode == 0
+    assert "APPROACHING" not in result.stdout
+
+
+def test_watch_band_orders_worst_first(tmp_path: Path) -> None:
+    result = _compare(tmp_path, ["mild", "severe"], _current_at({"mild": 13.0, "severe": 18.0}))
+    assert result.returncode == 0
+    block = result.stdout.split("APPROACHING")[1]
+    assert block.index("severe") < block.index("mild")
+    assert "2 cell(s) approaching the +20.0% threshold" in result.stdout
+
+
+def test_regression_goes_to_the_fail_list_not_the_watch_band(tmp_path: Path) -> None:
+    result = _compare(tmp_path, ["broken"], _current_at({"broken": 25.0}))
+    assert result.returncode == 1
+    assert "APPROACHING" not in result.stdout
+    assert "1 benchmark(s) regressed > +20.0%" in result.stdout
+
+
+def test_watch_band_derives_from_the_passed_threshold(tmp_path: Path) -> None:
+    """CI's two legs gate at 20% and 30%; the band follows whichever was passed."""
+    result = _compare(tmp_path, ["straddler"], _current_at({"straddler": 25.0}), extra_args=["--threshold", "30"])
+    assert result.returncode == 0
+    assert "APPROACHING (+22.0%..+30.0%)" in result.stdout
+    assert "1 cell(s) approaching the +30.0% threshold" in result.stdout
+
+
+def test_empty_band_leaves_the_quiet_pass_output_unchanged(tmp_path: Path) -> None:
+    result = _compare(tmp_path, ["a", "b"], _current_at({"a": 0.0, "b": -5.0}))
+    assert result.returncode == 0
+    assert result.stdout == "\nOK: no regressions > +20.0% on min across 2 benchmark(s).\n"
+
+
+def test_history_row_records_verdict_worst_cell_and_band(tmp_path: Path) -> None:
+    history = tmp_path / "gate-history.csv"
+    result = _compare(
+        tmp_path,
+        ["creeping", "steady"],
+        _current_at({"creeping": 19.0, "steady": 0.0}),
+        extra_args=["--record-history", str(history)],
+    )
+    assert result.returncode == 0
+    rows = list(csv.reader(history.read_text(encoding="utf-8").splitlines()))
+    assert rows[0] == [
+        "date",
+        "sha",
+        "verdict",
+        "metric",
+        "threshold_pct",
+        "worst_cell",
+        "worst_delta_pct",
+        "approaching",
+    ]
+    assert len(rows) == 2
+    row = dict(zip(rows[0], rows[1]))
+    assert row["date"] == datetime.date.today().isoformat()
+    assert row["verdict"] == "OK"
+    assert row["metric"] == "min"
+    assert row["threshold_pct"] == "20.0"
+    assert row["worst_cell"] == "creeping"
+    assert row["worst_delta_pct"] == "+19.0"
+    assert row["approaching"] == "creeping:+19.0%"
+
+
+def test_history_appends_without_clobbering_and_records_failures(tmp_path: Path) -> None:
+    history = tmp_path / "gate-history.csv"
+    first = _compare(
+        tmp_path,
+        ["cell"],
+        _current_at({"cell": 1.0}),
+        extra_args=["--record-history", str(history)],
+    )
+    second = _compare(
+        tmp_path,
+        ["cell"],
+        _current_at({"cell": 40.0}),
+        extra_args=["--record-history", str(history)],
+    )
+    assert (first.returncode, second.returncode) == (0, 1)
+    rows = list(csv.reader(history.read_text(encoding="utf-8").splitlines()))
+    assert len(rows) == 3, rows  # header + one row per run
+    assert rows[1][2] == "OK"
+    assert rows[2][2] == "FAIL"
+    assert rows[2][5:] == ["cell", "+40.0", ""]
+
+
+def test_history_is_skipped_when_the_local_folder_is_absent(tmp_path: Path) -> None:
+    """CI checkouts and fresh clones have no dev-docs/; the gate must not care."""
+    history = tmp_path / "not-a-dir" / "gate-history.csv"
+    result = _compare(
+        tmp_path,
+        ["cell"],
+        _current_at({"cell": 0.0}),
+        extra_args=["--record-history", str(history)],
+    )
+    assert result.returncode == 0
+    assert "recurrence record skipped" in result.stdout
+    assert not history.exists()


### PR DESCRIPTION
Response to the mcp-servers operator's 0.16.6 regression report (digests doubled fresh-written load; our gate had no load cell). Plan: dev-docs/plans/perf-gate-hardening.md (local).

- [x] R1 hardware CRC32 (crc32fast, identical digest values, compat proven vs the 0.16.6 wheel both directions; load 729→446 ms, overhead +5.3% with both layers kept) + fresh-written load cell (+72% non-vacuity vs 0.16.5) + CHANGELOG correction
- [x] G1 fresh disk-dir reopen cell + PERSISTENCE_SURFACES registry + bidirectional meta-test (4 mutations red)
- [x] G2+G3 watch-band APPROACHING block (per-leg threshold band) + local gate-history.csv recorded by the compare script itself
- [x] Final gate: full pytest 6891 + parity 115 + workspace clippy + make gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)