### PR TITLE
ci: hygiene — local gate gap, toolchain pin, main-push dedup, scheduled split, naming

### DIFF
--- a/.github/workflows/build_cli_wheels.yml
+++ b/.github/workflows/build_cli_wheels.yml
@@ -1,4 +1,4 @@
-name: Build & Publish kglite-cli wheels
+name: Publish CLI wheels
 # Builds the `kglite-cli` binary wheel (the `kglite` interactive shell) for each
 # platform and publishes it to PyPI as the separate `kglite-cli` distribution —
 # so `pip install kglite-cli` offers a standalone, libpython-free alternative

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Python Wheels
+name: Publish Python wheels
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,48 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  dedup:
+    name: Prior green PR run check
+    # On a push to main that fast-forwards a PR head already proven green,
+    # re-running the full ~20-job suite is pure duplication (~2.5
+    # runner-hours per release). This job asks whether THIS EXACT SHA has a
+    # completed successful pull_request run of this same workflow; if so,
+    # every gated job below skips, and `ci-success` (which tolerates
+    # `skipped`) still reports the green the publish gate waits on. Any
+    # other event, or no prior green run, means a fresh full suite.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      fresh: ${{ steps.check.outputs.fresh }}
+    steps:
+      - name: Look for a prior green pull_request run of this SHA
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "event=${{ github.event_name }} — full suite"
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Failure of the query itself must mean "run the suite", never
+          # "skip it" — a dedup that can silently skip on an API error is a
+          # gate that cannot fail.
+          green=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&event=pull_request&status=success&per_page=1"             -q '.workflow_runs | length' 2>/dev/null || echo 0)
+          if [ "$green" = "1" ]; then
+            echo "SHA $SHA already green in a pull_request run — skipping the suite"
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "no prior green pull_request run for $SHA — full suite"
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+          fi
+
   docs:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -52,6 +93,8 @@ jobs:
         run: sphinx-build -W --keep-going -b html docs docs/_build/html
 
   rust-checks:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Rust checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -102,6 +145,8 @@ jobs:
         run: bash scripts/check_packaged_features.sh
 
   rust-core-coverage:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Rust core coverage (report only)
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -138,6 +183,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   source-quality:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Production source quality
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -163,6 +210,8 @@ jobs:
         run: python scripts/check_rustsec_advisories.py --policy-only
 
   msrv-matrix:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     # Derives the MSRV job's matrix from the manifests themselves. A
     # hard-coded matrix would let the declared `rust-version` and the job
     # that verifies it drift apart — which is the exact failure a declared-
@@ -228,6 +277,8 @@ jobs:
         run: cargo check -p kglite --features okf,rdf
 
   minimal-versions:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     # WHAT THIS CATCHES
     # -----------------
     # A dependency requirement that understates the version our own code
@@ -373,6 +424,8 @@ jobs:
         run: python scripts/check_rustsec_advisories.py
 
   kglite-c:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: kglite-c (C ABI)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -432,6 +485,8 @@ jobs:
           }
 
   python-lint:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Python lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -452,6 +507,8 @@ jobs:
         run: ruff check .
 
   python-tests:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Python tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -581,6 +638,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   free-threading:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Free-threading (no-GIL) smoke
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -632,6 +691,8 @@ jobs:
           ./.ftvenv/bin/python -m pytest tests/test_freethreading.py tests/test_concurrency.py tests/test_session.py -v --tb=short
 
   perf-regression:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Perf regression gate
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -790,6 +851,8 @@ jobs:
           retention-days: 7
 
   public-api:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Feature-complete public API gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -829,6 +892,8 @@ jobs:
         run: bash scripts/check_packaged_features.sh
 
   storage-parity:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Cross-storage parity
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -861,6 +926,8 @@ jobs:
             tests/test_phase5_parity.py::test_graph_copy_cow_correctness_mapped
 
   disk-concurrency:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Disk concurrency regressions
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -893,6 +960,8 @@ jobs:
             tests/test_session.py::test_disk_session_reuses_writer_lineage_and_composes
 
   native-lifecycle-locks:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Native lifecycle locks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -930,6 +999,8 @@ jobs:
         run: cargo test -p kglite-cli
 
   loom-session:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Loom Session model
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -946,6 +1017,8 @@ jobs:
         run: RUSTFLAGS="--cfg loom" cargo test -p kglite --test loom_session
 
   miri-loaders:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Miri unsafe loader checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -963,6 +1036,8 @@ jobs:
           cargo miri test -p kglite --lib parse_line_preserves_utf8_literal_boundaries
 
   address-sanitizer:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: AddressSanitizer disk arenas
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -1062,6 +1137,8 @@ jobs:
         run: .venv/bin/pytest tests/test_bolt_server_concurrency.py -m bolt_stress -v --tb=short
 
   bolt-driver-conformance:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: Bolt conformance (official JS + Java drivers)
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -1175,6 +1252,8 @@ jobs:
         run: python scripts/assert_conformance_ran.py conformance.xml
 
   kglite-java:
+    needs: [dedup]
+    if: needs.dedup.outputs.fresh == 'true'
     name: kglite-java (JVM binding)
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -1267,6 +1346,7 @@ jobs:
     # `if: always()` makes this run after every dependency regardless of their
     # outcome, so it always produces a definitive pass/fail check to wait on.
     needs:
+      - dedup
       - docs
       - rust-checks
       - rust-core-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # Heavy race/stress verification stays off the per-PR critical path.
-    - cron: '23 3 * * 1'
-  # The schedule-only jobs below are otherwise unrunnable between Mondays, so a
-  # fix to one of them cannot be verified for up to a week. The thread-sanitizer
-  # job was broken from the day it was added and stayed red for five scheduled
-  # runs for exactly that reason. Manual dispatch runs the full workflow,
-  # scheduled-only jobs included.
   workflow_dispatch: {}
 
 # A rapid follow-up push to a PR branch supersedes the in-flight run — cancel
@@ -1060,82 +1052,6 @@ jobs:
   # anything: an uninstrumented std hides the synchronisation TSan is here to
   # observe. Do not silence the error with `-Cunsafe-allow-abi-mismatch` — that
   # restores a build that links two ABIs and reports races it cannot see.
-  scheduled-thread-sanitizer:
-    name: Scheduled ThreadSanitizer Session checks
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rust-src
-      # Three filters, not one. `graph::session` covers the concurrency model
-      # this job was built for; the two `parallel` filters cover the opt-in
-      # parallel Cypher runtime, whose regions fan a read-only `&DirGraph`
-      # across rayon workers. Those tests are where a data race would show up,
-      # and a substring filter does not pick them up on its own.
-      - name: Run Session, disk and parallel-runtime concurrency models under TSan
-        env:
-          RUSTFLAGS: -Zsanitizer=thread
-          RUSTDOCFLAGS: -Zsanitizer=thread
-        run: |
-          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu graph::session
-          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu graph::parallel
-          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu executor::tests::parallel
-
-  dependency-maintenance:
-    name: Scheduled dependency advisory report
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE }}
-      - name: Install pinned cargo-audit
-        uses: taiki-e/install-action@v2.85.4
-        with:
-          tool: cargo-audit@0.22.2
-      - name: Validate temporary advisory exceptions
-        run: python scripts/check_rustsec_advisories.py --policy-only
-      - name: Report compatible lockfile updates
-        continue-on-error: true
-        run: cargo update --workspace --dry-run
-      - name: Report RustSec advisories
-        continue-on-error: true
-        run: python scripts/check_rustsec_advisories.py
-
-  scheduled-concurrency-stress:
-    name: Scheduled bounded Session and Bolt stress
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_STABLE }}
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-          cache: pip
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: scheduled-concurrency-stress
-          workspaces: ". -> target"
-      - name: Build release extension and Bolt server
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install maturin pytest pytest-timeout pandas neo4j
-          .venv/bin/maturin develop --release
-          cargo build --release -p kglite-bolt-server
-      - name: Run bounded Session stress
-        run: .venv/bin/pytest tests/test_session_stress.py -m stress -v --tb=short
-      - name: Run bounded Bolt stress
-        run: .venv/bin/pytest tests/test_bolt_server_concurrency.py -m bolt_stress -v --tb=short
-
   bolt-driver-conformance:
     needs: [dedup]
     if: needs.dedup.outputs.fresh == 'true'
@@ -1371,9 +1287,6 @@ jobs:
       - loom-session
       - miri-loaders
       - address-sanitizer
-      - scheduled-thread-sanitizer
-      - dependency-maintenance
-      - scheduled-concurrency-stress
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  # Single-source pin for every stable-toolchain job in this workflow. Local
+  # dev verifies against it via `make check-toolchain-pin` (part of
+  # gate-push): floating `@stable` on both sides meant clippy verdicts
+  # diverged whenever either side updated first. Bump deliberately, together
+  # with the local toolchain.
+  RUST_STABLE: "1.98.0"
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -35,7 +41,9 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - name: Install documentation dependencies
         run: pip install -r docs/requirements.txt
       - name: Check generated documentation facts
@@ -51,8 +59,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_STABLE }}
           components: rustfmt, clippy
 
       - name: Cache cargo registry & target
@@ -100,8 +109,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable with coverage tools
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_STABLE }}
           components: llvm-tools-preview
 
       - name: Install pinned cargo-llvm-cov
@@ -293,7 +303,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install Rust stable (builds the lowered lockfile)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -350,7 +362,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - name: Install pinned cargo-audit
         uses: taiki-e/install-action@v2.85.4
         with:
@@ -366,8 +380,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_STABLE }}
           components: clippy
 
       - name: Cache cargo registry & target
@@ -448,7 +463,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -571,7 +588,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - name: Set up free-threaded Python 3.14t
         uses: actions/setup-python@v7
@@ -622,7 +641,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v7
@@ -813,7 +834,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -843,7 +866,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -877,7 +902,9 @@ jobs:
         os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: native-lifecycle-${{ matrix.os }}
@@ -908,7 +935,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: loom-session
@@ -987,7 +1016,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - name: Install pinned cargo-audit
         uses: taiki-e/install-action@v2.85.4
         with:
@@ -1008,7 +1039,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
@@ -1047,7 +1080,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - uses: actions/setup-python@v7
         with:
@@ -1158,7 +1193,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
 
       - name: Set up JDK 26
         # 26, not the 22 floor: build.gradle.kts pins the Gradle toolchain to

--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -1,4 +1,4 @@
-name: Publish to crates.io
+name: Publish crates
 on:
   push:
     branches: [main]

--- a/.github/workflows/publish_java.yml
+++ b/.github/workflows/publish_java.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Java Artifact
+name: Publish Java
 
 # Triggered by an explicit workflow_dispatch from build_wheels.yml's publish
 # job, after it creates the release tag. The tag trigger below still exists

--- a/.github/workflows/repo-traffic-stats.yml
+++ b/.github/workflows/repo-traffic-stats.yml
@@ -21,7 +21,7 @@
 #   Copy this workflow + scripts/repo_traffic_stats.py into that repo, add its
 #   own TRAFFIC_TOKEN. It auto-writes to `statistics/<that-repo-name>/`.
 
-name: repo-traffic-stats
+name: Repo traffic stats
 
 on:
   schedule:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,93 @@
+name: Scheduled
+
+# The heavy race/stress verification that stays off the per-PR critical path:
+# ThreadSanitizer Session checks, the dependency advisory report, and the
+# bounded Session/Bolt stress runs. Weekly by schedule; manual dispatch exists
+# because a schedule-only job is otherwise unrunnable between Mondays, so a
+# fix to one cannot be verified for up to a week (the thread-sanitizer job
+# was broken from the day it was added and stayed red for five scheduled runs
+# for exactly that reason). Split out of ci.yml (2026-08-26) so PR checks
+# stop listing three permanently-skipped rows.
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  scheduled-thread-sanitizer:
+    name: Scheduled ThreadSanitizer Session checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      # Three filters, not one. `graph::session` covers the concurrency model
+      # this job was built for; the two `parallel` filters cover the opt-in
+      # parallel Cypher runtime, whose regions fan a read-only `&DirGraph`
+      # across rayon workers. Those tests are where a data race would show up,
+      # and a substring filter does not pick them up on its own.
+      - name: Run Session, disk and parallel-runtime concurrency models under TSan
+        env:
+          RUSTFLAGS: -Zsanitizer=thread
+          RUSTDOCFLAGS: -Zsanitizer=thread
+        run: |
+          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu graph::session
+          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu graph::parallel
+          cargo test -Zbuild-std -p kglite --lib --target x86_64-unknown-linux-gnu executor::tests::parallel
+
+  dependency-maintenance:
+    name: Scheduled dependency advisory report
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+      - name: Install pinned cargo-audit
+        uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: cargo-audit@0.22.2
+      - name: Validate temporary advisory exceptions
+        run: python scripts/check_rustsec_advisories.py --policy-only
+      - name: Report compatible lockfile updates
+        continue-on-error: true
+        run: cargo update --workspace --dry-run
+      - name: Report RustSec advisories
+        continue-on-error: true
+        run: python scripts/check_rustsec_advisories.py
+
+  scheduled-concurrency-stress:
+    name: Scheduled bounded Session and Bolt stress
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: pip
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: scheduled-concurrency-stress
+          workspaces: ". -> target"
+      - name: Build release extension and Bolt server
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install maturin pytest pytest-timeout pandas neo4j
+          .venv/bin/maturin develop --release
+          cargo build --release -p kglite-bolt-server
+      - name: Run bounded Session stress
+        run: .venv/bin/pytest tests/test_session_stress.py -m stress -v --tb=short
+      - name: Run bounded Bolt stress
+        run: .venv/bin/pytest tests/test_bolt_server_concurrency.py -m bolt_stress -v --tb=short
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -687,6 +687,10 @@ When a plan has Steps 1 / 2 / 3 / …:
    phases, or before stepping away — not reflexively after each commit.
    `ci.yml` cancels superseded in-flight PR runs, so a follow-up push is
    cheap, but the habit should still be batching, with a final push covering
-   the completed plan.
+   the completed plan. **Run `make gate-push` once immediately before each
+   push** — it adds the CI-only checks that historically reddened first in CI
+   (public-API baselines, source quality, lint allowances, workspace clippy,
+   the `RUST_STABLE` toolchain-pin match). Per push, not per phase; a red
+   there costs seconds locally and a full 20-job round-trip in CI.
 6. **End with a perf gate — only if the plan touched perf-sensitive paths** (`core/pattern_matching/`, `cypher/executor/`, storage hot paths). Then run new + existing benchmarks per the Performance protocol above before the final release commit, and record the numbers in the release commit message or `[x.y.z]` CHANGELOG block. Fix regressions before the release commit, not in a follow-up. A plan that touched none of those paths skips this — CI's Linux perf gate and the release-time baseline capture cover it.
 7. **Final commit is the version bump + CHANGELOG promotion.** No earlier phase touches `Cargo.toml`. User pushes once.

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,24 @@ lint-policy: check-lint-allowances source-quality rustsec-policy
 	$(ACTIVATE) && python scripts/check_cypher_clean_room.py
 	$(ACTIVATE) && python scripts/check_dependency_licenses.py
 
+## Pre-push gate: the CI-only checks that historically reddened first in CI
+## (public-API baselines, source quality, lint allowances, workspace clippy).
+## Run once before each push — not per phase; make gate stays the phase gate.
+gate-push: gate check-lint-allowances source-quality
+	python3 scripts/rust_api_profiles.py check
+	cargo clippy --all-targets -- -D warnings
+	@$(MAKE) --no-print-directory check-toolchain-pin
+
+## Local stable must match the version CI's stable jobs pin (RUST_STABLE in
+## ci.yml), or clippy/test verdicts diverge between the two sides.
+check-toolchain-pin:
+	@PIN=$$(grep -m1 'RUST_STABLE:' .github/workflows/ci.yml | sed 's/.*"\(.*\)".*/\1/'); \
+	LOCAL=$$(rustc --version | awk '{print $$2}'); \
+	if [ -z "$$PIN" ]; then echo "toolchain pin: RUST_STABLE not found in ci.yml"; exit 1; fi; \
+	if [ "$$PIN" != "$$LOCAL" ]; then \
+	  echo "toolchain pin: local rustc $$LOCAL != CI pin $$PIN (rustup install $$PIN; or bump RUST_STABLE)"; exit 1; \
+	else echo "toolchain pin: local rustc $$LOCAL matches CI"; fi
+
 ## Explicit CI-equivalent lint sweep. Not part of routine local development.
 lint-full: gate lint-policy
 	cargo clippy --all-targets -- -D warnings

--- a/scripts/wait_for_release_ci.py
+++ b/scripts/wait_for_release_ci.py
@@ -52,9 +52,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # match `.github/workflows/*.yml` `name:` exactly.
 RELEASE_WORKFLOWS = (
     "CI",
-    "Publish to crates.io",
-    "Build and Publish Python Wheels",
-    "Build & Publish kglite-cli wheels",
+    "Publish crates",
+    "Publish Python wheels",
+    "Publish CLI wheels",
 )
 
 TERMINAL_STATUS = "completed"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1909,3 +1909,13 @@ def test_helper_java_platform_derivations_can_fail(tmp_path: Path) -> None:
     # exists — a commands-only reader reports the publish scan clean.
     assert "MavenCentral" in _step_text({"run": "gradle $TASK", "env": {"TASK": "publishToMavenCentral"}})
     assert "MavenCentral" not in _step_text({"run": "gradle build"})
+
+
+def test_ci_stable_toolchain_is_pinned() -> None:
+    """Floating `@stable` on CI while local floats independently produced
+    clippy-verdict skew whenever either side updated first (ontology train,
+    2026-08). Every stable job pins through the single RUST_STABLE env, which
+    `make check-toolchain-pin` verifies locally."""
+    text = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+    assert 'RUST_STABLE: "' in text, "workflow-level RUST_STABLE pin missing"
+    assert "dtolnay/rust-toolchain@stable" not in text, "a job floats on @stable instead of the RUST_STABLE pin"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1919,3 +1919,32 @@ def test_ci_stable_toolchain_is_pinned() -> None:
     text = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     assert 'RUST_STABLE: "' in text, "workflow-level RUST_STABLE pin missing"
     assert "dtolnay/rust-toolchain@stable" not in text, "a job floats on @stable instead of the RUST_STABLE pin"
+
+
+def test_dedup_gates_are_consistent() -> None:
+    """Every dedup-gated job must carry the fresh-check `if` (a `needs`
+    without the `if` re-runs anyway; an `if` without the `needs` reads an
+    empty output and NEVER runs). Deliberate exemptions: rustsec-audit
+    (advisories move independent of the SHA), the schedule-only jobs (never
+    run on push), msrv (skips transitively via msrv-matrix), ci-success."""
+    ci = yaml.safe_load((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
+    exempt = {
+        "dedup",
+        "rustsec-audit",
+        "msrv",
+        "ci-success",
+        "scheduled-thread-sanitizer",
+        "dependency-maintenance",
+        "scheduled-concurrency-stress",
+    }
+    fresh_if = "needs.dedup.outputs.fresh == 'true'"
+    for job, spec in ci["jobs"].items():
+        gated_needs = "dedup" in (spec.get("needs") or [])
+        gated_if = fresh_if in str(spec.get("if", ""))
+        if job == "ci-success":
+            assert gated_needs, "ci-success must aggregate dedup"
+            continue
+        if job in exempt:
+            assert not gated_needs, f"{job} is exempt from dedup but gated"
+        else:
+            assert gated_needs and gated_if, f"{job}: dedup gating incomplete (needs={gated_needs}, if={gated_if})"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -62,6 +62,7 @@ CI_PATH = WORKFLOWS / "ci.yml"
 WHEELS_PATH = WORKFLOWS / "build_wheels.yml"
 CLI_WHEELS_PATH = WORKFLOWS / "build_cli_wheels.yml"
 CRATES_PATH = WORKFLOWS / "publish_crates.yml"
+SCHEDULED_PATH = WORKFLOWS / "scheduled.yml"
 
 #: Jobs whose *existence* is a guarantee in its own right.
 #:
@@ -102,13 +103,14 @@ def _load_workflow(path: Path) -> dict:
 
 CI = _load_workflow(CI_PATH)
 #: The three heavy jobs (thread sanitizer, dependency maintenance, concurrency
-#: stress) stay off every push and PR, but must remain reachable on demand — a
+#: stress) live in scheduled.yml, whose only triggers are the weekly cron and
+#: manual dispatch — off every push and PR, but reachable on demand: a
 #: schedule-only job that breaks is invisible until the next Monday, which is
 #: how the thread sanitizer stayed red for five consecutive scheduled runs.
-SCHEDULED_ONLY_IF = "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"
 WHEELS = _load_workflow(WHEELS_PATH)
 CLI_WHEELS = _load_workflow(CLI_WHEELS_PATH)
 CRATES = _load_workflow(CRATES_PATH)
+SCHEDULED = _load_workflow(SCHEDULED_PATH)
 
 
 class _Job(dict):
@@ -128,6 +130,10 @@ def _job(workflow: dict, workflow_name: str, name: str) -> _Job:
 
 def _ci_job(name: str) -> _Job:
     return _job(CI, "ci.yml", name)
+
+
+def _scheduled_job(name: str) -> _Job:
+    return _job(SCHEDULED, "scheduled.yml", name)
 
 
 def _wheels_job(name: str) -> _Job:
@@ -269,10 +275,10 @@ def test_ci_success_needs_every_job_defined_in_ci_yml() -> None:
     same shape one layer up: a job added to `ci.yml` and forgotten in `needs`
     was gated by nothing, and nothing noticed.
 
-    `skipped` stays a pass in the aggregate's shell on purpose — three jobs
-    run only on the schedule or a manual dispatch (`SCHEDULED_ONLY_IF`) and skip
-    on every push and PR. That is a recorded trade-off, not something this test
-    may tighten.
+    `skipped` stays a pass in the aggregate's shell on purpose — the
+    dedup-gated jobs skip when the exact SHA is already PR-green (see
+    test_dedup_gates_are_consistent). That is a recorded trade-off, not
+    something this test may tighten.
     """
     jobs = set(CI["jobs"])
     assert len(jobs) > 1, "ci.yml defines no jobs — the derivation is broken"
@@ -299,8 +305,9 @@ def test_required_verification_jobs_still_exist() -> None:
     is gone. These names are checked for existence for that reason only — their
     aggregation is the derivation's job, not this one's.
     """
+    scheduled_owned = {"dependency-maintenance", "scheduled-concurrency-stress"}
     for name in sorted(REQUIRED_JOBS):
-        _ci_job(name)
+        (_scheduled_job if name in scheduled_owned else _ci_job)(name)
 
 
 def test_ci_success_actually_fails_when_a_dependency_does() -> None:
@@ -447,15 +454,18 @@ def test_loom_and_unsafe_jobs_use_the_intended_commands() -> None:
 
 
 def test_heavy_thread_sanitizer_is_scheduled_only() -> None:
-    scheduled = _ci_job("scheduled-thread-sanitizer")
-    assert scheduled["if"] == SCHEDULED_ONLY_IF
+    scheduled = _scheduled_job("scheduled-thread-sanitizer")
     tsan_steps = [step for step in _steps(scheduled) if step.get("env", {}).get("RUSTFLAGS") == "-Zsanitizer=thread"]
     assert tsan_steps, "scheduled-thread-sanitizer runs no step under -Zsanitizer=thread"
     # PyYAML resolves the YAML 1.1 key `on` to the boolean True.
-    assert "schedule" in CI[True], "ci.yml has no schedule trigger, so the scheduled-only jobs never run"
-    assert "workflow_dispatch" in CI[True], (
-        "ci.yml has no workflow_dispatch trigger, so a fix to a scheduled-only job cannot be verified "
+    triggers = set(SCHEDULED[True])
+    assert "schedule" in triggers, "scheduled.yml has no schedule trigger, so the heavy jobs never run"
+    assert "workflow_dispatch" in triggers, (
+        "scheduled.yml has no workflow_dispatch trigger, so a fix to a heavy job cannot be verified "
         "until the next scheduled run"
+    )
+    assert triggers <= {"schedule", "workflow_dispatch"}, (
+        "scheduled.yml gained a push/PR trigger — the heavy jobs belong off the per-PR critical path"
     )
 
 
@@ -467,7 +477,7 @@ def test_thread_sanitizer_covers_the_parallel_runtime():
     tests are precisely the ones a thread sanitizer exists to run. A filter
     that silently misses them leaves the job green while checking none of it.
     """
-    tsan = _ci_job("scheduled-thread-sanitizer")
+    tsan = _scheduled_job("scheduled-thread-sanitizer")
     runs = " ".join(step.get("run", "") for step in tsan["steps"])
     for module_filter in ("graph::session", "graph::parallel", "executor::tests::parallel"):
         assert module_filter in runs, (
@@ -487,7 +497,7 @@ def test_thread_sanitizer_builds_the_standard_library_from_source() -> None:
     against an uninstrumented std, i.e. green without observing the
     synchronisation it exists to check, so it is rejected here too.
     """
-    scheduled = _ci_job("scheduled-thread-sanitizer")
+    scheduled = _scheduled_job("scheduled-thread-sanitizer")
     toolchains = _steps_using(scheduled, "dtolnay/rust-toolchain@")
     assert toolchains, "scheduled-thread-sanitizer installs no toolchain"
     components = {c.strip() for step in toolchains for c in step.get("with", {}).get("components", "").split(",")}
@@ -563,8 +573,7 @@ def test_scheduled_dependency_maintenance_is_report_first() -> None:
     assert "ignore" not in group
     assert group["update-types"] == ["minor", "patch"], "grouped cargo updates must exclude majors"
 
-    maintenance = _ci_job("dependency-maintenance")
-    assert maintenance["if"] == SCHEDULED_ONLY_IF
+    maintenance = _scheduled_job("dependency-maintenance")
     tools = [step.get("with", {}).get("tool") for step in _steps_using(maintenance, "taiki-e/install-action@")]
     assert tools == ["cargo-audit@0.22.2"]
     # Report-first: the two report steps tolerate failure, the policy check does
@@ -580,7 +589,7 @@ def test_scheduled_dependency_maintenance_is_report_first() -> None:
 
 
 def test_scheduled_stress_is_bounded_and_excludes_large_runner_case() -> None:
-    stress = _ci_job("scheduled-concurrency-stress")
+    stress = _scheduled_job("scheduled-concurrency-stress")
     invocations = _pytest_invocations(stress)
     assert len(invocations) == 2, f"scheduled stress runs {len(invocations)} pytest invocations, expected 2"
     for target, marker in (
@@ -1933,9 +1942,6 @@ def test_dedup_gates_are_consistent() -> None:
         "rustsec-audit",
         "msrv",
         "ci-success",
-        "scheduled-thread-sanitizer",
-        "dependency-maintenance",
-        "scheduled-concurrency-stress",
     }
     fresh_if = "needs.dedup.outputs.fresh == 'true'"
     for job, spec in ci["jobs"].items():


### PR DESCRIPTION
Data: 62/126 CI runs failed over 11 days; census of 30 failed runs traced ~half the volume to gates whose first executor is CI, plus floating-toolchain skew and duplicate main-push suites.

- [x] `make gate-push` + `check-toolchain-pin` — the CI-only checks (public-API baselines, source quality, lint allowances, workspace clippy, pin match) run locally once per push
- [x] `RUST_STABLE` single-source pin, 17 jobs off floating `@stable` (MSRV/nightly untouched, guard mutation-proven)
- [x] dedup: a main push whose exact SHA is already PR-green skips the 21 gated root jobs (~2.5 runner-hrs/release saved); rustsec always runs; dedup query fails open; guard mutation-proven
- [x] schedule-only jobs → `scheduled.yml` (no more permanently-skipped PR rows)
- [x] consistent display names (poller + release skill updated same-commit)
- [ ] HELD: publish-workflow merge — PyPI Trusted Publishing binds to workflow filenames; needs user-side publisher reconfig first
- Flaky-leg hypothesis falsified: native-lifecycle re-runs the core suite per OS (one real red counts 3×); kglite-java red was the ABI pin catching real drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)