### PR TITLE
fix: 0.17.0 review findings (tz table columns, JSON parameter text contract, parse_json doc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ before upgrading.
   instant. Restoring a recorded aware dtype read the stored UTC time as a
   zone-local wall clock, shifting every cell in a non-UTC column by the zone
   offset.
+- `kglite::api::param::json_text_to_query_value_map` is the exact checked
+  Cypher parameter entry for a caller holding JSON text: it validates the
+  number lexemes before serde_json folds an out-of-range integer into a float.
+  The parsed-object entry `json_object_to_query_value_map` silently accepted
+  `-9223372036854775809`, `18446744073709551616` and `-18446744073709551616`
+  as `Float64`, and is now documented as exact only for the tokens serde_json
+  itself kept exact. The C ABI and MCP query routes already validated the raw
+  text and were unaffected.
+- Recipe query schemas now reject a `minimum` or `maximum` on a `type: integer`
+  variable that is not an exact signed 64-bit integer, instead of compiling a
+  rounded bound the recipe author did not write.
 
 ## [0.17.0] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ before upgrading.
 
 ## [Unreleased]
 
+### Fixed
+
+- `get_table_property` now returns timezone-aware columns at the stored
+  instant. Restoring a recorded aware dtype read the stored UTC time as a
+  zone-local wall clock, shifting every cell in a non-UTC column by the zone
+  offset.
+
 ## [0.17.0] - 2026-09-07
 
 ### Fixed

--- a/crates/kglite-c/src/session.rs
+++ b/crates/kglite-c/src/session.rs
@@ -12,8 +12,8 @@ use crate::status::KgliteStatusCode;
 use crate::strings::alloc_c_string;
 use kglite::api::mutation::{add_edges_from_specs, EdgeSpec};
 use kglite::api::param::{
-    json_object_to_query_value_map, json_object_to_value_map, json_value_to_kglite_value,
-    validate_json_query_numbers_at,
+    json_object_to_query_value_map, json_object_to_value_map, json_text_to_query_value_map,
+    json_value_to_kglite_value, validate_json_query_numbers_at, JsonQueryTextError,
 };
 use kglite::api::session::{execute_mut, execute_read, ExecuteOptions, Session};
 use kglite::api::{Embedder, Value};
@@ -825,26 +825,20 @@ fn parse_params_json(
     if s.is_empty() {
         return Ok(HashMap::new());
     }
-    validate_json_query_numbers_at(s, &[]).map_err(|error| {
-        QueryParamDecodeError::new(KgliteStatusCode::InvalidArgument, error.to_string())
-    })?;
-    let parsed: serde_json::Value = match serde_json::from_str(s) {
-        Ok(v) => v,
-        Err(error) => {
-            return Err(QueryParamDecodeError::new(
-                KgliteStatusCode::InvalidArgument,
-                format!("params_json is not valid JSON: {error}"),
-            ));
-        }
-    };
-    match parsed {
-        serde_json::Value::Object(obj) => json_object_to_query_value_map(&obj).map_err(|error| {
-            QueryParamDecodeError::new(KgliteStatusCode::InvalidArgument, error.to_string())
-        }),
-        serde_json::Value::Null => Ok(HashMap::new()),
-        _ => Err(QueryParamDecodeError::new(
+    match json_text_to_query_value_map(s) {
+        Ok(params) => Ok(params),
+        Err(JsonQueryTextError::TopLevelNull) => Ok(HashMap::new()),
+        Err(JsonQueryTextError::Syntax(message)) => Err(QueryParamDecodeError::new(
+            KgliteStatusCode::InvalidArgument,
+            format!("params_json is not valid JSON: {message}"),
+        )),
+        Err(JsonQueryTextError::TopLevelNotAnObject) => Err(QueryParamDecodeError::new(
             KgliteStatusCode::InvalidArgument,
             "params_json must be a JSON object or null",
+        )),
+        Err(error @ JsonQueryTextError::Parameter(_)) => Err(QueryParamDecodeError::new(
+            KgliteStatusCode::InvalidArgument,
+            error.to_string(),
         )),
     }
 }
@@ -1024,6 +1018,30 @@ mod tests {
         let s = CString::new("[1, 2, 3]").unwrap();
         let err = parse_params_json(s.as_ptr()).unwrap_err();
         assert_eq!(err.code, KgliteStatusCode::InvalidArgument);
+    }
+
+    /// The published `params_json` shapes, which the shared text entry
+    /// reports as separate variants: a JSON `null` document means "no
+    /// parameters", any other non-object is refused by name, and a syntax
+    /// error keeps serde_json's own diagnostic.
+    #[test]
+    fn parse_params_document_null_is_empty_and_other_shapes_keep_their_message() {
+        let null = CString::new("null").unwrap();
+        assert!(parse_params_json(null.as_ptr()).unwrap().is_empty());
+        for raw in ["[1, 2, 3]", "42", r#""text""#, "true"] {
+            let s = CString::new(raw).unwrap();
+            let err = parse_params_json(s.as_ptr()).unwrap_err();
+            assert_eq!(err.code, KgliteStatusCode::InvalidArgument);
+            assert_eq!(err.message, "params_json must be a JSON object or null");
+        }
+        let broken = CString::new("{").unwrap();
+        let err = parse_params_json(broken.as_ptr()).unwrap_err();
+        assert_eq!(err.code, KgliteStatusCode::InvalidArgument);
+        assert!(
+            err.message.starts_with("params_json is not valid JSON: "),
+            "{}",
+            err.message
+        );
     }
 
     /// The documented ownership-on-failure contract: a rejected

--- a/crates/kglite-mcp-server/src/recipe_queries/schema.rs
+++ b/crates/kglite-mcp-server/src/recipe_queries/schema.rs
@@ -177,8 +177,8 @@ impl SchemaNode {
             .map(|value| SchemaNode::compile(value, &format!("{path}.items")).map(Box::new))
             .transpose()?;
         let enum_values = parse_enum(map.get("enum"), path)?;
-        let minimum = parse_number_keyword(map, "minimum", path)?;
-        let maximum = parse_number_keyword(map, "maximum", path)?;
+        let minimum = parse_number_keyword(map, "minimum", path, &types)?;
+        let maximum = parse_number_keyword(map, "maximum", path, &types)?;
         let min_items = parse_usize_keyword(map, "minItems", path)?;
         let max_items = parse_usize_keyword(map, "maxItems", path)?;
 
@@ -351,13 +351,14 @@ fn parse_number_keyword(
     map: &Map<String, Value>,
     keyword: &str,
     path: &str,
+    types: &BTreeSet<ValueType>,
 ) -> Result<Option<Number>> {
     map.get(keyword)
         .map(|value| {
             let number = value
                 .as_number()
                 .ok_or_else(|| anyhow::anyhow!("{path}.{keyword} must be a number"))?;
-            validate_numeric_bound(number, &format!("{path}.{keyword}"))?;
+            validate_numeric_bound(number, &format!("{path}.{keyword}"), types)?;
             Ok(number.clone())
         })
         .transpose()
@@ -410,8 +411,21 @@ fn validate_keyword_applicability(
     Ok(())
 }
 
-fn validate_numeric_bound(number: &Number, path: &str) -> Result<()> {
-    if number.as_i64().is_some() || number.is_f64() {
+/// A compiled bound must still be the number the recipe author wrote.
+///
+/// serde_json folds every integer token outside `[i64::MIN, u64::MAX]` into an
+/// `f64` before compilation sees it, so a `type: integer` bound that is not
+/// `as_i64()`-exact was either spelled as a float or has already been rounded
+/// — and neither can honestly bound a variable whose accepted values are
+/// exact signed 64-bit integers.
+fn validate_numeric_bound(number: &Number, path: &str, types: &BTreeSet<ValueType>) -> Result<()> {
+    if number.as_i64().is_some() {
+        return Ok(());
+    }
+    if types.contains(&ValueType::Integer) && !types.contains(&ValueType::Number) {
+        bail!("{path} must be an exact signed 64-bit integer for type integer");
+    }
+    if number.is_f64() {
         return Ok(());
     }
     if number
@@ -452,6 +466,33 @@ mod numeric_bound_tests {
             "{error}"
         );
         assert!(error.contains("signed 64-bit range"), "{error}");
+    }
+
+    /// A recipe bound spelled beyond `i64` is folded to an `f64` by
+    /// serde_json before compilation sees it, so an integer variable would
+    /// silently be bounded by a different number than the author wrote.
+    #[test]
+    fn integer_typed_bounds_outside_exact_i64_are_rejected() {
+        for bound in [
+            r#""minimum":-9223372036854775809"#,
+            r#""maximum":18446744073709551616"#,
+            r#""minimum":-18446744073709551616"#,
+        ] {
+            let raw: Value = serde_json::from_str(&format!(
+                r#"{{
+                    "type":"object",
+                    "properties":{{"value":{{"type":"integer",{bound}}}}},
+                    "required":["value"],
+                    "additionalProperties":false
+                }}"#
+            ))
+            .unwrap();
+            let error = ParameterSchema::compile_root(&raw, &["value".to_string()])
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("parameters.properties.value"), "{error}");
+            assert!(error.contains("exact signed 64-bit integer"), "{error}");
+        }
     }
 
     #[test]

--- a/crates/kglite-mcp-server/src/recipe_queries/validation.rs
+++ b/crates/kglite-mcp-server/src/recipe_queries/validation.rs
@@ -218,6 +218,16 @@ impl fmt::Display for VariablesValidationError {
 
 impl std::error::Error for VariablesValidationError {}
 
+/// Defence in depth over *parsed* variables: reject a number serde_json kept
+/// outside `i64` (a `u64` above `i64::MAX`) and any non-finite float.
+///
+/// It cannot see an integer token serde_json already folded into an `f64` —
+/// below `i64::MIN` or above `u64::MAX` the result is byte-identical to the
+/// float of the same magnitude. What makes the contract exact is the raw-text
+/// pass the MCP stdio route runs before decoding
+/// (`kglite::api::param::validate_json_query_numbers_at` at the `variables`
+/// pointer); this walk is what still holds for a caller that arrives with
+/// values already parsed.
 pub(super) fn validate_exact_i64_recursive(
     value: &Value,
     path: &str,
@@ -438,10 +448,14 @@ mod tests {
             .any(|issue| issue.kind == VariableIssueKind::Unknown));
     }
 
+    /// A float bound is only compilable on a `number`-typed variable — an
+    /// `integer` one requires an exact i64 bound — but the value reaching it
+    /// is still an integer beyond f64's exact range, which is the comparison
+    /// under test.
     #[test]
     fn integer_bounds_above_f64_exact_range_are_compared_without_rounding() {
         let schema = compile(
-            json!({"value": {"type": "integer", "maximum": 9007199254740992.0}}),
+            json!({"value": {"type": "number", "maximum": 9007199254740992.0}}),
             json!(["value"]),
         );
         let error = schema

--- a/crates/kglite/src/graph/languages/cypher/executor/scalar_functions/shared.rs
+++ b/crates/kglite/src/graph/languages/cypher/executor/scalar_functions/shared.rs
@@ -71,8 +71,20 @@ geom, or wkt for WKT; latitude+longitude or lat+lon for points).";
 
 /// Recursively convert a parsed `serde_json::Value` into a kglite `Value`.
 /// Objects become `Value::Map`, arrays `Value::List`; integers that fit i64
-/// stay `Int64`, finite other numbers become `Float64`, and numbers outside
-/// finite `f64` become `Null`. Backs the `parse_json()` Cypher function.
+/// stay `Int64`, and every other number becomes `Float64` — including one
+/// past i64 (`9223372036854775808` folds to `9.223372036854776e18`). This is
+/// the tolerant policy; query parameters are the strict path.
+///
+/// **A number outside finite `f64` never reaches here under the shipped
+/// features.** Without `arbitrary_precision`, serde_json refuses `1e400` at
+/// parse time ("number out of range"), so `parse_json()` takes its
+/// invalid-JSON branch and yields `Null` for the *whole document*, not for
+/// the one field — pinned by `non_finite_number_token_fails_the_parse` below
+/// and by `tests/test_cypher_parse_json.py`. The `is_finite` filter guards
+/// the case where a downstream crate turns `arbitrary_precision` on through
+/// feature unification and such a token does get parsed.
+///
+/// Backs the `parse_json()` Cypher function.
 pub(super) fn json_to_value(j: &serde_json::Value) -> Value {
     match j {
         serde_json::Value::Null => Value::Null,
@@ -238,5 +250,39 @@ pub(super) fn coerce_naive_datetime(v: &Value) -> Option<chrono::NaiveDateTime> 
         Value::Timestamp(dt) => Some(*dt),
         Value::DateTime(d) => d.and_hms_opt(0, 0, 0),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::json_to_value;
+    use crate::datatypes::values::Value;
+
+    /// The premise of `json_to_value`'s doc: a non-finite number token is
+    /// refused by the parser, so the `is_finite` filter is unreachable and
+    /// `parse_json()` nulls the whole document. A red here means
+    /// `arbitrary_precision` got unified in and the filter is live again —
+    /// the doc, not the filter, is what has to change.
+    #[test]
+    fn non_finite_number_token_fails_the_parse() {
+        for text in [r#"{"a": 1e400}"#, "[1e400]", "-1e400"] {
+            let parsed = serde_json::from_str::<serde_json::Value>(text);
+            assert!(parsed.is_err(), "{text} unexpectedly parsed: {parsed:?}");
+        }
+    }
+
+    #[test]
+    fn parse_json_numbers_keep_int64_only_when_exact() {
+        let parsed: serde_json::Value = serde_json::from_str(
+            r#"{"a": 1e308, "c": 9223372036854775807, "d": 9223372036854775808}"#,
+        )
+        .expect("finite tokens parse");
+        let Value::Map(map) = json_to_value(&parsed) else {
+            panic!("object must convert to a map");
+        };
+        assert_eq!(map.get("a"), Some(&Value::Float64(1e308)));
+        assert_eq!(map.get("c"), Some(&Value::Int64(i64::MAX)));
+        // Past i64 the tolerant converter folds to f64 rather than nulling.
+        assert_eq!(map.get("d"), Some(&Value::Float64(9.223372036854776e18)));
     }
 }

--- a/crates/kglite/src/lib.rs
+++ b/crates/kglite/src/lib.rs
@@ -203,18 +203,24 @@ pub mod api {
     /// Parameter-shape helpers for bindings — wire-shaped values
     /// (JSON / protobuf-map / etc.) ↔ `kglite::api::Value`. The
     /// canonical converters both ways, so no binding re-implements the
-    /// JSON dispatch. `json_object_to_query_value_map` is the checked Cypher
-    /// parameter path: integer tokens must fit `i64`, decimal/exponent tokens
-    /// must fit finite `f64`, and errors retain their nested path.
+    /// JSON dispatch. `json_text_to_query_value_map` is the checked Cypher
+    /// parameter path: it validates the number lexemes in the source text
+    /// before serde_json can fold an out-of-range integer into an `f64`, so
+    /// integer tokens must fit `i64`, decimal/exponent tokens must fit finite
+    /// `f64`, and errors retain their nested path.
+    /// `json_object_to_query_value_map` is the same conversion for a caller
+    /// that only has the parsed object, and is therefore exact only for the
+    /// tokens serde_json itself kept exact.
     /// `json_value_to_kglite_value` remains the tolerant property/ingestion
     /// converter. `kglite_value_to_json` renders outbound result cells in
     /// natural untagged JSON; `kglite_value_to_csv_text` retains machine-value
     /// precision before the caller applies RFC CSV quoting.
     pub mod param {
         pub use crate::param::{
-            json_object_to_query_value_map, json_object_to_value_map, json_value_to_kglite_value,
-            kglite_value_to_csv_text, kglite_value_to_json, validate_json_query_numbers_at,
-            JsonQueryParameterError, JsonQueryParameterErrorKind,
+            json_object_to_query_value_map, json_object_to_value_map, json_text_to_query_value_map,
+            json_value_to_kglite_value, kglite_value_to_csv_text, kglite_value_to_json,
+            validate_json_query_numbers_at, JsonQueryParameterError, JsonQueryParameterErrorKind,
+            JsonQueryTextError,
         };
     }
 

--- a/crates/kglite/src/param/mod.rs
+++ b/crates/kglite/src/param/mod.rs
@@ -77,6 +77,40 @@ impl std::fmt::Display for JsonQueryParameterError {
 
 impl std::error::Error for JsonQueryParameterError {}
 
+/// The reason JSON **text** cannot become a Cypher parameter map.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonQueryTextError {
+    /// A number lexeme cannot be represented by [`Value`]; keeps its path.
+    Parameter(JsonQueryParameterError),
+    /// serde_json refused the text; carries its rendered syntax error.
+    Syntax(String),
+    /// The text is the JSON literal `null`. Reported apart from any other
+    /// non-object because a binding may publish it as "no parameters" (the
+    /// C ABI's `params_json` does).
+    TopLevelNull,
+    /// The text parsed to a value that is neither an object nor `null`.
+    TopLevelNotAnObject,
+}
+
+impl std::fmt::Display for JsonQueryTextError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parameter(error) => error.fmt(formatter),
+            Self::Syntax(message) => {
+                write!(formatter, "Query parameters are not valid JSON: {message}")
+            }
+            Self::TopLevelNull => {
+                write!(formatter, "Query parameters are JSON null, not an object")
+            }
+            Self::TopLevelNotAnObject => {
+                write!(formatter, "Query parameters must be a JSON object")
+            }
+        }
+    }
+}
+
+impl std::error::Error for JsonQueryTextError {}
+
 enum QueryConversionError {
     IntegerOutOfRange,
     NonFiniteFloat,
@@ -128,11 +162,19 @@ impl QueryConversionError {
     }
 }
 
-/// Convert a JSON object used as a query parameter map without losing numbers.
+/// Convert an **already parsed** JSON object into a query parameter map.
 ///
-/// Integer tokens must fit `i64`. Decimal/exponent tokens must fit finite
-/// `f64`. Arrays and objects recurse; path strings are assembled only when a
-/// child is rejected.
+/// Exact only for the tokens serde_json itself kept exact: an integer it
+/// retained as `u64` above `i64::MAX` and a decimal outside finite `f64` are
+/// rejected. An integer token serde_json already folded into an `f64` —
+/// anything below `i64::MIN` or above `u64::MAX`, since this crate does not
+/// enable `arbitrary_precision` — arrives here byte-identical to the float of
+/// the same magnitude and is accepted as `Value::Float64`. A caller that still
+/// holds the source text uses [`json_text_to_query_value_map`], which checks
+/// the lexeme before serde_json can fold it.
+///
+/// Arrays and objects recurse; path strings are assembled only when a child is
+/// rejected.
 pub fn json_object_to_query_value_map(
     map: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<HashMap<String, Value>, JsonQueryParameterError> {
@@ -144,6 +186,33 @@ pub fn json_object_to_query_value_map(
         })
         .collect::<Result<HashMap<_, _>, _>>()
         .map_err(QueryConversionError::into_public)
+}
+
+/// Convert JSON **text** holding a query parameter object into a `Value` map.
+///
+/// The exact checked parameter path: number lexemes are validated in the
+/// source text ([`validate_json_query_numbers_at`]) before serde_json parses
+/// it, so an integer token outside `i64` is rejected on its spelling instead
+/// of on the `f64` serde_json would otherwise have folded it into. Integer
+/// tokens must fit `i64`, decimal/exponent tokens must fit finite `f64`, and
+/// a rejection retains its nested path.
+///
+/// The top level must be a JSON object; `null` is reported as its own
+/// variant so a binding that publishes it as "no parameters" can keep that
+/// contract.
+pub fn json_text_to_query_value_map(
+    source: &str,
+) -> Result<HashMap<String, Value>, JsonQueryTextError> {
+    validate_json_query_numbers_at(source, &[]).map_err(JsonQueryTextError::Parameter)?;
+    let parsed: serde_json::Value = serde_json::from_str(source)
+        .map_err(|error| JsonQueryTextError::Syntax(error.to_string()))?;
+    match parsed {
+        serde_json::Value::Object(object) => {
+            json_object_to_query_value_map(&object).map_err(JsonQueryTextError::Parameter)
+        }
+        serde_json::Value::Null => Err(JsonQueryTextError::TopLevelNull),
+        _ => Err(JsonQueryTextError::TopLevelNotAnObject),
+    }
 }
 
 fn convert_query_value(v: &serde_json::Value) -> Result<Value, QueryConversionError> {
@@ -205,8 +274,11 @@ fn convert_query_value(v: &serde_json::Value) -> Result<Value, QueryConversionEr
 ///
 /// This converter is intentionally tolerant for declared ingestion and
 /// non-query JSON parsing: an integer outside `i64` falls through to `f64`.
-/// Query entry points must use [`json_object_to_query_value_map`], which rejects
-/// an integer token that cannot be represented exactly.
+/// Query entry points must use [`json_text_to_query_value_map`], which rejects
+/// an integer token that cannot be represented exactly;
+/// [`json_object_to_query_value_map`] is the parsed-value entry for a caller
+/// that no longer holds the text, and is exact only for what serde_json kept
+/// exact.
 ///
 /// Agents/bindings pass JSON-shaped tool args; the executor receives
 /// `HashMap<String, Value>` parameters. Compose multiple calls via
@@ -866,6 +938,96 @@ mod strict_query_parameter_tests {
             .as_object()
             .unwrap()
             .clone()
+    }
+
+    /// The integer spellings serde_json folds into `f64` before any
+    /// converter sees them: below `i64::MIN`, and either side of `2^64`.
+    const OVERFLOW_SPELLINGS: [&str; 3] = [
+        "-9223372036854775809",
+        "18446744073709551616",
+        "-18446744073709551616",
+    ];
+
+    #[test]
+    fn integer_overflow_spellings_are_rejected_with_their_nested_path() {
+        for spelling in OVERFLOW_SPELLINGS {
+            for (source, path) in [
+                (format!(r#"{{"value":{spelling}}}"#), "$.value"),
+                (format!(r#"{{"a":[{{"b":{spelling}}}]}}"#), "$.a[0].b"),
+            ] {
+                let Err(error) = json_text_to_query_value_map(&source) else {
+                    panic!("{source} must be rejected");
+                };
+                let JsonQueryTextError::Parameter(error) = error else {
+                    panic!("{source} must fail on its number lexeme, got {error}");
+                };
+                assert_eq!(error.kind(), JsonQueryParameterErrorKind::IntegerOutOfRange);
+                assert_eq!(error.path(), path);
+            }
+        }
+    }
+
+    /// The leniency the parsed-value converter documents: serde_json has
+    /// already folded these lexemes into an `f64` indistinguishable from the
+    /// float of the same magnitude, so they arrive as floats. This is why the
+    /// text entry exists, and why the doc must not promise exactness here.
+    #[test]
+    fn parsed_value_entry_is_exact_only_for_what_serde_kept_exact() {
+        for spelling in OVERFLOW_SPELLINGS {
+            let params =
+                json_object_to_query_value_map(&parsed_object(&format!(r#"{{"v":{spelling}}}"#)))
+                    .expect("serde_json already folded the token into an f64");
+            assert!(matches!(params["v"], Value::Float64(_)), "{spelling}");
+        }
+        // The band serde_json keeps as `u64` is still rejected exactly.
+        assert!(
+            json_object_to_query_value_map(&parsed_object(r#"{"v":9223372036854775808}"#)).is_err()
+        );
+    }
+
+    #[test]
+    fn text_entry_keeps_representable_numbers_in_their_exact_variant() {
+        let params = json_text_to_query_value_map(
+            r#"{"min":-9223372036854775808,"max":9223372036854775807,"huge":1e308,"negzero":-0.0,"half":1.5}"#,
+        )
+        .unwrap();
+        assert!(matches!(params["min"], Value::Int64(i64::MIN)));
+        assert!(matches!(params["max"], Value::Int64(i64::MAX)));
+        assert!(matches!(params["huge"], Value::Float64(value) if value == 1e308));
+        assert!(
+            matches!(params["negzero"], Value::Float64(value) if value == 0.0 && value.is_sign_negative())
+        );
+        assert!(matches!(params["half"], Value::Float64(value) if value == 1.5));
+    }
+
+    #[test]
+    fn text_entry_reports_shape_and_syntax_apart_from_number_rejections() {
+        assert_eq!(
+            json_text_to_query_value_map("null").unwrap_err(),
+            JsonQueryTextError::TopLevelNull
+        );
+        for source in ["[]", "1", r#""text""#, "true"] {
+            assert_eq!(
+                json_text_to_query_value_map(source).unwrap_err(),
+                JsonQueryTextError::TopLevelNotAnObject,
+                "{source}"
+            );
+        }
+        for source in ["{", "", r#"{"a":1} trailing"#] {
+            assert!(
+                matches!(
+                    json_text_to_query_value_map(source),
+                    Err(JsonQueryTextError::Syntax(_))
+                ),
+                "{source}"
+            );
+        }
+        assert_eq!(
+            json_text_to_query_value_map(r#"{"v":1e400}"#)
+                .unwrap_err()
+                .to_string(),
+            "Query parameter $.v number is outside the finite 64-bit float range"
+        );
     }
 
     #[test]

--- a/kglite/__init__.pyi
+++ b/kglite/__init__.pyi
@@ -4885,7 +4885,9 @@ class KnowledgeGraph:
 
         Preserves exact integer cells before restoring the column order and dtypes recorded by
         :meth:`set_table_property` (columns that held nulls come back as
-        pandas nullable dtypes, e.g. ``Int64``). A node without the property
+        pandas nullable dtypes, e.g. ``Int64``). Timezone-aware columns are
+        stored as UTC instants and come back at the recorded zone carrying
+        that instant. A node without the property
         yields an empty frame with the registered columns. Unsupported recorded
         dtypes retain a safe inferred representation.
 

--- a/kglite/_pandas.py
+++ b/kglite/_pandas.py
@@ -28,17 +28,37 @@ def dataframe(data, columns=None, dtypes=None, native_dtypes=None):
             prepared[name] = values
             continue
         try:
-            prepared[name] = pd.array(values, dtype=target) if target == "Int64" else pd.Series(values, dtype=target)
+            prepared[name] = _column(pd, values, target)
         except (TypeError, ValueError):
             if target == inferred:
                 raise
-            prepared[name] = (
-                values
-                if inferred is None
-                else (pd.array(values, dtype=inferred) if inferred == "Int64" else pd.Series(values, dtype=inferred))
-            )
+            prepared[name] = values if inferred is None else _column(pd, values, inferred)
     # Ordered/duplicate labels retain the existing constructor's semantics.
     return pd.DataFrame(prepared, columns=columns)
+
+
+def _column(pd, values, dtype):
+    """Build one column at the recorded dtype."""
+    if dtype == "Int64":
+        return pd.array(values, dtype=dtype)
+    aware = _aware_datetime_dtype(pd, dtype)
+    if aware is None:
+        return pd.Series(values, dtype=dtype)
+    # Aware cells are stored as UTC-naive instants, so constructing straight at
+    # the aware dtype would read the UTC wall clock as zone-local time and shift
+    # every value by the zone offset.
+    naive = pd.Series(values, dtype=f"datetime64[{aware.unit}]")
+    return naive.dt.tz_localize("UTC").dt.tz_convert(aware.tz)
+
+
+def _aware_datetime_dtype(pd, dtype):
+    """Return a tz-aware target as a dtype object; every other target is None."""
+    if isinstance(dtype, str):
+        if not dtype.startswith("datetime64[") or "," not in dtype:
+            return None
+        # An unusable zone raises here and reaches the caller's dtype fallback.
+        dtype = pd.api.types.pandas_dtype(dtype)
+    return dtype if isinstance(dtype, pd.DatetimeTZDtype) else None
 
 
 def _integer_dtype(values):

--- a/tests/api-baselines/rust/kglite-all-features.txt
+++ b/tests/api-baselines/rust/kglite-all-features.txt
@@ -2091,6 +2091,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::api::param::JsonQueryTextError
+pub kglite::api::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::api::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::api::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::api::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::api::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -2108,6 +2124,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::api::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::api::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
@@ -4991,6 +5008,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::param::JsonQueryTextError
+pub kglite::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -5008,6 +5041,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value

--- a/tests/api-baselines/rust/kglite-default.txt
+++ b/tests/api-baselines/rust/kglite-default.txt
@@ -2076,6 +2076,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::api::param::JsonQueryTextError
+pub kglite::api::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::api::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::api::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::api::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::api::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -2093,6 +2109,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::api::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::api::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
@@ -4816,6 +4833,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::param::JsonQueryTextError
+pub kglite::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -4833,6 +4866,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value

--- a/tests/api-baselines/rust/kglite-fastembed.txt
+++ b/tests/api-baselines/rust/kglite-fastembed.txt
@@ -2076,6 +2076,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::api::param::JsonQueryTextError
+pub kglite::api::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::api::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::api::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::api::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::api::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -2093,6 +2109,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::api::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::api::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
@@ -4831,6 +4848,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::param::JsonQueryTextError
+pub kglite::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -4848,6 +4881,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value

--- a/tests/api-baselines/rust/kglite-okf.txt
+++ b/tests/api-baselines/rust/kglite-okf.txt
@@ -2076,6 +2076,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::api::param::JsonQueryTextError
+pub kglite::api::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::api::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::api::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::api::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::api::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -2093,6 +2109,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::api::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::api::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
@@ -4961,6 +4978,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::param::JsonQueryTextError
+pub kglite::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -4978,6 +5011,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value

--- a/tests/api-baselines/rust/kglite-rdf.txt
+++ b/tests/api-baselines/rust/kglite-rdf.txt
@@ -2091,6 +2091,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::api::param::JsonQueryTextError
+pub kglite::api::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::api::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::api::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::api::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::api::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -2108,6 +2124,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::api::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::api::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::api::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::api::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::api::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::api::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value
@@ -4831,6 +4848,22 @@ impl core::fmt::Debug for kglite::param::JsonQueryParameterErrorKind
 pub fn kglite::param::JsonQueryParameterErrorKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for kglite::param::JsonQueryParameterErrorKind
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterErrorKind
+pub enum kglite::param::JsonQueryTextError
+pub kglite::param::JsonQueryTextError::Parameter(kglite::param::JsonQueryParameterError)
+pub kglite::param::JsonQueryTextError::Syntax(alloc::string::String)
+pub kglite::param::JsonQueryTextError::TopLevelNotAnObject
+pub kglite::param::JsonQueryTextError::TopLevelNull
+impl core::clone::Clone for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::clone(&self) -> kglite::param::JsonQueryTextError
+impl core::cmp::Eq for kglite::param::JsonQueryTextError
+impl core::cmp::PartialEq for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::eq(&self, other: &kglite::param::JsonQueryTextError) -> bool
+impl core::error::Error for kglite::param::JsonQueryTextError
+impl core::fmt::Debug for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for kglite::param::JsonQueryTextError
+pub fn kglite::param::JsonQueryTextError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for kglite::param::JsonQueryTextError
 pub struct kglite::param::JsonQueryParameterError
 impl kglite::param::JsonQueryParameterError
 pub fn kglite::param::JsonQueryParameterError::kind(&self) -> kglite::param::JsonQueryParameterErrorKind
@@ -4848,6 +4881,7 @@ pub fn kglite::param::JsonQueryParameterError::fmt(&self, formatter: &mut core::
 impl core::marker::StructuralPartialEq for kglite::param::JsonQueryParameterError
 pub fn kglite::param::json_object_to_query_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryParameterError>
 pub fn kglite::param::json_object_to_value_map(map: &serde_json::map::Map<alloc::string::String, serde_json::value::Value>) -> std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>
+pub fn kglite::param::json_text_to_query_value_map(source: &str) -> core::result::Result<std::collections::hash::map::HashMap<alloc::string::String, kglite::datatypes::values::Value>, kglite::param::JsonQueryTextError>
 pub fn kglite::param::json_value_to_kglite_value(v: &serde_json::value::Value) -> kglite::datatypes::values::Value
 pub fn kglite::param::kglite_value_to_csv_text(v: &kglite::datatypes::values::Value) -> alloc::string::String
 pub fn kglite::param::kglite_value_to_json(v: &kglite::datatypes::values::Value) -> serde_json::value::Value

--- a/tests/test_cypher_parse_json.py
+++ b/tests/test_cypher_parse_json.py
@@ -65,3 +65,48 @@ def test_parse_json_predicate_over_parameters() -> None:
         )
     }
     assert hits == {"takes_dataset"}, hits
+
+
+def test_parse_json_non_finite_number_nulls_the_whole_document() -> None:
+    """A number token outside finite f64 fails the *parse*, not one field.
+
+    Under the shipped serde_json features (no ``arbitrary_precision``) the
+    token ``1e400`` is refused with "number out of range" before any value is
+    built, so parse_json() takes its invalid-JSON branch and returns NULL for
+    the entire document. The sibling keys are gone with it — this is
+    deliberately *not* a per-number NULL, and the assertions below fail if
+    anyone converts it into one.
+    """
+    g = kglite.KnowledgeGraph()
+
+    rows = list(g.cypher("RETURN parse_json('{\"a\": 1e400}') AS r"))
+    assert rows[0]["r"] is None
+
+    rows = list(g.cypher("RETURN parse_json('[1e400]') AS r"))
+    assert rows[0]["r"] is None
+
+    # The surviving-siblings shape is what a per-number NULL would produce.
+    rows = list(g.cypher('RETURN parse_json(\'{"a": 1, "b": 1e400}\') AS r'))
+    assert rows[0]["r"] is None, "a non-finite token nulls the document, not just its own key"
+
+
+def test_parse_json_number_typing_at_the_f64_and_i64_edges() -> None:
+    """Every number serde_json *accepts* keeps the tolerant converter's typing.
+
+    ``1e308`` is finite, so it stays Float64; ``2**63 - 1`` fits i64 and stays
+    Int64; ``2**63`` does not, so the converter folds it to the nearest f64
+    (9.223372036854776e18) rather than nulling it. Query *parameters* are the
+    strict path — this one is documented as tolerant.
+    """
+    g = kglite.KnowledgeGraph()
+    rows = list(
+        g.cypher(
+            'RETURN parse_json(\'{"a": 1e308, "b": -1e308, "c": 9223372036854775807, "d": 9223372036854775808}\') AS r'
+        )
+    )
+    parsed = rows[0]["r"]
+    assert parsed is not None
+    assert parsed["a"] == 1e308 and isinstance(parsed["a"], float)
+    assert parsed["b"] == -1e308 and isinstance(parsed["b"], float)
+    assert parsed["c"] == 9223372036854775807 and isinstance(parsed["c"], int)
+    assert parsed["d"] == 9.223372036854776e18 and isinstance(parsed["d"], float)

--- a/tests/test_dataframe_value_preservation.py
+++ b/tests/test_dataframe_value_preservation.py
@@ -95,3 +95,31 @@ def test_table_setter_keeps_zero_column_refusal():
     with pytest.raises(ValueError, match="DataFrame has no columns"):
         graph.set_table_property("N", 1, "items", pd.DataFrame(index=range(2)))
     assert graph.cypher("MATCH (n:N) RETURN n.items AS items").column("items") == [None]
+
+
+def test_table_frame_restores_timezone_aware_instants(tmp_path):
+    graph = kglite.KnowledgeGraph()
+    graph.cypher("CREATE (:N{id:1})")
+    oslo = pd.Series(
+        [pd.Timestamp("2024-01-02 03:04:05.123456", tz="Europe/Oslo"), None],
+        dtype="datetime64[us, Europe/Oslo]",
+    )
+    utc = pd.Series(
+        [pd.Timestamp("2024-01-02 02:04:05.123456", tz="UTC"), None],
+        dtype="datetime64[us, UTC]",
+    )
+    naive = pd.Series([dt.datetime(2024, 1, 2, 3, 4, 5, 123456), None], dtype="datetime64[us]")
+    graph.set_table_property("N", 1, "items", pd.DataFrame({"oslo": oslo, "utc": utc, "naive": naive}))
+    path = tmp_path / "table.kgl"
+    graph.save(str(path))
+    for owner in [graph, kglite.load(str(path))]:
+        actual = owner.get_table_property("N", 1, "items")
+        assert str(actual.oslo.dtype) == "datetime64[us, Europe/Oslo]"
+        assert actual.oslo.dt.tz_convert("UTC").iloc[0] == oslo.dt.tz_convert("UTC").iloc[0]
+        assert pd.isna(actual.oslo.iloc[1])
+        assert str(actual.utc.dtype) == "datetime64[us, UTC]"
+        assert actual.utc.iloc[0] == utc.iloc[0]
+        assert pd.isna(actual.utc.iloc[1])
+        assert str(actual.naive.dtype) == "datetime64[us]"
+        assert actual.naive.iloc[0] == naive.iloc[0]
+        assert pd.isna(actual.naive.iloc[1])


### PR DESCRIPTION
Fixes the three findings from the 0.17.0 post-release review (tag v0.17.0 @ 02d7bee9). Each phase is one bisectable commit, red-first.

## Phases

- [x] **P1 `fix(python)`** — `get_table_property` restored timezone-aware timestamp columns shifted by the zone offset: cells are stored as UTC instants (0.17.0 contract) and were re-localized instead of converted. Column is now built naive UTC then `tz_convert`ed to the recorded zone. Golden test asserts the instant for a non-UTC zone with microseconds and a NULL cell, plus UTC and naive controls.
- [x] **P2 `fix(params)`** — the Rust API's checked JSON parameter path accepted `-9223372036854775809` and above-`u64` integer tokens as floats, because serde_json folds those to `f64` before the converter sees them. New `kglite::api::param::json_text_to_query_value_map` validates the raw lexemes first and is the documented checked entry; the C ABI route now calls it. The parsed-value converter is documented honestly. Recipe schemas reject `type: integer` bounds that are not exact `i64`. API baselines refreshed (additions only).
- [x] **P3 `docs(cypher)`** — `parse_json()`'s converter doc claimed per-number NULL for non-finite tokens; serde_json refuses them at parse, so the whole document is NULL. Doc corrected and the behaviour pinned in Rust and Python goldens.
- [x] **Final gate** — full default pytest, parity + differential corpora, `make gate-push`, `make lint-full`; CI on this HEAD.

No version bump; shipping is a separate release request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
